### PR TITLE
Fix an issue on some systems where SITE_ROOT was set incorrectly

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -18,7 +18,7 @@ ADMINS = (
 
 MANAGERS = ADMINS
 
-SITE_ROOT = '/'.join(os.path.dirname(__file__).split('/')[0:-2])
+SITE_ROOT = '/'.join(os.path.dirname(os.path.realpath(__file__)).split('/')[0:-2])
 DOCROOT = os.path.join(SITE_ROOT, 'user_builds')
 UPLOAD_ROOT = os.path.join(SITE_ROOT, 'user_uploads')
 CNAME_ROOT = os.path.join(SITE_ROOT, 'cnames')


### PR DESCRIPTION
On some systems, `__file__` only contains part of the filename to access the current file, such as where it is in relation to the calling file (`manage.py`). This breaks some systems, and this pull request fixes that by surrounding `__file__` with `os.path.realpath()`, which forces it to be an absolute URL, fixing it on my system.
