### PR TITLE
Pass the build_pk to the task instead of the build object itself

### DIFF
--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -133,7 +133,7 @@ def prepare_build(
 
     if build:
         # Send pending Build Status using Git Status API for External Builds.
-        send_external_build_status(build.id, BUILD_STATUS_PENDING)
+        send_external_build_status(version=version, build_pk=build.id, status=BUILD_STATUS_PENDING)
 
     return (
         update_docs_task.signature(

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -588,7 +588,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
                 version=self.version, build_pk=self.build['id'], status=BUILD_STATUS_SUCCESS
             )
         else:
-            msg = 'Unhandled Build State'
+             msg = 'Unhandled Build Status'
             log.warning(
                 LOG_TEMPLATE,
                 {
@@ -1808,12 +1808,12 @@ def retry_domain_verification(domain_pk):
 
 
 @app.task(queue='web')
-def send_build_status(build_pk, state):
+def send_build_status(build_pk, status):
     """
     Send Build Status to Git Status API for project external versions.
 
-    :param build_pk: Buil primary key
-    :param state: build state failed, pending, or success to be sent.
+    :param build_pk: Build primary key
+     :param status: build status failed, pending, or success to be sent.
     """
     build = Build.objects.get(pk=build_pk)
     try:
@@ -1839,8 +1839,9 @@ def send_external_build_status(version, build_pk, status):
     """
     Check if build is external and Send Build Status for project external versions.
 
-    :param build_pk: Build pk
-    :param state: build state failed, pending, or success to be sent.
+     :param version: Version instance
+     :param build_pk: Build pk
+     :param status: build status failed, pending, or success to be sent.
     """
 
     # Send status reports for only External (pull/merge request) Versions.

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -580,12 +580,12 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
             self.send_notifications(self.version.pk, self.build['id'])
             # send build failure status to git Status API
             send_external_build_status(
-                self.build['id'], BUILD_STATUS_FAILURE
+                version=self.version, build_pk=self.build['id'], status=BUILD_STATUS_FAILURE
             )
         elif self.build_env.successful:
             # send build successful status to git Status API
             send_external_build_status(
-                self.build['id'], BUILD_STATUS_SUCCESS
+                version=self.version, build_pk=self.build['id'], status=BUILD_STATUS_SUCCESS
             )
         else:
             msg = 'Unhandled Build State'
@@ -1808,13 +1808,14 @@ def retry_domain_verification(domain_pk):
 
 
 @app.task(queue='web')
-def send_build_status(build, state):
+def send_build_status(build_pk, state):
     """
     Send Build Status to Git Status API for project external versions.
 
-    :param build: Build
+    :param build_pk: Buil primary key
     :param state: build state failed, pending, or success to be sent.
     """
+    build = Build.objects.get(pk=build_pk)
     try:
         if build.project.remote_repository.account.provider == 'github':
             service = GitHubService(
@@ -1834,16 +1835,15 @@ def send_build_status(build, state):
     # TODO: Send build status for other providers.
 
 
-def send_external_build_status(build_pk, state):
+def send_external_build_status(version, build_pk, status):
     """
     Check if build is external and Send Build Status for project external versions.
 
     :param build_pk: Build pk
     :param state: build state failed, pending, or success to be sent.
     """
-    build = Build.objects.get(pk=build_pk)
 
     # Send status reports for only External (pull/merge request) Versions.
-    if build.version.type == EXTERNAL:
+    if version.type == EXTERNAL:
         # call the task that actually send the build status.
-        send_build_status.delay(build, state)
+        send_build_status.delay(build_pk, status)

--- a/readthedocs/rtd_tests/tests/test_projects_tasks.py
+++ b/readthedocs/rtd_tests/tests/test_projects_tasks.py
@@ -10,7 +10,6 @@ from readthedocs.projects.models import Project
 from readthedocs.projects.tasks import (
     sync_files,
     send_external_build_status,
-    send_build_status,
 )
 
 
@@ -139,12 +138,14 @@ class SendBuildStatusTests(TestCase):
 
     @patch('readthedocs.projects.tasks.send_build_status')
     def test_send_external_build_status_with_external_version(self, send_build_status):
-        send_external_build_status(self.external_build.id, BUILD_STATUS_SUCCESS)
+        send_external_build_status(self.external_version,
+                                   self.external_build.id, BUILD_STATUS_SUCCESS)
 
         send_build_status.delay.assert_called_once_with(self.external_build, BUILD_STATUS_SUCCESS)
 
     @patch('readthedocs.projects.tasks.send_build_status')
     def test_send_external_build_status_with_internal_version(self, send_build_status):
-        send_external_build_status(self.internal_build.id, BUILD_STATUS_SUCCESS)
+        send_external_build_status(self.internal_version,
+                                   self.internal_build.id, BUILD_STATUS_SUCCESS)
 
         send_build_status.delay.assert_not_called()


### PR DESCRIPTION
This breaks in celery when we will ship to prod.