### PR TITLE
Moved project search

### DIFF
--- a/readthedocs/restapi/urls.py
+++ b/readthedocs/restapi/urls.py
@@ -14,5 +14,6 @@ urlpatterns = patterns(
     url(r'footer_html/', 'restapi.views.footer_html', name='footer_html'),
     url(r'quick_search/', 'restapi.views.quick_search', name='quick_search'),
     url(r'index_search/', 'restapi.views.index_search', name='index_search'),
-    url(r'search/', 'restapi.views.search', name='search'),
+    url(r'search/$', 'restapi.views.search', name='search'),
+    url(r'search/project/$', 'restapi.views.project_search', name='project_search'),
 )

--- a/readthedocs/restapi/views.py
+++ b/readthedocs/restapi/views.py
@@ -333,3 +333,26 @@ def search(request):
         results = ProjectIndex().search(body, fields=['name', 'slug', 'description', 'lang'])
 
     return Response({'results': results})
+
+
+@decorators.api_view(['GET'])
+@decorators.permission_classes((permissions.AllowAny,))
+@decorators.renderer_classes((JSONRenderer, JSONPRenderer, BrowsableAPIRenderer))
+def project_search(request):
+    query = request.GET.get('q', None)
+
+    log.debug("(Project API Search) %s" % (query))
+    body = {
+        "query": {
+            "bool": {
+                "should": [
+                    {"match": {"name": {"query": query, "boost": 10}}},
+                    {"match": {"description": {"query": query}}},
+                ]
+            },
+        },
+        "fields": ["name", "slug", "description", "lang"]
+    }
+    results = ProjectIndex().search(body)
+
+    return Response({'results': results})

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -295,6 +295,12 @@ LOGGING = {
             'level': 'ERROR',
             'propagate': False,
         },
+        # Uncomment if you want to see Elasticsearch queries in the console.
+        #'elasticsearch.trace': {
+        #    'level': 'DEBUG',
+        #    'handlers': ['console'],
+        #},
+
         # Default handler for everything that we're doing. Hopefully this
         # doesn't double-print the Django things as well. Not 100% sure how
         # logging works :)


### PR DESCRIPTION
This allows us to remove project search from the search API to make it
both in-doc search and to search pages across projects.
