### PR TITLE
APIv3 refactor some fields

### DIFF
--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -303,11 +303,6 @@ class ProgrammingLanguageSerializer(serializers.Serializer):
 
 class ProjectURLsSerializer(serializers.Serializer):
     documentation = serializers.CharField(source='get_docs_url')
-    project_homepage = serializers.SerializerMethodField()
-
-    def get_project_homepage(self, obj):
-        # Overridden only to return ``None`` when the description is ``''``
-        return obj.project_url or None
 
 
 class RepositorySerializer(serializers.Serializer):
@@ -388,6 +383,7 @@ class ProjectLinksSerializer(BaseLinksSerializer):
 
 class ProjectSerializer(FlexFieldsModelSerializer):
 
+    project_homepage = serializers.SerializerMethodField()
     language = LanguageSerializer()
     programming_language = ProgrammingLanguageSerializer()
     repository = RepositorySerializer(source='*')
@@ -428,6 +424,7 @@ class ProjectSerializer(FlexFieldsModelSerializer):
             'modified',
             'language',
             'programming_language',
+            'project_homepage',
             'repository',
             'default_version',
             'default_branch',
@@ -445,6 +442,10 @@ class ProjectSerializer(FlexFieldsModelSerializer):
 
             '_links',
         ]
+
+    def get_project_homepage(self, obj):
+        # Overridden only to return ``None`` when the description is ``''``
+        return obj.project_url or None
 
     def get_description(self, obj):
         # Overridden only to return ``None`` when the description is ``''``

--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -399,8 +399,6 @@ class ProjectSerializer(FlexFieldsModelSerializer):
     tags = serializers.StringRelatedField(many=True)
     users = UserSerializer(many=True)
 
-    description = serializers.SerializerMethodField()
-
     _links = ProjectLinksSerializer(source='*')
 
     # TODO: adapt these fields with the proper names in the db and then remove
@@ -426,7 +424,6 @@ class ProjectSerializer(FlexFieldsModelSerializer):
             'id',
             'name',
             'slug',
-            'description',
             'created',
             'modified',
             'language',

--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -306,11 +306,11 @@ class ProjectURLsSerializer(BaseLinksSerializer, serializers.Serializer):
     """Serializer with all the user-facing URLs under Read the Docs."""
 
     documentation = serializers.CharField(source='get_docs_url')
-    homepage = serializers.SerializerMethodField()
+    home = serializers.SerializerMethodField()
     builds = serializers.SerializerMethodField()
     versions = serializers.SerializerMethodField()
 
-    def get_homepage(self, obj):
+    def get_home(self, obj):
         path = reverse('projects_detail', kwargs={'project_slug': obj.slug})
         return self._absolute_url(path)
 
@@ -401,7 +401,7 @@ class ProjectLinksSerializer(BaseLinksSerializer):
 
 class ProjectSerializer(FlexFieldsModelSerializer):
 
-    project_homepage = serializers.SerializerMethodField()
+    homepage = serializers.SerializerMethodField()
     language = LanguageSerializer()
     programming_language = ProgrammingLanguageSerializer()
     repository = RepositorySerializer(source='*')
@@ -442,7 +442,7 @@ class ProjectSerializer(FlexFieldsModelSerializer):
             'modified',
             'language',
             'programming_language',
-            'project_homepage',
+            'homepage',
             'repository',
             'default_version',
             'default_branch',
@@ -461,7 +461,7 @@ class ProjectSerializer(FlexFieldsModelSerializer):
             '_links',
         ]
 
-    def get_project_homepage(self, obj):
+    def get_homepage(self, obj):
         # Overridden only to return ``None`` when the project_url is ``''``
         return obj.project_url or None
 

--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -302,6 +302,7 @@ class ProgrammingLanguageSerializer(serializers.Serializer):
 
 
 class ProjectURLsSerializer(BaseLinksSerializer, serializers.Serializer):
+
     """Serializer with all the user-facing URLs under Read the Docs."""
 
     documentation = serializers.CharField(source='get_docs_url')

--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -465,10 +465,6 @@ class ProjectSerializer(FlexFieldsModelSerializer):
         # Overridden only to return ``None`` when the description is ``''``
         return obj.project_url or None
 
-    def get_description(self, obj):
-        # Overridden only to return ``None`` when the description is ``''``
-        return obj.description or None
-
     def get_translation_of(self, obj):
         if obj.main_language_project:
             return self.__class__(obj.main_language_project).data

