### PR TITLE
Improve Mock implementation

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -43,7 +43,12 @@ You can mock out the imports for these modules in your conf.py with the followin
 
         @classmethod
         def __getattr__(self, name):
-            return Mock() if name not in ('__file__', '__path__') else '/dev/null'
+            if name in ('__file__', '__path__'):
+                return '/dev/null'
+            elif name[0] == name[0].upper():
+                return type(name, (), {})
+            else:
+                return Mock()
 
     MOCK_MODULES = ['pygtk', 'gtk', 'gobject', 'argparse']
     for mod_name in MOCK_MODULES:


### PR DESCRIPTION
This one doesn't confuse Sphinx beyond repair when a project class inherits from a class in a mocked module.

There are two issues with the old code when a class inherits from a class defined in a mocked module:
- `sphinx.ext.autodoc` thinks the child class is only an alias, because its `__name__` method returns a mock object, which looks like '&lt;Mock ...&gt;' after casting to a string.
- `sphinx.ext.viewcode` also is confused for some reason and chops of part of files' sources (very strange).

The new heuristic tries to prevent this by returning a temporary class if an uppercase member is accessed. Of course this can cause errors in cases where module-level variables are named in uppercase and accessed from other modules, but I think it's better than the way this is handled now.
