### PR TITLE
Add `NGINX_X_ACCEL_REDIRECT` setting. Check this instead of `DEBUG` when...

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -69,3 +69,10 @@ USE_PIP_INSTALL
 Default: `False`
 
 Whether to use `pip install .` or `python setup.py install` when installing packages into the Virtualenv. Default is to use pip.
+
+NGINX_X_ACCEL_REDIRECT
+----------------------
+
+Default: `False`
+
+Enable this if you are using Nginx for improved file handling.

--- a/readthedocs/core/views.py
+++ b/readthedocs/core/views.py
@@ -306,7 +306,7 @@ def serve_docs(request, lang_slug, version_slug, filename, project_slug=None):
         basepath = proj.translations_path(lang_slug)
         basepath = os.path.join(basepath, version_slug)
     log.info('Serving %s for %s' % (filename, proj))
-    if not settings.DEBUG:
+    if getattr(settings, 'NGINX_X_ACCEL_REDIRECT', False):
         fullpath = os.path.join(basepath, filename)
         mimetype, encoding = mimetypes.guess_type(fullpath)
         mimetype = mimetype or 'application/octet-stream'


### PR DESCRIPTION
... deciding to use the `X-Accel-Redirect` header.

The current behaviour is overloading the `DEBUG` setting for multiple purposes. By de-coupling them, I can deploy to non-Nginx environments and I can also independently change `DEBUG` during development for enhanced error reporting without altering the actual behaviour of the application.