--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -301,8 +301,25 @@ class ProgrammingLanguageSerializer(serializers.Serializer):
         return 'Unknown'
 
 
-class ProjectURLsSerializer(serializers.Serializer):
+class ProjectURLsSerializer(BaseLinksSerializer, serializers.Serializer):
+    """Serializer with all the user-facing URLs under Read the Docs."""
+
     documentation = serializers.CharField(source='get_docs_url')
+    homepage = serializers.SerializerMethodField()
+    builds = serializers.SerializerMethodField()
+    versions = serializers.SerializerMethodField()
+
+    def get_homepage(self, obj):
+        path = reverse('projects_detail', kwargs={'project_slug': obj.slug})
+        return self._absolute_url(path)
+
+    def get_builds(self, obj):
+        path = reverse('builds_project_list', kwargs={'project_slug': obj.slug})
+        return self._absolute_url(path)
+
+    def get_versions(self, obj):
+        path = reverse('project_version_list', kwargs={'project_slug': obj.slug})
+        return self._absolute_url(path)
 
 
 class RepositorySerializer(serializers.Serializer):

--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -462,7 +462,7 @@ class ProjectSerializer(FlexFieldsModelSerializer):
         ]
 
     def get_project_homepage(self, obj):
-        # Overridden only to return ``None`` when the description is ``''``
+        # Overridden only to return ``None`` when the project_url is ``''``
         return obj.project_url or None
 
     def get_translation_of(self, obj):

--- a/readthedocs/api/v3/tests/responses/projects-detail.json
+++ b/readthedocs/api/v3/tests/responses/projects-detail.json
@@ -75,7 +75,7 @@
         "code": "words",
         "name": "Only Words"
     },
