### PR TITLE
Missing list.extend line when appending conda dependencies

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -510,6 +510,7 @@ class Conda(PythonEnvironment):
                     break
 
             dependencies.append(pip_dependencies)
+            dependencies.extend(conda_requirements)
             environment.update({'dependencies': dependencies})
             try:
                 outputfile = codecs.open(


### PR DESCRIPTION
It seems that in the last minute refactor of #5956 I deleted an important line that adds our conda core dependencies to the environment.yml file.

Now we are only adding our pip core dependencies, which is half of the work needed.