### PR TITLE
updated app.nginx.conf to prevent 413 error when uploading zipped docs

### DIFF
--- a/deploy/production/app.nginx.conf
+++ b/deploy/production/app.nginx.conf
@@ -138,6 +138,7 @@ server {
     listen 8000;
     server_name  readthedocs.org;
     access_log  /var/log/nginx/readthedocs.log host;
+    client_max_body_size 50m;
 
     location /favicon.ico {
         root /home/docs/sites/readthedocs.org/checkouts/readthedocs.org/media/images;


### PR DESCRIPTION
When uploading a pre-build zipped doc file larger than 1MB to the readthedocs.org site, it currently issues a 413 error because nginx defaults to a client_max_body_size  of 1M.  This PR fixes the nginx configuration so that it allows 50MB uploads to the readthedocs.org site.

I tested this on a local setup that mirrored the setup shown in http://read-the-docs.readthedocs.org/en/latest/architecture.html#diagram and it fixed the 413 error... although of course I can't test it on the production machines.
