### PR TITLE
Updates Github link to go directly to the edit page

### DIFF
--- a/readthedocs/templates/sphinx/sphinx_rtd_theme/breadcrumbs.html
+++ b/readthedocs/templates/sphinx/sphinx_rtd_theme/breadcrumbs.html
@@ -7,7 +7,7 @@
     <li>{{ title }}</li>
       <li class="wy-breadcrumbs-aside">
         {% if display_github %}
-          <a href="https://github.com/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}{{ conf_py_path }}{{ pagename }}.rst" class="fa fa-github"> Edit on GitHub</a>
+          <a href="https://github.com/{{ github_user }}/{{ github_repo }}/edit/{{ github_version }}{{ conf_py_path }}{{ pagename }}.rst" class="fa fa-github"> Edit on GitHub</a>
         {% elif display_bitbucket %}
           <a href="https://bitbucket.org/{{ bitbucket_user }}/{{ bitbucket_repo }}/src/{{ bitbucket_version}}{{ conf_py_path }}{{ pagename }}.rst" class="fa fa-bitbucket"> Edit on Bitbucket</a>
         {% elif show_source and has_source and sourcename %}


### PR DESCRIPTION
This updates the `Edit on GitHub` link for the sphinx rtd theme to go directly to the editing screen for that page. 

Github now handles the case of a logged-out user correctly, presenting them with a login screen that redirects back to the same URL after logging in or signing up. Previously, Github would 404 in this case.

/cc @jamesturk, since I was inspired to file this by the `Edit on GitHub` link at the top of http://docs.opencivicdata.org/en/latest/
