### PR TITLE
Add install help for OS X Mavericks libxml2 workaround

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -32,11 +32,13 @@ Next, install the dependencies using ``pip`` (included with virtualenv_)::
     cd readthedocs.org
     pip install -r pip_requirements.txt
 
-If you are having trouble on OS X Mavericks (or possibly other versions of
-OS X) with building ``lxml``, you probably might need to use Homebrew_
-to ``brew install libxml2``, and invoke the install with::
+.. note::
 
-    CFLAGS=-I/usr/local/opt/libxml2/include/libxml2 LDFLAGS=-L/usr/local/opt/libxml2/lib pip install -r pip_requirements.txt
+    If you are having trouble on OS X Mavericks (or possibly other versions of
+    OS X) with building ``lxml``, you probably might need to use Homebrew_
+    to ``brew install libxml2``, and invoke the install with::
+
+        CFLAGS=-I/usr/local/opt/libxml2/include/libxml2 LDFLAGS=-L/usr/local/opt/libxml2/lib pip install -r pip_requirements.txt
 
 .. _Homebrew: http://brew.sh/
 


### PR DESCRIPTION
Trying to follow the install directions just now on OS X Mavericks was surprisingly difficult due to `lixbml2` problems. This contains the proper magic invocation of `pip` to work on this latest version of OS X.
