### PR TITLE
Add stale build checkout cleanup command

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -1,4 +1,5 @@
 import re
+import os.path
 
 from django.core.urlresolvers import reverse
 from django.conf import settings
@@ -199,6 +200,12 @@ class Version(models.Model):
             self.project.checkout_path(self.slug), '')
         return conf_py_path.replace('conf.py', '')
 
+    def get_build_path(self):
+        '''Return version build path if path exists, otherwise `None`'''
+        path = self.project.checkout_path(version=self.slug)
+        if os.path.exists(path):
+            return path
+        return None
 
     def get_github_url(self, docroot, filename):
         GITHUB_REGEXS = [

--- a/readthedocs/builds/utils.py
+++ b/readthedocs/builds/utils.py
@@ -1,4 +1,9 @@
 import re
+import logging
+from shutil import rmtree
+
+log = logging.getLogger(__name__)
+
 
 GH_REGEXS = [
     re.compile('github.com/(.+)/(.+)(?:\.git){1}'),
@@ -52,3 +57,23 @@ def get_conf_py_path(version):
     conf_py_path = conf_py_path.replace(
         version.project.checkout_path(version.slug), '')
     return conf_py_path.replace('conf.py', '')
+
+
+def clean_build_path(version):
+    '''Clean build path for project version
+
+    Ensure build path is clean for project version. Used to ensure stale build
+    checkouts for each project version are removed.
+
+    version
+        Instance of :py:class:`readthedocs.builds.models.Version` to perform
+        build path cleanup on
+    '''
+    try:
+        path = version.get_build_path()
+        if path is not None:
+            log.debug('Removing build path {0} for {1}'.format(
+                path, version))
+            rmtree(path)
+    except OSError:
+        log.error('Build path cleanup failed', exc_info=True)

--- a/readthedocs/core/management/commands/clean_builds.py
+++ b/readthedocs/core/management/commands/clean_builds.py
@@ -1,0 +1,59 @@
+from datetime import datetime, timedelta
+import logging
+from optparse import make_option
+
+from django.core.management.base import BaseCommand
+from django.db.models import Max
+
+from builds.models import Build, Version
+from builds.utils import clean_build_path
+
+log = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+
+    help = ('Clean up stale build paths per project version')
+
+    option_list = BaseCommand.option_list + (
+        make_option('--days',
+                    dest='days',
+                    type='int',
+                    default=365,
+                    help='Find builds older than DAYS days, default: 365'),
+        make_option('--dryrun',
+                    action='store_true',
+                    dest='dryrun',
+                    help='Perform dry run on build cleanup'),
+    )
+
+    def handle(self, *args, **options):
+        '''
+        Find stale builds and remove build paths
+        '''
+        max_date = datetime.now() - timedelta(days=options['days'])
+        queryset = (Build.objects
+                    .values('project', 'version')
+                    .annotate(max_date=Max('date'))
+                    .filter(max_date__lt=max_date)
+                    .order_by('-max_date'))
+        for build in queryset:
+            try:
+                # Get version from build version id, perform sanity check on
+                # latest build date
+                version = Version.objects.get(id=build['version'])
+                latest_build = version.builds.latest('date')
+                if latest_build.date > max_date:
+                    log.warn('{0} is newer than {1}'.format(
+                        latest_build, max_date))
+                    next
+                path = version.get_build_path()
+                if path is not None:
+                    log.info(
+                        ('Found stale build path for {0} '
+                         'at {1}, last used on {2}').format(
+                            version, path, latest_build.date))
+                    if not options['dryrun']:
+                        clean_build_path(version)
+            except Version.DoesNotExist:
+                pass


### PR DESCRIPTION
Build cleanup finds versions where the last build date for the version is older than a specified maximum date. Build paths older than number of days specified by `--days=DAYS` (the examples below use 0 for an example only, normally this would be a sane value) are removed unless `--dryrun` is sepcified on the command:

```
% python manage.py clean_builds --days=0 --dryrun
...
[16/Mar/2014 21:19:29] INFO [core.management.commands.clean_builds:55] Found stale build path for Version latest of Kong (9) at /home/docs/sites/readthedocs.org/checkouts/readthedocs.org/user_builds/kong/checkouts/latest, last used on 2014-03-16 21:18:18.882387
```

Otherwise, a live run will produce:

```
% python manage.py clean_builds --days=0
...
[16/Mar/2014 21:17:24] INFO [core.management.commands.clean_builds:55] Found stale build path for Version latest of Kong (9) at /home/docs/sites/readthedocs.org/checkouts/readthedocs.org/user_builds/kong/checkouts/latest, last used on 2014-03-16 21:16:55.995807
[16/Mar/2014 21:17:24] DEBUG [builds.utils:76] Removing build path /home/docs/sites/readthedocs.org/checkouts/readthedocs.org/user_builds/kong/checkouts/latest for Version latest of Kong (9)
```
