### PR TITLE
Allow for multiple LaTeX sources and/or PDF images.

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx_pdf.py
+++ b/readthedocs/doc_builder/backends/sphinx_pdf.py
@@ -1,5 +1,4 @@
 from glob import glob
-import re
 import os
 import logging
 
@@ -9,9 +8,6 @@ from doc_builder.base import BaseBuilder, restoring_chdir
 from projects.utils import run
 from core.utils import copy_file_to_app_servers
 
-
-latex_re = re.compile('the LaTeX files are in (.*)\.')
-pdf_re = re.compile('Output written on (.+) \(')
 
 log = logging.getLogger(__name__)
 
@@ -32,27 +28,39 @@ class Builder(BaseBuilder):
 
         if latex_results[0] == 0:
             os.chdir('_build/latex')
-            tex_globs = glob('*.tex')
-            if tex_globs:
-                tex_file = tex_globs[0]
-                pdf_results = run('pdflatex -interaction=nonstopmode %s' % tex_file)
-                pdf_match = pdf_re.search(pdf_results[1])
-                if pdf_match:
+            if project.whitelisted:
+                # For whitelisted projects, read LaTeX sources from conf.py
+                conf_py_file = project.conf_file(self.version.slug)
+                conf = {}
+                execfile(conf_py_file, conf, conf)
+                tex_files = [d[1] for d in conf.get('latex_documents', [])]
+            else:
+                # Otherwise treat all .tex files as sources
+                tex_files = glob('*.tex')
+
+            # Run LaTeX -> PDF conversions
+            pdflatex_cmds = ['pdflatex -interaction=nonstopmode %s' % tex_file
+                             for tex_file in tex_files]
+            pdf_results = run(*pdflatex_cmds)
+
+            if pdf_results[0] == 0:
+                for tex_file in tex_files:
                     to_path = os.path.join(settings.MEDIA_ROOT,
                            'pdf',
                            project.slug,
                            self.version.slug)
-                    from_globs = glob(os.path.join(os.getcwd(), "*.pdf"))
-                    if from_globs:
-                        from_file = from_globs[0]
-                        to_file = os.path.join(to_path, '%s.pdf' % project.slug)
-                        if getattr(settings, "MULTIPLE_APP_SERVERS", None):
-                            copy_file_to_app_servers(from_file, to_file)
-                        else:
-                            if not os.path.exists(to_path):
-                                os.makedirs(to_path)
-                            run('mv -f %s %s' % (from_file, to_file))
-        else:
+                    to_file = os.path.join(to_path, '%s.pdf' % project.slug)
+                    # pdflatex names its output predictably: foo.tex -> foo.pdf
+                    pdf_filename = os.path.splitext(tex_file)[0] + '.pdf'
+                    from_file = os.path.join(os.getcwd(), pdf_filename)
+                    if getattr(settings, "MULTIPLE_APP_SERVERS", None):
+                        copy_file_to_app_servers(from_file, to_file)
+                    else:
+                        if not os.path.exists(to_path):
+                            os.makedirs(to_path)
+                        run('mv -f %s %s' % (from_file, to_file))
+
+        if latex_results[0] != 0 or pdf_results[0] != 0:
             log.warning("PDF Building failed. Moving on.")
         return (latex_results, pdf_results)
 


### PR DESCRIPTION
This addresses issue #183.  The builder will now only produce PDF's for the LaTeX files that Sphinx generated.

Reading the project's conf.py to determine the LaTeX sources probably isn't necessary.  It should be the same as using glob('*.tex'), but it seems cleaner.
