### PR TITLE
Git Backend refactoring and improvements

### DIFF
--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -1,7 +1,6 @@
 import logging
 import csv
 import os
-import re
 from StringIO import StringIO
 
 from projects.exceptions import ProjectImportError
@@ -12,8 +11,6 @@ log = logging.getLogger(__name__)
 
 
 class Backend(BaseVCS):
-    RE_SHA1 = re.compile(r'^[0-9a-f]{40}$')
-
     supports_tags = True
     supports_branches = True
     contribution_backends = [GithubContributionBackend]
@@ -165,10 +162,6 @@ class Backend(BaseVCS):
     def find_ref(self, ref):
         # Check if ref starts with 'origin/'
         if ref.startswith('origin/'):
-            return ref
-
-        # Check if ref is a SHA1 hash
-        if self.RE_SHA1.match(ref):
             return ref
 
         # Check if ref is a branch of the origin remote


### PR DESCRIPTION
### Summary
- Unnecessary duplicate `git fetch` removed (see 2218484)
- Submodules should work properly now (#606, see 44e911f)
- Repo URL change does not cause `git clone` anymore (doing `git remote set-url` instead, see f50a5fa)
- Using `git checkout` instead of `git reset` to jump to a specific revision (see 3dda85b)

I have tested these changes with a local instance of RTD and it worked as expected. If there are any questions or issues with the code please let me know.
