### PR TITLE
Initial Dash support.

### DIFF
--- a/docs/builds.rst
+++ b/docs/builds.rst
@@ -52,8 +52,8 @@ An example in code::
 
     update_imported_docs(project, version)
     (ret, out, err) = build_docs(project=project, version=version,
-                                         pdf=pdf, man=man, epub=epub,
-                                         record=record, force=force)
+                                 pdf=pdf, man=man, epub=epub, dash=dash,
+                                 record=record, force=force)
     #This follows the builder workflow layed out below.
     purge_version(version, subdomain=True,
                     mainsite=True, cname=True)

--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -27,7 +27,9 @@ slumber==0.4.2
 # Required for slumber because it just pulls down "requests"
 requests==0.14.1
 virtualenv==1.8.4
-
+doc2dash==1.1.0
+beautifulsoup4==4.1.3
+lxml==3.0.2
 
 # Pegged git requirements
 git+git://github.com/toastdriven/django-haystack@259274e4127f723d76b893c87a82777f9490b960#egg=django_haystack

--- a/readthedocs/api/base.py
+++ b/readthedocs/api/base.py
@@ -57,6 +57,7 @@ class ProjectResource(ModelResource, SearchMixin):
         downloads['epub'] = bundle.obj.get_epub_url()
         downloads['pdf'] = bundle.obj.get_pdf_url()
         downloads['manpage'] = bundle.obj.get_manpage_url()
+        downloads['dash'] = bundle.obj.get_dash_url()
         bundle.data['downloads'] = downloads
         return bundle
 

--- a/readthedocs/builds/constants.py
+++ b/readthedocs/builds/constants.py
@@ -11,4 +11,5 @@ BUILD_TYPES = (
     ('pdf', _('PDF')),
     ('epub', _('Epub')),
     ('man', _('Manpage')),
+    ('dash', _('Dash')),
 )

