### PR TITLE
Use a cwd where the user has access inside the container

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -420,6 +420,7 @@ class Conda(PythonEnvironment):
             '--name=base',
             '--channel=defaults',
             'conda',
+            cwd=self.checkout_path,
         )
 
     def setup_base(self):


### PR DESCRIPTION
Without a cwd with permissions, it fails with the error:

```
/bin/sh: 1: cd: can't cd to /home/docs/checkouts/readthedocs.org/readthedocs
```

![Screenshot_2019-07-17_11-35-39](https://user-images.githubusercontent.com/244656/61364919-05a10200-a887-11e9-850a-88f82fbb49e0.png)

> Long live to Feature Flags!