### PR TITLE
Broken 'More info' link

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -152,7 +152,7 @@ class Project(models.Model):
         _('Documentation type'), max_length=20,
         choices=constants.DOCUMENTATION_CHOICES, default='sphinx',
         help_text=_('Type of documentation you are building. <a href="http://'
-                    'sphinx.pocoo.org/builders.html#sphinx.builders.html.'
+                    'sphinx-doc.org/builders.html#sphinx.builders.html.'
                     'DirectoryHTMLBuilder">More info</a>.'))
     analytics_code = models.CharField(
         _('Analytics code'), max_length=50, null=True, blank=True,


### PR DESCRIPTION
In the project settings page, under 'Documentation Type' there is a "More Info..." link. This link is totally b0rked, it 404s. Looks like the correct link is http://sphinx-doc.org/builders.html#sphinx.builders.html.DirectoryHTMLBuilder.

Link is here:

![screen shot 2014-04-14 at 15 45 12](https://cloud.githubusercontent.com/assets/1382556/2699959/7ab0e86c-c40d-11e3-9335-3fca50899b35.png)
