### PR TITLE
Add the header X-Frame-Options DENY

### DIFF
--- a/deploy/nginx/app.nginx.conf
+++ b/deploy/nginx/app.nginx.conf
@@ -33,6 +33,8 @@ server {
     access_log  /var/log/nginx/readthedocs.log host;
     client_max_body_size 50m;
 
+    add_header X-Frame-Options DENY;
+
     location /favicon.ico {
         root /home/docs/checkouts/readthedocs.org/media/images;
         break;


### PR DESCRIPTION
Adding the `X-Frame-Options DENY` header should prevent [readthedocs.org](readthedocs.org) from being embedded in iFrames.

&mdash; @citruspi
