### PR TITLE
Update the Mock class to support * imports

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -39,6 +39,9 @@ You can mock out the imports for these modules in your conf.py with the followin
     import sys
 
     class Mock(object):
+        
+        __all__ = []
+       
         def __init__(self, *args, **kwargs):
             pass
 


### PR DESCRIPTION
The Mock class in the FAQs currently does not support `from module import *` type imports. As described here http://stackoverflow.com/questions/11877571/how-to-mock-so-that-from-x-import-works the solution is to add `__all__ = []` to the class definition.
