### PR TITLE
Added gzip and gzip_vary to the media.readthedocs.org domain

### DIFF
--- a/deploy/nginx/app.nginx.conf
+++ b/deploy/nginx/app.nginx.conf
@@ -8,6 +8,9 @@ server {
     server_name media.readthedocs.org;
     access_log  /var/log/nginx/rtdmedia.log;
 
+    gzip on;
+    gzip_vary on;
+
     location /wheelhouse/ {
         expires 60d;
         root /home/docs/checkouts/readthedocs.org/media;


### PR DESCRIPTION
`gzip` and `gzip_vary` were not being applied to the `media.readthedocs.org` domain, so I've manually applied them to that server as well.

&mdash; @citruspi
