### PR TITLE
Use Read the Docs for Business everywhere

### DIFF
--- a/docs/privacy-policy.rst
+++ b/docs/privacy-policy.rst
@@ -4,7 +4,7 @@
 Privacy Policy
 ==============
 
-Effective date: **May 30, 2018**
+Effective date: **August 1, 2019**
 
 Welcome to Read the Docs.
 At Read the Docs, we believe in protecting the privacy of our
@@ -29,12 +29,12 @@ Our services
 
 Read the Docs is made up of:
 
-readthedocs.org
+readthedocs.org ("Read the Docs Community")
     This is a website aimed at documentation authors writing and building
     software documentation. This Privacy Policy applies to this site
     in full without reservation.
 
-readthedocs.com
+readthedocs.com ("Read the Docs for Business")
     This website is a commercial hosted offering for hosting private
     documentation for corporate clients.
     It is governed by this privacy policy but also separate
@@ -193,7 +193,7 @@ Support Desk
 ++++++++++++
 
 Read the Docs uses Intercom to manage support requests
-for documentation hosted through our commercial hosting on readthedocs.com.
+for documentation hosted through Read the Docs for Business.
 If you request support -- typically via email -- Intercom may process
 your contact information.
 
@@ -241,7 +241,8 @@ For Read the Docs, this means:
   and user agent strings are deleted after 10 days unless a DNT exception applies.
 * Our full DNT policy is `available here`_.
 
-Our DNT policy applies without reservation to readthedocs.org and readthedocs.com.
+Our DNT policy applies without reservation
+to Read the Docs Community and Read the Docs for Business.
 A best effort is made to apply this to Documentation Sites,
 but we do not have complete control over the contents of these sites.
 
@@ -389,7 +390,8 @@ We will retain and use your information as necessary to comply with
 our legal obligations, resolve disputes, and enforce our agreements,
 but barring legal requirements, we will delete your full profile.
 
-Our web server logs for readthedocs.org, readthedocs.com, and Documentation Sites
+Our web server logs for Read the Docs Community,
+Read the Docs for Business, and Documentation Sites
 are deleted after 10 days barring legal obligations.
 
 

--- a/readthedocs/gold/templates/gold/subscription_form.html
+++ b/readthedocs/gold/templates/gold/subscription_form.html
@@ -52,7 +52,7 @@ $(document).ready(function () {
     <p>
     {% blocktrans trimmed %}
       If you are a company using Read the Docs,
-      please consider getting a <a href="https://readthedocs.com/services/#open-source-support">commercial support contract</a>.
+      please consider <a href="https://readthedocs.com/">Read the Docs for Business</a>.
       This will help us cover our costs,
       and provide you with a better experience on the site.
       If you aren't able to do that,

--- a/readthedocs/templates/base.html
+++ b/readthedocs/templates/base.html
@@ -178,7 +178,7 @@
               <a href="{{ advertising_url | default:'https://readthedocs.org/sustainability/advertising/' }}">{% trans 'Advertise with Us' %}</a>
             </li>
             <li>
-              <a href="https://readthedocs.com">{% trans 'Private Hosting' %}</a>
+              <a href="https://readthedocs.com">{% trans 'Read the Docs for Business' %}</a>
             </li>
             <li>
               {% url "donate" as donate_url %}

--- a/readthedocs/templates/projects/project_advertising.html
+++ b/readthedocs/templates/projects/project_advertising.html
@@ -70,9 +70,9 @@
     <li class="module-item">
       {% blocktrans trimmed %}
         If you are part of a company that uses Read the Docs to host documentation for a commercial product,
-        we offer <a href="https://readthedocs.com/pricing/">paid plans</a> on readthedocs.com
-        that offer a completely ad-free experience,
-        private repositories, private documentation, additional build resources, and CDN support.
+        please consider <a href="https://readthedocs.com/">Read the Docs for Business</a>
+        which offers a completely ad-free experience,
+        private repositories, private documentation, additional build resources, and dedicated support.
       {% endblocktrans %}
     </li>
 
@@ -87,8 +87,8 @@
     <li class="module-item">
       {% blocktrans trimmed %}
         If you would like to completely remove advertising from your open source project,
-        but our commercial plans don't seem like the right fit,
-        please <a href="mailto:ads@readthedocs.org?subject=Alternatives+to+advertising">get in touch</a>
+        but Read the Docs for Business doesn't seem like the right fit,
+        please <a href="mailto:ads@readthedocs.org?subject=Alternatives%20to%20advertising">get in touch</a>
         to discuss alternatives to advertising.
       {% endblocktrans %}
     </li>

--- a/readthedocs/templates/support.html
+++ b/readthedocs/templates/support.html
@@ -59,7 +59,8 @@ This includes:
 Commercial Support
 ------------------
 
-We offer commercial support for Read the Docs, commercial hosting,
+We offer commercial support for Read the Docs,
+commercial hosting with `Read the Docs for Business`_,
 as well as consulting around all documentation systems.
 You can contact us at hello@readthedocs.com to learn more,
 or read more at https://readthedocs.com/services/#open-source-support.
@@ -68,6 +69,7 @@ or read more at https://readthedocs.com/services/#open-source-support.
 .. _Github Issue Tracker: https://github.com/readthedocs/readthedocs.org/issues
 .. _Gold: https://readthedocs.org/accounts/gold/
 .. _Ethical Ads: https://docs.readthedocs.io/page/advertising/ethical-advertising.html
+.. _Read the Docs for Business: https://readthedocs.com
 
 {% endfilter %}
 </div>


### PR DESCRIPTION
This is a text-only change. It essentially updates a few places and standardizes on the verbiage "Read the Docs for Business" for readthedocs.com.