### PR TITLE
Better haystack default setting using sqlite.

### DIFF
--- a/readthedocs/settings/sqlite.py
+++ b/readthedocs/settings/sqlite.py
@@ -33,7 +33,8 @@ WEBSOCKET_HOST = 'localhost:8088'
 
 HAYSTACK_CONNECTIONS = {
     'default': {
-        'ENGINE': 'haystack.backends.simple_backend.SimpleEngine',
+        'ENGINE': 'haystack.backends.solr_backend.SolrEngine',
+        'URL': 'http://localhost:8983/solr',
     },
 }
 


### PR DESCRIPTION
This is a better default setting for people that would like to to try
setup readthedocs at home/job. Using the SQLite database with solr.
Solr usualy listens on localhost on port 8983 and it is accessible
on http://localhost:8983/solr .
With this commit, installation documentation behaves as expected.

This refers to issue #221 .
