### PR TITLE
Update Caveats section about whitelisting for conf.py.

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -88,7 +88,13 @@ whenever you commit to your repo, effectively letting you 'set it and forget it'
 Caveats
 -------
 
-We are auto-importing and generating ``conf.py`` files, so projects with special
-extensions, themes, or templates won't work correctly. This is because of the
-possibility of code execution within the python files. We are planning to support
-popular themes and white list users that we trust to have these abilities.
+Usually, `readthedocs.org <http://readthedocs.org>`_ generates its own ``conf.py``
+files, by extracting a few values (such as ``copyright``, ``html_theme``,
+``source_suffix`` and ``version``) from the project's ``conf.py`` file.  This is to
+avoid the possibility of arbitrary code execution within the python files.  As a
+result, projects with special extensions, themes, or templates won't work
+correctly.  We are planning to support popular themes in future.
+
+For projects which need to be able to run code in conf.py, there is a white list
+for users that we trust to have these abilities.  To get on the white list, ask
+on IRC.


### PR DESCRIPTION
Update Caveats section to be a bit more explicit about how the conf.py handling works, and to say that a white list exists.
