### PR TITLE
Update gitpython

### DIFF
--- a/readthedocs/projects/exceptions.py
+++ b/readthedocs/projects/exceptions.py
@@ -37,16 +37,10 @@ class RepositoryError(BuildEnvironmentError):
         'ensure that your repository URL is correct and your repository is public. '
         'Private repositories are not supported.',
     )
-
     INVALID_SUBMODULES = _(
         'One or more submodule URLs are not valid: {}, '
         'git/ssh URL schemas for submodules are not supported.'
     )
-    INVALID_SUBMODULES_PATH = _(
-        'One or more submodule paths are not valid. '
-        'Check that all your submodules in .gitmodules are used.'
-    )
-
     DUPLICATED_RESERVED_VERSIONS = _(
         'You can not have two versions with the name latest or stable.',
     )

--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -228,7 +228,7 @@ class TestGitBackend(RTDTestCase):
         repo.checkout('submodule')
         gitmodules_path = os.path.join(repo.working_dir, '.gitmodules')
 
-        with open(gitmodules_path, 'w+') as f:
+        with open(gitmodules_path, 'a') as f:
             content = textwrap.dedent("""
                 [submodule "not-valid-path"]
                     path = not-valid-path

--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -222,9 +222,11 @@ class TestGitBackend(RTDTestCase):
             RepositoryError.INVALID_SUBMODULES.format(['invalid']),
         )
 
-    def test_invalid_submodule_path(self):
-        repo_path = self.project.repo
-        gitmodules_path = os.path.join(repo_path, '.gitmodules')
+    def test_invalid_submodule_is_ignored(self):
+        repo = self.project.vcs_repo()
+        repo.update()
+        repo.checkout('submodule')
+        gitmodules_path = os.path.join(repo.working_dir, '.gitmodules')
 
         with open(gitmodules_path, 'w+') as f:
             content = textwrap.dedent("""
@@ -234,10 +236,9 @@ class TestGitBackend(RTDTestCase):
             """)
             f.write(content)
 
-        repo = self.project.vcs_repo()
-        repo.working_dir = repo_path
-        with self.assertRaises(RepositoryError, msg=RepositoryError.INVALID_SUBMODULES_PATH):
-            repo.update_submodules(self.dummy_conf)
+        valid, submodules = repo.validate_submodules(self.dummy_conf)
+        self.assertTrue(valid)
+        self.assertEqual(list(submodules), ['foobar'])
 
     @patch('readthedocs.projects.models.Project.checkout_path')
     def test_fetch_clean_tags_and_branches(self, checkout_path):

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -238,13 +238,8 @@ class Backend(BaseVCS):
 
     @property
     def submodules(self):
-        try:
-            repo = git.Repo(self.working_dir)
-            return list(repo.submodules)
-        except InvalidGitRepositoryError:
-            raise RepositoryError(
-                RepositoryError.INVALID_SUBMODULES_PATH,
-            )
+        repo = git.Repo(self.working_dir)
+        return list(repo.submodules)
 
     def checkout(self, identifier=None):
         """Checkout to identifier or latest."""

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -42,14 +42,7 @@ celery==4.1.1  # pyup: ignore
 
 django-allauth==0.39.1
 
-# GitPython 2.1.11 makes TestGitBackend.test_git_tags to fail because
-# of an UnicodeError
-# This commit,
-# https://github.com/gitpython-developers/GitPython/commit/7f08b7730438bde34ae55bc3793fa524047bb804,
-# introduces the usage of ``str`` which behaves differently in Py2 and
-# Py3 We should check if all the tests pass again when we drop Py2
-# support and we should be able to upgrade
-GitPython==2.1.10  # pyup: ignore
+GitPython==2.1.12
 
 # Search
 elasticsearch==6.4.0  # pyup: <7.0.0


### PR DESCRIPTION
Gitpython not longer fails when the path from a submodule isn't find.
New release drops support for python2, we are fully python3.

This removes the msg added in https://github.com/readthedocs/readthedocs.org/pull/5903 since gitpython not longer fails in those cases.

Closes #4371