### PR TITLE
Fabric docs now live at fabric-docs.rtfd not fabric.rtfd.

### DIFF
--- a/docs/alternate_domains.rst
+++ b/docs/alternate_domains.rst
@@ -21,7 +21,7 @@ As an example, fabric's dig record looks like this::
     -> dig docs.fabfile.org
     ...
     ;; ANSWER SECTION:
-    docs.fabfile.org.   7200    IN  CNAME   fabric.readthedocs.org.
+    docs.fabfile.org.   7200    IN  CNAME   fabric-docs.readthedocs.org.
 
 CNAME SSL
 ---------

--- a/docs/canonical.rst
+++ b/docs/canonical.rst
@@ -15,10 +15,10 @@ Example
 
 Fabric hosts their docs on Read the Docs.
 They mostly use their own domain for them ``http://docs.fabfile.org``.
-This means that Google will index both ``http://fabric.readthedocs.org`` and ``http://docs.fabfile.org`` for their documentation.
+This means that Google will index both ``http://fabric-docs.readthedocs.org`` and ``http://docs.fabfile.org`` for their documentation.
 
 Fabric will want to set ``http://docs.fabfile.org`` as their canonical URL.
-This means that when Google indexes ``http://fabric.readthedocs.org``, it will know that it should really point at ``http://docs.fabfile.org``.
+This means that when Google indexes ``http://fabric-docs.readthedocs.org``, it will know that it should really point at ``http://docs.fabfile.org``.
 
 Enabling
 --------

--- a/docs/locale/da/LC_MESSAGES/canonical.po
+++ b/docs/locale/da/LC_MESSAGES/canonical.po
@@ -57,7 +57,7 @@ msgstr ""
 msgid ""
 "Fabric hosts their docs on Read the Docs. They mostly use their own domain "
 "for them ``http://docs.fabfile.org``. This means that Google will index both"
-" ``http://fabric.readthedocs.org`` and ``http://docs.fabfile.org`` for their"
+" ``http://fabric-docs.readthedocs.org`` and ``http://docs.fabfile.org`` for their"
 " documentation."
 msgstr ""
 
@@ -65,7 +65,7 @@ msgstr ""
 #: ../../canonical.rst:20
 msgid ""
 "Fabric will want to set ``http://docs.fabfile.org`` as their canonical URL. "
-"This means that when Google indexes ``http://fabric.readthedocs.org``, it "
+"This means that when Google indexes ``http://fabric-docs.readthedocs.org``, it "
 "will know that it should really point at ``http://docs.fabfile.org``."
 msgstr ""
 

--- a/docs/locale/en/LC_MESSAGES/canonical.po
+++ b/docs/locale/en/LC_MESSAGES/canonical.po
@@ -57,17 +57,17 @@ msgstr "Example"
 msgid ""
 "Fabric hosts their docs on Read the Docs. They mostly use their own domain "
 "for them ``http://docs.fabfile.org``. This means that Google will index both"
-" ``http://fabric.readthedocs.org`` and ``http://docs.fabfile.org`` for their"
+" ``http://fabric-docs.readthedocs.org`` and ``http://docs.fabfile.org`` for their"
 " documentation."
-msgstr "Fabric hosts their docs on Read the Docs. They mostly use their own domain for them ``http://docs.fabfile.org``. This means that Google will index both ``http://fabric.readthedocs.org`` and ``http://docs.fabfile.org`` for their documentation."
+msgstr "Fabric hosts their docs on Read the Docs. They mostly use their own domain for them ``http://docs.fabfile.org``. This means that Google will index both ``http://fabric-docs.readthedocs.org`` and ``http://docs.fabfile.org`` for their documentation."
 
 # 8c83b33254cc46ce8275dc9c331e9c74
 #: ../../canonical.rst:20
 msgid ""
 "Fabric will want to set ``http://docs.fabfile.org`` as their canonical URL. "
-"This means that when Google indexes ``http://fabric.readthedocs.org``, it "
+"This means that when Google indexes ``http://fabric-docs.readthedocs.org``, it "
 "will know that it should really point at ``http://docs.fabfile.org``."
-msgstr "Fabric will want to set ``http://docs.fabfile.org`` as their canonical URL. This means that when Google indexes ``http://fabric.readthedocs.org``, it will know that it should really point at ``http://docs.fabfile.org``."
+msgstr "Fabric will want to set ``http://docs.fabfile.org`` as their canonical URL. This means that when Google indexes ``http://fabric-docs.readthedocs.org``, it will know that it should really point at ``http://docs.fabfile.org``."
 
 # fd6280eed84844f8a6c0c55e0672f9af
 #: ../../canonical.rst:24

