### PR TITLE
Fix typo in notification

### DIFF
--- a/readthedocs/locale/de/LC_MESSAGES/django.po
+++ b/readthedocs/locale/de/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Jannis Leidel <jannis@leidel.info>, 2012.
 # Jonas Obrist <ojiidotch@gmail.com>, 2012.
@@ -616,7 +616,7 @@ msgstr "Read the Docs"
 
 #: templates/base.html:54
 msgid ""
-"You docs are currently being built.  It may take a moment for them to "
+"Your docs are currently being built.  It may take a moment for them to "
 "appear."
 msgstr "Die Dokumentation wird erstellt. Er kann einen Moment dauern bis sie veröffentlicht wird."
 

--- a/readthedocs/locale/en/LC_MESSAGES/django.po
+++ b/readthedocs/locale/en/LC_MESSAGES/django.po
@@ -613,7 +613,7 @@ msgstr ""
 
 #: templates/base.html:54
 msgid ""
-"You docs are currently being built.  It may take a moment for them to appear."
+"Your docs are currently being built.  It may take a moment for them to appear."
 msgstr ""
 
 #: templates/base.html:55

--- a/readthedocs/locale/es/LC_MESSAGES/django.po
+++ b/readthedocs/locale/es/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Eric Holscher <eric@ericholscher.com>, 2012.
 msgid ""
@@ -615,7 +615,7 @@ msgstr ""
 
 #: templates/base.html:54
 msgid ""
-"You docs are currently being built.  It may take a moment for them to "
+"Your docs are currently being built.  It may take a moment for them to "
 "appear."
 msgstr ""
 

--- a/readthedocs/locale/eu/LC_MESSAGES/django.po
+++ b/readthedocs/locale/eu/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 #   <julenx@gmail.com>, 2012.
 msgid ""
@@ -615,7 +615,7 @@ msgstr "Read the Docs"
 
 #: templates/base.html:54
 msgid ""
-"You docs are currently being built.  It may take a moment for them to "
+"Your docs are currently being built.  It may take a moment for them to "
 "appear."
 msgstr "Dokumentazioa eraikitzen ari da. Une bat har lezake agertu aurretik."
 

--- a/readthedocs/locale/fr/LC_MESSAGES/django.po
+++ b/readthedocs/locale/fr/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 #   <htonal@wanadoo.fr>, 2012.
 msgid ""
@@ -615,7 +615,7 @@ msgstr "Lisez les Docs"
 
 #: templates/base.html:54
 msgid ""
-"You docs are currently being built.  It may take a moment for them to "
+"Your docs are currently being built.  It may take a moment for them to "
 "appear."
 msgstr "Docs en cours de compilation. Veuillez patienter pour les voir apparaitre."
 

--- a/readthedocs/locale/ja/LC_MESSAGES/django.po
+++ b/readthedocs/locale/ja/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Jonas Obrist <ojiidotch@gmail.com>, 2012.
 msgid ""
@@ -615,7 +615,7 @@ msgstr "Read the Docs"
 
 #: templates/base.html:54
 msgid ""
-"You docs are currently being built.  It may take a moment for them to "
+"Your docs are currently being built.  It may take a moment for them to "
 "appear."
 msgstr ""
 

--- a/readthedocs/locale/nb/LC_MESSAGES/django.po
+++ b/readthedocs/locale/nb/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# 
+#
 # Translators:
 # Stein Magnus Jodal <stein.magnus@jodal.no>, 2012.
 msgid ""
@@ -615,7 +615,7 @@ msgstr "Read the Docs"
 
 #: templates/base.html:54
 msgid ""
-"You docs are currently being built.  It may take a moment for them to "
+"Your docs are currently being built.  It may take a moment for them to "
 "appear."
 msgstr "Dokumentasjonen er under bygging.  Det kan ta litt tid før den er klar."
 

--- a/readthedocs/templates/base.html
+++ b/readthedocs/templates/base.html
@@ -52,7 +52,7 @@
 
         {% if request.GET.docs_not_built %}
           <div class="notification">
-            <p>{% trans "You docs are currently being built.  It may take a moment for them to appear." %}</p>
+            <p>{% trans "Your docs are currently being built.  It may take a moment for them to appear." %}</p>
             <p>{% trans "Read the Docs thanks you for your continued patience." %}</p>
           </div>
         {% endif %}


### PR DESCRIPTION
While waiting for docs to be built, users receive a notication that should read 'Your docs,' not 'You docs.' The typo is being fixed in both the template and the translation files.

It appears that there was also some trailing whitespace in the translation files. Trimming it should be a trivial change.
