### PR TITLE
Update get_absolute_url for External Versions

### DIFF
--- a/docs/development/settings.rst
+++ b/docs/development/settings.rst
@@ -180,3 +180,13 @@ project and build documentations without having elasticsearch.
 
 
 .. _elasticsearch-dsl-py.connections.configure: https://elasticsearch-dsl.readthedocs.io/en/stable/configuration.html#multiple-clusters
+
+EXTERNAL_VERSION_URL
+--------------------
+
+Default: ``None``
+
+The URL where we host external version builds (Pull Requests).
+Set this to the URL where the static files are uploaded to,
+with a prefix of `/external/`,
+to make it work.

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -277,7 +277,10 @@ class Version(models.Model):
         # TODO: We can integrate them into the resolver
         # but this is much simpler to handle since we only link them a couple places for now
         if self.type == EXTERNAL:
-            return f"{settings.EXTERNAL_VERSION_URL}/html/{self.project.slug}/{self.slug}/index.html"
+            url = f"{settings.EXTERNAL_VERSION_URL}/html/{self.project.slug}/{self.slug}/"
+            if settings.DEBUG:
+                url += 'index.html'
+            return url
         if not self.built and not self.uploaded:
             return reverse(
                 'project_version_detail',

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -277,7 +277,9 @@ class Version(models.Model):
         # TODO: We can integrate them into the resolver
         # but this is much simpler to handle since we only link them a couple places for now
         if self.type == EXTERNAL:
-            url = f"{settings.EXTERNAL_VERSION_URL}/html/{self.project.slug}/{self.slug}/"
+            url = f'{settings.EXTERNAL_VERSION_URL}/html/' \
+                f'{self.project.slug}/{self.slug}/'
+            # Django's static file serving doesn't automatically append index.html
             if settings.DEBUG:
                 url += 'index.html'
             return url

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -273,6 +273,11 @@ class Version(models.Model):
         return self.identifier
 
     def get_absolute_url(self):
+        # Hack external versions for now.
+        # TODO: We can integrate them into the resolver
+        # but this is much simpler to handle since we only link them a couple places for now
+        if self.type == EXTERNAL:
+            return f"{settings.EXTERNAL_VERSION_URL}/html/{self.project.slug}/{self.slug}/index.html"
         if not self.built and not self.uploaded:
             return reverse(
                 'project_version_detail',

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -41,6 +41,7 @@ class CommunityBaseSettings(Settings):
     PUBLIC_DOMAIN_USES_HTTPS = False
     USE_SUBDOMAIN = False
     PUBLIC_API_URL = 'https://{}'.format(PRODUCTION_DOMAIN)
+    EXTERNAL_VERSION_URL = None  # for pull request builds
 
     # Doc Builder Backends
     MKDOCS_BACKEND = 'readthedocs.doc_builder.backends.mkdocs'

--- a/readthedocs/settings/dev.py
+++ b/readthedocs/settings/dev.py
@@ -32,6 +32,8 @@ class CommunityDevSettings(CommunityBaseSettings):
     SLUMBER_API_HOST = 'http://127.0.0.1:8000'
     PUBLIC_API_URL = 'http://127.0.0.1:8000'
 
+    EXTERNAL_VERSION_URL = 'http://127.0.0.1:8000/static/external'
+
     BROKER_URL = 'redis://localhost:6379/0'
     CELERY_RESULT_BACKEND = 'redis://localhost:6379/0'
     CELERY_RESULT_SERIALIZER = 'json'


### PR DESCRIPTION
This allows us to properly set a new domain in production for the external version hosting.
It's a bit hacky for now,
mostly because we don't have a way to specify HTML or PDF versions of the external versions.

We will need to think more about the UX around multiple types,
but that's also an existing issue with our current doc builds (we only link to HTML).