### PR TITLE
Keep state in instance variable for VersionManager().

### DIFF
--- a/readthedocs/betterversion/better.py
+++ b/readthedocs/betterversion/better.py
@@ -16,7 +16,8 @@ class BetterVersion(AdaptiveVersion):
 
 class VersionManager(object):
 
-    _state = defaultdict(lambda: defaultdict(list))
+    def __init__(self):
+        self._state = defaultdict(lambda: defaultdict(list))
 
     def add(self, version):
         self._state[version.major_version][version.minor_version].append(version)

--- a/readthedocs/rtd_tests/tests/test_supported.py
+++ b/readthedocs/rtd_tests/tests/test_supported.py
@@ -24,7 +24,6 @@ class TestSupportedVersions(TestCase):
                                type='tag',
                                active=True)
 
-    """
     def test_supported_versions(self):
         self.pip.num_major = 1
         self.pip.num_minor = 1
@@ -65,4 +64,3 @@ class TestSupportedVersions(TestCase):
                                active=True)
         # This gets set to False on creation.
         self.assertEqual(self.pip.versions.get(slug='0.1.1').supported, False)
-    """


### PR DESCRIPTION
Previously, state was stored as a class variable for
betterversion.better.VersionManager(). That meant multiple tests were
mutating the same state across multiple VersionManagers, which is why the
tests in test_supported.py were failing ("data leakage") when all tests
were run, but not when they were run by themselves.

Uncommented tests in test_supported.py, now that they are passing.
