### PR TITLE
Use `requests` instead of `Httplib2`, which has problems with SSL on som...

### DIFF
--- a/readthedocs/tastyapi/client.py
+++ b/readthedocs/tastyapi/client.py
@@ -1,7 +1,7 @@
 import logging
 from django.conf import settings
 from django.utils import simplejson as json
-import httplib2
+import requests
 
 log = logging.getLogger(__name__)
 
@@ -18,14 +18,13 @@ def import_project(project):
     for BASE_SERVER in SERVER_LIST:
         API_SERVER = '%s/api/v1/' % BASE_SERVER
         URL = API_SERVER + "package/%s/" % project.slug
-        h = httplib2.Http(timeout=5)
         try:
             log.info("Trying to import from %s" % API_SERVER)
-            resp, content = h.request(URL, "GET")
+            resp = requests.get(URL)
         except AttributeError:
             log.error("Socket error trying to pull from Open Comparison", exc_info=True)
-        if resp['status'] == '200':
-            content_dict = json.loads(content)
+        if resp.status_code == 200:
+            content_dict = json.loads(resp.content)
             project.django_packages_url = BASE_SERVER + content_dict['absolute_url']
             project.save()
             return True
@@ -38,14 +37,13 @@ def import_crate(project):
     BASE_SERVER = 'http://crate.io'
     API_SERVER = '%s/api/v1/' % BASE_SERVER
     URL = API_SERVER + "package/?name__iexact=%s" % project.slug
-    h = httplib2.Http(timeout=5)
     try:
         log.info("Trying to import from %s" % API_SERVER)
-        resp, content = h.request(URL, "GET")
+        resp = requests.get(URL)
     except AttributeError:
         log.error("Socket error trying to pull from Crate.io", exc_info=True)
-    if resp['status'] == '200':
-        content_dict = json.loads(content)
+    if resp.status_code == 200:
+        content_dict = json.loads(resp.content)
         if content_dict['meta']['total_count'] != 0:
             project.crate_url = BASE_SERVER + content_dict['objects'][0]['absolute_url']
             log.debug('Crate URL: %s' % project.crate_url)


### PR DESCRIPTION
...e systems.

Apparently Httplib2 doesn't take into account system root certificates, and is patched to do so on several Linux distributions. Unfortunately it seems that when `Httplib2` is installed in a `virtualenv` on those systems, it is the un-patched version and you can get SSL certificate verification errors. The `requests` library doesn't seem to suffer from the same problems, so I have switched out `Httplib2` for `requests` in the `tastyapi.clients` module, where I was having problems.

More info: https://github.com/pennersr/django-allauth/issues/113