--- a/readthedocs/doc_builder/__init__.py
+++ b/readthedocs/doc_builder/__init__.py
@@ -4,7 +4,8 @@ from .backends import (
     sphinx_htmldir,
     sphinx_man,
     sphinx_pdf,
-    )
+    sphinx_dash,
+)
 
 
 loading = {'sphinx': sphinx.Builder,
@@ -12,4 +13,5 @@ loading = {'sphinx': sphinx.Builder,
            'sphinx_htmldir': sphinx_htmldir.Builder,
            'sphinx_man': sphinx_man.Builder,
            'sphinx_pdf': sphinx_pdf.Builder,
+           'sphinx_dash': sphinx_dash.Builder,
            }

--- a/readthedocs/doc_builder/backends/sphinx_dash.py
+++ b/readthedocs/doc_builder/backends/sphinx_dash.py
@@ -1,0 +1,77 @@
+from glob import glob
+import logging
+import os
+import shutil
+import zipfile
+from doc_builder.base import restoring_chdir
+from doc_builder.backends.sphinx import Builder as HtmlBuilder
+from projects.utils import run
+from core.utils import copy_file_to_app_servers
+
+from django.conf import settings
+
+log = logging.getLogger(__name__)
+
+
+class Builder(HtmlBuilder):
+
+    @restoring_chdir
+    def build(self, **kwargs):
+        project = self.version.project
+        os.chdir(project.conf_dir(self.version.slug))
+        force_str = " -E " if self.force else ""
+        if project.use_virtualenv:
+            html_build_command = "%s %s -b html . _build/html " % (
+                project.venv_bin(version=self.version.slug, bin='sphinx-build'),
+                force_str)
+        else:
+            html_build_command = "sphinx-build %s -b html . _build/html" % (force_str)
+        html_build_results = run(html_build_command, shell=True)
+        if 'no targets are out of date.' in html_build_results[1]:
+            self._changed = False
+
+        if os.path.exists('_build/dash'):
+            shutil.rmtree('_build/dash')
+        os.makedirs('_build/dash')
+        dash_build_command = ("doc2dash --name=\"%s\" --force "
+                              "--destination=_build/dash _build/html"
+                              % project.name)
+        dash_build_results = run(dash_build_command, shell=True)
+        self._zip_dash()
+        return dash_build_results
+
+    @restoring_chdir
+    def _zip_dash(self, **kwargs):
+        from_path = self.version.project.full_dash_path(self.version.slug)
+        to_path = self.version.project.checkout_path(self.version.slug)
+        to_file = os.path.join(to_path, '%s.docset.zip' % self.version.project.slug)
+
+        log.info("Creating zip file from %s" % from_path)
+        # Create a <slug>.zip file containing all files in file_path
+        os.chdir(from_path)
+        archive = zipfile.ZipFile(to_file, 'w')
+        for root, subfolders, files in os.walk('.'):
+            for file in files:
+                to_write = os.path.join(root, file)
+                archive.write(filename=to_write)
+        archive.close()
+
+        return to_file
+
+    def move(self, **kwargs):
+        project = self.version.project
+        outputted_path = self.version.project.checkout_path(self.version.slug)
+        to_path = os.path.join(settings.MEDIA_ROOT,
+                               'dash',
+                               project.slug,
+                               self.version.slug)
+        from_globs = glob(os.path.join(outputted_path, "*.docset.zip"))
+        if from_globs:
+            from_file = from_globs[0]
+            to_file = os.path.join(to_path, "%s.docset.zip" % project.slug)
+            if getattr(settings, "MULTIPLE_APP_SERVERS", None):
+                copy_file_to_app_servers(from_file, to_file)
+            else:
+                if not os.path.exists(to_path):
+                    os.makedirs(to_path)
+                run('mv -f %s %s' % (from_file, to_file))

--- a/readthedocs/projects/fixtures/test_data.json
+++ b/readthedocs/projects/fixtures/test_data.json
@@ -40,7 +40,7 @@
             "modified_date": "2010-08-15 13:18:23",
             "description": "",
             "project_url": "",
-            "repo": "http://github.com/jezdez/pip",
+            "repo": "http://github.com/pypa/pip",
             "version": "",
             "users": [
 		1
@@ -142,7 +142,7 @@
             "modified_date": "2010-08-15 13:18:19",
             "description": "",
             "project_url": "",
-            "repo": "http://github.com/bitprophet/fabric",
+            "repo": "http://github.com/fabric/fabric",
             "version": "0.1.0",
             "users": [
 		1

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -282,6 +282,22 @@ class Project(models.Model):
                                 '%s.zip' % self.slug)
         return path
 
+    def get_dash_url(self, version_slug='latest'):
+        path = os.path.join(settings.MEDIA_URL,
+                            'dash',
+                            self.slug,
+                            version_slug,
+                            '%s.docset.zip' % self.slug)
+        return path
+
+    def get_dash_path(self, version_slug='latest'):
+        path = os.path.join(settings.MEDIA_ROOT,
+                            'dash',
+                            self.slug,
+                            version_slug,
+                            '%s.docset.zip' % self.slug)
+        return path
+
     #Doc PATH:
     #MEDIA_ROOT/slug/checkouts/version/<repo>
 
@@ -332,6 +348,12 @@ class Project(models.Model):
         The path to the build latex docs in the project.
         """
         return os.path.join(self.conf_dir(version), "_build", "epub")
+
+    def full_dash_path(self, version='latest'):
+        """
+        The path to the build dash docs in the project.
+        """
+        return os.path.join(self.conf_dir(version), "_build", "dash")
 
     def rtd_build_path(self, version="latest"):
         """
@@ -394,6 +416,9 @@ class Project(models.Model):
 
     def has_epub(self, version_slug='latest'):
         return os.path.exists(self.get_epub_path(version_slug))
+
+    def has_dash(self, version_slug='latest'):
+        return os.path.exists(self.get_dash_path(version_slug))
 
     def has_htmlzip(self, version_slug='latest'):
         return os.path.exists(self.get_htmlzip_path(version_slug))

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -54,7 +54,8 @@ def remove_dir(path):
 
 @task
 @restoring_chdir
-def update_docs(pk, record=True, pdf=True, man=True, epub=True, version_pk=None, force=False, **kwargs):
+def update_docs(pk, record=True, pdf=True, man=True, epub=True, dash=True,
+                version_pk=None, force=False, **kwargs):
     """
     The main entry point for updating documentation.
 
@@ -168,9 +169,9 @@ def update_docs(pk, record=True, pdf=True, man=True, epub=True, version_pk=None,
     log.info("Building docs")
     # This is only checking the results of the HTML build, as it's a canary
     try:
-        (html_results, latex_results, pdf_results, man_results, epub_results) =  build_docs(
-                version_pk=version.pk, pdf=pdf, man=man, epub=epub, record=record, force=force
-        )
+        results = build_docs(version_pk=version.pk, pdf=pdf, man=man, epub=epub,
+                             dash=dash, record=record, force=force)
+        html_results, latex_results, pdf_results, man_results, epub_results, dash_results = results
         (ret, out, err) = html_results
     except Exception as e:
         log.error("Exception in flailboat build_docs", exc_info=True)
@@ -179,6 +180,7 @@ def update_docs(pk, record=True, pdf=True, man=True, epub=True, version_pk=None,
         pdf_results = (999, "Project build Failed", str(e))
         man_results = (999, "Project build Failed", str(e))
         epub_results = (999, "Project build Failed", str(e))
+        dash_results = (999, "Project build Failed", str(e))
         (ret, out, err) = html_results
 
     if record:
@@ -190,8 +192,8 @@ def update_docs(pk, record=True, pdf=True, man=True, epub=True, version_pk=None,
         api.build(build['id']).put(build)
 
         api.build.post(dict(
-            project = '/api/v1/project/%s/' % project.pk,
-            version = '/api/v1/version/%s/' % version.pk,
+            project='/api/v1/project/%s/' % project.pk,
+            version='/api/v1/version/%s/' % version.pk,
             success=pdf_results[0] == 0,
             type='pdf',
             setup=latex_results[1],
@@ -232,7 +234,7 @@ def update_docs(pk, record=True, pdf=True, man=True, epub=True, version_pk=None,
         fileify.delay(version.pk)
 
         # Things that touch redis
-        update_result = update_intersphinx(version.pk)
+        update_intersphinx(version.pk)
         # Needs to happen after update_intersphinx
         clear_artifacts(version.pk)
 
@@ -397,7 +399,7 @@ def update_imported_docs(version_pk):
     return update_docs_output
 
 @task
-def build_docs(version_pk, pdf, man, epub, record, force):
+def build_docs(version_pk, pdf, man, epub, dash, record, force):
     """
     This handles the actual building of the documentation and DB records
     """
@@ -443,9 +445,16 @@ def build_docs(version_pk, pdf, man, epub, record, force):
                     epub_builder.move()
             else:
                 epub_results = fake_results
+            if dash:
+                dash_builder = builder_loading.get('sphinx_dash')(version)
+                dash_results = dash_builder.build()
+                if dash_results[0] == 0:
+                    dash_builder.move()
+            else:
+                dash_results = fake_results
 
-    return (html_results, latex_results, pdf_results, man_results, epub_results)
-
+    return (html_results, latex_results, pdf_results, man_results,
+            epub_results, dash_results)
 
 
 @task

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -82,6 +82,8 @@ def project_downloads(request, project_slug):
             version_data[version.slug]['epub_url'] = project.get_epub_url(version.slug)
         if project.has_manpage(version.slug):
             version_data[version.slug]['manpage_url'] = project.get_manpage_url(version.slug)
+        if project.has_dash(version.slug):
+            version_data[version.slug]['dash_url'] = project.get_dash_url(version.slug)
         #Kill ones that have no downloads.
         if not len(version_data[version.slug]):
             del version_data[version.slug]

--- a/readthedocs/templates/core/project_downloads.html
+++ b/readthedocs/templates/core/project_downloads.html
@@ -24,6 +24,12 @@
 </li>
 {% endif %}
 
+{% if dict.dash_url %}
+<li class="module-item col-span">
+      <a class="module-item-title" href="{{ dict.dash_url }}">{{ version }} Dash docset</a>
+</li>
+{% endif %}
+
 {% empty %}
 <li class="module-item col-span">
       {% trans "No downloads for this project." %}


### PR DESCRIPTION
This adds support for creating docset files for the Mac app Dash -- an offline documentation browser: http://kapeli.com

docset files are actually Mac bundles, so basically directories with a conventional file and directory structure, which means the folder needs to be compressed into a file to be able to be downloaded, see http://kapeli.com/docsets/ for more information
