### PR TITLE
Fix around community ads with an explicit ad placement

### DIFF
--- a/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
@@ -285,6 +285,7 @@ function init() {
     ];
     var params;
     var placement;
+    var explicit_placement = false;
 
     rtd = rtddata.get();
 
@@ -292,9 +293,11 @@ function init() {
     placement = create_explicit_placement();
 
     if (placement) {
+        // Explicit placement
         div_ids.push(placement.div_id);
         display_types.push(placement.display_type);
         priorities.push(placement.priority || constants.DEFAULT_PROMO_PRIORITY);
+        explicit_placement = true;
     } else {
         // Standard placements
         if (!rtd.show_promo()) {
@@ -319,7 +322,7 @@ function init() {
 
     // These will get community only ads temporarily
     // After the fixed footer rollout is complete, this can be removed
-    request_data.community_only = rtd.theme_supports_paid_promo() ? 0 : 1;
+    request_data.community_only = (rtd.theme_supports_paid_promo() || explicit_placement) ? 0 : 1;
 
     if (typeof URL !== 'undefined' && typeof URLSearchParams !== 'undefined') {
         // Force a specific promo to be displayed


### PR DESCRIPTION
Mostly this just affected Pylons projects as they specify precisely where the ad on their themes should go but their theme is neither the RTD theme nor Alabaster.