### PR TITLE
Add .vagrant to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ user_uploads
 whoosh_index
 xml_output
 .idea
+.vagrant


### PR DESCRIPTION
Because the Vagrantfile is now in the top-level directory, the
.vagrant directory also gets created in the top-level directory.
