### PR TITLE
serve external version files through media

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -273,17 +273,7 @@ class Version(models.Model):
         return self.identifier
 
     def get_absolute_url(self):
-        if self.type == EXTERNAL:
-            scheme = 'http' if settings.DEBUG else 'https'
-            full_url = '{scheme}://{domain}{media_url}external/html/{project_slug}/{version_slug}'.format(
-                scheme=scheme,
-                domain=settings.PRODUCTION_DOMAIN,
-                media_url=settings.MEDIA_URL,
-                project_slug=self.project.slug,
-                version_slug=self.slug
-            )
-            return full_url
-        if not self.built and not self.uploaded:
+        if not self.built and not self.uploaded and self.type != EXTERNAL:
             return reverse(
                 'project_version_detail',
                 kwargs={
@@ -295,6 +285,7 @@ class Version(models.Model):
         return self.project.get_docs_url(
             version_slug=self.slug,
             private=private,
+            version_type=self.type
         )
 
     def save(self, *args, **kwargs):  # pylint: disable=arguments-differ

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -273,6 +273,16 @@ class Version(models.Model):
         return self.identifier
 
     def get_absolute_url(self):
+        if self.type == EXTERNAL:
+            scheme = 'http' if settings.DEBUG else 'https'
+            full_url = '{scheme}://{domain}{media_url}external/html/{project_slug}/{version_slug}'.format(
+                scheme=scheme,
+                domain=settings.PRODUCTION_DOMAIN,
+                media_url=settings.MEDIA_URL,
+                project_slug=self.project.slug,
+                version_slug=self.slug
+            )
+            return full_url
         if not self.built and not self.uploaded:
             return reverse(
                 'project_version_detail',

--- a/readthedocs/core/resolver.py
+++ b/readthedocs/core/resolver.py
@@ -75,12 +75,12 @@ class ResolverBase:
         else:
             url = '/docs/{project_slug}/'
 
+        if subproject_slug:
+            url += 'projects/{subproject_slug}/'
+
         if version_type == EXTERNAL:
             # we serve external version media files from media storage
             url = '/media/external/html/{project_slug}/'
-
-        if subproject_slug:
-            url += 'projects/{subproject_slug}/'
 
         if single_version:
             url += '{filename}'
@@ -126,22 +126,26 @@ class ResolverBase:
         subproject_slug = None
         # We currently support more than 2 levels of nesting subprojects and
         # translations, only loop twice to avoid sticking in the loop
-        for _ in range(0, 2):
-            main_language_project = current_project.main_language_project
-            relation = current_project.get_parent_relationship()
+        # We do not need this for external versions
+        # as we are serving from a different domain and
+        # not using main_language_project or relation slug
+        if version_type != EXTERNAL:
+            for _ in range(0, 2):
+                main_language_project = current_project.main_language_project
+                relation = current_project.get_parent_relationship()
 
-            if main_language_project:
-                current_project = main_language_project
-                project_slug = main_language_project.slug
-                language = project.language
-                subproject_slug = None
-            elif relation:
-                current_project = relation.parent
-                project_slug = relation.parent.slug
-                subproject_slug = relation.alias
-                cname = relation.parent.domains.filter(canonical=True).first()
-            else:
-                break
+                if main_language_project:
+                    current_project = main_language_project
+                    project_slug = main_language_project.slug
+                    language = project.language
+                    subproject_slug = None
+                elif relation:
+                    current_project = relation.parent
+                    project_slug = relation.parent.slug
+                    subproject_slug = relation.alias
+                    cname = relation.parent.domains.filter(canonical=True).first()
+                else:
+                    break
 
         single_version = bool(project.single_version or single_version)
 

--- a/readthedocs/core/resolver.py
+++ b/readthedocs/core/resolver.py
@@ -70,25 +70,22 @@ class ResolverBase:
         # Only support `/docs/project' URLs outside our normal environment. Normally
         # the path should always have a subdomain or CNAME domain
         # pylint: disable=unused-argument
-        if subdomain or cname or (self._use_subdomain()):
-            url = '/'
-        else:
-            url = '/docs/{project_slug}/'
+        if version_type != EXTERNAL:
+            if subdomain or cname or (self._use_subdomain()):
+                url = '/'
+            else:
+                url = '/docs/{project_slug}/'
 
-        if subproject_slug:
-            url += 'projects/{subproject_slug}/'
+            if subproject_slug:
+                url += 'projects/{subproject_slug}/'
 
-        if version_type == EXTERNAL:
-            # we serve external version media files from media storage
-            url = '/media/external/html/{project_slug}/'
-
-        if single_version:
-            url += '{filename}'
-        else:
-            if version_type == EXTERNAL:
-                url += '{version_slug}/{filename}'
+            if single_version:
+                url += '{filename}'
             else:
                 url += '{language}/{version_slug}/{filename}'
+        else:
+            # we serve external version media files from media storage
+            url = '/media/external/html/{project_slug}/{version_slug}/{filename}'
 
         return url.format(
             project_slug=project_slug,

--- a/readthedocs/core/resolver.py
+++ b/readthedocs/core/resolver.py
@@ -65,7 +65,6 @@ class ResolverBase:
             subdomain=None,
             cname=None,
             version_type=None
-
     ):
         """Resolve a with nothing smart, just filling in the blanks."""
         # Only support `/docs/project' URLs outside our normal environment. Normally

--- a/readthedocs/core/urls/__init__.py
+++ b/readthedocs/core/urls/__init__.py
@@ -38,6 +38,17 @@ docs_urls = [
         serve.serve_docs,
         name='docs_detail',
     ),
+    # Serving external version docs
+    url(
+        (
+            r'^media/external/html/(?P<project_slug>{project_slug})/'
+            r'(?:|projects/(?P<subproject_slug>{project_slug})/)'
+            r'(?P<version_slug>{version_slug})/'
+            r'(?P<filename>{filename_slug})'.format(**pattern_opts)
+        ),
+        serve.serve_docs,
+        name='docs_detail',
+    ),
 ]
 
 core_urls = [

--- a/readthedocs/core/views/serve.py
+++ b/readthedocs/core/views/serve.py
@@ -268,6 +268,7 @@ def _serve_symlink_docs(request, project, privacy_level, version_type=None, file
     if (settings.DEBUG or constants.PUBLIC in settings.SERVE_DOCS) and privacy_level != constants.PRIVATE:  # yapf: disable  # noqa
         if version_type == EXTERNAL:
             # we serve external version media files from media storage
+            # so we need to join site root with the filename which includes media path
             basepath = settings.SITE_ROOT
         else:
             public_symlink = PublicSymlink(project)
@@ -282,6 +283,7 @@ def _serve_symlink_docs(request, project, privacy_level, version_type=None, file
         # Handle private
         if version_type == EXTERNAL:
             # we serve external version media files from media storage
+            # so we need to join site root with the filename which includes media path
             basepath = settings.SITE_ROOT
         else:
             private_symlink = PrivateSymlink(project)

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -495,7 +495,11 @@ class Project(models.Model):
     def get_absolute_url(self):
         return reverse('projects_detail', args=[self.slug])
 
-    def get_docs_url(self, version_slug=None, lang_slug=None, private=None):
+    def get_docs_url(
+            self, version_slug=None,
+            lang_slug=None, private=None,
+            version_type=None
+    ):
         """
         Return a URL for the docs.
 
@@ -506,6 +510,7 @@ class Project(models.Model):
             version_slug=version_slug,
             language=lang_slug,
             private=private,
+            version_type=version_type
         )
 
     def get_builds_url(self):

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -810,17 +810,15 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
                 try:
                     storage.copy_directory(from_path, to_path)
                     # Update version if we have successfully built HTML output
-                    try:
-                        if html:
+                    if html:
+                        try:
                             version = api_v2.version(self.version.pk)
-                            version.patch({
-                                'built': True,
-                            })
-                    except HttpClientError:
-                        log.exception(
-                            'Updating version failed, version=%s',
-                            self.version,
-                        )
+                            version.patch({'built': True,})
+                        except HttpClientError:
+                            log.exception(
+                                'Updating version failed, version=%s',
+                                self.version,
+                            )
                 except Exception:
                     # Ideally this should just be an IOError
                     # but some storage backends unfortunately throw other errors

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -809,6 +809,18 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
                 )
                 try:
                     storage.copy_directory(from_path, to_path)
+                    # Update version if we have successfully built HTML output
+                    try:
+                        if html:
+                            version = api_v2.version(self.version.pk)
+                            version.patch({
+                                'built': True,
+                            })
+                    except HttpClientError:
+                        log.exception(
+                            'Updating version failed, version=%s',
+                            self.version,
+                        )
                 except Exception:
                     # Ideally this should just be an IOError
                     # but some storage backends unfortunately throw other errors

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -813,7 +813,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
                     if html:
                         try:
                             version = api_v2.version(self.version.pk)
-                            version.patch({'built': True,})
+                            version.patch({'built': True, })
                         except HttpClientError:
                             log.exception(
                                 'Updating version failed, version=%s',


### PR DESCRIPTION
I don't feel like this is a good way at all. I think we should not update `get_absolute_url` and serve from media as it looks like a hack not a proper solution. also it does not work when we go to the mail docs page it needs filenames to be added. also if we do this we wont be using the `serve_docs()` view.
Maybe we can create a different view or something to handle this but not sure. trying out different approaches :)
