### PR TITLE
Improvements for the build/version admin

### DIFF
--- a/readthedocs/builds/admin.py
+++ b/readthedocs/builds/admin.py
@@ -13,14 +13,22 @@ class BuildCommandResultInline(admin.TabularInline):
 
 class BuildAdmin(admin.ModelAdmin):
     fields = ('project', 'version', 'type', 'state', 'error', 'success', 'length', 'cold_storage')
-    list_display = ('project', 'success', 'type', 'state', 'date')
+    list_display = ('id', 'project', 'version_name', 'success', 'type', 'state', 'date')
+    list_filter = ('type', 'state', 'success')
+    list_select_related = ('project', 'version')
     raw_id_fields = ('project', 'version')
     inlines = (BuildCommandResultInline,)
+    search_fields = ('project__name', 'version__slug')
+
+    def version_name(self, obj):
+        return obj.version.verbose_name
 
 
 class VersionAdmin(GuardedModelAdmin):
     search_fields = ('slug', 'project__name')
-    list_filter = ('project', 'privacy_level')
+    list_display = ('slug', 'type', 'project', 'privacy_level', 'active', 'built')
+    list_filter = ('type', 'privacy_level', 'active', 'built')
+    raw_id_fields = ('project',)
 
 
 admin.site.register(Build, BuildAdmin)


### PR DESCRIPTION
While looking at #4001, I noted the pain of using the Django admin to look at builds and versions. These improvements are small improvements to make the admin usable.

- Project is a raw ID field on Version. Without this, we need to load tens of thousands of projects
- Select related is used for Build and Versions since foreign key objects are displayed
- Filtering on projects in the Version admin resulted in loading tens of thousands of projects
- Use a reasonable list display on Versions
- Show the version built in the Build admin


## Build admin screen
<img width="1362" alt="screen shot 2018-07-09 at 11 42 25 am" src="https://user-images.githubusercontent.com/185043/42469654-34ab523e-836d-11e8-8568-5c8f4c51e796.png">
