### PR TITLE
CSS fix for Firefox

### DIFF
--- a/readthedocs/templates/builds/build_list.html
+++ b/readthedocs/templates/builds/build_list.html
@@ -33,7 +33,7 @@
                 <form method="post" action="{% url generic_build project.pk %}">
                   <ul class="build_a_version">
                     <li style="display: inline-block">
-                      <input type="submit" value="{% trans "Build Version:" %}">
+                      <input style="display: inline-block" type="submit" value="{% trans "Build Version:" %}">
                     </li>
                     <li style="display: inline-block">
                       <select id="id_version" name="version_slug">


### PR DESCRIPTION
Firefox does not cause the Input box to inherit it's parent's display attribute. This fixes that.
