### PR TITLE
Fix activation email typo.

### DIFF
--- a/readthedocs/templates/registration/activation_email.txt
+++ b/readthedocs/templates/registration/activation_email.txt
@@ -3,6 +3,6 @@ To activate your registration, please visit the following page:
 
 http://{{ domain }}{{ activation_url }}
 
-This page will expire in {{ expiration_days }} day.
+This page will expire in {{ expiration_days }} days.
 
 If you didn't register this account you can simply delete this email and we won't bother you again.{% endblocktrans %}


### PR DESCRIPTION
It looks like there used to be some pluralization logic once upon a time, but
it got removed (presumably for a good reason).

I've no idea where `expiration_days` gets set (it doesn't seem to occur
anywhere other than this file), but on the actual site right now it's set to 7.
And 7 is plural, so saying "7 day" is wrong and awkward.  Now it's not wrong or
awkward.
