### PR TITLE
Adding Vietnamese to languages

### DIFF
--- a/readthedocs/projects/constants.py
+++ b/readthedocs/projects/constants.py
@@ -130,6 +130,7 @@ LANGUAGES = (
     ("sl", "Slovenian"),
     ("sv", "Swedish"),
     ("tr", "Turkish"),
+    ("vi", "Vietnamese"),
     # Try these to test our non-2 letter language support
     ("nb_NO", "Norwegian Bokmal"),
     ("pt_BR", "Brazilian Portuguese"),


### PR DESCRIPTION
As far as the list is concerned on this page http://sphinx-doc.org/latest/config.html#confval-language

Seems like Vietnamese is supported by Sphinx.

Thanks!
