### PR TITLE
Link to Read the Docs for Business docs from relevant sections

### DIFF
--- a/docs/advertising/ethical-advertising.rst
+++ b/docs/advertising/ethical-advertising.rst
@@ -175,8 +175,8 @@ We have added multiple ways to opt out of the advertising on Read the Docs.
    * Change your advertising settings
 
 4. If you are part of a company that uses Read the Docs to host documentation for a commercial product,
-   we offer `paid plans`_ on readthedocs.com that offer a completely ad-free experience, additional build resources,
-   and features like CDN support and private documentation.
+   we offer :doc:`Read the Docs for Business </commercial/index>` that offers a completely ad-free experience,
+   additional build resources, and other great features like CDN support and private documentation.
 
 5. If you would like to completely remove advertising from your open source project,
    but our commercial plans don't seem like the right fit,

--- a/docs/advertising/index.rst
+++ b/docs/advertising/index.rst
@@ -25,6 +25,9 @@ You may :ref:`opt out of paid advertising <advertising/ethical-advertising:Optin
 -- you will still see :ref:`community ads <advertising/ethical-advertising:Community Ads>` --
 or you can go ad-free by `becoming a Gold Member`_ or a `Supporter`_ of Read the Docs.
 
+For businesses looking to remove advertising,
+please consider :doc:`Read the Docs for Business </commercial/index>`.
+
 .. _becoming a Gold Member: https://readthedocs.org/accounts/gold/
 .. _Supporter: https://readthedocs.org/sustainability/#donations
 

--- a/docs/builds.rst
+++ b/docs/builds.rst
@@ -14,6 +14,9 @@ Our current build limits are:
 
 We can increase build limits on a per-project basis,
 sending an email to support@readthedocs.org providing a good reason why your documentation needs more resources.
+If your business is hitting build limits hosting documentation on Read the Docs,
+please consider :doc:`Read the Docs for Business </commercial/index>`
+which has much higher build resources.
 
 You can see the current Docker build images that we use in our `docker repository <https://github.com/readthedocs/readthedocs-docker-images>`_.
 `Docker Hub <https://hub.docker.com/r/readthedocs/build/>`_ also shows the latest set of images that have been built.

--- a/docs/commercial/custom_domains.rst
+++ b/docs/commercial/custom_domains.rst
@@ -1,12 +1,16 @@
 Custom Domains
 ==============
 
+.. note:: These directions are for projects hosted on Read the Docs for Business.
+          For setting up a custom domain on a project hosted on readthedocs.org,
+          please read our :doc:`community documentation </custom_domains>`.
+
 Subdomain support
 -----------------
 
-Once a project is imported under Read the Docs,
+Once a project is imported into Read the Docs,
 by default it's hosted under a subdomain on one of our domains.
-If you need a custom domain, continue on custom domain setup.
+If you need a custom domain, continue on to custom domain setup.
 
 
 Serving documentation with a custom domain

--- a/docs/commercial/index.rst
+++ b/docs/commercial/index.rst
@@ -1,9 +1,10 @@
-Read the Docs Commercial Features
----------------------------------
+Read the Docs for Business
+--------------------------
 
-Read the Docs has a community solution for open source projects on `readthedocs.org`_
-and we offer commercial documentation building and hosting on `readthedocs.com`_.
-Features in this section are specific to our commercial offering.
+Read the Docs is our community solution for open source projects at `readthedocs.org`_
+and we offer Read the Docs for Business
+for building and hosting commercial documentation at `readthedocs.com`_.
+Features in this section are specific to Read the Docs for Business.
 
 Private repositories and private documentation
     The largest difference between the community solution and our commercial offering

--- a/docs/commercial/organizations.rst
+++ b/docs/commercial/organizations.rst
@@ -1,6 +1,9 @@
 Organizations
 -------------
 
+.. note::
+    This feature only exists on `Read the Docs for Business <https://readthedocs.com/>`_.
+
 Organizations allow you to segment who has access to what projects in your company.
 Your company will be represented as an Organization,
 let's use ACME Corporation as our example.

--- a/docs/commercial/sharing.rst
+++ b/docs/commercial/sharing.rst
@@ -1,7 +1,8 @@
 Sharing
 -------
 
-.. note:: This feature only exists on our Business offering at `readthedocs.com <https://readthedocs.com/>`_.
+.. note::
+    This feature only exists on `Read the Docs for Business <https://readthedocs.com/>`_.
 
 You can share your project with users outside of your company.
 There are two ways to do this:

--- a/docs/custom_domains.rst
+++ b/docs/custom_domains.rst
@@ -1,11 +1,9 @@
 Custom Domains
 ==============
 
