### PR TITLE
Remove rtfd.org redirect in SubdomainMiddleware.

### DIFF
--- a/readthedocs/core/middleware.py
+++ b/readthedocs/core/middleware.py
@@ -33,14 +33,6 @@ class SubdomainMiddleware(object):
                 request.slug = subdomain
                 request.urlconf = 'core.subdomain_urls'
                 return None
-            # Serve rtfd.org
-            elif not is_www and not is_ssl and 'rtfd.org' in host:
-                # Disable RTFD django.me close stuff for now.
-                # AFAICT nobody uses it, and it causes 500s in templates :)
-                request.slug = subdomain
-                request.urlconf = 'core.djangome_urls'
-                log.debug(LOG_TEMPLATE.format(msg='Django.me request', **log_kwargs))
-                return None
         # Serve CNAMEs
         if settings.PRODUCTION_DOMAIN not in host and \
            'localhost' not in host and \


### PR DESCRIPTION
Since nginx now handles all rtfd.org redirects, this redirect
logic is no longer needed in middleware.
