### PR TITLE
Added humans.txt

### DIFF
--- a/media/humans.txt
+++ b/media/humans.txt
@@ -1,0 +1,34 @@
+Original Authors
+===============
+* Charlie Leifer
+* Eric Holscher
+* Bobby Grace
+
+Opeartions Team
+===============
+
+* Eric Holscher
+* Chris McDonald
+
+Awesome Contributors
+====================
+* Eric Pierce
+* Chris Dickinson
+* Jonas Obrist
+* Issac Kelly
+* Dan Colish
+* Jacob Kaplan-Moss
+* Paul McMillan
+* Daniel Greenfeld
+* Chris McDonald
+* Daniel Graña
+* Alex Gaynor
+* Richard Boulton
+* Mark Sandstrom
+* Thomas Purchas
+* Dustin J. Mitchell
+* Michael Kurze
+* Dag Odenhall
+* Jacob Burch
+
+For a list of all the contributions: https://github.com/rtfd/readthedocs.org/contributors


### PR DESCRIPTION
I've added the contents of the authors file to a humans.txt file - it's in the same place as robots.txt so I'm hoping it's in the correct place. See http://humanstxt.org/ for more details.
