### PR TITLE
APIv3 "Import Project" endpoint

### DIFF
--- a/readthedocs/api/v3/permissions.py
+++ b/readthedocs/api/v3/permissions.py
@@ -16,6 +16,7 @@ class PublicDetailPrivateListing(IsAuthenticated):
         if is_authenticated:
             if view.basename == 'projects' and any([
                     view.action == 'list',
+                    view.action == 'create',  # used to create Form in BrowsableAPIRenderer
                     view.action is None,  # needed for BrowsableAPIRenderer
             ]):
                 # hitting ``/projects/``, allowing

--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -394,14 +394,16 @@ class ProjectCreateSerializer(FlexFieldsModelSerializer):
     """Serializer used to Import a Project."""
 
     repository = RepositorySerializer(source='*')
+    homepage = serializers.URLField(source='project_url', required=False)
 
     class Meta:
         model = Project
         fields = (
             'name',
             'language',
+            'programming_language',
             'repository',
-            'project_url',  # project_homepage
+            'homepage',
         )
 
 

--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -9,7 +9,7 @@ from rest_flex_fields.serializers import FlexFieldsSerializerMixin
 from rest_framework import serializers
 
 from readthedocs.builds.models import Build, Version
-from readthedocs.projects.constants import LANGUAGES, PROGRAMMING_LANGUAGES
+from readthedocs.projects.constants import LANGUAGES, PROGRAMMING_LANGUAGES, REPO_CHOICES
 from readthedocs.projects.models import Project
 from readthedocs.redirects.models import Redirect, TYPE_CHOICES as REDIRECT_TYPE_CHOICES
 
@@ -313,7 +313,10 @@ class ProjectURLsSerializer(serializers.Serializer):
 class RepositorySerializer(serializers.Serializer):
 
     url = serializers.CharField(source='repo')
-    type = serializers.CharField(source='repo_type')
+    type = serializers.ChoiceField(
+        source='repo_type',
+        choices=REPO_CHOICES,
+    )
 
 
 class ProjectLinksSerializer(BaseLinksSerializer):

--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -389,6 +389,22 @@ class ProjectLinksSerializer(BaseLinksSerializer):
         return self._absolute_url(path)
 
 
+class ProjectCreateSerializer(FlexFieldsModelSerializer):
+
+    """Serializer used to Import a Project."""
+
+    repository = RepositorySerializer(source='*')
+
+    class Meta:
+        model = Project
+        fields = (
+            'name',
+            'language',
+            'repository',
+            'project_url',  # project_homepage
+        )
+
+
 class ProjectSerializer(FlexFieldsModelSerializer):
 
     language = LanguageSerializer()

--- a/readthedocs/api/v3/tests/responses/projects-list_POST.json
+++ b/readthedocs/api/v3/tests/responses/projects-list_POST.json
@@ -1,0 +1,47 @@
+{
+    "_links": {
+        "_self": "https://readthedocs.org/api/v3/projects/test-project/",
+        "builds": "https://readthedocs.org/api/v3/projects/test-project/builds/",
+        "subprojects": "https://readthedocs.org/api/v3/projects/test-project/subprojects/",
+        "superproject": "https://readthedocs.org/api/v3/projects/test-project/superproject/",
+        "translations": "https://readthedocs.org/api/v3/projects/test-project/translations/",
+        "versions": "https://readthedocs.org/api/v3/projects/test-project/versions/"
+    },
+    "created": "2019-04-29T14:00:00Z",
+    "default_branch": "master",
+    "default_version": "latest",
+    "description": null,
+    "id": 4,
+    "language": {
+        "code": "en",
+        "name": "English"
+    },
+    "modified": "2019-04-29T14:00:00Z",
+    "name": "Test Project",
+    "privacy_level": {
+        "code": "public",
+        "name": "Public"
+    },
+    "programming_language": {
+        "code": "words",
+        "name": "Only Words"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/rtfd/template"
+    },
+    "slug": "test-project",
+    "subproject_of": null,
+    "tags": [],
+    "translation_of": null,
+    "urls": {
+        "documentation": "http://readthedocs.org/docs/test-project/en/latest/",
+        "project_homepage": null
+    },
+    "users": [
+        {
+            "created": "2019-04-29T10:00:00Z",
+            "username": "testuser"
+        }
+    ]
+}

