### PR TITLE
Use django-textclassifier to validate Project.name and description

### DIFF
--- a/readthedocs/projects/admin.py
+++ b/readthedocs/projects/admin.py
@@ -127,7 +127,13 @@ class ProjectAdmin(GuardedModelAdmin):
                VersionInline, DomainInline]
     readonly_fields = ('feature_flags',)
     raw_id_fields = ('users', 'main_language_project')
-    actions = ['send_owner_email', 'ban_owner', classify_as_valid, classify_as_spam, classify_as_spam_and_delete]
+    actions = [
+        'send_owner_email',
+        'ban_owner',
+        classify_as_valid,
+        classify_as_spam,
+        classify_as_spam_and_delete,
+    ]
 
     def feature_flags(self, obj):
         return ', '.join([str(f.get_feature_display()) for f in obj.features])

--- a/readthedocs/projects/admin.py
+++ b/readthedocs/projects/admin.py
@@ -12,6 +12,7 @@ from django.contrib import admin, messages
 from django.contrib.admin.actions import delete_selected
 from django.utils.translation import ugettext_lazy as _
 from guardian.admin import GuardedModelAdmin
+from textclassifier.admin import classify_as_valid, classify_as_spam, classify_as_spam_and_delete
 
 from readthedocs.builds.models import Version
 from readthedocs.core.models import UserProfile
@@ -126,7 +127,7 @@ class ProjectAdmin(GuardedModelAdmin):
                VersionInline, DomainInline]
     readonly_fields = ('feature_flags',)
     raw_id_fields = ('users', 'main_language_project')
-    actions = ['send_owner_email', 'ban_owner']
+    actions = ['send_owner_email', 'ban_owner', classify_as_valid, classify_as_spam, classify_as_spam_and_delete]
 
     def feature_flags(self, obj):
         return ', '.join([str(f.get_feature_display()) for f in obj.features])

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -19,7 +19,6 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 from future.backports.urllib.parse import urlparse
 from guardian.shortcuts import assign
-from textclassifier.validators import ClassifierValidator
 
 from readthedocs.builds.constants import TAG
 from readthedocs.core.utils import slugify, trigger_build
@@ -27,8 +26,6 @@ from readthedocs.core.utils.extend import SettingsOverrideObject
 from readthedocs.integrations.models import Integration
 from readthedocs.oauth.models import RemoteRepository
 from readthedocs.projects import constants
-from readthedocs.projects.constants import PUBLIC
-from readthedocs.projects.exceptions import ProjectSpamError
 from readthedocs.projects.models import (
     Domain,
     EmailHook,
@@ -175,12 +172,6 @@ class ProjectExtraForm(ProjectForm):
             'tags',
             'project_url',
         )
-
-    description = forms.CharField(
-        validators=[ClassifierValidator(raises=ProjectSpamError)],
-        required=False,
-        widget=forms.Textarea,
-    )
 
 
 class ProjectAdvancedForm(ProjectTriggerBuildMixin, ProjectForm):

--- a/readthedocs/rtd_tests/tests/test_project_forms.py
+++ b/readthedocs/rtd_tests/tests/test_project_forms.py
@@ -12,7 +12,7 @@ from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test.utils import override_settings
 from django_dynamic_fixture import get
-from textclassifier.validators import ClassifierValidator
+from textclassifier.validators import TextClassificationValidator
 
 from readthedocs.builds.constants import LATEST
 from readthedocs.builds.models import Version
@@ -36,7 +36,7 @@ from readthedocs.projects.models import Project
 
 class TestProjectForms(TestCase):
 
-    @mock.patch.object(ClassifierValidator, '__call__')
+    @mock.patch.object(TextClassificationValidator, '__call__')
     def test_form_spam(self, mocked_validator):
         """Form description field fails spam validation."""
         mocked_validator.side_effect = ProjectSpamError

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -89,7 +89,9 @@ django-formtools==2.1
 # https://github.com/rtfd/readthedocs.org/issues/3999
 docker==3.1.3
 
-django-textclassifier==1.0
+# We want v2.0 but it's not released yet
+# django-textclassifier==2.0
+git+https://github.com/humitos/django-textclassifier.git@admin-action-on-validator#egg=django-textclassifier
 django-annoying==0.10.4
 django-messages-extends==0.6.0
 djangorestframework-jsonp==1.0.2


### PR DESCRIPTION
This classifier gives use scores for VALID or SPAM of the name and description of the project that it's about to be imported.

If the accuracy for SPAM is greater than 0.95 we block the import.

This commit also adds useful admin action to mark project as VALID or SPAM (optionally delete them) to increase the accuracy when checking new imports.

> NOTE: this PR needs all my PRs from https://github.com/agjohnson/django-textclassifier/pulls?q=is%3Apr+is%3Aopen+sort%3Aupdated-desc to be merged and setting the requirement properly in `pip.txt` file.

> **IMPORTANT**: once this gets deployed, we need to take a manual action. It's needed to go to the Admin and select a bunch of VALID project and mark them as VALID and the same for SPAM. Otherwise, the prediction could fail from the first time and detect everything as SPAM.

It's safe to deploy this to production because we are using 0.95 as accuracy threshold, which is quite high. In fact, after testing this for a couple of weeks, ~~I think we should decrease the threshold a little: maybe 0.90 or 0.85.~~

Related #3682 