### PR TITLE
Fix typos across readthedocs.org repository

### DIFF
--- a/docs/api/v3.rst
+++ b/docs/api/v3.rst
@@ -355,7 +355,7 @@ Version update
 
     :requestheader Authorization: token to authenticate.
 
-    :statuscode 204: Edited sucessfully
+    :statuscode 204: Edited successfully
     :statuscode 400: Some field is invalid
     :statuscode 401: Not valid permissions
     :statuscode 404: There is no ``Version`` with this slug for this project

--- a/docs/config-file/v1.rst
+++ b/docs/config-file/v1.rst
@@ -7,7 +7,7 @@ Read the Docs now has support for configuring builds with a YAML file.
 .. warning::
 
    Version 1 shouldn't be used.
-   The version 2 of the configuration file is now avaliable.
+   The version 2 of the configuration file is now available.
    See the :ref:`new features <config-file/v2:New settings>`
    and :ref:`how to migrate from v1 <config-file/v2:Migrating from v1>`.
 

--- a/docs/development/design/in-doc-search-ui.rst
+++ b/docs/development/design/in-doc-search-ui.rst
@@ -47,7 +47,7 @@ Non-Goals
 Existing Search Implementation
 ------------------------------
 
-We have a detailed documentation explaing the underlying architecture of our search backend
+We have a detailed documentation explaining the underlying architecture of our search backend
 and how we index documents to our Elasticsearch index.
 You can read about it :doc:`here <../search>`.
 

--- a/docs/development/docs.rst
+++ b/docs/development/docs.rst
@@ -6,7 +6,7 @@ the documentation for Read the Docs is built using Sphinx and hosted on Read the
 The docs are kept in the ``docs/`` directory at the top of the source tree.
 
 You can build the docs by first ensuring this project is set up locally according to the :doc:`Installation Guide <install>`.
-Follow the instructions just up to the point of activating the virtual enviroment and then continue here.
+Follow the instructions just up to the point of activating the virtual environment and then continue here.
 
 Next, install the documentation dependencies using ``pip`` (make sure you are inside of the virtual environment)::
 

--- a/docs/development/search.rst
+++ b/docs/development/search.rst
@@ -39,7 +39,7 @@ the search index will update automatically.
 
 Architecture
 ------------
-The search architecture is devided into 2 parts.
+The search architecture is divided into 2 parts.
 
 * One part is responsible for **indexing** the documents and projects (``documents.py``)
 * The other part is responsible for **querying** the Index to show the proper results to users (``faceted_search.py``)

--- a/docs/roadmap.rst
+++ b/docs/roadmap.rst
@@ -45,7 +45,7 @@ We follow `semantic versioning`_ for our release numbering and our point release
 milestones follow these guidelines. For example, our next release milestones
 might be ``2.8``, ``2.9``, and ``3.0``. Releases ``2.8`` and ``2.9`` will
 contain bug fix issues and one backwards compatible feature (this dictates the
-change in minor verison). Release ``3.0`` will contain bugfixes and at least one
+change in minor version). Release ``3.0`` will contain bugfixes and at least one
 backwards incompatible change.
 
 Point release milestones try to remain static, but can shift upwards on a

--- a/readthedocs/api/v2/views/integrations.py
+++ b/readthedocs/api/v2/views/integrations.py
@@ -113,7 +113,7 @@ class WebhookMixin:
         """
         Normalize posted data.
 
-        This can be overriden to support multiples content types.
+        This can be overridden to support multiples content types.
         """
         return self.request.data
 

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -101,7 +101,7 @@ class ProjectsViewSet(APIv3Settings, NestedViewSetMixin, ProjectQuerySetMixin,
     expensive to calculate. Although, they are available for those cases where
     they are needed.
 
-    Allowed via ``?expand=`` URL attribue:
+    Allowed via ``?expand=`` URL attribute:
 
     * users
     * active_versions

--- a/readthedocs/builds/admin.py
+++ b/readthedocs/builds/admin.py
@@ -66,7 +66,7 @@ class BuildAdmin(admin.ModelAdmin):
         'pretty_config',
     )
     readonly_fields = (
-        'pretty_config',  # required to be read-only becuase it's a @property
+        'pretty_config',  # required to be read-only because it's a @property
     )
     list_display = (
         'id',
@@ -104,7 +104,7 @@ class VersionAdmin(admin.ModelAdmin):
         'built',
     )
     readonly_fields = (
-        'pretty_config',  # required to be read-only becuase it's a @property
+        'pretty_config',  # required to be read-only because it's a @property
     )
     list_filter = ('type', 'privacy_level', 'active', 'built')
     search_fields = ('slug', 'project__slug')

--- a/readthedocs/builds/managers.py
+++ b/readthedocs/builds/managers.py
@@ -92,7 +92,7 @@ class InternalVersionManagerBase(VersionManagerBase):
     Version manager that only includes internal version.
 
     It will exclude pull request/merge request versions from the queries
