### PR TITLE
Fix link to Open Comparison docs

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -5,4 +5,4 @@ Contributing to Read the Docs
 You should read the `Open Comparison Contributing Docs`_. They are some of the best I've seen, this document will some day copy their structure with example for Read the Docs, but until that day, I highly recommend reading theirs.
 
 
-.. _Open Comparison Contributing Docs:: http://opencomparison.readthedocs.org/en/latest/contributing.html
+.. _Open Comparison Contributing Docs: http://opencomparison.readthedocs.org/en/latest/contributing.html


### PR DESCRIPTION
Step 1 for contributing to Read the Docs: Fix the Read the Docs "Contributing to Read the Docs" doc.
