### PR TITLE
Fixed type of display_bitbucket in template context

### DIFF
--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -78,7 +78,7 @@ context = {
     'bitbucket_user': '{{ bitbucket_user }}',
     'bitbucket_repo': '{{ bitbucket_repo }}',
     'bitbucket_version': '{{ bitbucket_version }}',
-    'display_bitbucket': '{{ display_bitbucket }}',
+    'display_bitbucket': {{ display_bitbucket }},
     'READTHEDOCS': True,
     'using_theme': (html_theme == "default"),
     'new_theme': (html_theme == "sphinx_rtd_theme"),


### PR DESCRIPTION
This fixes the remark made by @leehosung at https://github.com/rtfd/readthedocs.org/commit/89c86501ae3c8a7830c6e459f1fad9d8cf99205e
