### PR TITLE
Better msg when gitpython fails

### DIFF
--- a/readthedocs/projects/exceptions.py
+++ b/readthedocs/projects/exceptions.py
@@ -38,7 +38,11 @@ class RepositoryError(BuildEnvironmentError):
         'Private repositories are not supported.',
     )
 
-    INVALID_SUBMODULES = _('One or more submodule URLs are not valid: {}.',)
+    INVALID_SUBMODULES = _('One or more submodule URLs are not valid: {}.')
+    INVALID_SUBMODULES_PATH = _(
+        'One or more submodule paths are not valid. '
+        'Check that all your submodules in .gitmodules are used.'
+    )
 
     DUPLICATED_RESERVED_VERSIONS = _(
         'You can not have two versions with the name latest or stable.',

--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -202,6 +202,8 @@ class TestGitBackend(RTDTestCase):
             """)
             f.write(content)
 
+        repo = self.project.vcs_repo()
+        repo.working_dir = repo_path
         with self.assertRaises(RepositoryError, msg=RepositoryError.INVALID_SUBMODULES_PATH):
             repo.update_submodules(self.dummy_conf)
 

--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -189,6 +189,21 @@ class TestGitBackend(RTDTestCase):
             RepositoryError.INVALID_SUBMODULES.format(['invalid']),
         )
 
+    def test_invalid_submodule_path(self):
+        repo_path = self.project.repo
+        gitmodules_path = os.path.join(repo_path, '.gitmodules')
+
+        with open(gitmodules_path, 'w+') as f:
+            content = textwrap.dedent("""
+                [submodule "not-valid-path"]
+                    path = not-valid-path
+                    url = https://github.com/readthedocs/readthedocs.org
+            """)
+            f.write(content)
+
+        with self.assertRaises(RepositoryError, msg=RepositoryError.INVALID_SUBMODULES_PATH):
+            repo.update_submodules(self.dummy_conf)
+
     @patch('readthedocs.projects.models.Project.checkout_path')
     def test_fetch_clean_tags_and_branches(self, checkout_path):
         upstream_repo = self.project.repo

--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -3,6 +3,7 @@
 import os
 from os.path import exists
 from tempfile import mkdtemp
+import textwrap
 
 import django_dynamic_fixture as fixture
 from django.contrib.auth.models import User

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -230,7 +230,6 @@ class Backend(BaseVCS):
                 RepositoryError.INVALID_SUBMODULES_PATH,
             )
 
-
     def checkout(self, identifier=None):
         """Checkout to identifier or latest."""
         super().checkout()

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -80,8 +80,7 @@ class Backend(BaseVCS):
             return False
 
         # Keep compatibility with previous projects
-        repo = git.Repo(self.working_dir)
-        return bool(repo.submodules)
+        return bool(self.submodules)
 
     def validate_submodules(self, config):
         """
@@ -104,13 +103,7 @@ class Backend(BaseVCS):
         Returns `False` if at least one submodule is invalid.
         Returns the list of invalid submodules.
         """
-        repo = git.Repo(self.working_dir)
-        try:
-            submodules = {sub.path: sub for sub in repo.submodules}
-        except InvalidGitRepositoryError:
-            raise RepositoryError(
-                RepositoryError.INVALID_SUBMODULES_PATH,
-            )
+        submodules = {sub.path: sub for sub in self.submodules}
 
         for sub_path in config.submodules.exclude:
             path = sub_path.rstrip('/')
@@ -226,6 +219,17 @@ class Backend(BaseVCS):
             _, stdout, _ = self.run('git', 'rev-parse', 'HEAD')
             return stdout.strip()
         return None
+
+    @property
+    def submodules(self):
+        try:
+            repo = git.Repo(self.working_dir)
+            return list(repo.submodules)
+        except InvalidGitRepositoryError:
+            raise RepositoryError(
+                RepositoryError.INVALID_SUBMODULES_PATH,
+            )
+
 
     def checkout(self, identifier=None):
         """Checkout to identifier or latest."""

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -105,7 +105,12 @@ class Backend(BaseVCS):
         Returns the list of invalid submodules.
         """
         repo = git.Repo(self.working_dir)
-        submodules = {sub.path: sub for sub in repo.submodules}
+        try:
+            submodules = {sub.path: sub for sub in repo.submodules}
+        except InvalidGitRepositoryError:
+            raise RepositoryError(
+                RepositoryError.INVALID_SUBMODULES_PATH,
+            )
 
         for sub_path in config.submodules.exclude:
             path = sub_path.rstrip('/')


### PR DESCRIPTION
Currently we show a generic message.

Related: https://github.com/readthedocs/readthedocs.org/issues/4371

This can be removed when https://github.com/gitpython-developers/GitPython/pull/818/
gets merged.