### PR TITLE
Send media downloads to analytics

### DIFF
--- a/readthedocs/analytics/tasks.py
+++ b/readthedocs/analytics/tasks.py
@@ -16,8 +16,8 @@ DEFAULT_PARAMETERS = {
     'tid': settings.GLOBAL_ANALYTICS_CODE,
 
     # User data
-    'uip': None,  # User IP address
-    'ua': None,  # User agent
+    'uip': '',  # User IP address
+    'ua': '',  # User agent
 
     # Application info
     'an': 'Read the Docs',

--- a/readthedocs/analytics/utils.py
+++ b/readthedocs/analytics/utils.py
@@ -70,11 +70,11 @@ def send_to_analytics(data):
     if data.get('uip') and data.get('ua'):
         data['cid'] = generate_client_id(data['uip'], data['ua'])
 
-    if 'uip' in data:
+    if data.get('uip'):
         # Anonymize IP address if applicable
         data['uip'] = anonymize_ip_address(data['uip'])
 
-    if 'ua' in data:
+    if data.get('ua'):
         # Anonymize user agent if it is rare
         data['ua'] = anonymize_user_agent(data['ua'])
 


### PR DESCRIPTION
While data will be sampled, this will give us an idea of how frequently media (zips, PDFs, ePubs) are downloaded.