### PR TITLE
Create /translations/en directory before symlinking.

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -724,6 +724,7 @@ def symlink_translations(version):
 
     # Hack in the en version for backwards compat
     symlink = version.project.translations_symlink_path('en')
+    run_on_app_servers('mkdir -p %s' % '/'.join(symlink.split('/')[:-1]))
     docs_dir = os.path.join(settings.DOCROOT, version.project.slug, 'rtd-builds')
     run_on_app_servers('ln -nsf %s %s' % (docs_dir, symlink))
 


### PR DESCRIPTION
One of the last steps of the build process is to create the symlink
for /translations/en/, but the directory must exist before attempting
to symlink.

Fixes #598.
