### PR TITLE
Add redirect to specific page in default language/version (#282)

### DIFF
--- a/readthedocs/core/subdomain_urls.py
+++ b/readthedocs/core/subdomain_urls.py
@@ -15,6 +15,12 @@ urlpatterns = patterns('',
         'core.views.serve_docs',
         name='docs_detail'
     ),
+    url(r'^page/(?P<filename>.*)$',
+        'core.views.serve_docs',
+        {'version_slug': None,
+        'lang_slug': None},
+        name='docs_detail'
+    ),
     url(r'^(?P<lang_slug>\w{2})/(?P<version_slug>.*)/$',
         'core.views.serve_docs',
         {'filename': 'index.html'},

--- a/readthedocs/urls.py
+++ b/readthedocs/urls.py
@@ -34,12 +34,18 @@ urlpatterns = patterns('',
         name='docs_detail'
     ),
 
-    #This is for redirecting /docs/pip/ -> /docs/pip/en/latest/
+    # Redirect to default version.
     url(r'^docs/(?P<project_slug>[-\w]+)/$',
         'core.views.serve_docs',
         {'version_slug': None,
         'lang_slug': None,
         'filename': ''},
+        name='docs_detail'
+    ),
+    url(r'^docs/(?P<project_slug>[-\w]+)/page/(?P<filename>.*)$',
+        'core.views.serve_docs',
+        {'version_slug': None,
+        'lang_slug': None},
         name='docs_detail'
     ),
 


### PR DESCRIPTION
As I suggested in #282, this adds a URL pattern that can redirect to a specific
page under the default version. Using "/page/..." either on readthedocs.org or
a subdomain redirects.

Note that the redirect goes to "/docs/<project_slug>/..." even on subdomains.
This could be fixed by using a different URL pattern name for the subdomain
URLs and specifically requesting that in the call to `reverse()`.
