### PR TITLE
Remove django guardian

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,8 +7,6 @@ filterwarnings =
     ignore::django.utils.deprecation.RemovedInDjango20Warning
 
     # Ignore external dependencies warning deprecations
-    # django-guardian
-    ignore:Shortcut function 'assign'.*:DeprecationWarning
     # textclassifier
     ignore:The 'warn' method is deprecated, use 'warning' instead:DeprecationWarning
     # django-rest-framework

--- a/readthedocs/builds/admin.py
+++ b/readthedocs/builds/admin.py
@@ -1,7 +1,6 @@
 """Django admin interface for `~builds.models.Build` and related models."""
 
 from django.contrib import admin, messages
-from guardian.admin import GuardedModelAdmin
 from polymorphic.admin import (
     PolymorphicChildModelAdmin,
     PolymorphicParentModelAdmin,
@@ -56,7 +55,8 @@ class BuildAdmin(admin.ModelAdmin):
         return obj.version.verbose_name
 
 
-class VersionAdmin(GuardedModelAdmin):
+class VersionAdmin(admin.ModelAdmin):
+
     list_display = (
         'slug',
         'type',

--- a/readthedocs/projects/admin.py
+++ b/readthedocs/projects/admin.py
@@ -1,11 +1,8 @@
-# -*- coding: utf-8 -*-
-
 """Django administration interface for `projects.models`."""
 
 from django.contrib import admin, messages
 from django.contrib.admin.actions import delete_selected
 from django.utils.translation import ugettext_lazy as _
-from guardian.admin import GuardedModelAdmin
 
 from readthedocs.builds.models import Version
 from readthedocs.core.models import UserProfile
@@ -127,7 +124,7 @@ class ProjectOwnerBannedFilter(admin.SimpleListFilter):
         return queryset
 
 
-class ProjectAdmin(GuardedModelAdmin):
+class ProjectAdmin(admin.ModelAdmin):
 
     """Project model admin view."""
 

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 
 import getpass
@@ -107,7 +106,6 @@ class CommunityBaseSettings(Settings):
             # third party apps
             'dj_pagination',
             'taggit',
-            'guardian',
             'django_gravatar',
             'rest_framework',
             'rest_framework.authtoken',
@@ -474,9 +472,6 @@ class CommunityBaseSettings(Settings):
 
     INTERNAL_IPS = ('127.0.0.1',)
 
-    # Guardian Settings
-    GUARDIAN_RAISE_403 = True
-
     # Stripe
     STRIPE_SECRET = None
     STRIPE_PUBLISHABLE = None
@@ -514,7 +509,7 @@ class CommunityBaseSettings(Settings):
         'PAGE_SIZE': 10,
     }
 
-    SILENCED_SYSTEM_CHECKS = ['fields.W342', 'guardian.W001']
+    SILENCED_SYSTEM_CHECKS = ['fields.W342']
 
     # Logging
     LOG_FORMAT = '%(name)s:%(lineno)s[%(process)d]: %(levelname)s %(message)s'

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,7 +4,6 @@ appdirs==1.4.3
 virtualenv==16.6.1
 
 django==1.11.21  # pyup: <1.12
-django-guardian==1.5.1  # pyup: <2.0.0
 django-extensions==2.1.9
 django_polymorphic==2.0.3
 


### PR DESCRIPTION
What do I like more than deleting code? deleting a dependency :)

The only change on the admin is that the `Object permissions` tab is removed

![Screenshot_2019-06-27 Change version Django site admin](https://user-images.githubusercontent.com/4975310/60313061-44e0d080-9923-11e9-9d47-6a9f590a1ff8.png)
