### PR TITLE
Fix error in 'docs/settings.rst'

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -68,4 +68,4 @@ USE_PIP_INSTALL
 
 Default: `False`
 
-Whether to use `pip install .` or `python setup.py install` when installing packages into the Virtualenv. Default is to use pip.
+Whether to use `pip install .` or `python setup.py install` when installing packages into the Virtualenv. Default is to use `python setup.py install`.


### PR DESCRIPTION
According to http://git.io/_Qq98A (tasks.py) default is to use setup.py
