### PR TITLE
Fix TestGitBackend.parse_branches() test.

### DIFF
--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -39,6 +39,7 @@ class TestGitBackend(RTDTestCase):
             ('master', 'master'),
             ('release/2.0.0', 'release-2.0.0'),
             ('origin/2.0.X', '2.0.X'),
+            ('origin/master', 'master'),
             ('origin/release/2.0.0', 'release-2.0.0')
         ]
         given_ids = [(x.identifier, x.verbose_name) for x in


### PR DESCRIPTION
Commit 5f1ebf2 modified git.Backend.parse_branches() method so
that it no longer skipped a branch if it matched self.fallback_branch.
As a result, we need to modify the expected output for the
parse_branches() test.

Fixes #669.
