### PR TITLE
Move GitHub links to "This Page" section

### DIFF
--- a/readthedocs/templates/sphinx/layout.html
+++ b/readthedocs/templates/sphinx/layout.html
@@ -47,13 +47,25 @@ documentation without rebuilding every one. If this script is embedded in each b
             Full-text doc search.
         </p>
     </div>
-    {% if display_github %}
-        <p>
-            Go to<a href="https://github.com/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}{{ conf_py_path }}{{ pagename }}.rst"> this page </a>on GitHub.
-            (<a href="https://github.com/{{ github_user }}/{{ github_repo }}/edit/{{ github_version }}{{ conf_py_path }}{{ pagename }}.rst">Edit</a>)
-        </p>
-    {% endif %} 
 {% endif %}
+{% endblock %}
+
+{% block sidebarsourcelink %}
+  {% if show_source and has_source and sourcename or display_github %}
+    <h3>{{ _('This Page') }}</h3>
+    <ul class="this-page-menu">
+      {% if show_source and has_source and sourcename %}
+        <li><a href="{{ pathto('_sources/' + sourcename, true)|e }}"
+               rel="nofollow">{{ _('Show Source') }}</a></li>
+      {% endif %}
+      {% if display_github %}
+        <li><a href="https://github.com/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}{{ conf_py_path }}{{ pagename }}.rst">
+          Show on GitHub</a></li>
+        <li><a href="https://github.com/{{ github_user }}/{{ github_repo }}/edit/{{ github_version }}{{ conf_py_path }}{{ pagename }}.rst">
+          Edit on GitHub</a></li>
+      {% endif %}
+    </ul>
+  {% endif %}
 {% endblock %}
 
 {% block footer %}


### PR DESCRIPTION
IMHO the GitHub links had a too prominent location in the sidebar, prioritized
higher than the ToC for the current page and the docs navigation. This patch
moves the links down to the "This Page" section in the bottom of the sidebar.
The "This Page" section is also a natural location for the "Show/Edit on
GitHub" links as it already contains the similar "Show Source" link.

As I don't have a setup for testing this fully, I'm not 110% confident that this
patch is perfect. Thus, it should be reviewed or tested by someone with an
RTD setup before it's merged.
