### PR TITLE
Run Docker container with a specific user

### DIFF
--- a/docs/development/buildenvironments.rst
+++ b/docs/development/buildenvironments.rst
@@ -35,9 +35,17 @@ option.
 After this image is downloaded, you can update your settings to use the new
 image -- see `Configuration`_.
 
+.. warning::
+
+   There is a known bug when using our Docker images on Linux to build project's documentation that uses Conda.
+   In case you need to work locally with projects that need Conda to build,
+   you will need to re-build our Docker image to adjust some filesystem user persmissions.
+   See our `current work in progress guide`_ for more information.
+
 .. _`Docker`: http://docker.com
 .. _`Docker Hub repository`: https://hub.docker.com/r/readthedocs/build/
 .. _`container image repo`: https://github.com/rtfd/readthedocs-docker-images
+.. _`current work in progress guide`: https://github.com/rtfd/readthedocs.org/pull/4608
 
 Configuration
 -------------

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -1041,6 +1041,7 @@ class DockerBuildEnvironment(BuildEnvironment):
                 host_config=self.get_container_host_config(),
                 detach=True,
                 environment=self.environment,
+                user=settings.DOCKER_USER,
             )
             client.start(container=self.container_id)
         except ConnectionError:

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -340,6 +340,15 @@ class CommunityBaseSettings(Settings):
     # This settings has been deprecated in favor of DOCKER_IMAGE_SETTINGS
     DOCKER_BUILD_IMAGES = None
     DOCKER_LIMITS = {'memory': '200m', 'time': 600}
+
+    # User used to create the container.
+    # In production we use the same user than the one defined by the
+    # ``USER docs`` instruction inside the Dockerfile.
+    # In development, we can use the "UID:GID" of the current user running the
+    # instance to avoid file permissions issues.
+    # https://docs.docker.com/engine/reference/run/#user
+    DOCKER_USER = 'docs:docs'
+
     DOCKER_DEFAULT_IMAGE = 'readthedocs/build'
     DOCKER_VERSION = 'auto'
     DOCKER_DEFAULT_VERSION = 'latest'

--- a/readthedocs/settings/dev.py
+++ b/readthedocs/settings/dev.py
@@ -54,6 +54,10 @@ class CommunityDevSettings(CommunityBaseSettings):
     # Disable password validators on development
     AUTH_PASSWORD_VALIDATORS = []
 
+    # UID and GID used to create the Docker container. It defaults to the
+    # current UID and GID that it's running the Django app.
+    DOCKER_USER = f'{os.geteuid()}:{os.getegid()}'
+
     @property
     def LOGGING(self):  # noqa - avoid pep8 N802
         logging = super().LOGGING


### PR DESCRIPTION
Pass --user (`DOCKER_USER`) attribute when creating the container.

This has no effect in production since we are using the same user and
group than the one defined inside the Dockerfile image (docs:docs).
Although, this allow us to avoid permissions conflicts when running
the build with Docker locally (development) since we can pass our
current user.

That way, every file created/modified inside the container will be
done using the current UID and GID defined by the developer.

This can be done as,

```python
# local_settings.py
DOCKER_USER = f'{os.geteuid()}:{os.getegid()}'
```

With this change, there is no need to re-build the Docker image used
in production with our own custom `USER` instruction.

https://docs.docker.com/engine/reference/run/#user

@raulcd helped me to find out this and make it work properly considering production and development environment

Connected to #4608 
Related #2692 #3245 #3003 #3152 #1133