### PR TITLE
Add registration link to login page.

### DIFF
--- a/readthedocs/templates/registration/login.html
+++ b/readthedocs/templates/registration/login.html
@@ -29,4 +29,7 @@
 <p>
 {% blocktrans %}If you forgot your password, <a href="/accounts/password/reset/">reset it.</a>{% endblocktrans %}
 </p>
+<p>
+{% blocktrans %}Don't have an account?  <a href="/accounts/register/">Register</a> a new one.{% endblocktrans %}
+</p>
 {% endblock %}


### PR DESCRIPTION
The log in link is available on every page, but if you go there and don't have
an account, you previously had no easy way to create one.

Ideally, these should be on the same page, so we can reuse the username and
password (both as form elements and as things the user may have already filled
in).  This stuff is all handled by django-registration, though, and I don't
want to go hacking about in there.

So, we just leave a link below the login form redirecting to the registration
page, which should be Good Enough.
