### PR TITLE
Make the link tag self-closing.

### DIFF
--- a/readthedocs/templates/sphinx/layout.html
+++ b/readthedocs/templates/sphinx/layout.html
@@ -11,13 +11,13 @@
   Single version, so link without a language or version 
   http://docs.readthedocs.org/en/latest/canonical.html
   -->
-  <link rel="canonical" href="{{ canonical_url }}{{ canonical_page.replace("index.html", "").replace("index/", "") }}">
+  <link rel="canonical" href="{{ canonical_url }}{{ canonical_page.replace("index.html", "").replace("index/", "") }}" />
   {% else %}
   <!-- 
   Always link to the latest version, as canonical.
   http://docs.readthedocs.org/en/latest/canonical.html
   -->
-  <link rel="canonical" href="{{ canonical_url }}{{ rtd_language }}/latest/{{ canonical_page.replace("index.html", "").replace("index/", "") }}">
+  <link rel="canonical" href="{{ canonical_url }}{{ rtd_language }}/latest/{{ canonical_page.replace("index.html", "").replace("index/", "") }}" />
   {% endif %}
 {% else %}
 <!-- 
@@ -25,7 +25,7 @@ Read the Docs is acting as the canonical URL for your project.
 If you want to change it, more info is available in our docs:
   http://docs.readthedocs.org/en/latest/canonical.html
 -->
-<link rel="canonical" href="http://{{ slug }}.readthedocs.org/{{ rtd_language }}/latest/{{ canonical_page.replace("index.html", "").replace("index/", "") }}">
+<link rel="canonical" href="http://{{ slug }}.readthedocs.org/{{ rtd_language }}/latest/{{ canonical_page.replace("index.html", "").replace("index/", "") }}" />
 {% endif %}
 <script type="text/javascript">
   // This is included here because other places don't have access to the pagename variable.


### PR DESCRIPTION
Solves #744 by closing the link tags in the header and making the output XHTML valid again (needed for ePub).
