### PR TITLE
Update to docs, fixed typo.

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -25,7 +25,7 @@ When RTD builds your project, it sets the `READTHEDOCS` environment variable to 
     else:
         html_theme = 'nature'
 
-I get import errors on librarires that depend on C modules
+I get import errors on libraries that depend on C modules
 ----------------------------------------------------------
 
 This happens because our build system doesn't have the dependencies for building your project. This happens with things like libevent and mysql, and other python things that depend on C libraries. We can't support installing random C binaries on our system, so there is another way to fix these imports.


### PR DESCRIPTION
Changed typo in docs, 'librarires to libraries'.

Thanks for the project.
