### PR TITLE
Update symlinks.rst: Typo correction.

### DIFF
--- a/docs/symlinks.rst
+++ b/docs/symlinks.rst
@@ -75,6 +75,6 @@ $host would be ``docs.fabfile.org``:
         error_page 500 = @fallback;
     }
 
-Notice that nowhere in the above path is the projects slug mentioned.
+Notice that nowhere in the above path is the project's slug mentioned.
 It is simply there in the symlink in the cnames directory,
 and the docs are served from there.


### PR DESCRIPTION
line 78: Add apostrophe.

line 80: Unchanged. Same deal as with my previous commit. It appears in the diff, but I didn't intend to update line 80 either time, and it doesn't appear to have actually changed.
