### PR TITLE
Doesn't build after changing repo type from hg to git

### DIFF
--- a/readthedocs/vcs_support/backends/bzr.py
+++ b/readthedocs/vcs_support/backends/bzr.py
@@ -34,6 +34,7 @@ class Backend(BaseVCS):
         return up_output
 
     def clone(self):
+        self.make_clean_working_dir()
         retcode = self.run('bzr', 'checkout', self.repo_url, '.')[0]
         if retcode != 0:
             raise ProjectImportError(

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -136,6 +136,7 @@ class Backend(BaseVCS):
             self.set_remote_url(self.repo_url)
             self.fetch()
         else:
+            self.make_clean_working_dir()
             self.clone()
 
         # Find proper identifier

--- a/readthedocs/vcs_support/backends/hg.py
+++ b/readthedocs/vcs_support/backends/hg.py
@@ -31,6 +31,7 @@ class Backend(BaseVCS):
         return update_output
 
     def clone(self):
+        self.make_clean_working_dir()
         output = self.run('hg', 'clone', self.repo_url, '.')
         if output[0] != 0:
             raise ProjectImportError(

--- a/readthedocs/vcs_support/backends/svn.py
+++ b/readthedocs/vcs_support/backends/svn.py
@@ -46,6 +46,7 @@ class Backend(BaseVCS):
             )
 
     def co(self, identifier=None):
+        self.make_clean_working_dir()
         if identifier:
             url = self.base_url + identifier
         else:

--- a/readthedocs/vcs_support/base.py
+++ b/readthedocs/vcs_support/base.py
@@ -2,6 +2,7 @@ import logging
 from collections import namedtuple
 import os
 from os.path import basename
+import shutil
 import subprocess
 
 from django.template.defaultfilters import slugify
@@ -95,6 +96,11 @@ class BaseVCS(BaseCLI):
     def check_working_dir(self):
         if not os.path.exists(self.working_dir):
             os.makedirs(self.working_dir)
+
+    def make_clean_working_dir(self):
+        "Ensures that the working dir exists and is empty"
+        shutil.rmtree(self.working_dir, ignore_errors=True)
+        self.check_working_dir()
 
     def update(self):
         """


### PR DESCRIPTION
I have a project on BitBucket which I changed from Mercurial to Git. I changed the repo URL in RTD accordingly.

The project now fails to build and doesn't supply an error message.

I tried creating a new RTD project for this repo and it built successfully. However after deleting my project and creating a new one with the same name, it still won't build.

An example of a failed build is the one with id 1524296.

I would think the project clone directory just needs to be deleted.

Cheers
