### PR TITLE
fix #561 - de-slugify remote branch when / present

### DIFF
--- a/readthedocs/builds/utils.py
+++ b/readthedocs/builds/utils.py
@@ -30,14 +30,22 @@ def get_bitbucket_username_repo(version):
                 return match.groups()
     return (None, None)
 
-def get_vcs_version(version):
+def get_vcs_version_slug(version):
+    slug = None
     if version.slug == 'latest':
         if version.project.default_branch:
-            return version.project.default_branch
+            slug = version.project.default_branch
         else:
-            return version.project.vcs_repo().fallback_branch
+            slug = version.project.vcs_repo().fallback_branch
     else:
-        return version.slug
+        slug = version.slug
+    # https://github.com/rtfd/readthedocs.org/issues/561
+    # version identifiers with / characters in branch name need to un-slugify
+    # the branch name for remote links to work
+    if slug.replace('-', '/') in version.identifier:
+        slug = slug.replace('-', '/')
+    return slug
+
 
 def get_conf_py_path(version):
     conf_py_path = version.project.conf_file(version.slug)

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -126,7 +126,7 @@ class Builder(BaseBuilder):
                               encoding='utf-8', mode='a')
         outfile.write("\n")
         conf_py_path = version_utils.get_conf_py_path(self.version)
-        remote_version = version_utils.get_vcs_version(self.version)
+        remote_version = version_utils.get_vcs_version_slug(self.version)
         github_info = version_utils.get_github_username_repo(self.version)
         bitbucket_info = version_utils.get_bitbucket_username_repo(self.version)
         if github_info[0] is None:


### PR DESCRIPTION
This should fix #561 though I'm not sure if it's the best way or place to do it.

Also, I couldn't find any tests for `get_vcs_version` but I grep'd for it and only found the one usage in `sphinx.py`, which I updated.
