### PR TITLE
API v3: Endpoint to trigger build on default version

### DIFF
--- a/readthedocs/api/v3/tests/responses/projects-builds-list_POST.json
+++ b/readthedocs/api/v3/tests/responses/projects-builds-list_POST.json
@@ -23,6 +23,7 @@
         "created": "2019-04-29T10:00:00Z",
         "default_branch": "master",
         "default_version": "latest",
+        "description": "Project description",
         "id": 1,
         "language": {
             "code": "en",
@@ -31,7 +32,6 @@
         "_links": {
             "_self": "https://readthedocs.org/api/v3/projects/project/",
             "builds": "https://readthedocs.org/api/v3/projects/project/builds/",
-            "redirects": "https://readthedocs.org/api/v3/projects/project/redirects/",
             "subprojects": "https://readthedocs.org/api/v3/projects/project/subprojects/",
             "superproject": "https://readthedocs.org/api/v3/projects/project/superproject/",
             "translations": "https://readthedocs.org/api/v3/projects/project/translations/",
@@ -47,7 +47,6 @@
             "code": "words",
             "name": "Only Words"
         },
-        "project_homepage": "http://project.com",
         "repository": {
             "type": "git",
             "url": "https://github.com/rtfd/project"
@@ -61,7 +60,8 @@
         ],
         "translation_of": null,
         "urls": {
-            "documentation": "http://readthedocs.org/docs/project/en/latest/"
+            "documentation": "http://readthedocs.org/docs/project/en/latest/",
+            "project_homepage": "http://project.com"
         },
         "users": [
             {

--- a/readthedocs/api/v3/tests/responses/projects-builds-list_POST.json
+++ b/readthedocs/api/v3/tests/responses/projects-builds-list_POST.json
@@ -1,0 +1,98 @@
+{
+    "build": {
+        "commit": null,
+        "created": "2019-04-29T14:00:00Z",
+        "duration": null,
+        "error": "",
+        "finished": null,
+        "id": 2,
+        "_links": {
+            "_self": "https://readthedocs.org/api/v3/projects/project/builds/2/",
+            "project": "https://readthedocs.org/api/v3/projects/project/",
+            "version": "https://readthedocs.org/api/v3/projects/project/versions/latest/"
+        },
+        "project": "project",
+        "state": {
+            "code": "triggered",
+            "name": "Triggered"
+        },
+        "success": null,
+        "version": "latest"
+    },
+    "project": {
+        "created": "2019-04-29T10:00:00Z",
+        "default_branch": "master",
+        "default_version": "latest",
+        "id": 1,
+        "language": {
+            "code": "en",
+            "name": "English"
+        },
+        "_links": {
+            "_self": "https://readthedocs.org/api/v3/projects/project/",
+            "builds": "https://readthedocs.org/api/v3/projects/project/builds/",
+            "redirects": "https://readthedocs.org/api/v3/projects/project/redirects/",
+            "subprojects": "https://readthedocs.org/api/v3/projects/project/subprojects/",
+            "superproject": "https://readthedocs.org/api/v3/projects/project/superproject/",
+            "translations": "https://readthedocs.org/api/v3/projects/project/translations/",
+            "versions": "https://readthedocs.org/api/v3/projects/project/versions/"
+        },
+        "modified": "2019-04-29T12:00:00Z",
+        "name": "project",
+        "privacy_level": {
+            "code": "public",
+            "name": "Public"
+        },
+        "programming_language": {
+            "code": "words",
+            "name": "Only Words"
+        },
+        "project_homepage": "http://project.com",
+        "repository": {
+            "type": "git",
+            "url": "https://github.com/rtfd/project"
+        },
+        "slug": "project",
+        "subproject_of": null,
+        "tags": [
+            "tag",
+            "project",
+            "test"
+        ],
+        "translation_of": null,
+        "urls": {
+            "documentation": "http://readthedocs.org/docs/project/en/latest/"
+        },
+        "users": [
+            {
+                "created": "2019-04-29T10:00:00Z",
+                "username": "testuser"
+            }
+        ]
+    },
+    "triggered": true,
+    "version": {
+        "active": true,
+        "built": false,
+        "downloads": {},
+        "id": 1,
+        "identifier": "master",
+        "_links": {
+            "_self": "https://readthedocs.org/api/v3/projects/project/versions/latest/",
+            "builds": "https://readthedocs.org/api/v3/projects/project/versions/latest/builds/",
+            "project": "https://readthedocs.org/api/v3/projects/project/"
+        },
+        "privacy_level": {
+            "code": "public",
+            "name": "Public"
+        },
+        "ref": null,
+        "slug": "latest",
+        "type": "branch",
+        "urls": {
+            "documentation": "http://readthedocs.org/docs/project/en/latest/",
+            "vcs": "https://github.com/rtfd/project/tree/master/"
+        },
+        "verbose_name": "latest"
+    }
+}

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -299,7 +299,7 @@ class BuildsViewSet(APIv3Settings, NestedViewSetMixin, ProjectQuerySetMixin,
         version = project.versions.get(slug=version_slug)
         return version
 
-    def create(self, request, **kwargs):
+    def create(self, request, *args, **kwargs):
         project = self._get_project_to_build()
         version = self._get_version_to_build()
         _, build = trigger_build(project, version=version)


### PR DESCRIPTION
Making a `POST` request on `/api/v3/projects/<project_slug>/builds/`
will trigger a build for the default version of that project.