### PR TITLE
Update Mercurial dependency to 2.6.3 (fixes #418).

### DIFF
--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -16,7 +16,7 @@ django==1.4.3
 docutils==0.8.1
 github2==0.5.2
 httplib2==0.7.2
-mercurial==2.4
+mercurial==2.6.3
 mimeparse==0.1.3
 redis==2.7.1
 simplejson==2.3.0


### PR DESCRIPTION
Mercurial 2.4 is no longer available from PyPI.
