### PR TITLE
Add READTHEDOCS_LANGUAGE to the environment during builds

### DIFF
--- a/docs/builds.rst
+++ b/docs/builds.rst
@@ -174,12 +174,11 @@ The *Sphinx* and *Mkdocs* builders set the following RTD-specific environment va
 .. csv-table::
    :header-rows: 1
 
- Environment variable, Description , Example value  
+ Environment variable, Description, Example value  
  ``READTHEDOCS``, Whether the build is running inside RTD, ``True``   
  ``READTHEDOCS_VERSION``, The RTD name of the version which is being built, ``latest``   
  ``READTHEDOCS_PROJECT``, The RTD slug of the project which is being built, ``my-example-project``
  ``READTHEDOCS_LANGUAGE``, The RTD language slug of the project which is being built, ``en``
-
 
 .. tip::
 

--- a/docs/builds.rst
+++ b/docs/builds.rst
@@ -171,15 +171,15 @@ Build environment
 
 The *Sphinx* and *Mkdocs* builders set the following RTD-specific environment variables when building your documentation:
 
-+-------------------------+--------------------------------------------------+----------------------+
-| Environment variable    | Description                                      | Example value        |
-+-------------------------+--------------------------------------------------+----------------------+
-| ``READTHEDOCS``         | Whether the build is running inside RTD          | ``True``             |
-+-------------------------+--------------------------------------------------+----------------------+
-| ``READTHEDOCS_VERSION`` | The RTD name of the version which is being built | ``latest``           |
-+-------------------------+--------------------------------------------------+----------------------+
-| ``READTHEDOCS_PROJECT`` | The RTD name of the project which is being built | ``myexampleproject`` |
-+-------------------------+--------------------------------------------------+----------------------+
+.. csv-table::
+   :header-rows: 1
+
+ Environment variable, Description , Example value  
+ ``READTHEDOCS``, Whether the build is running inside RTD, ``True``   
+ ``READTHEDOCS_VERSION``, The RTD name of the version which is being built, ``latest``   
+ ``READTHEDOCS_PROJECT``, The RTD slug of the project which is being built, ``my-example-project``
+ ``READTHEDOCS_LANGUAGE``, The RTD language slug of the project which is being built, ``en``
+
 
 .. tip::
 

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -156,6 +156,7 @@ class BuildCommand(BuildCommandResultMixin):
         if self.build_env is not None:
             environment['READTHEDOCS_VERSION'] = self.build_env.version.slug
             environment['READTHEDOCS_PROJECT'] = self.build_env.project.slug
+            environment['READTHEDOCS_LANGUAGE'] = self.build_env.project.language
         if 'DJANGO_SETTINGS_MODULE' in environment:
             del environment['DJANGO_SETTINGS_MODULE']
         if 'PYTHONPATH' in environment:


### PR DESCRIPTION
This was requested by a user since they can't get it via conf.py,
because we inject our logic after their conf.py data.