--- a/docs/locale/es/LC_MESSAGES/canonical.po
+++ b/docs/locale/es/LC_MESSAGES/canonical.po
@@ -57,7 +57,7 @@ msgstr ""
 msgid ""
 "Fabric hosts their docs on Read the Docs. They mostly use their own domain "
 "for them ``http://docs.fabfile.org``. This means that Google will index both"
-" ``http://fabric.readthedocs.org`` and ``http://docs.fabfile.org`` for their"
+" ``http://fabric-docs.readthedocs.org`` and ``http://docs.fabfile.org`` for their"
 " documentation."
 msgstr ""
 
@@ -65,7 +65,7 @@ msgstr ""
 #: ../../canonical.rst:20
 msgid ""
 "Fabric will want to set ``http://docs.fabfile.org`` as their canonical URL. "
-"This means that when Google indexes ``http://fabric.readthedocs.org``, it "
+"This means that when Google indexes ``http://fabric-docs.readthedocs.org``, it "
 "will know that it should really point at ``http://docs.fabfile.org``."
 msgstr ""
 

--- a/docs/locale/it/LC_MESSAGES/canonical.po
+++ b/docs/locale/it/LC_MESSAGES/canonical.po
@@ -57,7 +57,7 @@ msgstr ""
 msgid ""
 "Fabric hosts their docs on Read the Docs. They mostly use their own domain "
 "for them ``http://docs.fabfile.org``. This means that Google will index both"
-" ``http://fabric.readthedocs.org`` and ``http://docs.fabfile.org`` for their"
+" ``http://fabric-docs.readthedocs.org`` and ``http://docs.fabfile.org`` for their"
 " documentation."
 msgstr ""
 
@@ -65,7 +65,7 @@ msgstr ""
 #: ../../canonical.rst:20
 msgid ""
 "Fabric will want to set ``http://docs.fabfile.org`` as their canonical URL. "
-"This means that when Google indexes ``http://fabric.readthedocs.org``, it "
+"This means that when Google indexes ``http://fabric-docs.readthedocs.org``, it "
 "will know that it should really point at ``http://docs.fabfile.org``."
 msgstr ""
 

--- a/docs/locale/ja/LC_MESSAGES/canonical.po
+++ b/docs/locale/ja/LC_MESSAGES/canonical.po
@@ -57,7 +57,7 @@ msgstr ""
 msgid ""
 "Fabric hosts their docs on Read the Docs. They mostly use their own domain "
 "for them ``http://docs.fabfile.org``. This means that Google will index both"
-" ``http://fabric.readthedocs.org`` and ``http://docs.fabfile.org`` for their"
+" ``http://fabric-docs.readthedocs.org`` and ``http://docs.fabfile.org`` for their"
 " documentation."
 msgstr ""
 
@@ -65,7 +65,7 @@ msgstr ""
 #: ../../canonical.rst:20
 msgid ""
 "Fabric will want to set ``http://docs.fabfile.org`` as their canonical URL. "
-"This means that when Google indexes ``http://fabric.readthedocs.org``, it "
+"This means that when Google indexes ``http://fabric-docs.readthedocs.org``, it "
 "will know that it should really point at ``http://docs.fabfile.org``."
 msgstr ""
 

--- a/docs/locale/nb/LC_MESSAGES/canonical.po
+++ b/docs/locale/nb/LC_MESSAGES/canonical.po
@@ -57,7 +57,7 @@ msgstr ""
 msgid ""
 "Fabric hosts their docs on Read the Docs. They mostly use their own domain "
 "for them ``http://docs.fabfile.org``. This means that Google will index both"
-" ``http://fabric.readthedocs.org`` and ``http://docs.fabfile.org`` for their"
+" ``http://fabric-docs.readthedocs.org`` and ``http://docs.fabfile.org`` for their"
 " documentation."
 msgstr ""
 
@@ -65,7 +65,7 @@ msgstr ""
 #: ../../canonical.rst:20
 msgid ""
 "Fabric will want to set ``http://docs.fabfile.org`` as their canonical URL. "
-"This means that when Google indexes ``http://fabric.readthedocs.org``, it "
+"This means that when Google indexes ``http://fabric-docs.readthedocs.org``, it "
 "will know that it should really point at ``http://docs.fabfile.org``."
 msgstr ""
 


### PR DESCRIPTION
Sorry! Figure best to keep examples reflecting reality...
