### PR TITLE
Change status README to use image directive.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,10 @@
 Welcome to Read The Docs
 ========================
 
-|status|
-
-.. |status| image:: https://travis-ci.org/rtfd/readthedocs.org.png?branch=master
-.. _status: https://travis-ci.org/rtfd/readthedocs.org
+.. image:: https://travis-ci.org/rtfd/readthedocs.org.png?branch=master
+    :alt: status
+    :scale: 100%
+    :target: https://travis-ci.org/rtfd/readthedocs.org
 
 `Read the Docs`_ hosts documentation for the open source community. It supports
 Sphinx_ docs written with reStructuredText_, and can pull from your Subversion_,


### PR DESCRIPTION
Fixes status link to open travis-ci website, and not build-master image.

Clicking on the 'build' image in the README will open up the image file. This fixes the behavior to open up the build status page, which is most likely what you actually want.
