### PR TITLE
Reduce the number of queries we do on search indexing

### DIFF
--- a/readthedocs/search/documents.py
+++ b/readthedocs/search/documents.py
@@ -160,7 +160,7 @@ class PageDocument(RTDDocTypeMixin, DocType):
         # Do not index files that belong to non sphinx project
         # Also do not index certain files
         queryset = queryset.filter(
-            project__documentation_type__contains='sphinx'
+            project__documentation_type__in=['sphinx', 'sphinx_htmldir']
         )
         queryset = queryset.select_related('project', 'version')
 

--- a/readthedocs/search/documents.py
+++ b/readthedocs/search/documents.py
@@ -72,6 +72,7 @@ class SphinxDomainDocument(RTDDocTypeMixin, DocType):
 
         for exclude in excluded_types:
             queryset = queryset.exclude(**exclude)
+        queryset = queryset.select_related('project', 'version')
         return queryset
 
 
@@ -161,6 +162,7 @@ class PageDocument(RTDDocTypeMixin, DocType):
         queryset = queryset.filter(
             project__documentation_type__contains='sphinx'
         )
+        queryset = queryset.select_related('project', 'version')
 
         # TODO: Make this smarter
         # This was causing issues excluding some valid user documentation pages

--- a/readthedocs/search/tasks.py
+++ b/readthedocs/search/tasks.py
@@ -39,8 +39,6 @@ def index_objects_to_es(
         queryset = queryset.filter(id__in=objects_id)
         log.info("Indexing model: %s, ids %s", model.__name__, objects_id)
 
-    queryset = queryset.select_related('project', 'version')
-
     if index_name:
         # Hack the index name temporarily for reindexing tasks
         old_index_name = document._doc_type.index

--- a/readthedocs/search/tasks.py
+++ b/readthedocs/search/tasks.py
@@ -34,8 +34,12 @@ def index_objects_to_es(
         start = chunk[0]
         end = chunk[1]
         queryset = queryset[start:end]
+        log.info("Indexing model: %s, Range [%s:%s]", model.__name__, start, end)
     elif objects_id:
         queryset = queryset.filter(id__in=objects_id)
+        log.info("Indexing model: %s, ids %s", model.__name__, objects_id)
+
+    queryset = queryset.select_related('project', 'version')
 
     if index_name:
         # Hack the index name temporarily for reindexing tasks
@@ -43,7 +47,6 @@ def index_objects_to_es(
         document._doc_type.index = index_name
         log.info('Replacing index name %s with %s', old_index_name, index_name)
 
-    log.info("Indexing model: %s, '%s' objects", model.__name__, queryset.count())
     doc_obj.update(queryset.iterator())
 
     if index_name:

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -539,6 +539,12 @@ class CommunityBaseSettings(Settings):
                 'filename': os.path.join(LOGS_ROOT, 'debug.log'),
                 'formatter': 'default',
             },
+            'db': {
+                'level': 'DEBUG',
+                'class': 'logging.handlers.RotatingFileHandler',
+                'filename': os.path.join(LOGS_ROOT, 'db.log'),
+                'formatter': 'default',
+            },
             'null': {
                 'class': 'logging.NullHandler',
             },
@@ -548,6 +554,11 @@ class CommunityBaseSettings(Settings):
                 'handlers': ['debug', 'console'],
                 # Always send from the root, handlers can filter levels
                 'level': 'DEBUG',
+            },
+            'django.db.backends': {
+                'level': 'DEBUG',
+                'handlers': ['db'],
+                'propagate': False,
             },
             'readthedocs': {
                 'handlers': ['debug', 'console'],


### PR DESCRIPTION
This does two things:

* Removes a `count` which wasn't useful
* Does a select_related on the `project` and `version` which we were querying for each object.

In my testing this vastly reduced query counts during indexing from 2+N*2 to 2