--- a/readthedocs/api/v3/tests/responses/projects-list_POST.json
+++ b/readthedocs/api/v3/tests/responses/projects-list_POST.json
@@ -7,7 +7,7 @@
         "translations": "https://readthedocs.org/api/v3/projects/test-project/translations/",
         "versions": "https://readthedocs.org/api/v3/projects/test-project/versions/"
     },
-    "created": "2019-04-29T14:00:00Z",
+    "created": "2019-04-29T10:00:00Z",
     "default_branch": "master",
     "default_version": "latest",
     "description": null,
@@ -16,7 +16,7 @@
         "code": "en",
         "name": "English"
     },
-    "modified": "2019-04-29T14:00:00Z",
+    "modified": "2019-04-29T12:00:00Z",
     "name": "Test Project",
     "privacy_level": {
         "code": "public",

--- a/readthedocs/api/v3/tests/responses/projects-list_POST.json
+++ b/readthedocs/api/v3/tests/responses/projects-list_POST.json
@@ -2,6 +2,7 @@
     "_links": {
         "_self": "https://readthedocs.org/api/v3/projects/test-project/",
         "builds": "https://readthedocs.org/api/v3/projects/test-project/builds/",
+        "redirects": "https://readthedocs.org/api/v3/projects/test-project/redirects/",
         "subprojects": "https://readthedocs.org/api/v3/projects/test-project/subprojects/",
         "superproject": "https://readthedocs.org/api/v3/projects/test-project/superproject/",
         "translations": "https://readthedocs.org/api/v3/projects/test-project/translations/",

--- a/readthedocs/api/v3/tests/responses/projects-list_POST.json
+++ b/readthedocs/api/v3/tests/responses/projects-list_POST.json
@@ -23,8 +23,8 @@
         "name": "Public"
     },
     "programming_language": {
-        "code": "words",
-        "name": "Only Words"
+        "code": "py",
+        "name": "Python"
     },
     "repository": {
         "type": "git",
@@ -36,7 +36,7 @@
     "translation_of": null,
     "urls": {
         "documentation": "http://readthedocs.org/docs/test-project/en/latest/",
-        "project_homepage": null
+        "project_homepage": "http://template.readthedocs.io/"
     },
     "users": [
         {

--- a/readthedocs/api/v3/tests/test_projects.py
+++ b/readthedocs/api/v3/tests/test_projects.py
@@ -1,5 +1,4 @@
 import datetime
-import mock
 import json
 from pathlib import Path
 

--- a/readthedocs/api/v3/tests/test_projects.py
+++ b/readthedocs/api/v3/tests/test_projects.py
@@ -533,9 +533,7 @@ class APIEndpointTests(TestCase):
         self.assertEqual(self.project.redirects.count(), 0)
 
 
-    @mock.patch('readthedocs.api.v3.views.trigger_initial_build')
-    @mock.patch('readthedocs.api.v3.views.project_import')
-    def test_import_project(self, project_import, trigger_initial_build):
+    def test_import_project(self):
         data = {
             'name': 'Test Project',
             'repository': {
@@ -557,30 +555,12 @@ class APIEndpointTests(TestCase):
         self.assertEqual(project.repo, 'https://github.com/rtfd/template')
         self.assertEqual(project.language, 'en')
         self.assertIn(self.me, project.users.all())
-
-        # Signal sent
-        project_import.send.assert_has_calls(
-            [
-                mock.call(
-                    sender=project,
-                    request=mock.ANY,
-                ),
-            ],
-        )
-
-        # Build triggered
-        trigger_initial_build.assert_has_calls(
-            [
-                mock.call(
-                    project,
-                    self.me,
-                ),
-            ],
-        )
+        self.assertEqual(project.builds.count(), 1)
 
         response_json = response.json()
-        response_json['created'] = '2019-04-29T14:00:00Z'
-        response_json['modified'] = '2019-04-29T14:00:00Z'
+        response_json['created'] = '2019-04-29T10:00:00Z'
+        response_json['modified'] = '2019-04-29T12:00:00Z'
+
         self.assertDictEqual(
             response_json,
             self._get_response_dict('projects-list_POST'),

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -1,6 +1,7 @@
 import django_filters.rest_framework as filters
 from django.utils.safestring import mark_safe
 from rest_flex_fields.views import FlexFieldsMixin
+from rest_framework import status
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.decorators import action
 from rest_framework.metadata import SimpleMetadata
@@ -174,7 +175,7 @@ class ProjectsViewSet(APIv3Settings, NestedViewSetMixin, ProjectQuerySetMixin,
             data = self.get_serializer(superproject).data
             return Response(data)
         except Exception:
-            return Response(status=404)
+            return Response(status=status.HTTP_404_NOT_FOUND)
 
 
 class SubprojectRelationshipViewSet(APIv3Settings, NestedViewSetMixin,
@@ -263,7 +264,7 @@ class VersionsViewSet(APIv3Settings, NestedViewSetMixin, ProjectQuerySetMixin,
         # ``httpOnly`` on our cookies and the ``PUT/PATCH`` method are triggered
         # via Javascript
         super().update(request, *args, **kwargs)
-        return Response(status=204)
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class BuildsViewSet(APIv3Settings, NestedViewSetMixin, ProjectQuerySetMixin,
@@ -303,11 +304,11 @@ class BuildsCreateViewSet(BuildsViewSet, CreateModelMixin):
 
         if build:
             data.update({'triggered': True})
-            status = 202
+            code = status.HTTP_202_ACCEPTED
         else:
             data.update({'triggered': False})
-            status = 400
-        return Response(data=data, status=status)
+            code = status.HTTP_400_BAD_REQUEST
+        return Response(data=data, status=code)
 
 
 class RedirectsViewSet(APIv3Settings, NestedViewSetMixin, ProjectQuerySetMixin,

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -145,7 +145,7 @@ class ProjectsViewSet(APIv3Settings, NestedViewSetMixin, ProjectQuerySetMixin,
             # ProjectViewSet that returns the superproject of a project.
             return ProjectSerializer
 
-        if self.action in ('create',):
+        if self.action == 'create':
             return ProjectCreateSerializer
 
     def get_queryset(self):

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -22,6 +22,7 @@ from readthedocs.builds.models import Build, Version
 from readthedocs.core.utils import trigger_build
 from readthedocs.projects.models import Project
 from readthedocs.projects.views.mixins import ProjectImportMixin
+from readthedocs.redirects.models import Redirect
 
 
 from .filters import BuildFilter, ProjectFilter, VersionFilter
@@ -206,8 +207,6 @@ class ProjectsViewSet(APIv3Settings, NestedViewSetMixin, ProjectQuerySetMixin,
         Trigger our internal mechanism to import a project after it's saved in
         the database.
         """
-        serializer = self.get_serializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
         project = serializer.save()
         self.finish_import_project(self.request, project)
 

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -21,7 +21,8 @@ from rest_framework_extensions.mixins import NestedViewSetMixin
 from readthedocs.builds.models import Build, Version
 from readthedocs.core.utils import trigger_build
 from readthedocs.projects.models import Project
-from readthedocs.redirects.models import Redirect
+from readthedocs.projects.views.mixins import ProjectImportMixin
+
 
 from .filters import BuildFilter, ProjectFilter, VersionFilter
 from .mixins import ProjectQuerySetMixin
@@ -68,7 +69,8 @@ class APIv3Settings:
 
 
 class ProjectsViewSet(APIv3Settings, NestedViewSetMixin, ProjectQuerySetMixin,
-                      FlexFieldsMixin, CreateModelMixin, ReadOnlyModelViewSet):
+                      FlexFieldsMixin, ProjectImportMixin, CreateModelMixin,
+                      ReadOnlyModelViewSet):
 
     # Markdown docstring is automatically rendered by BrowsableAPIRenderer.
 
@@ -180,32 +182,17 @@ class ProjectsViewSet(APIv3Settings, NestedViewSetMixin, ProjectQuerySetMixin,
                 return mark_safe(description.format(project_slug=project.slug))
         return description
 
-    def create(self, request, *args, **kwargs):
+    def perform_create(self, serializer):
         """
-        Override method to importing a Project.
+        Import Project.
 
-        * Save the Project object
-        * Assign the user from the request as owner
-        * Sent project_import signal
-        * Trigger an initial Build
+        Trigger our internal mechanism to import a project after it's saved in
+        the database.
         """
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         project = serializer.save()
-        headers = self.get_success_headers(serializer.data)
-
-        # TODO: these lines need to be adapted for Corporate
-        project.users.add(request.user)
-        project_import.send(sender=project, request=request)
-        trigger_initial_build(project, request.user)
-
-        # Full render Project
-        serializer = ProjectSerializer(instance=project)
-        return Response(
-            serializer.data,
-            status=status.HTTP_201_CREATED,
-            headers=headers,
-        )
+        self.import_project(project, [], self.request)
 
     @action(detail=True, methods=['get'])
     def superproject(self, request, project_slug):

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -138,7 +138,7 @@ class ProjectsViewSet(APIv3Settings, NestedViewSetMixin, ProjectQuerySetMixin,
         For GET it returns a serializer with many fields and on PUT/PATCH/POST,
         it return a serializer to validate just a few fields.
         """
-        if self.action in ('list', 'retrieve'):
+        if self.action in ('list', 'retrieve', 'superproject'):
             return ProjectSerializer
         elif self.action in ('create',):
             return ProjectCreateSerializer

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -142,10 +142,9 @@ class ProjectsViewSet(APIv3Settings, NestedViewSetMixin, ProjectQuerySetMixin,
         """
         if self.action in ('list', 'retrieve', 'superproject'):
             return ProjectSerializer
-        elif self.action in ('create',):
+
+        if self.action in ('create',):
             return ProjectCreateSerializer
-        # elif self.action in ('update', 'partial_update'):
-        #     return ProjectUpdateSerializer
 
     def get_queryset(self):
         # Allow hitting ``/api/v3/projects/`` to list their own projects

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -182,6 +182,22 @@ class ProjectsViewSet(APIv3Settings, NestedViewSetMixin, ProjectQuerySetMixin,
                 return mark_safe(description.format(project_slug=project.slug))
         return description
 
+    def create(self, request, *args, **kwargs):
+        """
+        Import Project.
+
+        Override to use a different serializer in the response.
+        """
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        headers = self.get_success_headers(serializer.data)
+
+        # Use serializer that fully render a Project
+        serializer = ProjectSerializer(instance=serializer.instance)
+
+        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+
     def perform_create(self, serializer):
         """
         Import Project.

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -141,6 +141,8 @@ class ProjectsViewSet(APIv3Settings, NestedViewSetMixin, ProjectQuerySetMixin,
         it return a serializer to validate just a few fields.
         """
         if self.action in ('list', 'retrieve', 'superproject'):
+            # NOTE: ``superproject`` is the @action defined in the
+            # ProjectViewSet that returns the superproject of a project.
             return ProjectSerializer
 
         if self.action in ('create',):

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -209,7 +209,7 @@ class ProjectsViewSet(APIv3Settings, NestedViewSetMixin, ProjectQuerySetMixin,
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         project = serializer.save()
-        self.import_project(project, [], self.request)
+        self.finish_import_project(self.request, project)
 
     @action(detail=True, methods=['get'])
     def superproject(self, request, project_slug):

--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -5,7 +5,7 @@ import logging
 import os
 import re
 
-from celery import chord, group, chain
+from celery import chord, group
 from django.conf import settings
 from django.utils.functional import keep_lazy
 from django.utils.safestring import SafeText, mark_safe
@@ -163,27 +163,6 @@ def trigger_build(project, version=None, record=True, force=False):
         return (None, None)
 
     return (update_docs_task.apply_async(), build)
-
-
-def trigger_initial_build(project, user):
-    """
-    Trigger initial build after project is imported.
-
-    :param project: project's documentation to be built
-    :returns: Celery AsyncResult promise
-    """
-
-    update_docs, build = prepare_build(project)
-    if (update_docs, build) == (None, None):
-        return None
-
-    from readthedocs.oauth.tasks import attach_webhook
-    task_promise = chain(
-        attach_webhook.si(project.pk, user.pk),
-        update_docs,
-    )
-    async_result = task_promise.apply_async()
-    return async_result
 
 
 def send_email(

--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -5,7 +5,7 @@ import logging
 import os
 import re
 
-from celery import chord, group
+from celery import chord, group, chain
 from django.conf import settings
 from django.utils.functional import keep_lazy
 from django.utils.safestring import SafeText, mark_safe
@@ -163,6 +163,27 @@ def trigger_build(project, version=None, record=True, force=False):
         return (None, None)
 
     return (update_docs_task.apply_async(), build)
+
+
+def trigger_initial_build(project, user):
+    """
+    Trigger initial build after project is imported.
+
+    :param project: project's documentation to be built
+    :returns: Celery AsyncResult promise
+    """
+
+    update_docs, build = prepare_build(project)
+    if (update_docs, build) == (None, None):
+        return None
+
+    from readthedocs.oauth.tasks import attach_webhook
+    task_promise = chain(
+        attach_webhook.si(project.pk, user.pk),
+        update_docs,
+    )
+    async_result = task_promise.apply_async()
+    return async_result
 
 
 def send_email(

--- a/readthedocs/projects/views/mixins.py
+++ b/readthedocs/projects/views/mixins.py
@@ -53,7 +53,7 @@ class ProjectImportMixin:
 
     """Helpers to import a Project."""
 
-    def import_project(self, project, tags, request):
+    def finish_import_project(self, request, project, tags=None):
         """
         Import a Project into Read the Docs.
 
@@ -62,6 +62,9 @@ class ProjectImportMixin:
         - Send Django Signal
         - Trigger initial build
         """
+        if not tags:
+            tags = []
+
         project.users.add(request.user)
         for tag in tags:
             project.tags.add(tag)

--- a/readthedocs/projects/views/mixins.py
+++ b/readthedocs/projects/views/mixins.py
@@ -55,12 +55,18 @@ class ProjectImportMixin:
 
     def finish_import_project(self, request, project, tags=None):
         """
-        Import a Project into Read the Docs.
+        Perform last steps to import a project into Read the Docs.
 
         - Add the user from request as maintainer
         - Set all the tags to the project
         - Send Django Signal
         - Trigger initial build
+
+        It requires the Project was already saved into the DB.
+
+        :param request: Django Request object
+        :param project: Project instance just imported (already saved)
+        :param tags: tags to add to the project
         """
         if not tags:
             tags = []

--- a/readthedocs/projects/views/mixins.py
+++ b/readthedocs/projects/views/mixins.py
@@ -2,9 +2,12 @@
 
 """Mixin classes for project views."""
 
+from celery import chain
 from django.shortcuts import get_object_or_404
 
+from readthedocs.core.utils import prepare_build
 from readthedocs.projects.models import Project
+from readthedocs.projects.signals import project_import
 
 
 class ProjectRelationMixin:
@@ -44,3 +47,46 @@ class ProjectRelationMixin:
         context = super().get_context_data(**kwargs)
         context[self.project_context_object_name] = self.get_project()
         return context
+
+
+class ProjectImportMixin:
+
+    """Helpers to import a Project."""
+
+    def import_project(self, project, tags, request):
+        """
+        Import a Project into Read the Docs.
+
+        - Add the user from request as maintainer
+        - Set all the tags to the project
+        - Send Django Signal
+        - Trigger initial build
+        """
+        project.users.add(request.user)
+        for tag in tags:
+            project.tags.add(tag)
+
+        # TODO: this signal could be removed, or used for sync task
+        project_import.send(sender=project, request=request)
+
+        self.trigger_initial_build(project, request.user)
+
+    def trigger_initial_build(self, project, user):
+        """
+        Trigger initial build after project is imported.
+
+        :param project: project's documentation to be built
+        :returns: Celery AsyncResult promise
+        """
+
+        update_docs, build = prepare_build(project)
+        if (update_docs, build) == (None, None):
+            return None
+
+        from readthedocs.oauth.tasks import attach_webhook
+        task_promise = chain(
+            attach_webhook.si(project.pk, user.pk),
+            update_docs,
+        )
+        async_result = task_promise.apply_async()
+        return async_result

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -341,7 +341,7 @@ class ImportDemoView(PrivateViewMixin, ProjectImportMixin, View):
 
         Allow to override the behavior from outside.
         """
-        return trigger_build(project, user)
+        return trigger_build(project)
 
 
 class ImportView(PrivateViewMixin, TemplateView):

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -257,12 +257,15 @@ class ImportWizardView(
         # Save the basics form to create the project instance, then alter
         # attributes directly from other forms
         project = basics_form.save()
+
+        # Remove tags to avoid setting them in raw instead of using ``.add``
+        tags = form_data.pop('tags', [])
+
         for field, value in list(form_data.items()):
             if field in extra_fields:
                 setattr(project, field, value)
         project.save()
 
-        tags = form_data.pop('tags', [])
         self.import_project(project, tags, self.request)
 
         return HttpResponseRedirect(

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -266,7 +266,7 @@ class ImportWizardView(
                 setattr(project, field, value)
         project.save()
 
-        self.import_project(project, tags, self.request)
+        self.finish_import_project(self.request, project, tags)
 
         return HttpResponseRedirect(
             reverse('projects_detail', args=[project.slug]),

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -308,7 +308,7 @@ class ImportDemoView(PrivateViewMixin, ProjectImportMixin, View):
             if form.is_valid():
                 project = form.save()
                 project.save()
-                self.trigger_initial_build(project)
+                self.trigger_initial_build(project, request.user)
                 messages.success(
                     request,
                     _('Your demo project is currently being imported'),
@@ -335,13 +335,13 @@ class ImportDemoView(PrivateViewMixin, ProjectImportMixin, View):
         """Form kwargs passed in during instantiation."""
         return {'user': self.request.user}
 
-    def trigger_initial_build(self, project):
+    def trigger_initial_build(self, project, user):
         """
         Trigger initial build.
 
         Allow to override the behavior from outside.
         """
-        return trigger_build(project)
+        return trigger_build(project, user)
 
 
 class ImportView(PrivateViewMixin, TemplateView):

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -507,6 +507,7 @@ class CommunityBaseSettings(Settings):
             'user': '60/minute',
         },
         'PAGE_SIZE': 10,
+        'TEST_REQUEST_DEFAULT_FORMAT': 'json',
     }
 
     SILENCED_SYSTEM_CHECKS = ['fields.W342']


### PR DESCRIPTION
This PR allows `POST` at `/api/v3/projects` to Import a Project.

It follows the same idea that importing from the Dashboard:

1. Create the Project object
1. Assign the user who makes the request as maintainer
1. Send `project_import` Django signal
1. Trigger an initial build 

> Note that I had to refactor the function that trigger the initial build to be able to call the same logic from two different places.