### PR TITLE
Removed Meta.exclude from UserProfileForm.

### DIFF
--- a/readthedocs/core/forms.py
+++ b/readthedocs/core/forms.py
@@ -17,7 +17,6 @@ class UserProfileForm(forms.ModelForm):
     class Meta:
         model = UserProfile
         # Don't allow users edit someone else's user page,
-        exclude = ('user', 'whitelisted')
         fields = ['first_name', 'last_name', 'homepage']
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
We are using both `Meta.exclude` and `Meta.fields` in `UserProfileForm` at same time.
