### PR TITLE
Added gzip_vary on; to the Nginx configuration

### DIFF
--- a/deploy/nginx/main.nginx.conf
+++ b/deploy/nginx/main.nginx.conf
@@ -24,6 +24,7 @@ http {
       '"$http_user_agent" "$http_x_forwarded_for"';
 
     gzip on;
+    gzip_vary on;
     gzip_disable "msie6";
 
     include /etc/nginx/sites-enabled/lb;


### PR DESCRIPTION
Adding `gzip_vary on;` to the Nginx configuration will add the `Vary: Accept-Encoding` header to responses.

This should improve performance, you can read more about it [here](http://blog.maxcdn.com/accept-encoding-its-vary-important/).

&mdash; @citruspi
