### PR TITLE
Revive faceted search and avoid unneeded searches in docs.

### DIFF
--- a/media/javascript/rtd.js
+++ b/media/javascript/rtd.js
@@ -68,8 +68,6 @@
 
     checkVersion(slug, version);
     getVersions(slug, version);
-
-    Search.init();
   });
 
 })();

--- a/readthedocs/templates/search/base_facet.html
+++ b/readthedocs/templates/search/base_facet.html
@@ -4,6 +4,11 @@
 
 {% block extra_scripts %}
 <script type="text/javascript" src="{{ MEDIA_URL }}javascript/instantsearch.js"></script>
+<script type="text/javascript">
+  $(function() {
+    Search.init();
+  });
+</script>
 {% endblock %}
 
 {% block content %}

--- a/readthedocs/templates/sphinx/layout.html
+++ b/readthedocs/templates/sphinx/layout.html
@@ -9,7 +9,6 @@
 <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
 <script type="text/javascript" src="{{ MEDIA_URL }}javascript/underscore.js"></script>
 <script type="text/javascript" src="{{ MEDIA_URL }}javascript/doctools.js"></script>
-<script type="text/javascript" src="{{ MEDIA_URL }}javascript/searchtools.js"></script>
 {% if using_theme %}
   <meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;"/>
 {% endif %}


### PR DESCRIPTION
There was an odd thing here: two scripts, one from RTD
(instantsearch.js) and another one from Sphinx (searchtools.js), define
a Search object which has an init function.

This function was called right in rtd.js, which was decoupled in
f6420bac35, and since the initialization function was only called in the
generated docs, faceted searches didn't work. The call to the
confusingly-named Search.init has been moved to the faceted search
template.

Also, the RTD theme was including searchtools.js twice: first in the
main layout.html, and after in search.html. Because RTD's theme extends
the Sphinx's 'basic' theme (most of the existing themes out there do the
same), and its search template already includes this script, it wasn't
necessary to include it again.
