### PR TITLE
Do not show wipe version message on build details page for External versions

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -340,6 +340,11 @@ class Version(models.Model):
     def is_editable(self):
         return self.type == BRANCH
 
+    @property
+    def supports_wipe(self):
+        """Return True if version is not external."""
+        return not self.type == EXTERNAL
+
     def get_subdomain_url(self):
         private = self.privacy_level == PRIVATE
         return self.project.get_docs_url(

--- a/readthedocs/rtd_tests/tests/test_version.py
+++ b/readthedocs/rtd_tests/tests/test_version.py
@@ -66,3 +66,9 @@ class TestVersionModel(VersionMixin, TestCase):
 
     def test_commit_name_for_external_version(self):
         self.assertEqual(self.external_version.commit_name, self.external_version.identifier)
+
+    def test_version_does_not_support_wipe(self):
+        self.assertFalse(self.external_version.supports_wipe)
+
+    def test_version_supports_wipe(self):
+        self.assertTrue(self.branch_version.supports_wipe)

--- a/readthedocs/templates/builds/build_detail.html
+++ b/readthedocs/templates/builds/build_detail.html
@@ -122,7 +122,7 @@ $(document).ready(function () {
     </div>
 
     {% if request.user|is_admin:project %}
-      {% if not build.success and build.commands.count < 4 and not build.is_external %}
+      {% if not build.success and build.commands.count < 4 and build.version.supports_wipe %}
         <div class="build-ideas">
           <p>
             {% url 'wipe_version' build.version.project.slug build.version.slug as wipe_url %}

--- a/readthedocs/templates/builds/build_detail.html
+++ b/readthedocs/templates/builds/build_detail.html
@@ -122,7 +122,7 @@ $(document).ready(function () {
     </div>
 
     {% if request.user|is_admin:project %}
-      {% if not build.success and build.commands.count < 4 %}
+      {% if not build.success and build.commands.count < 4 and not build.is_external %}
         <div class="build-ideas">
           <p>
             {% url 'wipe_version' build.version.project.slug build.version.slug as wipe_url %}


### PR DESCRIPTION
We should not show wipe version message on the build details page for external versions as we disabled wipe version functionality for external versions.
https://github.com/readthedocs/readthedocs.org/blob/93bcf8d19c367e1088893a4902b15a05d1ad190f/readthedocs/core/views/__init__.py#L74-L79