### PR TITLE
Don't claim the outcome of an unfinished build is 'failed'

### DIFF
--- a/media/javascript/build_updater.js
+++ b/media/javascript/build_updater.js
@@ -30,12 +30,17 @@
                 var el = $(this.buildDiv + ' span#build-' + prop);
 
                 if (prop == 'success') {
-                    val = val ? "Passed" : "Failed";
+                    if (data.hasOwnProperty('state') && data['state'] != 'finished') {
+                        val = "Not yet finished";
+                    }
+                    else {
+                        val = val ? "Passed" : "Failed";
+                    }
                 }
 
                 if (prop == 'state') {
                     val = val.charAt(0).toUpperCase() + val.slice(1);
-                    
+
                     if (val == 'Finished') {
                         _this.stopPolling();
                     }

--- a/readthedocs/templates/builds/build_detail.html
+++ b/readthedocs/templates/builds/build_detail.html
@@ -17,17 +17,23 @@
   <div id="build-{{ build.id }}">
     <p>{% blocktrans with build.date|date:"N j, Y. P" as build_date %}Built: {{ build_date }}{% endblocktrans %}</p>
 
-    <p>{% trans "Outcome:" %} <b><span id="build-success">{% if build.success %}{% trans "Passed" %}{% else %}{% trans "Failed" %}{% endif %}</span></b></p>
+    <p>{% trans "State:" %} <b><span id="build-state">{{ build.get_state_display }}</span></b>
+      <img src="{{ MEDIA_URL }}images/loader.gif" class="hide build-loading">
+    </p>
+
+    <p>{% trans "Outcome:" %}
+      <b>
+        <span id="build-success">
+          {% if build.state != 'finished' %}{% trans "Not yet finished" %} {% else %} {% if build.success %}{% trans "Passed" %}{% else %}{% trans "Failed" %}{% endif %}{% endif %}
+        </span>
+      </b>
+    </p>
 
     {% if build.version %}
     <p>{% trans "Version:" %} <b>{{ build.version.slug }}</b></p>
     {% endif %}
 
     <p>{% trans "Type:" %} <b>{{ build.type }}</b></p>
-
-    <p>{% trans "State:" %} <b><span id="build-state">{{ build.get_state_display }}</span></b>
-      <img src="{{ MEDIA_URL }}images/loader.gif" class="hide build-loading">
-    </p>
 
     <h3>{% trans "Sphinx Standard Output" %}</h3>
     <pre class="build-output"><span id="build-output">{{ build.output }}</span></pre>


### PR DESCRIPTION
This moves the 'build-state' span before the 'build-success' one to make
it more obvious that the build is still running. It also changes the
text of the 'build-success' span to 'Not yet finished' if the build
state is not 'finished'.
