### PR TITLE
Update MkDocs to 0.11.1

### DIFF
--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -12,7 +12,7 @@ pip==1.5.6
 virtualenv==1.11.6
 docutils==0.11
 Sphinx==1.2.2
-mkdocs==0.11
+mkdocs==0.11.1
 
 django==1.6.6
 django-tastypie==0.11.1

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -282,7 +282,7 @@ def setup_environment(version):
     ret_dict['doc_builder'] = run(
         (
             '{cmd} install --use-wheel --find-links={wheeldir} -U {ignore_option} '
-            'sphinx==1.2.2 virtualenv==1.10.1 setuptools==1.1 docutils==0.11 readthedocs-sphinx-ext==0.4.4 mkdocs==0.11 mock==1.0.1 pillow==2.6.1'
+            'sphinx==1.2.2 virtualenv==1.10.1 setuptools==1.1 docutils==0.11 readthedocs-sphinx-ext==0.4.4 mkdocs==0.11.1 mock==1.0.1 pillow==2.6.1'
         ).format(
             cmd=project.venv_bin(version=version.slug, bin='pip'),
             ignore_option=ignore_option,


### PR DESCRIPTION
This fixes an issue with code highlighting and the ReadTheDocs theme that @ericholscher noticed after 37d3bf8 landed.

Related MkDocs issue: https://github.com/tomchristie/mkdocs/issues/233
