### PR TITLE
Bump the Sphinx extension to 1.0

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -325,7 +325,7 @@ class Virtualenv(PythonEnvironment):
                     negative='sphinx<2',
                 ),
                 'sphinx-rtd-theme<0.5',
-                'readthedocs-sphinx-ext<0.7',
+                'readthedocs-sphinx-ext<1.1',
             ])
 
         cmd = copy.copy(pip_install_cmd)


### PR DESCRIPTION
This will be the release with the upgrades for our search deploy,
so we need to wait until that code is deployed on RTD before we start installing it.

Refs https://github.com/readthedocs/readthedocs-sphinx-ext/pull/73