### PR TITLE
Send Build Status Report Using GitHub Status API

### DIFF
--- a/readthedocs/builds/constants.py
+++ b/readthedocs/builds/constants.py
@@ -67,7 +67,7 @@ GITHUB_BUILD_STATE_FAILURE = 'failure'
 GITHUB_BUILD_STATE_PENDING = 'pending'
 GITHUB_BUILD_STATE_SUCCESS = 'success'
 
-# GitHub Build Statuses
+# GitLab Build Statuses
 GITLAB_BUILD_STATE_FAILURE = 'failed'
 GITLAB_BUILD_STATE_PENDING = 'pending'
 GITLAB_BUILD_STATE_SUCCESS = 'success'

--- a/readthedocs/builds/constants.py
+++ b/readthedocs/builds/constants.py
@@ -67,11 +67,6 @@ GITHUB_BUILD_STATE_FAILURE = 'failure'
 GITHUB_BUILD_STATE_PENDING = 'pending'
 GITHUB_BUILD_STATE_SUCCESS = 'success'
 
-# GitLab Build Statuses
-GITLAB_BUILD_STATE_FAILURE = 'failed'
-GITLAB_BUILD_STATE_PENDING = 'pending'
-GITLAB_BUILD_STATE_SUCCESS = 'success'
-
 # General Build Statuses
 BUILD_STATUS_FAILURE = 'failed'
 BUILD_STATUS_PENDING = 'pending'
@@ -81,17 +76,14 @@ BUILD_STATUS_SUCCESS = 'success'
 SELECT_BUILD_STATUS = {
     BUILD_STATUS_FAILURE: {
         'github': GITHUB_BUILD_STATE_FAILURE,
-        'gitlab': GITLAB_BUILD_STATE_FAILURE,
         'description': 'The build failed!',
     },
     BUILD_STATUS_PENDING: {
         'github': GITHUB_BUILD_STATE_PENDING,
-        'gitlab': GITLAB_BUILD_STATE_PENDING,
         'description': 'The build is pending!',
     },
     BUILD_STATUS_SUCCESS: {
         'github': GITHUB_BUILD_STATE_SUCCESS,
-        'gitlab': GITLAB_BUILD_STATE_SUCCESS,
         'description': 'The build succeeded!',
     },
 }

--- a/readthedocs/builds/constants.py
+++ b/readthedocs/builds/constants.py
@@ -61,3 +61,34 @@ NON_REPOSITORY_VERSIONS = (
     LATEST,
     STABLE,
 )
+
+# GitHub Build Statuses
+GITHUB_BUILD_STATE_FAILURE = 'failure'
+GITHUB_BUILD_STATE_PENDING = 'pending'
+GITHUB_BUILD_STATE_SUCCESS = 'success'
+
+# GitHub Build Statuses
+GITLAB_BUILD_STATE_FAILURE = 'failed'
+GITLAB_BUILD_STATE_PENDING = 'pending'
+GITLAB_BUILD_STATE_SUCCESS = 'success'
+
+# General Build Statuses
+BUILD_STATUS_FAILURE = 'failed'
+BUILD_STATUS_PENDING = 'pending'
+BUILD_STATUS_SUCCESS = 'success'
+
+# Used to select correct Build status to be sent for each service
+SELECT_BUILD_STATUS = {
+    BUILD_STATUS_FAILURE: {
+        'github': GITHUB_BUILD_STATE_FAILURE,
+        'gitlab': GITLAB_BUILD_STATE_FAILURE,
+    },
+    BUILD_STATUS_PENDING: {
+        'github': GITHUB_BUILD_STATE_PENDING,
+        'gitlab': GITLAB_BUILD_STATE_PENDING,
+    },
+    BUILD_STATUS_SUCCESS: {
+        'github': GITHUB_BUILD_STATE_SUCCESS,
+        'gitlab': GITLAB_BUILD_STATE_SUCCESS,
+    },
+}

--- a/readthedocs/builds/constants.py
+++ b/readthedocs/builds/constants.py
@@ -77,18 +77,21 @@ BUILD_STATUS_FAILURE = 'failed'
 BUILD_STATUS_PENDING = 'pending'
 BUILD_STATUS_SUCCESS = 'success'
 
