### PR TITLE
Remove warning about beta state of conda support

### DIFF
--- a/docs/guides/conda.rst
+++ b/docs/guides/conda.rst
@@ -1,9 +1,6 @@
 Conda Support
 =============
 
-.. warning:: This feature is in a beta state.
-             Please file an `issue`_ if you find anything wrong.
-
 Read the Docs supports Conda as an environment management tool,
 along with Virtualenv.
 Conda support is useful for people who depend on C libraries,


### PR DESCRIPTION
Just remove the warning note since it's not in beta anymore.