### PR TITLE
Add tests for version and project querysets

### DIFF
--- a/readthedocs/projects/querysets.py
+++ b/readthedocs/projects/querysets.py
@@ -99,7 +99,7 @@ class ProjectQuerySetBase(models.QuerySet):
 
     # Aliases
 
-    def dashboard(self, user=None):
+    def dashboard(self, user):
         """Get the projects for this user including the latest build."""
         return self.for_admin_user(user).prefetch_latest_build()
 

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -1484,7 +1484,6 @@ class AutoWipeEnvironmentBase:
             python_env.save_environment_json()
             json_data = json.load(open(python_env.environment_json_path()))
 
-        
         expected_data = {
             'build': {
                 'image': 'readthedocs/build:2.0',

--- a/readthedocs/rtd_tests/tests/test_project_querysets.py
+++ b/readthedocs/rtd_tests/tests/test_project_querysets.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 import django_dynamic_fixture as fixture
 from django_dynamic_fixture import get
 from django.contrib.auth.models import User

--- a/readthedocs/rtd_tests/tests/test_project_querysets.py
+++ b/readthedocs/rtd_tests/tests/test_project_querysets.py
@@ -1,11 +1,11 @@
-# -*- coding: utf-8 -*-
-from datetime import timedelta
-
 import django_dynamic_fixture as fixture
+from django_dynamic_fixture import get
 from django.contrib.auth.models import User
 from django.test import TestCase
 
 from readthedocs.projects.models import Feature, Project
+from readthedocs.projects.constants import PRIVATE, PUBLIC, PROTECTED
+from readthedocs.builds.models import Version
 from readthedocs.projects.querysets import (
     ChildRelatedProjectQuerySet,
     ParentRelatedProjectQuerySet,
@@ -13,6 +13,85 @@ from readthedocs.projects.querysets import (
 
 
 class ProjectQuerySetTests(TestCase):
+
+    def setUp(self):
+        self.user = get(User)
+        self.another_user = get(User)
+
+        self.project = get(
+            Project,
+            privacy_level=PUBLIC,
+            users=[self.user],
+            main_language_project=None,
+        )
+        self.project_private = get(
+            Project,
+            privacy_level=PRIVATE,
+            users=[self.user],
+            main_language_project=None,
+        )
+        self.project_protected = get(
+            Project,
+            privacy_level=PROTECTED,
+            users=[self.user],
+            main_language_project=None,
+        )
+
+        self.another_project = get(
+            Project,
+            privacy_level=PUBLIC,
+            users=[self.another_user],
+            main_language_project=None,
+        )
+        self.another_project_private = get(
+            Project,
+            privacy_level=PRIVATE,
+            users=[self.another_user],
+            main_language_project=None,
+        )
+        self.another_project_protected = get(
+            Project,
+            privacy_level=PROTECTED,
+            users=[self.another_user],
+            main_language_project=None,
+        )
+
+        self.shared_project = get(
+            Project,
+            privacy_level=PUBLIC,
+            users=[self.user, self.another_user],
+            main_language_project=None,
+        )
+        self.shared_project_private = get(
+            Project,
+            privacy_level=PRIVATE,
+            users=[self.user, self.another_user],
+            main_language_project=None,
+        )
+        self.shared_project_protected = get(
+            Project,
+            privacy_level=PROTECTED,
+            users=[self.user, self.another_user],
+            main_language_project=None,
+        )
+
+        self.user_projects = {
+            self.project,
+            self.project_private,
+            self.project_protected,
+            self.shared_project,
+            self.shared_project_private,
+            self.shared_project_protected,
+        }
+
+        self.another_user_projects = {
+            self.another_project,
+            self.another_project_private,
+            self.another_project_protected,
+            self.shared_project,
+            self.shared_project_private,
+            self.shared_project_protected,
+        }
 
     def test_subproject_queryset_attributes(self):
         self.assertEqual(ParentRelatedProjectQuerySet.project_field, 'parent')
@@ -44,6 +123,100 @@ class ProjectQuerySetTests(TestCase):
         user.profile.save()
         project = fixture.get(Project, skip=False, users=[user])
         self.assertFalse(Project.objects.is_active(project))
+
+    def test_dashboard(self):
+        query = Project.objects.dashboard(user=self.user)
+        self.assertEqual(query.count(), len(self.user_projects))
+        self.assertEqual(set(query), self.user_projects)
+
+        query = Project.objects.dashboard(user=self.another_user)
+        self.assertEqual(query.count(), len(self.another_user_projects))
+        self.assertEqual(set(query), self.another_user_projects)
+
+    def test_private(self):
+        query = Project.objects.private()
+        projects = {
+            self.project_private,
+            self.another_project_private,
+            self.shared_project_private,
+        }
+        self.assertEqual(query.count(), len(projects))
+        self.assertEqual(set(query), projects)
+
+    def test_private_user(self):
+        query = Project.objects.private(user=self.user)
+        projects = (
+            self.user_projects |
+            {self.another_project_private}
+        )
+        self.assertEqual(query.count(), len(projects))
+        self.assertEqual(set(query), projects)
+
+        query = Project.objects.private(user=self.another_user)
+        projects = (
+            self.another_user_projects |
+            {self.project_private}
+        )
+        self.assertEqual(query.count(), len(projects))
+        self.assertEqual(set(query), projects)
+
+    def test_public(self):
+        query = Project.objects.public()
+        projects = {
+            self.project,
+            self.another_project,
+            self.shared_project,
+        }
+        self.assertEqual(query.count(), len(projects))
+        self.assertEqual(set(query), projects)
+
+    def test_public_user(self):
+        query = Project.objects.public(user=self.user)
+        projects = (
+            self.user_projects |
+            {self.another_project}
+        )
+        self.assertEqual(query.count(), len(projects))
+        self.assertEqual(set(query), projects)
+
+        query = Project.objects.public(user=self.another_user)
+        projects = (
+            self.another_user_projects |
+            {self.project}
+        )
+        self.assertEqual(query.count(), len(projects))
+        self.assertEqual(set(query), projects)
+
+
+    def test_protected(self):
+        query = Project.objects.protected()
+        projects = {
+            self.project,
+            self.project_protected,
+            self.another_project,
+            self.another_project_protected,
+            self.shared_project,
+            self.shared_project_protected,
+        }
+        self.assertEqual(query.count(), len(projects))
+        self.assertEqual(set(query), projects)
+
+    def test_protected_user(self):
+        query = Project.objects.protected(user=self.user)
+        projects = (
+            self.user_projects |
+            {self.another_project, self.another_project_protected}
+        )
+        self.assertEqual(query.count(), len(projects))
+        self.assertEqual(set(query), projects)
+
+        query = Project.objects.protected(user=self.another_user)
+        projects = (
+            self.another_user_projects |
+            {self.project, self.project_protected}
+        )
+        self.assertEqual(query.count(), len(projects))
+        self.assertEqual(set(query), projects)
 
 
 class FeatureQuerySetTests(TestCase):

--- a/readthedocs/rtd_tests/tests/test_version_querysets.py
+++ b/readthedocs/rtd_tests/tests/test_version_querysets.py
@@ -1,0 +1,257 @@
+from django_dynamic_fixture import get
+from django.contrib.auth.models import User
+from django.test import TestCase
+from readthedocs.projects.models import Project
+from readthedocs.projects.constants import PRIVATE, PUBLIC, PROTECTED
+from readthedocs.builds.constants import LATEST
+from readthedocs.builds.models import Version
+
+
+class VersionQuerySetTests(TestCase):
+
+    def setUp(self):
+        self.user = get(User)
+        self.another_user = get(User)
+
+        self.project = get(
+            Project,
+            privacy_level=PUBLIC,
+            users=[self.user],
+            main_language_project=None,
+            versions=[],
+        )
+        self.version_latest = self.project.versions.get(slug=LATEST)
+        self.version = get(
+            Version,
+            privacy_level=PUBLIC,
+            project=self.project,
+            active=True,
+        )
+        self.version_private = get(
+            Version,
+            privacy_level=PRIVATE,
+            project=self.project,
+            active=True,
+        )
+        self.version_protected = get(
+            Version,
+            privacy_level=PROTECTED,
+            project=self.project,
+            active=True,
+        )
+
+        self.another_project = get(
+            Project,
+            privacy_level=PUBLIC,
+            users=[self.another_user],
+            main_language_project=None,
+            versions=[],
+        )
+        self.another_version_latest = self.another_project.versions.get(slug=LATEST)
+        self.another_version = get(
+            Version,
+            privacy_level=PUBLIC,
+            project=self.another_project,
+            active=True,
+        )
+        self.another_version_private = get(
+            Version,
+            privacy_level=PRIVATE,
+            project=self.another_project,
+            active=True,
+        )
+        self.another_version_protected = get(
+            Version,
+            privacy_level=PROTECTED,
+            project=self.another_project,
+            active=True,
+        )
+
+        self.shared_project = get(
+            Project,
+            privacy_level=PUBLIC,
+            users=[self.user, self.another_user],
+            main_language_project=None,
+            versions=[],
+        )
+        self.shared_version_latest = self.shared_project.versions.get(slug=LATEST)
+        self.shared_version = get(
+            Version,
+            privacy_level=PUBLIC,
+            project=self.shared_project,
+            active=True,
+        )
+        self.shared_version_private = get(
+            Version,
+            privacy_level=PRIVATE,
+            project=self.shared_project,
+            active=True,
+        )
+        self.shared_version_protected = get(
+            Version,
+            privacy_level=PROTECTED,
+            project=self.shared_project,
+            active=True,
+        )
+
+        self.user_versions = {
+            self.version,
+            self.version_latest,
+            self.version_private,
+            self.version_protected,
+            self.shared_version,
+            self.shared_version_latest,
+            self.shared_version_private,
+            self.shared_version_protected,
+        }
+
+        self.another_user_versions = {
+            self.another_version_latest,
+            self.another_version,
+            self.another_version_private,
+            self.another_version_protected,
+            self.shared_version,
+            self.shared_version_latest,
+            self.shared_version_private,
+            self.shared_version_protected,
+        }
+
+    def test_public(self):
+        query = Version.objects.public()
+        versions = {
+            self.version_latest,
+            self.version,
+            self.another_version,
+            self.another_version_latest,
+            self.shared_version,
+            self.shared_version_latest,
+        }
+        self.assertEqual(query.count(), len(versions))
+        self.assertEqual(set(query), versions)
+
+    def test_public_user(self):
+        query = Version.objects.public(user=self.user)
+        versions = (
+            self.user_versions |
+            {self.another_version_latest, self.another_version}
+        )
+        self.assertEqual(query.count(), len(versions))
+        self.assertEqual(set(query), versions)
+
+    def test_public_project(self):
+        query = Version.objects.public(user=self.user, project=self.project)
+        versions = {
+            self.version,
+            self.version_latest,
+            self.version_private,
+            self.version_protected,
+        }
+        self.assertEqual(query.count(), len(versions))
+        self.assertEqual(set(query), versions)
+
+    def test_protected(self):
+        query = Version.objects.protected()
+        versions = {
+            self.version,
+            self.version_latest,
+            self.version_protected,
+            self.another_version,
+            self.another_version_latest,
+            self.another_version_protected,
+            self.shared_version,
+            self.shared_version_latest,
+            self.shared_version_protected,
+        }
+        self.assertEqual(query.count(), len(versions))
+        self.assertEqual(set(query), versions)
+
+    def test_protected_user(self):
+        query = Version.objects.protected(user=self.user)
+        versions = (
+            self.user_versions |
+            {
+                self.another_version,
+                self.another_version_latest,
+                self.another_version_protected,
+            }
+        )
+        self.assertEqual(query.count(), len(versions))
+        self.assertEqual(set(query), versions)
+
+    def test_protected_project(self):
+        query = Version.objects.protected(user=self.user, project=self.project)
+        versions = {
+            self.version,
+            self.version_latest,
+            self.version_private,
+            self.version_protected,
+        }
+        self.assertEqual(query.count(), len(versions))
+        self.assertEqual(set(query), versions)
+
+    def test_private(self):
+        query = Version.objects.private()
+        versions = {
+            self.version_private,
+            self.another_version_private,
+            self.shared_version_private,
+        }
+        self.assertEqual(query.count(), len(versions))
+        self.assertEqual(set(query), versions)
+
+    def test_private_user(self):
+        query = Version.objects.private(user=self.user)
+        versions = (
+            self.user_versions |
+            {self.another_version_private}
+        )
+        self.assertEqual(query.count(), len(versions))
+        self.assertEqual(set(query), versions)
+
+    def test_private_project(self):
+        query = Version.objects.private(user=self.user, project=self.project)
+        versions = {
+            self.version,
+            self.version_latest,
+            self.version_private,
+            self.version_protected,
+        }
+        self.assertEqual(query.count(), len(versions))
+        self.assertEqual(set(query), versions)
+
+    def test_api(self):
+        query = Version.objects.api()
+        versions = {
+            self.version_latest,
+            self.version,
+            self.another_version,
+            self.another_version_latest,
+            self.shared_version,
+            self.shared_version_latest,
+        }
+        self.assertEqual(query.count(), len(versions))
+        self.assertEqual(set(query), versions)
+
+    def test_api_user(self):
+        query = Version.objects.api(user=self.user, detail=False)
+        versions = self.user_versions
+        self.assertEqual(query.count(), len(versions))
+        self.assertEqual(set(query), versions)
+
+    def test_for_project(self):
+        self.another_project.main_language_project = self.project
+        self.another_project.save()
+
+        query = Version.objects.for_project(self.project)
+        versions = {
+            self.version,
+            self.version_latest,
+            self.version_protected,
+            self.version_private,
+            self.another_version,
+            self.another_version_latest,
+            self.another_version_protected,
+            self.another_version_private,
+        }
+        self.assertEqual(query.count(), len(versions))
+        self.assertEqual(set(query), versions)


### PR DESCRIPTION
Related #5872

I could reproduce having duplicates in the project's querysets, but not in the versions' querysets.

You can test this by removing the distinct() call in the querysets. This is only to make sure the other PR doesn't break anything.