### PR TITLE
Explicitly delete SphinxDomain objects from previous versions

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1493,6 +1493,16 @@ def _sync_imported_files(version, build, changed_files):
         build=build,
     )
 
+    # Delete SphinxDomain objects from previous versions
+    # This has to be done before deleting ImportedFiles and not with a cascade,
+    # because multiple Domain's can reference a specific HTMLFile. 
+    (
+        SphinxDomain.objects
+        .filter(project=version.project, version=version)
+        .exclude(build=build)
+        .delete()
+    )
+
     # Delete ImportedFiles objects (including HTMLFiles)
     # from the previous build of the version.
     (

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1495,7 +1495,7 @@ def _sync_imported_files(version, build, changed_files):
 
     # Delete SphinxDomain objects from previous versions
     # This has to be done before deleting ImportedFiles and not with a cascade,
-    # because multiple Domain's can reference a specific HTMLFile. 
+    # because multiple Domain's can reference a specific HTMLFile.
     (
         SphinxDomain.objects
         .filter(project=version.project, version=version)


### PR DESCRIPTION
This has to be done before deleting ImportedFiles and not with a cascade,
because multiple Domain's can reference a specific HTMLFile.