### PR TITLE
Change how port forwarding is done 

### DIFF
--- a/deploy/Vagrantfile
+++ b/deploy/Vagrantfile
@@ -19,8 +19,8 @@ Vagrant::Config.run do |config|
 
   # Forward a port from the guest to the host, which allows for outside
   # computers to access the VM, whereas host only networking does not.
-  config.vm.forward_port "http", 80, 8080
-  config.vm.forward_port("web", 9999, 9999)
+  config.vm.forward_port  80, 8080
+  config.vm.forward_port  9999, 9999
 
 
   # Share an additional folder to the guest VM. The first argument is


### PR DESCRIPTION
This fixes an issue with 0.9 and 1.0 version of vagrant. It does not take 3 arguments anymore.

null:deploy tlpinney$ vagrant up
/Users/tlpinney/.rvm/gems/ruby-1.9.3-p0/gems/vagrant-1.0.1/lib/vagrant/config/vm.rb:44:in `to_s': wrong number of arguments(1 for 0) (ArgumentError)
    from /Users/tlpinney/.rvm/gems/ruby-1.9.3-p0/gems/vagrant-1.0.1/lib/vagrant/config/vm.rb:44:in`forward_port'
    from /Users/tlpinney/project/readthedocs.org/deploy/Vagrantfile:22:in `block in <top (required)>'
    from /Users/tlpinney/.rvm/gems/ruby-1.9.3-p0/gems/vagrant-1.0.1/lib/vagrant/config/loader.rb:83:in`call'
    from /Users/tlpinney/.rvm/gems/ruby-1.9.3-p0/gems/vagrant-1.0.1/lib/vagrant/config/loader.rb:83:in `block (2 levels) in load'
    from /Users/tlpinney/.rvm/gems/ruby-1.9.3-p0/gems/vagrant-1.0.1/lib/vagrant/config/loader.rb:79:in`each'
    from /Users/tlpinney/.rvm/gems/ruby-1.9.3-p0/gems/vagrant-1.0.1/lib/vagrant/config/loader.rb:79:in `block in load'
    from /Users/tlpinney/.rvm/gems/ruby-1.9.3-p0/gems/vagrant-1.0.1/lib/vagrant/config/loader.rb:76:in`each'
    from /Users/tlpinney/.rvm/gems/ruby-1.9.3-p0/gems/vagrant-1.0.1/lib/vagrant/config/loader.rb:76:in `load'
    from /Users/tlpinney/.rvm/gems/ruby-1.9.3-p0/gems/vagrant-1.0.1/lib/vagrant/environment.rb:387:in`block in load_config!'
    from /Users/tlpinney/.rvm/gems/ruby-1.9.3-p0/gems/vagrant-1.0.1/lib/vagrant/environment.rb:392:in `call'
    from /Users/tlpinney/.rvm/gems/ruby-1.9.3-p0/gems/vagrant-1.0.1/lib/vagrant/environment.rb:392:in`load_config!'
    from /Users/tlpinney/.rvm/gems/ruby-1.9.3-p0/gems/vagrant-1.0.1/lib/vagrant/environment.rb:327:in `load!'
    from /Users/tlpinney/.rvm/gems/ruby-1.9.3-p0/gems/vagrant-1.0.1/bin/vagrant:40:in`<top (required)>'
    from /Users/tlpinney/.rvm/gems/ruby-1.9.3-p0/bin/vagrant:19:in `load'
    from /Users/tlpinney/.rvm/gems/ruby-1.9.3-p0/bin/vagrant:19:in`<main>'
