### PR TITLE
Index more domain data into elasticsearch

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -38,7 +38,7 @@ from readthedocs.projects.validators import (
     validate_repository_url,
 )
 from readthedocs.projects.version_handling import determine_stable_version
-from readthedocs.search.parse_json import process_file
+from readthedocs.search.parse_json import process_file, process_domain_file
 from readthedocs.vcs_support.backends import backend_cls
 from readthedocs.vcs_support.utils import Lock, NonBlockingLock
 
@@ -1276,6 +1276,33 @@ class HTMLFile(ImportedFile):
     @cached_property
     def processed_json(self):
         return self.get_processed_json()
+
+    def get_domain_data(self):
+        """Get sphinx domain data from ``readthedocs-sphinx-domain-data.json`` file for indexing."""
+        domain_data_dir = self.project.get_production_media_path(
+            type_='json',
+            version_slug=self.version.slug,
+            include_file=False
+        )
+
+        domain_data_json = os.path.join(
+            domain_data_dir,
+            'readthedocs-sphinx-domain-data.json'
+        )
+
+        domain_data = {}
+        try:
+            domain_data = process_domain_file(domain_data_json)
+        except Exception as e:
+            log.warning(
+                'Unhandled exception during search process domain data file: %s',
+                domain_data_json
+            )
+        return domain_data
+
+    @cached_property
+    def domain_data_json(self):
+        return self.get_domain_data()
 
 
 class Notification(models.Model):

--- a/readthedocs/search/documents.py
+++ b/readthedocs/search/documents.py
@@ -94,6 +94,7 @@ class PageDocument(RTDDocTypeMixin, DocType):
             # For showing in the search result
             'type_display': fields.TextField(),
             'doc_display': fields.TextField(),
+            'docstrings': fields.TextField(),
 
             # Simple analyzer breaks on `.`,
             # otherwise search results are too strict for this use case
@@ -123,6 +124,7 @@ class PageDocument(RTDDocTypeMixin, DocType):
                 'anchor': domain.anchor,
                 'type_display': domain.type_display,
                 'doc_display': domain.doc_display,
+                'docstrings': html_file.domain_data_json.get(domain.anchor, ''),
                 'name': domain.name,
                 'display_name': domain.display_name if domain.display_name != '-' else '',
             }

--- a/readthedocs/search/faceted_search.py
+++ b/readthedocs/search/faceted_search.py
@@ -107,6 +107,7 @@ class PageSearchBase(RTDFacetedSearch):
         'domains.type_display',
         'domains.name^2',
         'domains.display_name',
+        'domains.docstrings',
     ]
     fields = _outer_fields
 
@@ -161,6 +162,7 @@ class PageSearchBase(RTDFacetedSearch):
                         'domains.type_display': {},
                         'domains.name': {},
                         'domains.display_name': {},
+                        'domains.docstrings': {},
                     }
                 }
             }

--- a/readthedocs/search/parse_json.py
+++ b/readthedocs/search/parse_json.py
@@ -3,6 +3,7 @@
 import codecs
 import json
 import logging
+import os
 
 from pyquery import PyQuery
 
@@ -107,3 +108,13 @@ def parse_content(content):
     # converting newlines to ". "
     content = '. '.join([text.strip().rstrip('.') for text in content])
     return content
+
+
+def process_domain_file(file_path):
+    """Read the ``readthedocs-sphinx-domain-data.json`` file and return its data."""
+    if not os.path.exists(file_path):
+        return {}
+
+    with open(file_path, 'r') as file:
+        data = json.load(file)
+    return data


### PR DESCRIPTION
PR https://github.com/readthedocs/readthedocs-sphinx-ext/pull/74 will dump a json file -- `readthedocs-sphinx-domain-data.json` with the following content:

```json
{
    "domain-id-1": "domain-docstring-1",
    "domain-id-2": "domain-docstring-2",
    "domain-id-3": "domain-docstring-3"
}
```
We already have values for `domain.anchor` which is same as that of keys in `readthedocs-sphinx-domain-data.json`
During reindexing/indexing of  project, that file will be read and docstrings for a particular domain will available from its `domain.anchor` value.