### PR TITLE
Extend webhook notifications with build status

### DIFF
--- a/docs/guides/build-notifications.rst
+++ b/docs/guides/build-notifications.rst
@@ -18,7 +18,7 @@ You should now get notified by email when your builds fail!
 Using webhook
 -------------
 
-Read the Docs can also send webhooks when builds fail.
+Read the Docs can also send webhooks when builds are triggered, successful or failed.
 
 Take these steps to enable build notifications using a webhook:
 
@@ -26,7 +26,7 @@ Take these steps to enable build notifications using a webhook:
 * Fill in the **URL** field under the **New Webhook Notifications** heading
 * Submit the form
 
-The project name, slug and its details for the build that failed will be sent as POST request to your webhook URL:
+The project name, slug and its details for the build will be sent as POST request to your webhook URL:
 
 .. code-block:: json
 
@@ -35,9 +35,11 @@ The project name, slug and its details for the build that failed will be sent as
             "slug": "rtd",
             "build": {
                 "id": 6321373,
+                "commit": "e8dd17a3f1627dd206d721e4be08ae6766fda40",
+                "state": "finished",
                 "success": false,
                 "date": "2017-02-15 20:35:54"
             }
        }
 
-You should now get notified on your webhook when your builds fail!
+You should now get notified on your webhook when your builds start and finish (failure/success)!

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -604,6 +604,8 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
                 )
         elif self.build_env.successful:
             # TODO: Send RTD Webhook notification for build success.
+            self.send_notifications(self.version.pk, self.build['id'])
+
             if self.commit:
                 send_external_build_status(
                     version_type=self.version.type,

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1627,11 +1627,11 @@ def send_notifications(version_pk, build_pk, email=False):
         webhook_notification(version, build, hook.url)
 
     if email:
-        for email in version.project.emailhook_notifications.all().values_list(
+        for email_address in version.project.emailhook_notifications.all().values_list(
             'email',
             flat=True,
         ):
-            email_notification(version, build, email)
+            email_notification(version, build, email_address)
 
 
 def email_notification(version, build, email):

--- a/readthedocs/rtd_tests/tests/test_build_notifications.py
+++ b/readthedocs/rtd_tests/tests/test_build_notifications.py
@@ -40,7 +40,7 @@ class BuildNotificationsTests(TestCase):
 
     def test_send_email_notification(self):
         fixture.get(EmailHook, project=self.project)
-        send_notifications(self.version.pk, self.build.pk)
+        send_notifications(self.version.pk, self.build.pk, email=True)
         self.assertEqual(len(mail.outbox), 1)
 
     def test_send_email_and_webhook__notification(self):
@@ -48,7 +48,7 @@ class BuildNotificationsTests(TestCase):
         fixture.get(WebHook, project=self.project)
         with patch('readthedocs.projects.tasks.requests.post') as mock:
             mock.return_value = None
-            send_notifications(self.version.pk, self.build.pk)
+            send_notifications(self.version.pk, self.build.pk, email=True)
             mock.assert_called_once()
         self.assertEqual(len(mail.outbox), 1)
 


### PR DESCRIPTION
~~I did not add support for build status API of GitHub, Gitlab etc. as those need a different approach than what we currently have. We need to send the `sha` of the commit with the URL as the their docs Suggests.~~
~~ie: `POST /repos/:owner/:repo/statuses/:sha`
[Github Build Status API Docs](https://developer.github.com/v3/repos/statuses/#create-a-status) Gitlab also has a similar implementation. 
We need  some `Design Decisions` for adding support for this. We can add some kind of module to handle the status APIs.~~


We are sending PR Build Status reports using GitHub Status API https://github.com/readthedocs/readthedocs.org/pull/5865 and planning to extend to other providers.

closes #2251 