-    "project_homepage": "http://project.com",
+    "homepage": "http://project.com",
     "repository": {
         "type": "git",
         "url": "https://github.com/rtfd/project"
@@ -91,7 +91,7 @@
     "urls": {
         "builds": "https://readthedocs.org/projects/project/builds/",
         "documentation": "http://readthedocs.org/docs/project/en/latest/",
-        "homepage": "https://readthedocs.org/projects/project/",
+        "home": "https://readthedocs.org/projects/project/",
         "versions": "https://readthedocs.org/projects/project/versions/"
     },
     "users": [

--- a/readthedocs/api/v3/tests/responses/projects-detail.json
+++ b/readthedocs/api/v3/tests/responses/projects-detail.json
@@ -89,7 +89,10 @@
     ],
     "translation_of": null,
     "urls": {
-        "documentation": "http://readthedocs.org/docs/project/en/latest/"
+        "builds": "https://readthedocs.org/projects/project/builds/",
+        "documentation": "http://readthedocs.org/docs/project/en/latest/",
+        "homepage": "https://readthedocs.org/projects/project/",
+        "versions": "https://readthedocs.org/projects/project/versions/"
     },
     "users": [
         {

--- a/readthedocs/api/v3/tests/responses/projects-detail.json
+++ b/readthedocs/api/v3/tests/responses/projects-detail.json
@@ -75,6 +75,7 @@
         "code": "words",
         "name": "Only Words"
     },
+    "project_homepage": "http://project.com",
     "repository": {
         "type": "git",
         "url": "https://github.com/rtfd/project"
@@ -88,8 +89,7 @@
     ],
     "translation_of": null,
     "urls": {
-        "documentation": "http://readthedocs.org/docs/project/en/latest/",
-        "project_homepage": "http://project.com"
+        "documentation": "http://readthedocs.org/docs/project/en/latest/"
     },
     "users": [
         {

--- a/readthedocs/api/v3/tests/responses/projects-detail.json
+++ b/readthedocs/api/v3/tests/responses/projects-detail.json
@@ -51,7 +51,6 @@
     "created": "2019-04-29T10:00:00Z",
     "default_branch": "master",
     "default_version": "latest",
-    "description": "Project description",
     "id": 1,
     "language": {
         "code": "en",

--- a/readthedocs/api/v3/tests/responses/projects-list.json
+++ b/readthedocs/api/v3/tests/responses/projects-list.json
@@ -7,7 +7,6 @@
             "id": 1,
             "name": "project",
             "slug": "project",
-            "description": "Project description",
             "created": "2019-04-29T10:00:00Z",
             "modified": "2019-04-29T12:00:00Z",
             "language": {

--- a/readthedocs/api/v3/tests/responses/projects-list.json
+++ b/readthedocs/api/v3/tests/responses/projects-list.json
@@ -17,6 +17,7 @@
                 "code": "words",
                 "name": "Only Words"
             },
+            "project_homepage": "http://project.com",
             "repository": {
                 "url": "https://github.com/rtfd/project",
                 "type": "git"
@@ -30,8 +31,7 @@
             "subproject_of": null,
             "translation_of": null,
             "urls": {
-                "documentation": "http://readthedocs.org/docs/project/en/latest/",
-                "project_homepage": "http://project.com"
+                "documentation": "http://readthedocs.org/docs/project/en/latest/"
             },
             "tags": [
                 "tag",

--- a/readthedocs/api/v3/tests/responses/projects-list.json
+++ b/readthedocs/api/v3/tests/responses/projects-list.json
@@ -17,7 +17,7 @@
                 "code": "words",
                 "name": "Only Words"
             },
-            "project_homepage": "http://project.com",
+            "homepage": "http://project.com",
             "repository": {
                 "url": "https://github.com/rtfd/project",
                 "type": "git"
@@ -33,7 +33,7 @@
             "urls": {
                 "builds": "https://readthedocs.org/projects/project/builds/",
                 "documentation": "http://readthedocs.org/docs/project/en/latest/",
-                "homepage": "https://readthedocs.org/projects/project/",
+                "home": "https://readthedocs.org/projects/project/",
                 "versions": "https://readthedocs.org/projects/project/versions/"
             },
             "tags": [

--- a/readthedocs/api/v3/tests/responses/projects-list.json
+++ b/readthedocs/api/v3/tests/responses/projects-list.json
@@ -31,7 +31,10 @@
             "subproject_of": null,
             "translation_of": null,
             "urls": {
-                "documentation": "http://readthedocs.org/docs/project/en/latest/"
+                "builds": "https://readthedocs.org/projects/project/builds/",
+                "documentation": "http://readthedocs.org/docs/project/en/latest/",
+                "homepage": "https://readthedocs.org/projects/project/",
+                "versions": "https://readthedocs.org/projects/project/versions/"
             },
             "tags": [
                 "tag",

--- a/readthedocs/api/v3/tests/responses/projects-subprojects-list.json
+++ b/readthedocs/api/v3/tests/responses/projects-subprojects-list.json
@@ -56,7 +56,10 @@
                 "subproject_of": null,
                 "translation_of": null,
                 "urls": {
-                    "documentation": "http://readthedocs.org/docs/project/en/latest/"
+                    "builds": "https://readthedocs.org/projects/project/builds/",
+                    "documentation": "http://readthedocs.org/docs/project/en/latest/",
+                    "homepage": "https://readthedocs.org/projects/project/",
+                    "versions": "https://readthedocs.org/projects/project/versions/"
                 },
                 "tags": [
                     "tag",
@@ -81,7 +84,10 @@
             },
             "translation_of": null,
             "urls": {
-                "documentation": "http://readthedocs.org/docs/project/projects/subproject/en/latest/"
+                "builds": "https://readthedocs.org/projects/subproject/builds/",
+                "documentation": "http://readthedocs.org/docs/project/projects/subproject/en/latest/",
+                "homepage": "https://readthedocs.org/projects/subproject/",
+                "versions": "https://readthedocs.org/projects/subproject/versions/"
             },
             "tags": [],
             "users": [],

--- a/readthedocs/api/v3/tests/responses/projects-subprojects-list.json
+++ b/readthedocs/api/v3/tests/responses/projects-subprojects-list.json
@@ -17,6 +17,7 @@
                 "code": "words",
                 "name": "Only Words"
             },
+            "project_homepage": "http://subproject.com",
             "repository": {
                 "url": "https://github.com/rtfd/subproject",
                 "type": "git"
@@ -41,6 +42,7 @@
                     "code": "words",
                     "name": "Only Words"
                 },
+                "project_homepage": "http://project.com",
                 "repository": {
                     "url": "https://github.com/rtfd/project",
                     "type": "git"
@@ -54,8 +56,7 @@
                 "subproject_of": null,
                 "translation_of": null,
                 "urls": {
-                    "documentation": "http://readthedocs.org/docs/project/en/latest/",
-                    "project_homepage": "http://project.com"
+                    "documentation": "http://readthedocs.org/docs/project/en/latest/"
                 },
                 "tags": [
                     "tag",
@@ -80,8 +81,7 @@
             },
             "translation_of": null,
             "urls": {
-                "documentation": "http://readthedocs.org/docs/project/projects/subproject/en/latest/",
-                "project_homepage": "http://subproject.com"
+                "documentation": "http://readthedocs.org/docs/project/projects/subproject/en/latest/"
             },
             "tags": [],
             "users": [],

--- a/readthedocs/api/v3/tests/responses/projects-subprojects-list.json
+++ b/readthedocs/api/v3/tests/responses/projects-subprojects-list.json
@@ -7,7 +7,6 @@
             "id": 2,
             "name": "subproject",
             "slug": "subproject",
-            "description": "SubProject description",
             "created": "2019-04-29T10:00:00Z",
             "modified": "2019-04-29T12:00:00Z",
             "language": {
@@ -32,7 +31,6 @@
                 "id": 1,
                 "name": "project",
                 "slug": "project",
-                "description": "Project description",
                 "created": "2019-04-29T10:00:00Z",
                 "modified": "2019-04-29T12:00:00Z",
                 "language": {

--- a/readthedocs/api/v3/tests/responses/projects-subprojects-list.json
+++ b/readthedocs/api/v3/tests/responses/projects-subprojects-list.json
@@ -17,7 +17,7 @@
                 "code": "words",
                 "name": "Only Words"
             },
-            "project_homepage": "http://subproject.com",
+            "homepage": "http://subproject.com",
             "repository": {
                 "url": "https://github.com/rtfd/subproject",
                 "type": "git"
@@ -42,7 +42,7 @@
                     "code": "words",
                     "name": "Only Words"
                 },
-                "project_homepage": "http://project.com",
+                "homepage": "http://project.com",
                 "repository": {
                     "url": "https://github.com/rtfd/project",
                     "type": "git"
@@ -58,7 +58,7 @@
                 "urls": {
                     "builds": "https://readthedocs.org/projects/project/builds/",
                     "documentation": "http://readthedocs.org/docs/project/en/latest/",
-                    "homepage": "https://readthedocs.org/projects/project/",
+                    "home": "https://readthedocs.org/projects/project/",
                     "versions": "https://readthedocs.org/projects/project/versions/"
                 },
                 "tags": [
@@ -86,7 +86,7 @@
             "urls": {
                 "builds": "https://readthedocs.org/projects/subproject/builds/",
                 "documentation": "http://readthedocs.org/docs/project/projects/subproject/en/latest/",
-                "homepage": "https://readthedocs.org/projects/subproject/",
+                "home": "https://readthedocs.org/projects/subproject/",
                 "versions": "https://readthedocs.org/projects/subproject/versions/"
             },
             "tags": [],

--- a/readthedocs/api/v3/tests/responses/projects-superproject.json
+++ b/readthedocs/api/v3/tests/responses/projects-superproject.json
@@ -26,6 +26,7 @@
         "code": "words",
         "name": "Only Words"
     },
+    "project_homepage": "http://project.com",
     "repository": {
         "type": "git",
         "url": "https://github.com/rtfd/project"
@@ -39,8 +40,7 @@
     ],
     "translation_of": null,
     "urls": {
-        "documentation": "http://readthedocs.org/docs/project/en/latest/",
-        "project_homepage": "http://project.com"
+        "documentation": "http://readthedocs.org/docs/project/en/latest/"
     },
     "users": [
         {

--- a/readthedocs/api/v3/tests/responses/projects-superproject.json
+++ b/readthedocs/api/v3/tests/responses/projects-superproject.json
@@ -26,7 +26,7 @@
         "code": "words",
         "name": "Only Words"
     },
-    "project_homepage": "http://project.com",
+    "homepage": "http://project.com",
     "repository": {
         "type": "git",
         "url": "https://github.com/rtfd/project"
@@ -42,7 +42,7 @@
     "urls": {
         "builds": "https://readthedocs.org/projects/project/builds/",
         "documentation": "http://readthedocs.org/docs/project/en/latest/",
-        "homepage": "https://readthedocs.org/projects/project/",
+        "home": "https://readthedocs.org/projects/project/",
         "versions": "https://readthedocs.org/projects/project/versions/"
     },
     "users": [

--- a/readthedocs/api/v3/tests/responses/projects-superproject.json
+++ b/readthedocs/api/v3/tests/responses/projects-superproject.json
@@ -40,7 +40,10 @@
     ],
     "translation_of": null,
     "urls": {
-        "documentation": "http://readthedocs.org/docs/project/en/latest/"
+        "builds": "https://readthedocs.org/projects/project/builds/",
+        "documentation": "http://readthedocs.org/docs/project/en/latest/",
+        "homepage": "https://readthedocs.org/projects/project/",
+        "versions": "https://readthedocs.org/projects/project/versions/"
     },
     "users": [
         {

--- a/readthedocs/api/v3/tests/responses/projects-superproject.json
+++ b/readthedocs/api/v3/tests/responses/projects-superproject.json
@@ -2,7 +2,6 @@
     "created": "2019-04-29T10:00:00Z",
     "default_branch": "master",
     "default_version": "latest",
-    "description": "Project description",
     "id": 1,
     "language": {
         "code": "en",

--- a/readthedocs/api/v3/tests/responses/projects-versions-builds-list_POST.json
+++ b/readthedocs/api/v3/tests/responses/projects-versions-builds-list_POST.json
@@ -23,7 +23,6 @@
         "created": "2019-04-29T10:00:00Z",
         "default_branch": "master",
         "default_version": "latest",
-        "description": "Project description",
         "id": 1,
         "language": {
             "code": "en",

--- a/readthedocs/api/v3/tests/responses/projects-versions-builds-list_POST.json
+++ b/readthedocs/api/v3/tests/responses/projects-versions-builds-list_POST.json
@@ -61,7 +61,10 @@
         ],
         "translation_of": null,
         "urls": {
-            "documentation": "http://readthedocs.org/docs/project/en/latest/"
+            "builds": "https://readthedocs.org/projects/project/builds/",
+            "documentation": "http://readthedocs.org/docs/project/en/latest/",
+            "homepage": "https://readthedocs.org/projects/project/",
+            "versions": "https://readthedocs.org/projects/project/versions/"
         },
         "users": [
             {

--- a/readthedocs/api/v3/tests/responses/projects-versions-builds-list_POST.json
+++ b/readthedocs/api/v3/tests/responses/projects-versions-builds-list_POST.json
@@ -47,6 +47,7 @@
             "code": "words",
             "name": "Only Words"
         },
+        "project_homepage": "http://project.com",
         "repository": {
             "type": "git",
             "url": "https://github.com/rtfd/project"
@@ -60,8 +61,7 @@
         ],
         "translation_of": null,
         "urls": {
-            "documentation": "http://readthedocs.org/docs/project/en/latest/",
-            "project_homepage": "http://project.com"
+            "documentation": "http://readthedocs.org/docs/project/en/latest/"
         },
         "users": [
             {

--- a/readthedocs/api/v3/tests/responses/projects-versions-builds-list_POST.json
+++ b/readthedocs/api/v3/tests/responses/projects-versions-builds-list_POST.json
@@ -47,7 +47,7 @@
             "code": "words",
             "name": "Only Words"
         },
-        "project_homepage": "http://project.com",
+        "homepage": "http://project.com",
         "repository": {
             "type": "git",
             "url": "https://github.com/rtfd/project"
@@ -63,7 +63,7 @@
         "urls": {
             "builds": "https://readthedocs.org/projects/project/builds/",
             "documentation": "http://readthedocs.org/docs/project/en/latest/",
-            "homepage": "https://readthedocs.org/projects/project/",
+            "home": "https://readthedocs.org/projects/project/",
             "versions": "https://readthedocs.org/projects/project/versions/"
         },
         "users": [


### PR DESCRIPTION
* Move `urls.project_homepage` to the root of the Project object
* Add Project, Builds, Versions and Documentation (all URLs under Read the Docs) in `urls`

These changes make the object detail more clear, although I'm not sold on the name `urls` --I'd like to have something more related to "Read the Docs URLs" or "URLs under Read the Docs platform". Any suggestion here?

Besides the above concern, I'd like to rename `project_homepage` to just `homepage` (once I get a better name for `urls`) since it's a field of the project itself.