### PR TITLE
Updated 'update_repos' command info in installation instructions (ref: #391)

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -55,8 +55,8 @@ the admin interface via http://127.0.0.1:8000/admin (logging in with the
 superuser account you just created).
 
 While the webserver is running, you can build documentation for the latest version of
-a project called 'pip' (should be setup after loading the test data) with the
-``update_repos`` command::
+a project called 'pip' with the ``update_repos`` command.  You can replace 'pip'
+with the name of any added project::
 
    ./manage.py update_repos pip
 


### PR DESCRIPTION
I found the documentation on using the update_repos command confusing.  I didn't know 'pip' was the name of a project created with the test data.
