### PR TITLE
Fix docstrings in projects/models.py.

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -560,7 +560,7 @@ class Project(models.Model):
 
     def rtd_build_path(self, version="latest"):
         """
-        The path to the build html docs in the project.
+        The destination path where the built docs are copied.
         """
         return os.path.join(self.doc_path, 'rtd-builds', version)
 


### PR DESCRIPTION
Several of the full_path() methods had inaccurate docstrings.
