### PR TITLE
Convert regular asserts to unittest assert methods.

### DIFF
--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -44,12 +44,12 @@ class TestGitBackend(RTDTestCase):
         ]
         given_ids = [(x.identifier, x.verbose_name) for x in
                      self.project.vcs_repo().parse_branches(data)]
-        assert expected_ids == given_ids
+        self.assertEqual(expected_ids, given_ids)
 
     def test_git_checkout(self):
         repo = self.project.vcs_repo()
         repo.checkout()
-        assert exists(repo.working_dir)
+        self.assertTrue(exists(repo.working_dir))
 
     def test_parse_git_tags(self):
         data = """\
@@ -71,7 +71,7 @@ class TestGitBackend(RTDTestCase):
 
         given_ids = [(x.identifier, x.verbose_name) for x in
                      self.project.vcs_repo().parse_tags(data)]
-        assert expected_tags == given_ids
+        self.assertEqual(expected_tags, given_ids)
 
 
 class TestHgBackend(RTDTestCase):
@@ -98,12 +98,12 @@ class TestHgBackend(RTDTestCase):
         expected_ids = ['stable', 'default']
         given_ids = [x.identifier for x in
                      self.project.vcs_repo().parse_branches(data)]
-        assert expected_ids == given_ids
+        self.assertEqual(expected_ids, given_ids)
 
     def test_checkout(self):
         repo = self.project.vcs_repo()
         repo.checkout()
-        assert exists(repo.working_dir)
+        self.assertTrue(exists(repo.working_dir))
 
     def test_parse_tags(self):
         data = """\
@@ -120,4 +120,4 @@ class TestHgBackend(RTDTestCase):
 
         given_ids = [(x.identifier, x.verbose_name) for x in
                      self.project.vcs_repo().parse_tags(data)]
-        assert expected_tags == given_ids
+        self.assertEqual(expected_tags, given_ids)

--- a/readthedocs/rtd_tests/tests/test_celery.py
+++ b/readthedocs/rtd_tests/tests/test_celery.py
@@ -35,17 +35,17 @@ class TestCeleryBuilding(RTDTestCase):
 
     def test_remove_dir(self):
         directory = mkdtemp()
-        assert exists(directory)
+        self.assertTrue(exists(directory))
         result = tasks.remove_dir.delay(directory)
-        assert result.successful()
-        assert not exists(directory)
+        self.assertTrue(result.successful())
+        self.assertFalse(exists(directory))
 
     def test_update_docs(self):
         result = tasks.update_docs.delay(self.project.pk, record=False,
             intersphinx=False, api=MockApi(self.repo))
-        assert result.successful()
+        self.assertTrue(result.successful())
 
     def test_update_imported_doc(self):
         result = tasks.update_imported_docs.delay(self.project.pk,
             api=MockApi(self.repo))
-        assert result.successful()
+        self.assertTrue(result.successful())


### PR DESCRIPTION
This makes the tests in test_backend.py and test_celery.py more
consistent with the rest of the test suite. Plus, unittest asserts
give you more detailed error messages when a test fails.
