### PR TITLE
improve Mock class

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -38,8 +38,12 @@ You can mock out the imports for these modules in your conf.py with the followin
         def __init__(self, *args, **kwargs):
             pass
 
-        def __getattr__(self, name):
+        def __call__(self, *args, **kwargs):
             return Mock()
+
+        @classmethod
+        def __getattr__(self, name):
+            return Mock() if name not in ('__file__', '__path__') else '/dev/null'
 
     MOCK_MODULES = ['pygtk', 'gtk', 'gobject', 'argparse']
     for mod_name in MOCK_MODULES:


### PR DESCRIPTION
The python import machinery expects **path** to be a string, so
**getattr** has to return a mock string instead of a mock object.

**getattr** now also returns Mock objects instead of the Mock class
and Mock objects are now callable.

credits to teyphoon:
https://github.com/pazz/alot/commit/96e66e0ab7d9439acae9efb88e9c97a8c176a6ef
https://github.com/pazz/alot/commit/022edcff715856024c116e3b2a059fb0517cded9
