### PR TITLE
Use better CNAME in nginx-smoke-test.py.

### DIFF
--- a/deploy/scripts/nginx-smoke-test.py
+++ b/deploy/scripts/nginx-smoke-test.py
@@ -113,8 +113,8 @@ if __name__ == '__main__':
     cname_urls = [
         'http://docs.fabfile.org/en/latest/',
         'http://docs.fabfile.org/en/latest/faq.html',
-        'http://site.ericholscher.com/',
-        'http://site.ericholscher.com/bike/',
+        'http://www.pip-installer.org/en/latest/',
+        'http://www.pip-installer.org/en/latest/news.html',
     ]
 
     translation_urls = [


### PR DESCRIPTION
site.ericholscher.com disappeared! Need more reliable CNAME.
