### PR TITLE
Fix moving of man, pdf and epub files.

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx_epub.py
+++ b/readthedocs/doc_builder/backends/sphinx_epub.py
@@ -1,3 +1,4 @@
+from glob import glob
 import os
 from doc_builder.base import restoring_chdir
 from doc_builder.backends.sphinx import Builder as HtmlBuilder
@@ -30,11 +31,13 @@ class Builder(HtmlBuilder):
                                'epub',
                                project.slug,
                                self.version.slug)
-        from_file = os.path.join(outputted_path, "*.epub")
-        to_file = os.path.join(to_path, "%s.epub" % project.slug)
-        if getattr(settings, "MULTIPLE_APP_SERVERS", None):
-            copy_file_to_app_servers(from_file, to_file)
-        else:
-            if not os.path.exists(to_path):
-                os.makedirs(to_path)
-            run('mv -f %s %s' % (from_file, to_file))
+        from_globs = glob(os.path.join(outputted_path, "*.epub"))
+        if from_globs:
+            from_file = from_globs[0]
+            to_file = os.path.join(to_path, "%s.epub" % project.slug)
+            if getattr(settings, "MULTIPLE_APP_SERVERS", None):
+                copy_file_to_app_servers(from_file, to_file)
+            else:
+                if not os.path.exists(to_path):
+                    os.makedirs(to_path)
+                run('mv -f %s %s' % (from_file, to_file))

--- a/readthedocs/doc_builder/backends/sphinx_man.py
+++ b/readthedocs/doc_builder/backends/sphinx_man.py
@@ -1,3 +1,4 @@
+from glob import glob
 import os
 
 from django.conf import settings
@@ -30,11 +31,13 @@ class Builder(ManpageBuilder):
                                'man',
                                project.slug,
                                self.version.slug)
-        from_file = os.path.join(outputted_path, "*.1")
-        to_file = os.path.join(to_path, '%s.1' % project.slug)
-        if getattr(settings, "MULTIPLE_APP_SERVERS", None):
-            copy_file_to_app_servers(from_file, to_file)
-        else:
-            if not os.path.exists(to_path):
-                os.makedirs(to_path)
-            run('mv -f %s %s' % (from_file, to_file))
+        from_globs = glob(os.path.join(outputted_path, "*.1"))
+        if from_globs:
+            from_file = from_globs[0]
+            to_file = os.path.join(to_path, '%s.1' % project.slug)
+            if getattr(settings, "MULTIPLE_APP_SERVERS", None):
+                copy_file_to_app_servers(from_file, to_file)
+            else:
+                if not os.path.exists(to_path):
+                    os.makedirs(to_path)
+                run('mv -f %s %s' % (from_file, to_file))

--- a/readthedocs/doc_builder/backends/sphinx_pdf.py
+++ b/readthedocs/doc_builder/backends/sphinx_pdf.py
@@ -40,14 +40,16 @@ class Builder(BaseBuilder):
                            'pdf',
                            project.slug,
                            self.version.slug)
-                    from_file = os.path.join(os.getcwd(), "*.pdf")
-                    to_file = os.path.join(to_path, '%s.pdf' % project.slug)
-                    if getattr(settings, "MULTIPLE_APP_SERVERS", None):
-                        copy_file_to_app_servers(from_file, to_file)
-                    else:
-                        if not os.path.exists(to_path):
-                            os.makedirs(to_path)
-                        run('mv -f %s %s' % (from_file, to_file))
+                    from_globs = glob(os.path.join(os.getcwd(), "*.pdf"))
+                    if from_globs:
+                        from_file = from_globs[0]
+                        to_file = os.path.join(to_path, '%s.pdf' % project.slug)
+                        if getattr(settings, "MULTIPLE_APP_SERVERS", None):
+                            copy_file_to_app_servers(from_file, to_file)
+                        else:
+                            if not os.path.exists(to_path):
+                                os.makedirs(to_path)
+                            run('mv -f %s %s' % (from_file, to_file))
         else:
             print "PDF Building failed. Moving on."
         return (latex_results, pdf_results)


### PR DESCRIPTION
PDF, man, and epub files were being built, but were not being moved to the /media directory when no app servers were being used.

The from_file variable contains a '*' shell wildcard.

For installs where MULTIPLE_APP_SERVERS is set, copy_to_app_servers() works fine. It uses os.system, and so works with '*' wildcards.

When MULTIPLE_APP_SERVERS is not set, the move command is run(mv -f from_file to_file), which uses subprocess.Popen (with shell=False). That doesn't expand '*' shell wildcards, so the mv command fails.

Solution is to use glob to figure out exact name of built files, rather than using '*' wildcard expansion in mv command.
