### PR TITLE
Hotfix: Return empty dict when no highlight dict is present

### DIFF
--- a/readthedocs/search/api.py
+++ b/readthedocs/search/api.py
@@ -1,6 +1,5 @@
 import itertools
 import logging
-from pprint import pformat
 
 from rest_framework import generics, serializers
 from rest_framework.exceptions import ValidationError
@@ -38,7 +37,7 @@ class PageSearchSerializer(serializers.Serializer):
         highlight = getattr(obj.meta, 'highlight', None)
         if highlight:
             ret = highlight.to_dict()
-            log.debug('API Search highlight [Page title]: %s', pformat(ret))
+            log.debug('API Search highlight [Page title]: %s', ret)
             return ret
 
     def get_inner_hits(self, obj):
@@ -47,11 +46,13 @@ class PageSearchSerializer(serializers.Serializer):
             sections = inner_hits.sections or []
             domains = inner_hits.domains or []
             all_results = itertools.chain(sections, domains)
-            sorted_results = list(utils._get_sorted_results(
+
+            sorted_results = utils._get_sorted_results(
                 results=all_results,
                 source_key='_source',
-                logging=True,
-            ))
+            )
+
+            log.debug('[API] Sorted Results: %s', sorted_results)
             return sorted_results
 
 

--- a/readthedocs/search/api.py
+++ b/readthedocs/search/api.py
@@ -37,7 +37,7 @@ class PageSearchSerializer(serializers.Serializer):
     def get_highlight(self, obj):
         highlight = getattr(obj.meta, 'highlight', None)
         if highlight:
-            ret = utils._remove_newlines_from_dict(highlight.to_dict())
+            ret = highlight.to_dict()
             log.debug('API Search highlight [Page title]: %s', pformat(ret))
             return ret
 

--- a/readthedocs/search/utils.py
+++ b/readthedocs/search/utils.py
@@ -155,35 +155,10 @@ def _indexing_helper(html_objs_qs, wipe=False):
                 delete_objects_in_es.delay(**kwargs)
 
 
-def _remove_newlines_from_dict(highlight):
-    """
-    Recursively change results to turn newlines into periods.
-
-    See: https://github.com/rtfd/readthedocs.org/issues/5168
-    :param highlight: highlight dict whose contents are to be edited.
-    :type highlight: dict
-    :returns: dict with all the newlines changed to periods.
-    :rtype: dict
-    """
-    for k, v in highlight.items():
-        if isinstance(v, dict):
-            highlight[k] = _remove_newlines_from_dict(v)
-        else:
-            # elastic returns the contents of the
-            # highlighted field in a list.
-            if isinstance(v, list):
-                v_new_list = [res.replace('\n', '. ') for res in v]
-                highlight[k] = v_new_list
-
-    return highlight
-
-
 def _get_inner_hits_highlights(hit, logging=False):
-    """Removes new lines from highlight dict"""
+    """Returns highlight dict and does conditional logging of the same."""
     if hasattr(hit, 'highlight'):
-        highlight_dict = _remove_newlines_from_dict(
-            hit.highlight.to_dict()
-        )
+        highlight_dict = hit.highlight.to_dict()
 
         if logging:
             log.debug('API Search highlight: %s', pformat(highlight_dict))

--- a/readthedocs/search/views.py
+++ b/readthedocs/search/views.py
@@ -117,21 +117,11 @@ def elastic_search(request, project_slug=None):
                     domains = inner_hits.domains or []
                     all_results = itertools.chain(sections, domains)
 
-                    sorted_results = [
-                        {
-                            'type': hit._nested.field,
-
-                            # here _source term is not used because
-                            # django gives error if the names of the
-                            # variables start with underscore
-                            'source': hit._source.to_dict(),
-
-                            'highlight': utils._remove_newlines_from_dict(
-                                hit.highlight.to_dict()
-                            ),
-                        }
-                        for hit in sorted(all_results, key=attrgetter('_score'), reverse=True)
-                    ]
+                    sorted_results = list(utils._get_sorted_results(
+                        results=all_results,
+                        source_key='source',
+                        logging=False,
+                    ))
 
                     result.meta.inner_hits = sorted_results
             except Exception:

--- a/readthedocs/search/views.py
+++ b/readthedocs/search/views.py
@@ -3,7 +3,6 @@ import collections
 import itertools
 import logging
 from operator import attrgetter
-from pprint import pformat
 
 from django.shortcuts import get_object_or_404, render
 
@@ -117,18 +116,17 @@ def elastic_search(request, project_slug=None):
                     domains = inner_hits.domains or []
                     all_results = itertools.chain(sections, domains)
 
-                    sorted_results = list(utils._get_sorted_results(
+                    sorted_results = utils._get_sorted_results(
                         results=all_results,
                         source_key='source',
-                        logging=False,
-                    ))
+                    )
 
                     result.meta.inner_hits = sorted_results
             except Exception:
                 log.exception('Error while sorting the results (inner_hits).')
 
-        log.debug('Search results: %s', pformat(results.to_dict()))
-        log.debug('Search facets: %s', pformat(results.facets.to_dict()))
+        log.debug('Search results: %s', results.to_dict())
+        log.debug('Search facets: %s', results.facets.to_dict())
 
     template_vars = user_input._asdict()
     template_vars.update({


### PR DESCRIPTION
I have moved the sorting logic to `search.utils`.