### PR TITLE
Loosening subdomain detection logic

### DIFF
--- a/readthedocs/core/middleware.py
+++ b/readthedocs/core/middleware.py
@@ -32,10 +32,11 @@ class SubdomainMiddleware(object):
             # Serve subdomains
             is_www = subdomain.lower() == 'www'
             is_ssl = subdomain.lower() == 'ssl'
-            if not is_www and not is_ssl and settings.PRODUCTION_DOMAIN in host:
+            if not is_www and not is_ssl:
                 request.subdomain = True
                 request.slug = subdomain
                 request.urlconf = 'core.subdomain_urls'
+                log.debug(LOG_TEMPLATE.format(msg='3-part domain detected with slug: %s' % request.slug, **log_kwargs))
                 return None
         # Serve CNAMEs
         if settings.PRODUCTION_DOMAIN not in host and \


### PR DESCRIPTION
This is a humble and simple attempt to address #625.

Knowing relatively little about the implications, I would argue that we don't really care if the user arrived via the `settings.PRODUCTION_DOMAIN` domain. If they arrived via a 3-part domain, just take the first part of the domain as the slug. If the project exists, great. If not, RTD will throw up a 404.

This should allow CloudFlare to work without trouble, and it has the additional benefit of greatly reducing CNAME DNS lookups as lines 53 to 71 won't get exec'd unless the CNAME has 4+ parts.
