### PR TITLE
Use a bare '--' to separate the revision from an empty list of filenames 

### DIFF
--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -147,7 +147,7 @@ class Backend(BaseVCS):
             if self.default_branch:
                 identifier = self.default_branch
         #Checkout the correct identifier for this branch.
-        return self.run('git', 'reset', '--hard', identifier)
+        return self.run('git', 'reset', '--hard', identifier, '--')
 
     @property
     def env(self):


### PR DESCRIPTION
From the bottom of
 http://readthedocs.org/builds/buildbot/23876

<pre>
fatal: ambiguous argument 'master': both revision and filename
Use '--' to separate filenames from revisions
</pre>
