### PR TITLE
Correct Bitbucket instructions

### DIFF
--- a/docs/webhooks.rst
+++ b/docs/webhooks.rst
@@ -28,9 +28,9 @@ If your project is hosted on Bitbucket, you can easily add a hook that will rebu
 your docs whenever you push updates:
 
 * Go to the "admin" page for your project
-* Click "Services"
+* Click "Hooks"
 * In the available service hooks, select "Read the Docs"
-* Click "Add service"
+* Click "Add hook"
 
 Others
 ------


### PR DESCRIPTION
Services are currently called "hooks" on Bitbucket.
