### PR TITLE
Don't rely on instance to save translation

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -619,7 +619,14 @@ class TranslationBaseForm(forms.Form):
             self.get_translation_queryset()
             .get(slug=translation_slug)
         )
-        project = self.parent.translations.add(translation)
+        project = self.parent.translations.add(
+            translation,
+            # Django only allows to add an object from the same database
+            # used for write. The translation object could have been retrieved
+            # from a replica, with bulk False Django ignores from where
+            # the object came.
+            bulk=False
+        )
         # Run symlinking and other sync logic to make sure we are in a good
         # state.
         self.parent.save()


### PR DESCRIPTION
There is not reason to rely on the instance
(well, just save one query).

We are having a weird bug on the corporate site
I wasn't able to replicate it locally
or find any other explanation.

Hope that fetching the object in an explicit way
fix the bug.

Also, we could just rely on the object id instead
of the slug, that way there is not need to fetch
the object in the save method :)