### PR TITLE
Show APIv3 Token under Profile settings

### DIFF
--- a/readthedocs/profiles/urls/private.py
+++ b/readthedocs/profiles/urls/private.py
@@ -25,3 +25,13 @@ urlpatterns = [
         name='account_advertising',
     ),
 ]
+
+tokens_urls = [
+    url(
+        r'^tokens/$',
+        views.TokenList.as_view(),
+        name='profiles_tokens',
+    ),
+]
+
+urlpatterns += tokens_urls

--- a/readthedocs/profiles/urls/private.py
+++ b/readthedocs/profiles/urls/private.py
@@ -7,8 +7,12 @@ from django.conf.urls import url
 from readthedocs.core.forms import UserProfileForm
 from readthedocs.profiles import views
 
+# Split URLs into different lists to be able to selectively import them from a
+# another application (like Read the Docs Corporate), where we may don't need to
+# define Token URLs, for example.
+urlpatterns = []
 
-urlpatterns = [
+account_urls = [
     url(
         r'^edit/',
         views.edit_profile,
@@ -25,6 +29,8 @@ urlpatterns = [
         name='account_advertising',
     ),
 ]
+
+urlpatterns += account_urls
 
 tokens_urls = [
     url(

--- a/readthedocs/profiles/views.py
+++ b/readthedocs/profiles/views.py
@@ -10,6 +10,8 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
+from django.views.generic import ListView
+from rest_framework.authtoken.models import Token
 
 from readthedocs.core.forms import UserAdvertisingForm, UserDeleteForm
 
@@ -207,3 +209,26 @@ def account_advertising(request):
             'user': profile_obj.user,
         },
     )
+
+
+class TokenMixin:
+
+    """Environment Variables to be added when building the Project."""
+
+    model = Token
+    lookup_url_kwarg = 'token_pk'
+    template_name = 'profiles/private/token_list.html'
+
+    def get_queryset(self):
+        # Token has a OneToOneField relation with User
+        return Token.objects.filter(user__in=[self.request.user])
+
+    def get_success_url(self):
+        return reverse(
+            'projects_token',
+            args=[self.get_project().slug],
+        )
+
+
+class TokenList(TokenMixin, ListView):
+    pass

--- a/readthedocs/templates/profiles/base_profile_edit.html
+++ b/readthedocs/templates/profiles/base_profile_edit.html
@@ -49,7 +49,7 @@
           <li class="{% block profile-admin-social-accounts %}{% endblock %}"><a href="{% url 'socialaccount_connections' %}">{% trans "Connected Services" %}</a></li>
           <li class="{% block profile-admin-change-password %}{% endblock %}"><a href="{% url 'account_change_password' %}">{% trans "Change Password" %}</a></li>
           <li class="{% block profile-admin-change-email %}{% endblock %}"><a href="{% url 'account_email' %}">{% trans "Change Email" %}</a></li>
-          <li class="{% block profile-admin-tokens %}{% endblock %}"><a href="{% url 'profiles_tokens' %}">{% trans "Personal Access Tokens" %}</a></li>
+          <li class="{% block profile-admin-tokens %}{% endblock %}"><a href="{% url 'profiles_tokens' %}">{% trans "API Tokens" %}</a></li>
           <li class="{% block profile-admin-delete-account %}{% endblock %}"><a href="{% url 'delete_account' %}">{% trans "Delete Account" %}</a></li>
           <li class="{% block profile-admin-gold-edit %}{% endblock %}"><a href="{% url 'gold_detail' %}">{% trans "Gold" %}</a></li>
           {% if USE_PROMOS %}

--- a/readthedocs/templates/profiles/base_profile_edit.html
+++ b/readthedocs/templates/profiles/base_profile_edit.html
@@ -49,6 +49,7 @@
           <li class="{% block profile-admin-social-accounts %}{% endblock %}"><a href="{% url 'socialaccount_connections' %}">{% trans "Connected Services" %}</a></li>
           <li class="{% block profile-admin-change-password %}{% endblock %}"><a href="{% url 'account_change_password' %}">{% trans "Change Password" %}</a></li>
           <li class="{% block profile-admin-change-email %}{% endblock %}"><a href="{% url 'account_email' %}">{% trans "Change Email" %}</a></li>
+          <li class="{% block profile-admin-tokens %}{% endblock %}"><a href="{% url 'profiles_tokens' %}">{% trans "Personal Access Tokens" %}</a></li>
           <li class="{% block profile-admin-delete-account %}{% endblock %}"><a href="{% url 'delete_account' %}">{% trans "Delete Account" %}</a></li>
           <li class="{% block profile-admin-gold-edit %}{% endblock %}"><a href="{% url 'gold_detail' %}">{% trans "Gold" %}</a></li>
           {% if USE_PROMOS %}

--- a/readthedocs/templates/profiles/private/token_list.html
+++ b/readthedocs/templates/profiles/private/token_list.html
@@ -1,0 +1,34 @@
+{% extends "profiles/base_profile_edit.html" %}
+
+{% load i18n %}
+
+{% block title %}{% trans "Personal Access Tokens" %}{% endblock %}
+
+{% block profile-admin-tokens %}active{% endblock %}
+
+{% block edit_content_header %} {% trans "Personal Access Tokens" %} {% endblock %}
+
+{% block edit_content %}
+  <p>Personal Access Token are tokens that allow you to use the Read the Docs APIv3 being authenticated as yourself. See <a href="https://docs.readthedocs.org/page/api/v3.html">APIv3 documentation</a> for more information.</p>
+
+    <div class="module">
+      <div class="module-list">
+        <div class="module-list-wrapper">
+          <ul>
+            {% for token in object_list %}
+              <li class="module-item">
+                  <div>Created: {{ token.created }}</div>
+                  <div>Token: {{ token.key }}</div>
+              </li>
+            {% empty %}
+              <li class="module-item">
+                <p class="quiet">
+                  {% trans 'No Personal Access Tokens currently configured.' %}
+                </p>
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+    </div>
+{% endblock %}

--- a/readthedocs/templates/profiles/private/token_list.html
+++ b/readthedocs/templates/profiles/private/token_list.html
@@ -2,16 +2,16 @@
 
 {% load i18n %}
 
-{% block title %}{% trans "Personal Access Tokens" %}{% endblock %}
+{% block title %}{% trans "API Tokens" %}{% endblock %}
 
 {% block profile-admin-tokens %}active{% endblock %}
 
-{% block edit_content_header %} {% trans "Personal Access Tokens" %} {% endblock %}
+{% block edit_content_header %} {% trans "API Tokens" %} {% endblock %}
 
 {% block edit_content %}
   <p class="empty">
     {% blocktrans trimmed with contact_email="support@readthedocs.org" %}
-      Access Tokens are currently in Beta state and are not possible to create by yourself.
+      API Tokens are currently in Beta state and are not possible to create by yourself.
       In case you want to test APIv3 and help giving us feedback,
       please <a href="mailto:{{ contact_email }}">contact us</a> and let us know.
     {% endblocktrans %}
@@ -31,7 +31,7 @@
             {% empty %}
               <li class="module-item">
                 <p class="quiet">
-                  {% trans 'No Personal Access Tokens currently configured.' %}
+                  {% trans 'No API Tokens currently configured.' %}
                 </p>
               </li>
             {% endfor %}

--- a/readthedocs/templates/profiles/private/token_list.html
+++ b/readthedocs/templates/profiles/private/token_list.html
@@ -9,6 +9,14 @@
 {% block edit_content_header %} {% trans "Personal Access Tokens" %} {% endblock %}
 
 {% block edit_content %}
+  <p class="empty">
+    {% blocktrans trimmed with contact_email="support@readthedocs.org" %}
+      Access Tokens are currently in Beta state and are not possible to create by yourself.
+      In case you want to test APIv3 and help giving us feedback,
+      please <a href="mailto:{{ contact_email }}">contact us</a> and let us know.
+    {% endblocktrans %}
+  </p>
+
   <p>Personal Access Token are tokens that allow you to use the Read the Docs APIv3 being authenticated as yourself. See <a href="https://docs.readthedocs.org/page/api/v3.html">APIv3 documentation</a> for more information.</p>
 
     <div class="module">


### PR DESCRIPTION
Some comments here:

- Currently we support one Token per User (it's a OneToOne relation on the model that comes with DRF) --although, the Django view it's a ListView
- I added this token under the user's settings since it's where I think it makes the most sense
- Once we support Scoped Tokens, we can refactor this page to show them all here mentioning their limitations/allowed permissions.
- In case the Scoped Tokens would be Project-based, we can add a similar page under Project's Admin.

I'm not sold on this page and I accept comments and probably a complete re-work or re-structure (*)

![Screenshot_2019-07-18_14-16-44](https://user-images.githubusercontent.com/244656/61456556-b03c2200-a966-11e9-98c2-aafac2e099fb.png)

(*) my other idea was to just add a message like: "Hey there! We are testing our APIv3 and you were given early access to help us with your feedback. Here you have the token to start testing it out: {token}." in a gray small box similar to what we shown under Project Admin Settings.

Example,

![Screenshot_2019-07-18_14-27-34](https://user-images.githubusercontent.com/244656/61457261-36a53380-a968-11e9-9c02-1b1084822576.png)

