### PR TITLE
Add stderr logging to 'git fetch' operation

### DIFF
--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -51,8 +51,8 @@ class Backend(BaseVCS):
         code, out, err = self.run('git', 'fetch', '--prune')
         if code != 0:
             raise ProjectImportError(
-                "Failed to get code from '%s' (git fetch): %s" % (
-                    self.repo_url, code)
+                "Failed to get code from '%s' (git fetch): %s\n\nStderr:\n\n%s\n\n" % (
+                    self.repo_url, code, err)
             )
 
     def checkout_revision(self, revision=None):


### PR DESCRIPTION
This part of the code sees frequent failures on our internal RTD for random stuff like "user put in a public Github https URL for a private repo" (causes password prompt on stdin), "user checked in a pyc file for a sphinx extension" (so builds mutate the git repo in a non-pullable/fetchable fashion), etc.

Git returns code 128 for almost any error condition so having just the code is not useful :)
