### PR TITLE
Add option to add extra doc packages

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -278,15 +278,21 @@ def setup_environment(version):
     else:
         ignore_option = ''
 
+    try:
+        extra_doc_packages = " ".join(settings.EXTRA_DOC_VENV_PACKAGES)
+    except NameError:
+        extra_doc_packages = ""
+
     wheeldir = os.path.join(settings.SITE_ROOT, 'deploy', 'wheels')
     ret_dict['doc_builder'] = run(
         (
             '{cmd} install --use-wheel --find-links={wheeldir} -U {ignore_option} '
-            'sphinx==1.2.2 virtualenv==1.10.1 setuptools==1.1 docutils==0.11 readthedocs-sphinx-ext==0.4.4 mkdocs==0.11.1 mock==1.0.1 pillow==2.6.1'
+            'sphinx==1.2.2 virtualenv==1.10.1 setuptools==1.1 docutils==0.11 readthedocs-sphinx-ext==0.4.4 mkdocs==0.11.1 mock==1.0.1 pillow==2.6.1 {extras}'
         ).format(
             cmd=project.venv_bin(version=version.slug, bin='pip'),
             ignore_option=ignore_option,
             wheeldir=wheeldir,
+            extras=extra_doc_packages,
         )
     )
 


### PR DESCRIPTION
You can now specify in settings if you want to install any additional packages to the virtualenv that builds your docs
