### PR TITLE
Add trailing slash to buildUrl, avoid a redirect

### DIFF
--- a/media/javascript/build_updater.js
+++ b/media/javascript/build_updater.js
@@ -3,7 +3,7 @@
     // An updater that renders details about a build.
     this.BuildUpdater = function(buildId) {
         this.buildId = buildId;
-        this.buildUrl = '/api/v1/build/' + this.buildId;
+        this.buildUrl = '/api/v1/build/' + this.buildId + '/';
         this.buildDiv = 'div#build-' + this.buildId;
         this.buildLoadingImg = this.buildDiv + ' img.build-loading';
         this.intervalId = null;


### PR DESCRIPTION
Noticed all polling requests were being redirected to the correct URL, makes sense to set it to avoid these

![screen shot 2014-09-07 at 15 38 46](https://cloud.githubusercontent.com/assets/1097349/4178583/164a3448-369d-11e4-80a4-b620141d442b.png)
