### PR TITLE
Add a docker file for building frontend assets

### DIFF
--- a/docker/frontend.dockerfile
+++ b/docker/frontend.dockerfile
@@ -1,0 +1,38 @@
+FROM ubuntu:bionic
+
+ENV LANG C.UTF-8
+
+# install latest python and nodejs
+RUN apt-get update && \
+    apt-get install -y \
+      nodejs \
+      npm \
+      gettext \
+      git \
+      sudo \
+      build-essential \
+      python3 \
+      python3-dev \
+      python3-pip \
+      libxml2-dev \
+      libxslt1-dev \
+      zlib1g-dev
+
+RUN bash -c "pip3 install pip setuptools --upgrade --force-reinstall"
+RUN bash -c "pip3 install virtualenv"
+RUN bash -c "npm install -g bower"
+
+# RUN adduser --system --shell /bin/bash --home "/repo" rtd
+
+# A volume used to share `pex`/`whl` files and fixtures with docker host
+VOLUME /repo
+
+# do the time-consuming base install commands
+CMD /bin/bash -c "/usr/local/bin/virtualenv -p python3 rtd \
+    && source rtd/bin/activate \
+    && cd /repo \
+    && pip install -r requirements.txt \
+    && npm install \
+    && bower --allow-root install \
+    && npm run vendor \
+    && npm run build"

--- a/docs/development/standards.rst
+++ b/docs/development/standards.rst
@@ -53,8 +53,16 @@ may change, so that assets are compiled before deployment, however as our front
 end assets are in a state of flux, it's easier to keep absolute sources checked
 in.
 
+
+Getting Started
+---------------
+
+We describe two different ways of building front end assets: Either in a
+containerized environment (Docker) or step-by-step in your local development
+environment.
+
 Containerized build (Docker)
-----------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Front end assets can be built in a Docker container. This reduces the steps
 required and can be considered more secure, since you won't expose your local
@@ -72,8 +80,8 @@ from the root of your repository:
     docker run -v $PWD/:/repo "rtd-frontend"
 
 
-Local build: Getting Started
-----------------------------
+Local builds
+~~~~~~~~~~~~
 
 You will need a working version of Node and NPM to get started. We won't cover
 that here, as it varies from platform to platform.

--- a/docs/development/standards.rst
+++ b/docs/development/standards.rst
@@ -53,8 +53,27 @@ may change, so that assets are compiled before deployment, however as our front
 end assets are in a state of flux, it's easier to keep absolute sources checked
 in.
 
-Getting Started
----------------
+Containerized build (Docker)
+----------------------------
+
+Front end assets can be built in a Docker container. This reduces the steps
+required and can be considered more secure, since you won't expose your local
+development environment to packages from NPM.
+
+You will need to install Docker on your system, then run the following commands
+from the root of your repository:
+
+.. code-block:: console
+
+    # Builds the Docker image
+    docker image build . -t "rtd-frontend" -f docker/frontend.dockerfile
+
+    # Runs the image from the repository root
+    docker run -v $PWD/:/repo "rtd-frontend"
+
+
+Local build: Getting Started
+----------------------------
 
 You will need a working version of Node and NPM to get started. We won't cover
 that here, as it varies from platform to platform.


### PR DESCRIPTION
I built the assets in #4842 using this docker file.

Following several incidents of malware on NPM, I think it's better to describe this practice before the other practices for building assets? It's simpler, anyways.

I would also note that tracking built assets in the repo is insecure since minified or vendorized assets are hard/impossible to verify during review processes. So actually, you should reject the assets that I put in #4842 :)