### PR TITLE
The Solr package version 3.5.0 moved to another URI. refs #228

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -69,7 +69,7 @@ Additional python requirements necessary to use Solr::
 
 Fetch and unpack Solr::
 
-    curl -O http://apache.mirrors.tds.net/lucene/solr/3.5.0/apache-solr-3.5.0.tgz
+    curl -O http://archive.apache.org/dist/lucene/solr/3.5.0/apache-solr-3.5.0.tgz
     tar xvzf apache-solr-3.5.0.tgz && SOLR_PATH=`pwd`/apache-solr-3.5.0/example
 
 Generate the schema.xml file::


### PR DESCRIPTION
The Solr guys removed the 3.5.0 from the official mirrors to the
archives. Took me some time to find the old package. The docs need
a change until the RTD project is tested to work wit 3.6.1 or newer.
