### PR TITLE
Edit test docs to reflect using ./runtests.sh

### DIFF
--- a/docs/tests.rst
+++ b/docs/tests.rst
@@ -4,7 +4,7 @@ Running tests
 Currently RTD isn't well tested. This is a problem, and it is being worked on. However, we do have a basic test suite. To run the tests, you need simply need to run::
 
     pip install coverage 
-    ./runtests/sh
+    ./runtests.sh
 
 This should spit out a bunch of information and eventually pass.
 


### PR DESCRIPTION
The documentation on testing outdated; the original command was causing numerous errors. 
