### PR TITLE
Integrate coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,11 @@ language: python
 python:
  - "2.7"
 install:
- - pip install flake8 
- - pip install --allow-all-external --allow-unverified bzr --allow-unverified launchpadlib --allow-unverified lazr.authentication -r pip_requirements.txt 
+ - pip install flake8
+ - pip install --allow-all-external --allow-unverified bzr --allow-unverified launchpadlib --allow-unverified lazr.authentication -r pip_requirements.txt
+ - pip install coveralls
 script:
  #- flake8 `find . -iname "*.py" -not -ipath "*migration*"`
  - ./runtests.sh
+after_success:
+ - coveralls

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Welcome to Read The Docs
 ========================
 
-|build-status| |docs|
+|build-status| |coverage-status| |docs|
 
 Purpose
 -------
@@ -53,9 +53,13 @@ when you push to Github.
 
 
 .. |build-status| image:: https://travis-ci.org/rtfd/readthedocs.org.png?branch=master
-    :alt: status
+    :alt: build status
     :scale: 100%
     :target: https://travis-ci.org/rtfd/readthedocs.org
+
+.. |coverage-status| image:: https://coveralls.io/repos/rtfd/readthedocs.org/badge.png
+    :alt: coverage status
+    :target: https://coveralls.io/r/readthedocs.org
 
 .. |docs| image:: https://readthedocs.org/projects/docs/badge/?version=latest
     :alt: status

--- a/runtests.sh
+++ b/runtests.sh
@@ -2,7 +2,7 @@ cd readthedocs
 rm -rf rtd_tests/builds/
 export PYTHONPATH=`pwd`:$PYTHONPATH
 export DJANGO_SETTINGS_MODULE=settings.test
-py.test $1
+coverage run py.test $1
 exit=$?
 cd -
 exit $exit


### PR DESCRIPTION
[Coveralls.io](https://coveralls.io) is a nifty free service to track test coverage of your code. It's similar to Travis: you'll need to log in and enable your project before it will track for you.
