### PR TITLE
Fix a bug with 'Edit on Bitbucket' with .org urls

### DIFF
--- a/readthedocs/builds/utils.py
+++ b/readthedocs/builds/utils.py
@@ -10,6 +10,9 @@ BB_REGEXS = [
     re.compile('bitbucket.com/(.+)/(.+)/'),
     re.compile('bitbucket.com/(.+)/(.+)'),
     re.compile('bitbucket.com:(.+)/(.+)\.git'),
+    re.compile('bitbucket.org/(.+)/(.+)/'),
+    re.compile('bitbucket.org/(.+)/(.+)'),
+    re.compile('bitbucket.org:(.+)/(.+)\.git'),
 ]
 
 def get_github_username_repo(version):


### PR DESCRIPTION
Bitbucket.org is the 'canonical' domain, though Bitbucket.com also works, so I added a few more lines to the regex patterns for that url
