### PR TITLE
Use `--satisfied-skip-solve` on `conda install`

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -463,6 +463,7 @@ class Conda(PythonEnvironment):
             'install',
             '--yes',
             '--quiet',
+            '--satisfied-skip-solve',
             '--name',
             self.version.slug,
         ]

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -1375,6 +1375,7 @@ class TestPythonEnvironment(TestCase):
             'install',
             '--yes',
             '--quiet',
+            '--satisfied-skip-solve',
             '--name',
             self.version_sphinx.slug,
         ]
@@ -1416,6 +1417,7 @@ class TestPythonEnvironment(TestCase):
             'install',
             '--yes',
             '--quiet',
+            '--satisfied-skip-solve',
             '--name',
             self.version_mkdocs.slug,
         ]


### PR DESCRIPTION
Skip (do not upgrade) already satisfied dependencies that were
installed by the user when creating the environment, when installing
our own dependencies.

> I'm building the images locally to do some QA before merging it.

Closes #3829
Related https://github.com/rtfd/readthedocs-docker-images/pull/102