### PR TITLE
Add check for external version in conf.py.tmpl for warning banner

### DIFF
--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -141,6 +141,10 @@ if 'extensions' in globals():
 else:
     extensions = ["readthedocs_ext.readthedocs"]
 
+# Add External version warning banner to the external version documentation
+if '{{ version.type }}' == 'external':
+    extensions.insert(1, "readthedocs_ext.external_version_warning")
+
 project_language = '{{ project.language }}'
 
 # User's Sphinx configurations


### PR DESCRIPTION
This will add a warning banner to external version docs.

To use this we need to add this in the requirements as its not merged
`git+https://github.com/saadmk11/readthedocs-sphinx-ext/@external-version-warning`

Sphinx Extension PR: https://github.com/readthedocs/readthedocs-sphinx-ext/pull/72

![Screenshot from 2019-07-10 22-54-01](https://user-images.githubusercontent.com/24854406/60989252-4371c800-a367-11e9-99fc-690453b0339d.png)