-# Used to select correct Build status to be sent for each service
+# Used to select correct Build status and description to be sent to each service API
 SELECT_BUILD_STATUS = {
     BUILD_STATUS_FAILURE: {
         'github': GITHUB_BUILD_STATE_FAILURE,
         'gitlab': GITLAB_BUILD_STATE_FAILURE,
+        'description': 'The build failed!',
     },
     BUILD_STATUS_PENDING: {
         'github': GITHUB_BUILD_STATE_PENDING,
         'gitlab': GITLAB_BUILD_STATE_PENDING,
+        'description': 'The build is pending!',
     },
     BUILD_STATUS_SUCCESS: {
         'github': GITHUB_BUILD_STATE_SUCCESS,
         'gitlab': GITLAB_BUILD_STATE_SUCCESS,
+        'description': 'The build succeeded!',
     },
 }

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -736,7 +736,9 @@ class Build(models.Model):
 
     def get_full_url(self):
         """Get full url including domain"""
-        full_url = 'https://{domain}{absolute_url}'.format(
+        scheme = 'http' if settings.DEBUG else 'https'
+        full_url = '{scheme}://{domain}{absolute_url}'.format(
+            scheme=scheme,
             domain=settings.PRODUCTION_DOMAIN,
             absolute_url=self.get_absolute_url()
         )

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -737,7 +737,7 @@ class Build(models.Model):
     def get_full_url(self):
         """Get full url including domain"""
         full_url = 'https://{domain}{absolute_url}'.format(
-            domain=settings.PUBLIC_API_URL,
+            domain=settings.PRODUCTION_DOMAIN,
             absolute_url=self.get_absolute_url()
         )
         return full_url

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -736,7 +736,7 @@ class Build(models.Model):
 
     def get_full_url(self):
         """Get full url including domain"""
-        full_url = '{domain}{absolute_url}'.format(
+        full_url = 'https://{domain}{absolute_url}'.format(
             domain=settings.PUBLIC_API_URL,
             absolute_url=self.get_absolute_url()
         )

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -734,6 +734,14 @@ class Build(models.Model):
     def get_absolute_url(self):
         return reverse('builds_detail', args=[self.project.slug, self.pk])
 
+    def get_full_url(self):
+        """Get url including domain and scheme"""
+        full_url = '{domain}{absolute_url}'.format(
+            domain=settings.PUBLIC_API_URL,
+            absolute_url=self.get_absolute_url()
+        )
+        return full_url
+
     @property
     def finished(self):
         """Return if build has a finished state."""

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -735,7 +735,7 @@ class Build(models.Model):
         return reverse('builds_detail', args=[self.project.slug, self.pk])
 
     def get_full_url(self):
-        """Get url including domain and scheme"""
+        """Get full url including domain"""
         full_url = '{domain}{absolute_url}'.format(
             domain=settings.PUBLIC_API_URL,
             absolute_url=self.get_absolute_url()

--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -81,7 +81,10 @@ def prepare_build(
     # Avoid circular import
     from readthedocs.builds.models import Build
     from readthedocs.projects.models import Project
-    from readthedocs.projects.tasks import update_docs_task, send_build_status
+    from readthedocs.projects.tasks import (
+        update_docs_task,
+        send_external_build_status,
+    )
 
     build = None
 
@@ -129,8 +132,8 @@ def prepare_build(
     options['time_limit'] = int(time_limit * 1.2)
 
     if build:
-        # Send pending Build Status to Git Status API
-        send_build_status.delay(build.id, BUILD_STATUS_PENDING)
+        # Send pending Build Status using Git Status API for External Builds.
+        send_external_build_status(build.id, BUILD_STATUS_PENDING)
 
     return (
         update_docs_task.signature(

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -658,7 +658,7 @@ class BuildEnvironment(BaseEnvironment):
     def done(self):
         """Is build in finished state."""
         return (
-            self.build is not None and
+            self.build and
             self.build['state'] == BUILD_STATE_FINISHED
         )
 

--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -216,7 +216,7 @@ class Service:
     def update_webhook(self, project, integration):
         raise NotImplementedError
 
-    def send_status(self, project, identifier, state, build_url):
+    def send_build_status(self, build, state):
         raise NotImplementedError
 
     @classmethod

--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -184,12 +184,28 @@ class Service:
             return []
 
     def sync(self):
+        """Sync repositories and organizations."""
         raise NotImplementedError
 
     def create_repository(self, fields, privacy=None, organization=None):
+        """
+        Update or create a repository from API response.
+
+        :param fields: dictionary of response data from API
+        :param privacy: privacy level to support
+        :param organization: remote organization to associate with
+        :type organization: RemoteOrganization
+        :rtype: RemoteRepository
+        """
         raise NotImplementedError
 
     def create_organization(self, fields):
+        """
+        Update or create remote organization from API response.
+
+        :param fields: dictionary response of data from API
+        :rtype: RemoteOrganization
+        """
         raise NotImplementedError
 
     def get_next_url_to_paginate(self, response):
@@ -211,12 +227,40 @@ class Service:
         raise NotImplementedError
 
     def setup_webhook(self, project):
+        """
+        Setup webhook for project.
+
+        :param project: project to set up webhook for
+        :type project: Project
+        :returns: boolean based on webhook set up success, and requests Response object
+        :rtype: (Bool, Response)
+        """
         raise NotImplementedError
 
     def update_webhook(self, project, integration):
+        """
+        Update webhook integration.
+
+        :param project: project to set up webhook for
+        :type project: Project
+        :param integration: Webhook integration to update
+        :type integration: Integration
+        :returns: boolean based on webhook update success, and requests Response object
+        :rtype: (Bool, Response)
+        """
         raise NotImplementedError
 
     def send_build_status(self, build, state):
+        """
+        Create commit status for project.
+
+        :param build: Build to set up commit status for
+        :type build: Build
+        :param state: build state failure, pending, or success.
+        :type state: str
+        :returns: boolean based on commit status creation was successful or not.
+        :rtype: Bool
+        """
         raise NotImplementedError
 
     @classmethod

--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -216,6 +216,9 @@ class Service:
     def update_webhook(self, project, integration):
         raise NotImplementedError
 
+    def send_status(self, project, identifier, state, build_url):
+        raise NotImplementedError
+
     @classmethod
     def is_project_service(cls, project):
         """

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -372,13 +372,14 @@ class GitHubService(Service):
             )
             # Response data should always be JSON, still try to log if not
             # though
-            try:
-                debug_data = resp.json()
-            except ValueError:
-                if resp is not None:
+            if resp is not None:
+                try:
+                    debug_data = resp.json()
+                except ValueError:
                     debug_data = resp.content
-                else:
-                    debug_data = resp
+            else:
+                debug_data = resp
+
             log.debug(
                 'GitHub commit status creation failure response: %s',
                 debug_data,

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -340,8 +340,8 @@ class GitHubService(Service):
         }
 
         resp = None
-        try:
 
+        try:
             resp = session.post(
                 f'https://api.github.com/repos/{owner}/{repo}/statuses/{build_sha}',
                 data=json.dumps(data),
@@ -362,6 +362,8 @@ class GitHubService(Service):
                 )
                 return False
 
+            return False
+
         # Catch exceptions with request or deserializing JSON
         except (RequestException, ValueError):
             log.exception(
@@ -373,7 +375,10 @@ class GitHubService(Service):
             try:
                 debug_data = resp.json()
             except ValueError:
-                debug_data = resp.content
+                if resp is not None:
+                    debug_data = resp.content
+                else:
+                    debug_data = resp
             log.debug(
                 'GitHub commit status creation failure response: %s',
                 debug_data,

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1531,9 +1531,11 @@ def _manage_imported_files(version, path, commit, build):
 @app.task(queue='web')
 def send_notifications(version_pk, build_pk):
     version = Version.objects.get_object_or_log(pk=version_pk)
+
     # only send notification for Internal versions
-    if not version or version.type != EXTERNAL:
+    if not version or version.type == EXTERNAL:
         return
+
     build = Build.objects.get(pk=build_pk)
 
     for hook in version.project.webhook_notifications.all():

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1818,7 +1818,7 @@ def send_build_status(build, state):
         log.info('Remote repository does not exist for %s', build.project)
 
     except Exception:
-        log.exception('Send build status task failed.')
+        log.exception('Send build status task failed for %s', build.project)
 
     # TODO: Send build status for other providers.
 

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -588,9 +588,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
                 self.build['id'], BUILD_STATUS_SUCCESS
             )
         else:
-            msg = 'Unhandled Build State: Build ID:'.format(
-                self.build['id'],
-            )
+            msg = 'Unhandled Build State'
             log.warning(
                 LOG_TEMPLATE,
                 {

--- a/readthedocs/rtd_tests/tests/test_celery.py
+++ b/readthedocs/rtd_tests/tests/test_celery.py
@@ -347,9 +347,8 @@ class TestCeleryBuilding(RTDTestCase):
 
         send_build_status.assert_called_once_with(external_build, BUILD_STATUS_SUCCESS)
 
-    @patch('readthedocs.projects.tasks.log')
     @patch('readthedocs.projects.tasks.GitHubService.send_build_status')
-    def test_send_build_status_task_without_remote_repo(self, send_build_status, mock_logger):
+    def test_send_build_status_task_without_remote_repo(self, send_build_status):
         external_version = get(Version, project=self.project, type=EXTERNAL)
         external_build = get(
             Build, project=self.project, version=external_version
@@ -357,7 +356,3 @@ class TestCeleryBuilding(RTDTestCase):
         tasks.send_build_status(external_build, BUILD_STATUS_SUCCESS)
 
         send_build_status.assert_not_called()
-        mock_logger.info.assert_called_with(
-            'Remote repository does not exist for %s',
-            self.project,
-        )

--- a/readthedocs/rtd_tests/tests/test_celery.py
+++ b/readthedocs/rtd_tests/tests/test_celery.py
@@ -346,3 +346,18 @@ class TestCeleryBuilding(RTDTestCase):
         tasks.send_build_status(external_build, BUILD_STATUS_SUCCESS)
 
         send_build_status.assert_called_once_with(external_build, BUILD_STATUS_SUCCESS)
+
+    @patch('readthedocs.projects.tasks.log')
+    @patch('readthedocs.projects.tasks.GitHubService.send_build_status')
+    def test_send_build_status_task_without_remote_repo(self, send_build_status, mock_logger):
+        external_version = get(Version, project=self.project, type=EXTERNAL)
+        external_build = get(
+            Build, project=self.project, version=external_version
+        )
+        tasks.send_build_status(external_build, BUILD_STATUS_SUCCESS)
+
+        send_build_status.assert_not_called()
+        mock_logger.info.assert_called_with(
+            'Remote repository does not exist for %s',
+            self.project,
+        )

--- a/readthedocs/rtd_tests/tests/test_celery.py
+++ b/readthedocs/rtd_tests/tests/test_celery.py
@@ -7,11 +7,14 @@ from django.contrib.auth.models import User
 from django_dynamic_fixture import get
 from mock import MagicMock, patch
 
-from readthedocs.builds.constants import LATEST
+from allauth.socialaccount.models import SocialAccount
+
+from readthedocs.builds.constants import LATEST, BUILD_STATUS_SUCCESS, EXTERNAL
 from readthedocs.builds.models import Build
 from readthedocs.doc_builder.exceptions import VersionLockedError
 from readthedocs.projects import tasks
 from readthedocs.builds.models import Version
+from readthedocs.oauth.models import RemoteRepository
 from readthedocs.projects.exceptions import RepositoryError
 from readthedocs.projects.models import Project
 from readthedocs.rtd_tests.base import RTDTestCase
@@ -329,3 +332,17 @@ class TestCeleryBuilding(RTDTestCase):
         self.assertFalse(Version.objects.filter(pk=345343).exists())
         tasks.fileify(version_pk=345343, commit=None, build=1)
         mock_logger.warning.assert_called_with("Version not found for given kwargs. {'pk': 345343}")
+
+    @patch('readthedocs.projects.tasks.GitHubService.send_build_status')
+    def test_send_build_status_task(self, send_build_status):
+        social_account = get(SocialAccount, provider='github')
+        remote_repo = get(RemoteRepository, account=social_account, project=self.project)
+        remote_repo.users.add(self.eric)
+
+        external_version = get(Version, project=self.project, type=EXTERNAL)
+        external_build = get(
+            Build, project=self.project, version=external_version
+        )
+        tasks.send_build_status(external_build, BUILD_STATUS_SUCCESS)
+
+        send_build_status.assert_called_once_with(external_build, BUILD_STATUS_SUCCESS)

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -5,6 +5,10 @@ from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test.utils import override_settings
 
+from django_dynamic_fixture import get
+
+from readthedocs.builds.constants import EXTERNAL, BUILD_STATUS_SUCCESS
+from readthedocs.builds.models import Version, Build
 from readthedocs.oauth.models import RemoteOrganization, RemoteRepository
 from readthedocs.oauth.services import (
     BitbucketService,
@@ -26,6 +30,10 @@ class GitHubOAuthTests(TestCase):
         self.org = RemoteOrganization.objects.create(slug='rtfd', json='')
         self.privacy = self.project.version_privacy_level
         self.service = GitHubService(user=self.user, account=None)
+        self.external_version = get(Version, project=self.project, type=EXTERNAL)
+        self.external_build = get(
+            Build, project=self.project, version=self.external_version
+        )
 
     def test_make_project_pass(self):
         repo_json = {
@@ -141,6 +149,51 @@ class GitHubOAuthTests(TestCase):
 
         self.assertEqual(github_project, github_project_5)
         self.assertEqual(github_project_2, github_project_6)
+
+    @mock.patch('readthedocs.oauth.services.github.log')
+    @mock.patch('readthedocs.oauth.services.github.GitHubService.get_session')
+    def test_send_build_status_successful(self, session, mock_logger):
+        session().post.return_value.status_code = 201
+        success = self.service.send_build_status(
+            self.external_build,
+            BUILD_STATUS_SUCCESS
+        )
+
+        self.assertTrue(success)
+        mock_logger.info.assert_called_with(
+            'GitHub commit status for project: %s',
+            self.project
+        )
+
+    @mock.patch('readthedocs.oauth.services.github.log')
+    @mock.patch('readthedocs.oauth.services.github.GitHubService.get_session')
+    def test_send_build_status_404_error(self, session, mock_logger):
+        session().post.return_value.status_code = 404
+        success = self.service.send_build_status(
+            self.external_build,
+            BUILD_STATUS_SUCCESS
+        )
+
+        self.assertFalse(success)
+        mock_logger.info.assert_called_with(
+            'GitHub project does not exist or user does not have '
+            'permissions: project=%s',
+            self.project
+        )
+
+    @mock.patch('readthedocs.oauth.services.github.log')
+    @mock.patch('readthedocs.oauth.services.github.GitHubService.get_session')
+    def test_send_build_status_value_error(self, session, mock_logger):
+        session().post.side_effect = ValueError
+        success = self.service.send_build_status(
+            self.external_build, BUILD_STATUS_SUCCESS
+        )
+
+        self.assertFalse(success)
+        mock_logger.exception.assert_called_with(
+                'GitHub commit status creation failed for project: %s',
+                self.project,
+        )
 
     @override_settings(DEFAULT_PRIVACY_LEVEL='private')
     def test_make_private_project(self):

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -191,8 +191,8 @@ class GitHubOAuthTests(TestCase):
 
         self.assertFalse(success)
         mock_logger.exception.assert_called_with(
-                'GitHub commit status creation failed for project: %s',
-                self.project,
+            'GitHub commit status creation failed for project: %s',
+            self.project,
         )
 
     @override_settings(DEFAULT_PRIVACY_LEVEL='private')


### PR DESCRIPTION
Sending build status `pending` and `suncess` or `failed` using GitHub Status API.
Will extend this for other services in the future (e.g: gitlab, bitbucket)

**TODO:**

- [ ] Add Tests.