### PR TITLE
Change badge color to 'brightgreen'

### DIFF
--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -107,7 +107,7 @@ def project_badge(request, project_slug, redirect=False):
         return _badge_return(redirect, url)
     last_build = version_builds[0]
     if last_build.success:
-        color = 'green'
+        color = 'brightgreen'
     else:
         color = 'red'
     url = 'http://img.shields.io/badge/Docs-%s-%s.svg?style=%s' % (version.slug.replace('-', '--'), color, style)


### PR DESCRIPTION
Shields.io has three different greens: `brightgreen`, `green`, and `yellowgreen`.  RTD currently uses `green`, but the usual color used to indicate 'success' is `brightgreen`.  

This ends up making the RTD shield look off next to shields from coveralls, Travis, etc.
