### PR TITLE
Fix link to pip requirements files documentation

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -145,7 +145,7 @@ class Project(models.Model):
         _('Requirements file'), max_length=255, default=None, null=True,
         blank=True, help_text=_(
             'Requires Virtualenv. A <a '
-            'href="http://www.pip-installer.org/en/latest/cookbook.html#requirements-files">'
+            'href="https://pip.pypa.io/en/latest/user_guide.html#requirements-files">'
             'pip requirements file</a> needed to build your documentation. '
             'Path from the root of your project.'))
     documentation_type = models.CharField(


### PR DESCRIPTION
This documentation has moved, and the link is out of date.
