### PR TITLE
Removing importlib from requirements.

### DIFF
--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -5,7 +5,6 @@ celery
 django-celery
 django-kombu
 celery-haystack
-importlib
 django-extensions
 django-haystack
 mimeparse


### PR DESCRIPTION
This lib causes install problems on python 2.7, it is a dependency of other libs so lets rely on them to install correctly based on if it is python 2.7 or 2.6 rather than doing it ourselves.
