### PR TITLE
Update conda at startup

### DIFF
--- a/docs/guides/feature-flags.rst
+++ b/docs/guides/feature-flags.rst
@@ -14,6 +14,12 @@ Available Flags
 
 ``PIP_ALWAYS_UPGRADE``: :featureflags:`PIP_ALWAYS_UPGRADE`
 
+``UPDATE_CONDA_STARTUP``: :featureflags:`UPDATE_CONDA_STARTUP`
+
+The version of ``conda`` used in the build process could not be the latest one.
+This is because we use Miniconda, which its release process is a little more slow than ``conda`` itself.
+In case you prefer to use the latest ``conda`` version available, this is the flag you need.
+
 ``DONT_OVERWRITE_SPHINX_CONTEXT``: :featureflags:`DONT_OVERWRITE_SPHINX_CONTEXT`
 
 ``DONT_SHALLOW_CLONE``: :featureflags:`DONT_SHALLOW_CLONE`

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1391,6 +1391,7 @@ class Feature(models.Model):
     SHARE_SPHINX_DOCTREE = 'share_sphinx_doctree'
     DEFAULT_TO_MKDOCS_0_17_3 = 'default_to_mkdocs_0_17_3'
     CLEAN_AFTER_BUILD = 'clean_after_build'
+    UPDATE_CONDA_STARTUP = 'update_conda_startup'
 
     FEATURES = (
         (USE_SPHINX_LATEST, _('Use latest version of Sphinx')),
@@ -1430,6 +1431,10 @@ class Feature(models.Model):
         (
             CLEAN_AFTER_BUILD,
             _('Clean all files used in the build process'),
+        ),
+        (
+            UPDATE_CONDA_STARTUP,
+            _('Upgrade conda before creating the environment'),
         ),
     )
 


### PR DESCRIPTION
Behind a Feature flag, we can decide if we want to update the version of ``conda`` from the system to its latest version available.

This allow us to use a new release of ``conda`` that is not released under Miniconda yet, but also to not upgrade the Docker image just because of a new release of Miniconda.

(the overhead added is around 60 seconds in total --but they say that the new resolver is way faster... so :1st_place_medal: )

> We can test this for a while under a feature flag, and then we can decide if it worth to enable it by default.