-    and only include BRANCH, TAG, UNKONWN type Versions.
+    and only include BRANCH, TAG, UNKNOWN type Versions.
     """
 
     def get_queryset(self):
@@ -150,7 +150,7 @@ class InternalBuildManagerBase(BuildManagerBase):
     Build manager that only includes internal version builds.
 
     It will exclude pull request/merge request version builds from the queries
-    and only include BRANCH, TAG, UNKONWN type Version builds.
+    and only include BRANCH, TAG, UNKNOWN type Version builds.
     """
 
     def get_queryset(self):

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -129,7 +129,7 @@ class Version(models.Model):
     machine = models.BooleanField(_('Machine Created'), default=False)
 
     objects = VersionManager.from_queryset(VersionQuerySet)()
-    # Only include BRANCH, TAG, UNKONWN type Versions.
+    # Only include BRANCH, TAG, UNKNOWN type Versions.
     internal = InternalVersionManager.from_queryset(VersionQuerySet)()
     # Only include EXTERNAL type Versions.
     external = ExternalVersionManager.from_queryset(VersionQuerySet)()
@@ -641,7 +641,7 @@ class Build(models.Model):
 
     # Managers
     objects = BuildManager.from_queryset(BuildQuerySet)()
-    # Only include BRANCH, TAG, UNKONWN type Version builds.
+    # Only include BRANCH, TAG, UNKNOWN type Version builds.
     internal = InternalBuildManager.from_queryset(BuildQuerySet)()
     # Only include EXTERNAL type Version builds.
     external = ExternalBuildManager.from_queryset(BuildQuerySet)()

--- a/readthedocs/config/tests/test_config.py
+++ b/readthedocs/config/tests/test_config.py
@@ -1798,7 +1798,7 @@ class TestBuildConfigV2:
             build.validate()
         assert excinfo.value.key == 'submodules.recursive'
 
