### PR TITLE
Fix issue with save on translation form

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -616,6 +616,10 @@ class TranslationBaseForm(forms.Form):
 
     def save(self, commit=True):
         if commit:
+            # Don't use ``self.parent.translations.add()`` here as this
+            # triggeres a problem with database routing and multiple databases.
+            # Directly set the ``main_language_project`` instead of doing a
+            # bulk update.
             self.translation.main_language_project = self.parent
             self.translation.save()
             # Run symlinking and other sync logic to make sure we are in a good

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -614,12 +614,14 @@ class TranslationBaseForm(forms.Form):
         )
         return queryset
 
-    def save(self):
-        project = self.parent.translations.add(self.translation)
-        # Run symlinking and other sync logic to make sure we are in a good
-        # state.
-        self.parent.save()
-        return project
+    def save(self, commit=True):
+        if commit:
+            self.translation.save()
+            self.parent.translations.add(self.translation)
+            # Run symlinking and other sync logic to make sure we are in a good
+            # state.
+            self.parent.save()
+        return self.parent
 
 
 class TranslationForm(SettingsOverrideObject):

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -616,8 +616,8 @@ class TranslationBaseForm(forms.Form):
 
     def save(self, commit=True):
         if commit:
+            self.translation.main_language_project = self.parent
             self.translation.save()
-            self.parent.translations.add(self.translation)
             # Run symlinking and other sync logic to make sure we are in a good
             # state.
             self.parent.save()


### PR DESCRIPTION
The translation was not being saved before adding to the parent project.
This surfaced an issue when the database is different, like in the case
where we use a database router to send read/write operations to
different databases.