### PR TITLE
use translations when not in debug mode

### DIFF
--- a/readthedocs/core/views.py
+++ b/readthedocs/core/views.py
@@ -364,10 +364,8 @@ def serve_docs(request, lang_slug, version_slug, filename, project_slug=None):
         if encoding:
             response["Content-Encoding"] = encoding
         try:
-            response['X-Accel-Redirect'] = os.path.join('/user_builds',
-                                                        proj.slug,
-                                                        'rtd-builds',
-                                                        version_slug, filename)
+            response['X-Accel-Redirect'] = os.path.join(basepath[len(settings.SITE_ROOT):],
+                                                        filename)
         except UnicodeEncodeError:
             raise Http404
 


### PR DESCRIPTION
In production environment (in case of settings.DEBUG == False), translations are not used because X-Accel-Redirect header value always indicates the path for project's original language.

I've not tested this yet because I have no nginx environment, but it should work.
