### PR TITLE
IPv6 in X-Forwarded-For fix

### DIFF
--- a/readthedocs/analytics/utils.py
+++ b/readthedocs/analytics/utils.py
@@ -34,7 +34,7 @@ def get_client_ip(request):
         # Removing the port number (if present)
         # But be careful about IPv6 addresses
         if client_ip.count(':') == 1:
-            client_ip = client_ip.rsplit(':')[0]
+            client_ip = client_ip.rsplit(':', maxsplit=1)[0]
     else:
         client_ip = request.META.get('REMOTE_ADDR', None)
 

--- a/readthedocs/analytics/utils.py
+++ b/readthedocs/analytics/utils.py
@@ -32,7 +32,9 @@ def get_client_ip(request):
         client_ip = x_forwarded_for.split(',')[0].strip()
 
         # Removing the port number (if present)
-        client_ip = client_ip.rsplit(':')[0]
+        # But be careful about IPv6 addresses
+        if client_ip.count(':') == 1:
+            client_ip = client_ip.rsplit(':')[0]
     else:
         client_ip = request.META.get('REMOTE_ADDR', None)
 


### PR DESCRIPTION
It's unclear to me whether our production proxies would ever include an IPv6 with port. In the errors I'm seeing in prod, I don't see that. X-Forwarded-For is not exactly a standard so there isn't something to look up here.