### PR TITLE
When called via SyncRepositoryTaskStep this doesn't exist

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -147,7 +147,7 @@ class SyncRepositoryMixin:
         version_repo = self.get_vcs_repo()
         version_repo.update()
         self.sync_versions(version_repo)
-        identifier = self.commit or self.version.identifier
+        identifier = getattr(self, 'commit', None) or self.version.identifier
         version_repo.checkout(identifier)
 
     def sync_versions(self, version_repo):


### PR DESCRIPTION
We should be more careful checking for it.