### PR TITLE
Do not delete media storage files for external version

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -317,9 +317,10 @@ class Version(models.Model):
             args=[self.get_artifact_paths()],
         )
 
-        # Remove build artifacts from storage
-        storage_paths = self.get_storage_paths()
-        tasks.remove_build_storage_paths.delay(storage_paths)
+        # Remove build artifacts from storage if the version is not external
+        if self.type != EXTERNAL:
+            storage_paths = self.get_storage_paths()
+            tasks.remove_build_storage_paths.delay(storage_paths)
 
         project_pk = self.project.pk
         super().delete(*args, **kwargs)


### PR DESCRIPTION
We should not delete the external version files from the storage so that the links sent through GitHub Status API still work.