### PR TITLE
add faq entry for 401 errors for users who do not load test data

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -57,11 +57,11 @@ Of course, replacing `MOCK_MODULES` with the modules that you want to mock out.
 My server gives a 401 error when building documentation
 ----------------------------------------------------------
 
-This error is a result of SLUMBER not having access to a database superuser account. You can fix this by loading test data::
+This error stems from the builder not having access to a database super user account. You can fix this by loading test data::
 
     ./manage.py loaddata test_data
 
-If you'd prefer not to install test data, you'll need to create a database account for SLUMBER to use. You can provide these credentials by editing the following variables::
+If you'd prefer not to install the test data, you'll need to provide a database account for the builder to use. You can provide these credentials by editing the following settings::
 
     SLUMBER_USERNAME = 'test'
     SLUMBER_PASSWORD = 'test'


### PR DESCRIPTION
Add a FAQ entry to address possible issue for users who do not load test_data. If Slumber settings are not updated with proper database credentials the server will give a 401 error::

```
"POST /api/v1/version/ HTTP/1.1" 401 0
(Build) [readthedocsorg:] Exception in creating version: Client Error 401:http://localhost:8000/api/v1/version/
```

Updated the doc with instructions to change SLUMBER_USERNAME and SLUMBER_PASSWORD if test_data is not loaded.
