### PR TITLE
Fill title content in 404 template

### DIFF
--- a/readthedocs/templates/404.html
+++ b/readthedocs/templates/404.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
 
+    {% block title %}
+      {% trans "Not Found" %}
+    {% endblock %}
+
     {% block header-wrapper %}
       {% include "error_header.html" %}
     {% endblock %}


### PR DESCRIPTION
Hi!
Currently 404.html template [renders](https://readthedocs.org/not_found) title without content and this PR fixes it.
