### PR TITLE
Moving READTHEDOCS application settings to RTD prefix for docker only

### DIFF
--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -151,7 +151,7 @@ class BuildConfigBase:
         'submodules',
     ]
 
-    default_build_image = settings.DOCKER_DEFAULT_VERSION
+    default_build_image = settings.RTD_DOCKER_DEFAULT_VERSION
 
     version = None
 

--- a/readthedocs/doc_builder/constants.py
+++ b/readthedocs/doc_builder/constants.py
@@ -13,12 +13,12 @@ log = logging.getLogger(__name__)
 PDF_RE = re.compile('Output written on (.*?)')
 
 # Docker
-DOCKER_SOCKET = settings.DOCKER_SOCKET
-DOCKER_VERSION = settings.DOCKER_VERSION
-DOCKER_IMAGE = settings.DOCKER_IMAGE
-DOCKER_IMAGE_SETTINGS = settings.DOCKER_IMAGE_SETTINGS
+DOCKER_SOCKET = settings.RTD_DOCKER_SOCKET
+DOCKER_VERSION = settings.RTD_DOCKER_VERSION
+DOCKER_IMAGE = settings.RTD_DOCKER_IMAGE
+DOCKER_IMAGE_SETTINGS = settings.RTD_DOCKER_IMAGE_SETTINGS
 
-old_config = settings.DOCKER_BUILD_IMAGES
+old_config = settings.RTD_DOCKER_BUILD_IMAGES
 if old_config:
     log.warning(
         'Old config detected, DOCKER_BUILD_IMAGES->DOCKER_IMAGE_SETTINGS',
@@ -26,7 +26,7 @@ if old_config:
     DOCKER_IMAGE_SETTINGS.update(old_config)
 
 DOCKER_LIMITS = {'memory': '200m', 'time': 600}
-DOCKER_LIMITS.update(settings.DOCKER_LIMITS)
+DOCKER_LIMITS.update(settings.RTD_DOCKER_LIMITS)
 
 DOCKER_TIMEOUT_EXIT_CODE = 42
 DOCKER_OOM_EXIT_CODE = 137

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -334,16 +334,16 @@ class CommunityBaseSettings(Settings):
     SENTRY_CELERY_IGNORE_EXPECTED = True
 
     # Docker
-    DOCKER_ENABLE = False
-    DOCKER_SOCKET = 'unix:///var/run/docker.sock'
+    RTD_DOCKER_ENABLE = False
+    RTD_DOCKER_SOCKET = 'unix:///var/run/docker.sock'
     # This settings has been deprecated in favor of DOCKER_IMAGE_SETTINGS
-    DOCKER_BUILD_IMAGES = None
-    DOCKER_LIMITS = {'memory': '200m', 'time': 600}
-    DOCKER_DEFAULT_IMAGE = 'readthedocs/build'
-    DOCKER_VERSION = 'auto'
-    DOCKER_DEFAULT_VERSION = 'latest'
-    DOCKER_IMAGE = '{}:{}'.format(DOCKER_DEFAULT_IMAGE, DOCKER_DEFAULT_VERSION)
-    DOCKER_IMAGE_SETTINGS = {
+    RTD_DOCKER_BUILD_IMAGES = None
+    RTD_DOCKER_LIMITS = {'memory': '200m', 'time': 600}
+    RTD_DOCKER_DEFAULT_IMAGE = 'readthedocs/build'
+    RTD_DOCKER_VERSION = 'auto'
+    RTD_DOCKER_DEFAULT_VERSION = 'latest'
+    RTD_DOCKER_IMAGE = '{}:{}'.format(RTD_DOCKER_DEFAULT_IMAGE, RTD_DOCKER_DEFAULT_VERSION)
+    RTD_DOCKER_IMAGE_SETTINGS = {
         'readthedocs/build:1.0': {
             'python': {'supported_versions': [2, 2.7, 3, 3.4]},
         },
@@ -362,9 +362,9 @@ class CommunityBaseSettings(Settings):
     }
 
     # Alias tagged via ``docker tag`` on the build servers
-    DOCKER_IMAGE_SETTINGS.update({
-        'readthedocs/build:stable': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:4.0'),
-        'readthedocs/build:latest': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:5.0'),
+    RTD_DOCKER_IMAGE_SETTINGS.update({
+        'readthedocs/build:stable': RTD_DOCKER_IMAGE_SETTINGS.get('readthedocs/build:4.0'),
+        'readthedocs/build:latest': RTD_DOCKER_IMAGE_SETTINGS.get('readthedocs/build:5.0'),
     })
 
     # All auth


### PR DESCRIPTION
Fixes #5586 