### PR TITLE
font-awesome 4.0

### DIFF
--- a/media/javascript/readthedocs-doc-embed.js
+++ b/media/javascript/readthedocs-doc-embed.js
@@ -68,7 +68,7 @@ $(document).ready(function () {
     });
     $(document).on('click', "[data-toggle='rst-current-version']", function() {
       $("[data-toggle='rst-versions']").toggleClass("shift-up");
-    });  
+    });
     // Make tables responsive
     $("table.docutils:not(.field-list)").wrap("<div class='wy-table-responsive'></div>");
 
@@ -137,21 +137,21 @@ $(document).ready(function () {
       clearSearch()
       var query = $("#rtd-search-form input[name='q']").val()
       getSearch(query, true)
-    }) 
+    })
 
     $(document).on('click', '.search-result', function (ev) {
       ev.preventDefault();
       //console.log(ev.target)
       html = $(ev.target).next().html()
       displayContent(html);
-    }) 
+    })
 
     function searchLanding() {
       // Highlight based on highlight GET arg
       var params = $.getQueryParameters();
       var query = (params.q) ? params.q[0].split(/\s+/) : [];
       var clear = true
-      /* Don't "search" on highlight phrases 
+      /* Don't "search" on highlight phrases
       if (!query.length) {
         // Only clear on q
         clear = false
@@ -242,7 +242,7 @@ $(document).ready(function () {
           li.show()
           li.attr("href", li.attr('href') + "?highlight=" + query)
           li.parent().addClass("current")
-          li.append("<i style='position:absolute;right:30px;top:6px;' class='icon icon-search result-icon'></i>")
+          li.append("<i style='position:absolute;right:30px;top:6px;' class='fa fa-search result-icon'></i>")
           ul.empty()
           FIRSTRUN[path] = true
         }
@@ -253,7 +253,7 @@ $(document).ready(function () {
           if (score > 1) {
             $(".toctree-l2 ")
             inserted = $('.toctree-l2 > [pageId="' + pageId + '"]')
-            inserted.append("<i style='position:absolute;right:30px;top:6px;' class='icon icon-fire'></i>")
+            inserted.append("<i style='position:absolute;right:30px;top:6px;' class='fa fa-fire'></i>")
           }
           FIRSTRUN[path+title] = true
         }


### PR DESCRIPTION
I updated the theme to use Font Awesome's newest version. This has no real added benefit for us, but keeps us in step with their documentation. Unfortunately they decided to change their naming, so I had to change our stuff to match. I believe you only use it for your search stuff, but if you're using the pack anywhere else, just change from `icon` to `fa` in the naming.

Along with this you'll want to run an update of the theme repo, making sure that the fonts below come over as well. (The fonts now use a -, not a _ ...btw).

https://github.com/snide/sphinx_rtd_theme/tree/master/sphinx_rtd_theme/static/fonts
