### PR TITLE
Limit section width to 50em and justify.

### DIFF
--- a/readthedocs/templates/sphinx/_static/rtd.css
+++ b/readthedocs/templates/sphinx/_static/rtd.css
@@ -591,6 +591,11 @@ p {
     margin: 0.8em 0 0.5em 0;
 }
 
+.section {
+    text-align: justify;
+    width: 50em;
+}
+
 .section p img.math {
     margin: 0;
 }


### PR DESCRIPTION
Because shorter lines are easier to read. :D

Screenshot of change in Firefox Nightly: http://cl.ly/1a383m240z1K3v0V1r2p

(Also if anyone knows how to add a lang attribute to the html tag we could add `hyphens: auto` as well.)
