### PR TITLE
Allow numbers in project slugs so API driven builds work

### DIFF
--- a/readthedocs/api/base.py
+++ b/readthedocs/api/base.py
@@ -150,7 +150,7 @@ class ProjectResource(ModelResource, SearchMixin):
             url(r"^(?P<resource_name>%s)/(?P<pk>\d+)/sync_versions%s$" % (
                 self._meta.resource_name, trailing_slash()),
                 self.wrap_view('sync_versions'), name="api_sync_versions"),
-            url((r"^(?P<resource_name>%s)/(?P<slug>[a-z-_]+)/$")
+            url((r"^(?P<resource_name>%s)/(?P<slug>[0-9a-z-_]+)/$")
                 % self._meta.resource_name, self.wrap_view('dispatch_detail'),
                 name="api_dispatch_detail"),
         ]


### PR DESCRIPTION
Without this, a project whose slug is e.g. `api-v3` will kaboom at build time (at the Celery layer) because URL resolution finds the PK version of the URL (intended for `sync_versions`) and eventually tries querying the database for kwargs like `{'pk': 'api-v3'}`. This of course is invalid and causes a lookup error (which in turn is masking the core `ValueError` that happens when the ORM tries to `int('api-v3')`.)

I'm not 100% sure why this API endpoint is hit via Celery builds but not, apparently, user/WWW-driven builds. Either way it seems like a clear cut bug.