-.. note:: These setup directions are for our community site.
-          If you want to setup a custom domain under our `commercial hosting`_,
-          please read our :ref:`commercial documentation <commercial/custom_domains:Custom Domains>`.
-
-.. _commercial hosting: https://readthedocs.com
+.. note:: These directions are for projects hosted on our community site.
+          If you want to setup a custom domain on `Read the Docs for Business <https://readthedocs.com/>`_,
+          please read our :doc:`commercial documentation <commercial/custom_domains>`.
 
 Read the Docs supports a number of custom domains for your convenience. Shorter URLs make everyone happy, and we like making people happy!
 

--- a/docs/custom_installs/index.rst
+++ b/docs/custom_installs/index.rst
@@ -11,9 +11,10 @@ please consider :doc:`Read the Docs for Business </commercial/index>`.
 It has those features and more!
 
 .. warning::
-    Read the Docs developers do not support custom installs of our software.
     These documents are maintained by the community, and might not be up to date.
-
+    Read the Docs developers do not support custom installs of our software
+    in our public issue tracker. For additional support of a custom installation,
+    please see our `paid support plans <https://readthedocs.com/services/#open-source-support>`_.
 
 .. toctree::
     :maxdepth: 2

--- a/docs/custom_installs/index.rst
+++ b/docs/custom_installs/index.rst
@@ -1,9 +1,18 @@
 Info about custom installs
 ==========================
 
-Read the Docs is open source, which means you can run your own version of it. There are many reasons to do this, the main one being if you want a private instance. If you have to keep everything behind a firewall or VPN, this is for you.
+Read the Docs is open source, which means you can run your own version of it.
+There are many reasons to do this, the main one being if you want a private instance.
+If you have to keep everything behind a firewall or VPN, this is for you.
 
-.. warning:: Read the Docs developers do not support custom installs of our software. These documents are maintained by the community, and might not be up to date.
+If your main reasons for considering a custom installation
+are to connect to private repositories or to have fine grained access control over your documentation,
+please consider :doc:`Read the Docs for Business </commercial/index>`.
+It has those features and more!
+
+.. warning::
+    Read the Docs developers do not support custom installs of our software.
+    These documents are maintained by the community, and might not be up to date.
 
 
 .. toctree::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -176,7 +176,7 @@ of Read the Docs and the larger software documentation ecosystem.
   :doc:`advertising/index` |
   :doc:`Sponsors <sponsors>`
 
-* **Read the Docs for business**:
+* **Read the Docs for Business**:
   :doc:`Support and additional features <commercial/index>`
 
 * **Running your own version of Read the Docs**:

--- a/docs/intro/import-guide.rst
+++ b/docs/intro/import-guide.rst
@@ -5,8 +5,8 @@ Importing Your Documentation
    :description lang=en: Import your existing technical documentation from version control into Read the Docs.
 
 
-To import a public documentation repository, visit your `Read the Docs dashboard`_ and click Import_. For private
-repositories, use the Read the Docs  :doc:`commercial solution <../commercial/index>`.
+To import a public documentation repository, visit your `Read the Docs dashboard`_ and click Import_.
+For private repositories, please use :doc:`Read the Docs for Business </commercial/index>`.
 
 
 If you have :doc:`connected your Read the Docs account <../connected-accounts>` to GitHub, Bitbucket, or GitLab,

--- a/docs/privacy.rst
+++ b/docs/privacy.rst
@@ -1,6 +1,10 @@
 Privacy Levels
 ==============
 
+.. note::
+    For private documentation or docs from private repositories,
+    use :doc:`Read the Docs for Business </commercial/index>`.
+
 Read the Docs supports 3 different privacy levels on 2 different objects;
 Public, Private on Projects and Versions.
 

--- a/docs/support.rst
+++ b/docs/support.rst
@@ -57,9 +57,11 @@ Send an email to support@readthedocs.org.
 Commercial Support
 ------------------
 
-We offer commercial support for Read the Docs, :doc:`commercial hosting </commercial/index>`,
-as well as consulting around all documentation systems.
-You can contact us at hello@readthedocs.com to learn more,
+We offer commercial support with :doc:`Read the Docs for Business </commercial/index>`
+and we have a dedicated team that responds to support requests during business hours.
+
+For consulting services around documentation systems,
+you can `contact us <mailto:hello@readthedocs.com?subject=Consulting%20Services%20Inquiry>`_
 or read more at https://readthedocs.com/services/#open-source-support.
 
 .. _Stack Overflow: http://stackoverflow.com/questions/tagged/read-the-docs


### PR DESCRIPTION
- This PR exclusively updates docs
- Link to the RTD for Business docs from relevant pages (eg. "Need commercial support? See RTD.com")
- I did only a very minor update to the privacy levels docs which probably need a more major overhaul to explain what RTD for Business offers there relative to the community site. This is on the roadmap already, I believe.