### PR TITLE
Pass project's language to sphinx-build command

### DIFF
--- a/readthedocs/doc_builder/backends/asciidoc
+++ b/readthedocs/doc_builder/backends/asciidoc
@@ -24,13 +24,14 @@ class Builder(BaseBuilder):
         os.chdir(project.conf_dir(self.version.slug))
         force_str = " -E " if self.force else ""
         if project.use_virtualenv:
-            build_command = "%s %s -b html . _build/html " % (
+            build_command = "%s %s -b html -D language=%s . _build/html " % (
                 project.venv_bin(version=self.version.slug,
                                  bin='sphinx-build'),
-                force_str)
+                force_str,
+                project.language)
         else:
-            build_command = ("sphinx-build %s -b html . _build/html"
-                             % (force_str))
+            build_command = ("sphinx-build %s -b html -D language=%s . _build/html"
+                             % (force_str, project.language))
         build_results = run(build_command, shell=True)
         self._zip_html()
         if 'no targets are out of date.' in build_results[1]:

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -178,13 +178,14 @@ class Builder(BaseBuilder):
         os.chdir(project.conf_dir(self.version.slug))
         force_str = " -E " if self.force else ""
         if project.use_virtualenv:
-            build_command = "%s %s -b readthedocs . _build/html " % (
+            build_command = "%s %s -b readthedocs -D language=%s . _build/html " % (
                 project.venv_bin(version=self.version.slug,
                                  bin='sphinx-build'),
-                force_str)
+                force_str,
+                project.language)
         else:
-            build_command = ("sphinx-build %s -b readthedocs . _build/html"
-                             % (force_str))
+            build_command = ("sphinx-build %s -b readthedocs -D language=%s . _build/html"
+                             % (force_str, project.language))
         build_results = run(build_command, shell=True)
         self._zip_html()
         if 'no targets are out of date.' in build_results[1]:

--- a/readthedocs/doc_builder/backends/sphinx_epub.py
+++ b/readthedocs/doc_builder/backends/sphinx_epub.py
@@ -15,10 +15,10 @@ class Builder(HtmlBuilder):
         project = self.version.project
         os.chdir(project.conf_dir(self.version.slug))
         if project.use_virtualenv:
-            build_command = '%s -b epub . _build/epub' % project.venv_bin(
-                version=self.version.slug, bin='sphinx-build')
+            build_command = '%s -b epub -D language=%s . _build/epub' % (project.venv_bin(
+                version=self.version.slug, bin='sphinx-build'), project.language)
         else:
-            build_command = "sphinx-build -b epub . _build/epub"
+            build_command = "sphinx-build -D language=%s -b epub . _build/epub" % project.language
         build_results = run(build_command)
         return build_results
 

--- a/readthedocs/doc_builder/backends/sphinx_htmldir.py
+++ b/readthedocs/doc_builder/backends/sphinx_htmldir.py
@@ -15,10 +15,10 @@ class Builder(HtmlBuilder):
         project = self.version.project
         os.chdir(self.version.project.conf_dir(self.version.slug))
         if project.use_virtualenv:
-            build_command = '%s -b readthedocsdirhtml . _build/html' % project.venv_bin(
-                version=self.version.slug, bin='sphinx-build')
+            build_command = '%s -b readthedocsdirhtml -D language=%s . _build/html' % (project.venv_bin(
+                version=self.version.slug, bin='sphinx-build'), project.language)
         else:
-            build_command = "sphinx-build -b readthedocsdirhtml . _build/html"
+            build_command = "sphinx-build -D language=%s -b readthedocsdirhtml . _build/html" % project.language
         build_results = run(build_command)
         self._zip_html()
         if 'no targets are out of date.' in build_results[1]:

--- a/readthedocs/doc_builder/backends/sphinx_man.py
+++ b/readthedocs/doc_builder/backends/sphinx_man.py
@@ -16,12 +16,12 @@ class Builder(ManpageBuilder):
         project = self.version.project
         os.chdir(self.version.project.conf_dir(self.version.slug))
         if project.use_virtualenv:
