### PR TITLE
Avoid returning invalid domain when using USE_SUBDOMAIN=True in dev

### DIFF
--- a/readthedocs/core/middleware.py
+++ b/readthedocs/core/middleware.py
@@ -61,7 +61,7 @@ class SubdomainMiddleware(MiddlewareMixin):
         # Serve CNAMEs
         if (
             public_domain not in host and
-            settings.PRODUCTION_DOMAIN not in host and
+            settings.PRODUCTION_DOMAIN not in (host, full_host) and
             'localhost' not in host and
             'testserver' not in host
         ):


### PR DESCRIPTION
When running in development with `USE_SUBDOMAIN=True` and
`PRODUCTION_DOMAIN=dev.readthedocs.io:8000` we receive an error when
accessing the docs.

This allows this case to succeed,
skip these checks and serve the docs properly.