-    def test_submodules_recursive_explict_default(self):
+    def test_submodules_recursive_explicit_default(self):
         build = self.get_build_config({
             'submodules': {
                 'include': [],

--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -31,7 +31,7 @@ if globals().get('source_suffix', False):
         # Sphinx >= 1.3 supports list/tuple to define multiple suffixes
         SUFFIX = source_suffix[0]
     elif isinstance(source_suffix, dict):
-        # Sphinx >= 1.8 supports a mapping dictionary for mulitple suffixes
+        # Sphinx >= 1.8 supports a mapping dictionary for multiple suffixes
         SUFFIX = list(source_suffix.keys())[0]  # make a ``list()`` for py2/py3 compatibility
     else:
         # default to .rst

--- a/readthedocs/projects/admin.py
+++ b/readthedocs/projects/admin.py
@@ -174,7 +174,7 @@ class ProjectAdmin(admin.ModelAdmin):
 
         This will only ban single owners, because a malicious user could add a
         user as a co-owner of the project. We don't want to induce and
-        collatoral damage when flagging users.
+        collateral damage when flagging users.
         """
         total = 0
         for project in queryset:

--- a/readthedocs/projects/querysets.py
+++ b/readthedocs/projects/querysets.py
@@ -221,7 +221,7 @@ class HTMLFileQuerySetBase(models.QuerySet):
         HTMLFileQuerySet method that only includes internal version html files.
 
         It will exclude pull request/merge request Version html files from the queries
-        and only include BRANCH, TAG, UNKONWN type Version html files.
+        and only include BRANCH, TAG, UNKNOWN type Version html files.
         """
         return self.exclude(version__type=EXTERNAL)
 

--- a/readthedocs/rtd_tests/fixtures/spec/v2/schema.yml
+++ b/readthedocs/rtd_tests/fixtures/spec/v2/schema.yml
@@ -45,7 +45,7 @@ conda:
 build:
   # The build docker image to be used
   # Default: 'latest'
-  # Note: it can be overriden by a project
+  # Note: it can be overridden by a project
   image: enum('stable', 'latest', required=False)
 
 python:

--- a/readthedocs/rtd_tests/tests/test_managers.py
+++ b/readthedocs/rtd_tests/tests/test_managers.py
@@ -50,7 +50,7 @@ class TestInternalVersionManager(TestVersionManagerBase):
     Queries using Internal Manager should only include Internal Versions.
 
     It will exclude EXTERNAL type Versions from the queries
-    and only include BRANCH, TAG, UNKONWN type Versions.
+    and only include BRANCH, TAG, UNKNOWN type Versions.
     """
 
     def test_internal_version_manager_with_all(self):
@@ -163,7 +163,7 @@ class TestInternalBuildManager(TestBuildManagerBase):
     Queries using Internal Manager should only include Internal Version builds.
 
     It will exclude pull/merge request Version builds from the queries
-    and only include BRANCH, TAG, UNKONWN type Versions.
+    and only include BRANCH, TAG, UNKNOWN type Versions.
     """
 
     def test_internal_build_manager_with_all(self):
@@ -243,7 +243,7 @@ class TestHTMLFileManager(TestCase):
     def test_internal_html_file_queryset(self):
         """
         It will exclude pull/merge request Version html files from the queries
-        and only include BRANCH, TAG, UNKONWN type Version files.
+        and only include BRANCH, TAG, UNKNOWN type Version files.
         """
         self.assertNotIn(self.html_file, HTMLFile.objects.internal())
 

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -100,10 +100,10 @@ class Backend(BaseVCS):
 
         Returns `True` if all required submodules URLs are valid.
         Returns a list of all required submodules:
-        - Include is `ALL`, returns all submodules avaliable.
+        - Include is `ALL`, returns all submodules available.
         - Include is a list, returns just those.
         - Exclude is `ALL` - this should never happen.
-        - Exlude is a list, returns all avaliable submodules
+        - Exlude is a list, returns all available submodules
           but those from the list.
 
         Returns `False` if at least one submodule is invalid.


### PR DESCRIPTION
Fix typos across **readthedocs.org repository**

**Fixed files**

```
readthedocs.org/docs/api/v3.rst:358:28: "sucessfully" is a misspelling of "successfully"
readthedocs.org/docs/config-file/v1.rst:10:50: "avaliable" is a misspelling of "available"
readthedocs.org/docs/development/design/in-doc-search-ui.rst:50:33: "explaing" is a misspelling of "explaining"
readthedocs.org/docs/development/docs.rst:9:71: "enviroment" is a misspelling of "environment"
readthedocs.org/docs/development/search.rst:42:27: "devided" is a misspelling of "divided"
readthedocs.org/docs/roadmap.rst:48:16: "verison" is a misspelling of "version"
readthedocs.org/readthedocs/api/v2/views/integrations.py:116:20: "overriden" is a misspelling of "overridden"
readthedocs.org/readthedocs/api/v3/views.py:104:33: "attribue" is a misspelling of "attribute"
readthedocs.org/readthedocs/builds/admin.py:69:53: "becuase" is a misspelling of "because"
readthedocs.org/readthedocs/builds/admin.py:107:53: "becuase" is a misspelling of "because"
readthedocs.org/readthedocs/builds/managers.py:95:34: "UNKONWN" is a misspelling of "UNKNOWN"
readthedocs.org/readthedocs/builds/managers.py:153:34: "UNKONWN" is a misspelling of "UNKNOWN"
readthedocs.org/readthedocs/builds/models.py:132:32: "UNKONWN" is a misspelling of "UNKNOWN"
readthedocs.org/readthedocs/builds/models.py:644:32: "UNKONWN" is a misspelling of "UNKNOWN"
readthedocs.org/readthedocs/config/tests/test_config.py:1801:34: "explict" is a misspelling of "explicit"
readthedocs.org/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl:34:58: "mulitple" is a misspelling of "multiple"
readthedocs.org/readthedocs/projects/admin.py:177:8: "collatoral" is a misspelling of "collateral"
readthedocs.org/readthedocs/projects/querysets.py:224:38: "UNKONWN" is a misspelling of "UNKNOWN"
readthedocs.org/readthedocs/rtd_tests/fixtures/spec/v2/schema.yml:48:20: "overriden" is a misspelling of "overridden"
readthedocs.org/readthedocs/rtd_tests/tests/test_managers.py:53:34: "UNKONWN" is a misspelling of "UNKNOWN"
readthedocs.org/readthedocs/rtd_tests/tests/test_managers.py:166:34: "UNKONWN" is a misspelling of "UNKNOWN"
readthedocs.org/readthedocs/rtd_tests/tests/test_managers.py:246:38: "UNKONWN" is a misspelling of "UNKNOWN"
readthedocs.org/readthedocs/vcs_support/backends/git.py:103:51: "avaliable" is a misspelling of "available"
readthedocs.org/readthedocs/vcs_support/backends/git.py:106:40: "avaliable" is a misspelling of "available"
```

Can I fix the history too?

```
readthedocs.org/CHANGELOG.rst:215:71: "versoin" is a misspelling of "version"
readthedocs.org/CHANGELOG.rst:245:71: "versoin" is a misspelling of "version"
readthedocs.org/CHANGELOG.rst:600:44: "Appropiate" is a misspelling of "Appropriate"
readthedocs.org/CHANGELOG.rst:737:44: "Appropiate" is a misspelling of "Appropriate"
readthedocs.org/CHANGELOG.rst:1060:42: "Calrify" is a misspelling of "Clarify"
readthedocs.org/CHANGELOG.rst:1400:90: "accross" is a misspelling of "across"
```