### PR TITLE
Add reCaptcha on import page

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Fieldset, Layout, HTML, Submit
+from captcha.fields import ReCaptchaField
 from django import forms
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -82,6 +83,8 @@ class ProjectBackendForm(forms.Form):
 class ProjectBasicsForm(ProjectForm):
 
     """Form for basic project fields."""
+
+    recaptcha = ReCaptchaField()
 
     class Meta:
         model = Project

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -118,6 +118,7 @@ class CommunityBaseSettings(Settings):
             'django_elasticsearch_dsl',
             'django_filters',
             'polymorphic',
+            'captcha',
 
             # our apps
             'readthedocs.projects',

--- a/readthedocs/settings/dev.py
+++ b/readthedocs/settings/dev.py
@@ -54,6 +54,9 @@ class CommunityDevSettings(CommunityBaseSettings):
     # Disable password validators on development
     AUTH_PASSWORD_VALIDATORS = []
 
+    # reCaptcha settings
+    SILENCED_SYSTEM_CHECKS = ['captcha.recaptcha_test_key_error']
+
     @property
     def LOGGING(self):  # noqa - avoid pep8 N802
         logging = super().LOGGING

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -77,6 +77,7 @@ Unipath==1.1
 django-kombu==0.9.4
 mock==3.0.5
 stripe==2.32.1
+django-recaptcha==2.0.4
 
 # unicode-slugify==0.1.5 is not released on PyPI yet
 git+https://github.com/mozilla/unicode-slugify@b696c37#egg=unicode-slugify==0.1.5


### PR DESCRIPTION
I have used [django-recaptcha](https://github.com/praekelt/django-recaptcha).
**This PR does not includes settings for production.**
To enable this in production -- these instructions are to be followed: https://github.com/praekelt/django-recaptcha#installation

These settings should do the work in Google Admin Console.

![Screenshot from 2019-07-29 22-19-08](https://user-images.githubusercontent.com/29149191/62066667-75cc6200-b24f-11e9-92d1-736728160ce9.png)
