### PR TITLE
update build status message for github

### DIFF
--- a/readthedocs/builds/constants.py
+++ b/readthedocs/builds/constants.py
@@ -76,15 +76,15 @@ BUILD_STATUS_SUCCESS = 'success'
 SELECT_BUILD_STATUS = {
     BUILD_STATUS_FAILURE: {
         'github': GITHUB_BUILD_STATE_FAILURE,
-        'description': 'The build failed!',
+        'description': 'Read the Docs build failed!',
     },
     BUILD_STATUS_PENDING: {
         'github': GITHUB_BUILD_STATE_PENDING,
-        'description': 'The build is pending!',
+        'description': 'Read the Docs build is in progress!',
     },
     BUILD_STATUS_SUCCESS: {
         'github': GITHUB_BUILD_STATE_SUCCESS,
-        'description': 'The build succeeded!',
+        'description': 'Read the Docs build succeeded!',
     },
 }
 

--- a/readthedocs/builds/constants.py
+++ b/readthedocs/builds/constants.py
@@ -76,15 +76,15 @@ GITHUB_BUILD_STATUS_SUCCESS = 'success'
 SELECT_BUILD_STATUS = {
     BUILD_STATUS_FAILURE: {
         'github': GITHUB_BUILD_STATUS_FAILURE,
-        'description': 'The build failed!',
+        'description': 'Read the Docs build failed!',
     },
     BUILD_STATUS_PENDING: {
         'github': GITHUB_BUILD_STATUS_PENDING,
-        'description': 'The build is pending!',
+        'description': 'Read the Docs build is in progress!',
     },
     BUILD_STATUS_SUCCESS: {
         'github': GITHUB_BUILD_STATUS_SUCCESS,
-        'description': 'The build succeeded!',
+        'description': 'Read the Docs build succeeded!',
     },
 }
 


### PR DESCRIPTION
This will improve the mobile view as mobile view of github does not show the name of the service.

### Before:
![Screenshot from 2019-07-17 14-09-13](https://user-images.githubusercontent.com/24854406/61358648-9fbf7500-a89c-11e9-8798-2cb8d7fc48c2.png)
### After:
![Screenshot from 2019-07-17 14-08-07](https://user-images.githubusercontent.com/24854406/61358654-a0f0a200-a89c-11e9-9b8a-4c7d5ce31783.png)
