### PR TITLE
Missed a couple places to set READTHEDOCS_LANGUAGE

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -649,6 +649,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
             'READTHEDOCS': True,
             'READTHEDOCS_VERSION': self.version.slug,
             'READTHEDOCS_PROJECT': self.project.slug,
+            'READTHEDOCS_LANGUAGE': self.project.language,
         }
 
         if self.config.conda is not None:

--- a/readthedocs/rtd_tests/tests/test_builds.py
+++ b/readthedocs/rtd_tests/tests/test_builds.py
@@ -341,6 +341,7 @@ class BuildEnvironmentTests(TestCase):
             'READTHEDOCS': True,
             'READTHEDOCS_VERSION': version.slug,
             'READTHEDOCS_PROJECT': project.slug,
+            'READTHEDOCS_LANGUAGE': project.language,
             'BIN_PATH': os.path.join(
                 project.doc_path,
                 'envs',


### PR DESCRIPTION
Not sure how I missed this.
This should cause us to have proper env vars in builds

I've tested it locally and it looks :100: on `test-builds`.