### PR TITLE
Use lower-case words throughout badges

### DIFF
--- a/docs/badges.rst
+++ b/docs/badges.rst
@@ -50,9 +50,9 @@ This will allow you to have custom style badges.
 
 .. _Read the Docs README: https://github.com/rtfd/readthedocs.org/blob/master/README.rst
 .. _project page: https://readthedocs.org/projects/pip/
-.. |green| image:: https://img.shields.io/badge/Docs-latest-brightgreen.svg?style=flat
-.. |red| image:: https://img.shields.io/badge/Docs-release--1.6-red.svg?style=flat
-.. |yellow| image:: https://img.shields.io/badge/Docs-No%20Builds-yellow.svg?style=flat
+.. |green| image:: https://img.shields.io/badge/docs-latest-brightgreen.svg?style=flat
+.. |red| image:: https://img.shields.io/badge/docs-release--1.6-red.svg?style=flat
+.. |yellow| image:: https://img.shields.io/badge/docs-no%20builds-yellow.svg?style=flat
 .. |nbsp| unicode:: 0xA0 
    :trim:
 

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -113,18 +113,18 @@ def project_badge(request, project_slug, redirect=False):
     try:
         version = Version.objects.get(project__slug=project_slug, slug=version_slug)
     except Version.DoesNotExist:
-        url = 'http://img.shields.io/badge/Docs-Unknown%20Version-yellow.svg?style={style}'.format(style=style)
+        url = 'http://img.shields.io/badge/docs-unknown%20version-yellow.svg?style={style}'.format(style=style)
         return _badge_return(redirect, url)
     version_builds = version.builds.filter(type='html', state='finished').order_by('-date')
     if not version_builds.exists():
-        url = 'http://img.shields.io/badge/Docs-No%20Builds-yellow.svg?style={style}'.format(style=style)
+        url = 'http://img.shields.io/badge/docs-no%20builds-yellow.svg?style={style}'.format(style=style)
         return _badge_return(redirect, url)
     last_build = version_builds[0]
     if last_build.success:
         color = 'brightgreen'
     else:
         color = 'red'
-    url = 'http://img.shields.io/badge/Docs-%s-%s.svg?style=%s' % (version.slug.replace('-', '--'), color, style)
+    url = 'http://img.shields.io/badge/docs-%s-%s.svg?style=%s' % (version.slug.replace('-', '--'), color, style)
     return _badge_return(redirect, url)
 
 


### PR DESCRIPTION
Standardise badge capitalisation, all of the badges from http://shields.io/
are lower-case throughout.