-            build_command = ('%s -b man  -d _build/doctrees . _build/man'
-                             % project.venv_bin(
+            build_command = ('%s -b man -D language=%s -d _build/doctrees . _build/man'
+                             % (project.venv_bin(
                                  version=self.version.slug,
-                                 bin='sphinx-build'))
+                                 bin='sphinx-build'), project.language))
         else:
-            build_command = "sphinx-build -b man . _build/man"
+            build_command = "sphinx-build -D language=%s -b man . _build/man" % project.language
         build_results = run(build_command)
         return build_results
 

--- a/readthedocs/doc_builder/backends/sphinx_pdf.py
+++ b/readthedocs/doc_builder/backends/sphinx_pdf.py
@@ -21,12 +21,12 @@ class Builder(BaseBuilder):
         #Default to this so we can return it always.
         pdf_results = (1, '', '')
         if project.use_virtualenv:
-            latex_results = run('%s -b latex -d _build/doctrees . _build/latex'
-                                % project.venv_bin(version=self.version.slug,
-                                                   bin='sphinx-build'))
+            latex_results = run('%s -b latex -D language=%s -d _build/doctrees . _build/latex'
+                                % (project.venv_bin(version=self.version.slug,
+                                                   bin='sphinx-build'), project.language))
         else:
-            latex_results = run('sphinx-build -b latex -d _build/doctrees '
-                                '. _build/latex')
+            latex_results = run('sphinx-build -b latex -D language=%s -d _build/doctrees '
+                                '. _build/latex' % project.language)
 
         if latex_results[0] == 0:
             os.chdir('_build/latex')

--- a/readthedocs/doc_builder/backends/sphinx_search.py
+++ b/readthedocs/doc_builder/backends/sphinx_search.py
@@ -17,10 +17,10 @@ class Builder(HtmlBuilder):
         project = self.version.project
         os.chdir(self.version.project.conf_dir(self.version.slug))
         if project.use_virtualenv:
-            build_command = '%s -b json . _build/json' % project.venv_bin(
-                version=self.version.slug, bin='sphinx-build')
+            build_command = '%s -b json -D language=%s . _build/json' % (project.venv_bin(
+                version=self.version.slug, bin='sphinx-build'), project.language)
         else:
-            build_command = "sphinx-build -b json . _build/json"
+            build_command = "sphinx-build -b json -D language=%s . _build/json" % project.language
         build_results = run(build_command)
         if 'no targets are out of date.' in build_results[1]:
             self._changed = False

--- a/readthedocs/doc_builder/backends/sphinx_websupport2.py
+++ b/readthedocs/doc_builder/backends/sphinx_websupport2.py
@@ -17,10 +17,10 @@ class Builder(HtmlBuilder):
         project = self.version.project
         os.chdir(self.version.project.conf_dir(self.version.slug))
         if project.use_virtualenv:
-            build_command = '%s -E -b websupport2 . _build/html' % project.venv_bin(
-                version=self.version.slug, bin='sphinx-build')
+            build_command = '%s -E -b websupport2 -D language=%s . _build/html' % (project.venv_bin(
+                version=self.version.slug, bin='sphinx-build'), project.language)
         else:
-            build_command = "sphinx-build -E -b websupport2 . _build/html"
+            build_command = "sphinx-build -E -b websupport2 -D language=%s . _build/html" % project.language
         build_results = run(build_command)
         if 'no targets are out of date.' in build_results[1]:
             self._changed = False


### PR DESCRIPTION
This change passes project's language setting to `sphinx-build` using `-D` option.

I know this is not enough because users still need to generate .mo files out of the RTD.
However, if users do so, this allows users to build documents in multiple languages with just a single conf.py file.
I think it's a good small step.
