### PR TITLE
Gold makes projects ad-free again

### DIFF
--- a/docs/advertising/ad-blocking.rst
+++ b/docs/advertising/ad-blocking.rst
@@ -53,7 +53,7 @@ Going ad-free
 -------------
 
 Users can go completely ad-free
-by becoming a `Gold Member <https://readthedocs.org/accounts/gold/>`_
+by becoming a `Gold member <https://readthedocs.org/accounts/gold/>`_
 or a `Supporter <https://readthedocs.org/sustainability/#donations>`_.
 Thank you for supporting Read the Docs.
 

--- a/docs/advertising/ethical-advertising.rst
+++ b/docs/advertising/ethical-advertising.rst
@@ -156,9 +156,9 @@ Opting Out
 We have added multiple ways to opt out of the advertising on Read the Docs.
 
 1. You can go completely ad-free
-   by becoming a `Gold Member <https://readthedocs.org/accounts/gold/>`_
+   by becoming a `Gold member <https://readthedocs.org/accounts/gold/>`_
    or a `Supporter <https://readthedocs.org/sustainability/#donations>`_.
-   Additionally, Gold Members may remove advertising from their projects for all visitors.
+   Additionally, Gold members may remove advertising from their projects for all visitors.
 
 2. You can opt out of seeing paid advertisements on documentation pages:
 

--- a/docs/advertising/ethical-advertising.rst
+++ b/docs/advertising/ethical-advertising.rst
@@ -158,6 +158,7 @@ We have added multiple ways to opt out of the advertising on Read the Docs.
 1. You can go completely ad-free
    by becoming a `Gold Member <https://readthedocs.org/accounts/gold/>`_
    or a `Supporter <https://readthedocs.org/sustainability/#donations>`_.
+   Additionally, Gold Members may remove advertising from their projects for all visitors.
 
 2. You can opt out of seeing paid advertisements on documentation pages:
 
@@ -182,5 +183,4 @@ We have added multiple ways to opt out of the advertising on Read the Docs.
    but our commercial plans don't seem like the right fit,
    please `get in touch`_ to discuss alternatives to advertising.
 
-.. _paid plans: https://readthedocs.com/pricing/
 .. _get in touch: mailto:ads@readthedocs.org?subject=Alternatives%20to%20advertising

--- a/docs/advertising/index.rst
+++ b/docs/advertising/index.rst
@@ -23,13 +23,13 @@ that respects user privacy.
 We recognize that advertising is not for everyone.
 You may :ref:`opt out of paid advertising <advertising/ethical-advertising:Opting Out>`
 although you will still see :ref:`community ads <advertising/ethical-advertising:Community Ads>`.
-You can go ad-free by `becoming a Gold Member`_ or a `Supporter`_ of Read the Docs.
-Gold Members can also remove advertising from their projects for all visitors.
+You can go ad-free by `becoming a Gold member`_ or a `Supporter`_ of Read the Docs.
+Gold members can also remove advertising from their projects for all visitors.
 
 For businesses looking to remove advertising,
 please consider :doc:`Read the Docs for Business </commercial/index>`.
 
-.. _becoming a Gold Member: https://readthedocs.org/accounts/gold/
+.. _becoming a Gold member: https://readthedocs.org/accounts/gold/
 .. _Supporter: https://readthedocs.org/sustainability/#donations
 
 .. toctree::

--- a/docs/advertising/index.rst
+++ b/docs/advertising/index.rst
@@ -22,8 +22,9 @@ that respects user privacy.
 
 We recognize that advertising is not for everyone.
 You may :ref:`opt out of paid advertising <advertising/ethical-advertising:Opting Out>`
--- you will still see :ref:`community ads <advertising/ethical-advertising:Community Ads>` --
-or you can go ad-free by `becoming a Gold Member`_ or a `Supporter`_ of Read the Docs.
+although you will still see :ref:`community ads <advertising/ethical-advertising:Community Ads>`.
+You can go ad-free by `becoming a Gold Member`_ or a `Supporter`_ of Read the Docs.
+Gold Members can also remove advertising from their projects for all visitors.
 
 For businesses looking to remove advertising,
 please consider :doc:`Read the Docs for Business </commercial/index>`.

--- a/docs/privacy-policy.rst
+++ b/docs/privacy-policy.rst
@@ -166,12 +166,12 @@ and we encourage you to check back periodically.
 Payment processing
 ++++++++++++++++++
 
-Should you choose to become a `Supporter`_, purchase a `Gold Membership`_,
+Should you choose to become a `Supporter`_, purchase a `Gold membership`_,
 or become a subscriber to Read the Docs' commercial hosting product,
 your payment information and details will be processed by Stripe.
 Read the Docs does not store your payment information.
 
-.. _Gold Membership: https://readthedocs.org/accounts/gold/
+.. _Gold membership: https://readthedocs.org/accounts/gold/
 .. _Supporter: https://readthedocs.org/sustainability/
 
 Site monitoring

--- a/media/css/core.css
+++ b/media/css/core.css
@@ -873,9 +873,12 @@ div.donate-stats h2 {
     margin: .5em 0em 1.5em 0em;
 }
 
+#content ul.donate-about {
+    margin-bottom: 1em;
+}
 ul.donate-about li {
-    margin-left: 1em;
-    list-style: inside;
+    margin-left: 1.5em;
+    list-style: initial;
 }
 
 div.donate-stats-sm form {

--- a/readthedocs/gold/__init__.py
+++ b/readthedocs/gold/__init__.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 """
-A Django app for Gold Membership.
+A Django app for Gold membership.
 
-Gold Membership is Read the Docs' program for recurring, monthly donations.
+Gold membership is Read the Docs' program for recurring, monthly donations.
 """
 default_app_config = 'readthedocs.gold.apps.GoldAppConfig'

--- a/readthedocs/gold/admin.py
+++ b/readthedocs/gold/admin.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-"""Django admin configuration for the Gold Membership app."""
+"""Django admin configuration for the Gold membership app."""
 
 from django.contrib import admin
 

--- a/readthedocs/gold/apps.py
+++ b/readthedocs/gold/apps.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-"""Django app configuration for the Gold Membership app."""
+"""Django app configuration for the Gold membership app."""
 
 from django.apps import AppConfig
 

--- a/readthedocs/gold/models.py
+++ b/readthedocs/gold/models.py
@@ -1,4 +1,4 @@
-"""Django models for recurring donations aka Gold Membership."""
+"""Django models for recurring donations aka Gold membership."""
 import math
 from datetime import datetime
 
@@ -25,7 +25,7 @@ DOLLARS_PER_PROJECT = 5
 
 class GoldUser(models.Model):
 
-    """A user subscription for gold membership."""
+    """A user subscription for Gold membership."""
 
     pub_date = models.DateTimeField(_('Publication date'), auto_now_add=True)
     modified_date = models.DateTimeField(_('Modified date'), auto_now=True)

--- a/readthedocs/gold/models.py
+++ b/readthedocs/gold/models.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """Django models for recurring donations aka Gold Membership."""
 import math
 from datetime import datetime
@@ -28,9 +26,6 @@ DOLLARS_PER_PROJECT = 5
 class GoldUser(models.Model):
 
     """A user subscription for gold membership."""
-
-    # Gold members created after this date can no longer sponsor projects to be ad-free
-    SPONSOR_PROJECT_CUTOFF = pytz.utc.localize(datetime(year=2019, month=5, day=1))
 
     pub_date = models.DateTimeField(_('Publication date'), auto_now_add=True)
     modified_date = models.DateTimeField(_('Modified date'), auto_now=True)
@@ -66,9 +61,3 @@ class GoldUser(models.Model):
         dollars = int(self.level.split('-')[-1])
         num_projects = int(math.floor(dollars // DOLLARS_PER_PROJECT))
         return num_projects
-
-    def can_sponsor_projects(self):
-        if self.pub_date < self.SPONSOR_PROJECT_CUTOFF or self.projects.exists():
-            return True
-
-        return False

--- a/readthedocs/gold/templates/gold/projects.html
+++ b/readthedocs/gold/templates/gold/projects.html
@@ -12,7 +12,7 @@
   <h3>{% trans "Gold Projects" %}</h3>
   <p>
     {% blocktrans trimmed %}
-      Gold Members may completely remove advertising for all visitors to their projects.
+      Gold members may completely remove advertising for all visitors to their projects.
     {% endblocktrans %}
   </p>
 
@@ -46,8 +46,9 @@
     </form>
   {% else %}
     <p>
-      {% blocktrans trimmed with gold_level=gold_user.get_level_display %}
-        You have already adopted all the projects you can with your current Gold Membership of {{ gold_level }}.
+      {% blocktrans trimmed with gold_level=gold_user.get_level_display gold_projects_count=gold_user.num_supported_projects %}
+        You can't make any more projects ad-free with your current Gold membership of {{ gold_level }}.
+        You can either increase the level of your membership or change which projects you make ad-free.
       {% endblocktrans %}
     </p>
   {% endif %}

--- a/readthedocs/gold/templates/gold/projects.html
+++ b/readthedocs/gold/templates/gold/projects.html
@@ -21,7 +21,7 @@
     <li>{% trans 'For corporate supported open source projects, we ask for a $50 membership in order to cover our support and operations costs.' %}</li>
   </ul>
 
-  <h3>{% trans 'Adopted projects' %}</h3>
+  <h3>{% trans 'Ad-free projects' %}</h3>
   <ul class="donate-about">
     {% for project in projects %}
       <li>

--- a/readthedocs/gold/templates/gold/projects.html
+++ b/readthedocs/gold/templates/gold/projects.html
@@ -33,7 +33,7 @@
     {% endfor %}
   </ul>
 
-  <h3>{% trans "Adopt a project" %}</h3>
+  <h3>{% trans "Make a project ad-free" %}</h3>
   {% if gold_user.num_supported_projects > projects|length %}
     <p>
       {% trans "Choose which project you would like to make ad-free." %}

--- a/readthedocs/gold/templates/gold/projects.html
+++ b/readthedocs/gold/templates/gold/projects.html
@@ -4,53 +4,52 @@
 
 {% block profile-admin-gold-edit %}active{% endblock %}
 
-{% block title %}
-Gold Projects
-{% endblock %}
+{% block title %}{% trans "Gold Projects" %}{% endblock %}
 
 
 {% block edit_content %}
 
-  <p class="empty">
-    {% blocktrans trimmed %}
-      <strong>Note:</strong> this is a legacy feature.
-      New gold members cannot sponsor projects to be ad-free.
-    {% endblocktrans %}
-  </p>
-
-  <p class="help_text">
-    {% trans "Choose projects that will have all promos removed, and extra features added to them. You get to pick one for every $5/mo you support Read the Docs with." %}
-  </p>
-
-  <h3> {% trans "Existing Projects" %} </h3>
+  <h3>{% trans "Gold Projects" %}</h3>
   <p>
-    {% blocktrans trimmed count projects=gold_user.num_supported_projects %}
-      You can adopt one project with your subscription.
-    {% plural %}
-      You can adopt {{ projects }} projects with your subscription.
+    {% blocktrans trimmed %}
+      Gold Members may completely remove advertising for all visitors to their projects.
     {% endblocktrans %}
   </p>
 
-  <ul>
-  {% for project in projects %}
-      <li>
-      <a href="{{ project.get_absolute_url }}">
-      {{ project }}
-      </a>
-      (<a href="{% url "gold_projects_remove" project.slug %}">{% trans "Remove" %}</a>)
-      </li>
-  {% endfor %}
+  <ul class="donate-about">
+    <li>{% trans 'For small businesses or personal projects, we ask for $5 per month to remove ads from a project.' %}</li>
+    <li>{% trans 'For corporate supported open source projects, we ask for a $50 membership in order to cover our support and operations costs.' %}</li>
   </ul>
 
-  <h3>{% trans "Add a project" %}</h3>
-  <p>
-    {% trans "Choose which project you would like to add." %}
-  </p>
-  <form method="post" action=".">{% csrf_token %}
-    {{ form.as_p }}
+  <h3>{% trans 'Adopted projects' %}</h3>
+  <ul class="donate-about">
+    {% for project in projects %}
+      <li>
+        <a href="{{ project.get_absolute_url }}">{{ project }}</a>
+        <span>(<a href="{% url "gold_projects_remove" project.slug %}">{% trans "Remove Ad-Free Status" %}</a>)</span>
+      </li>
+    {% empty %}
+      <p>{% trans 'You have not adopted any projects.' %}</p>
+    {% endfor %}
+  </ul>
+
+  <h3>{% trans "Adopt a project" %}</h3>
+  {% if gold_user.num_supported_projects > projects|length %}
     <p>
-      <input style="display: inline;" type="submit" value="{% trans "Submit" %}">
+      {% trans "Choose which project you would like to make ad-free." %}
     </p>
-  </form>
+    <form method="post" action=".">{% csrf_token %}
+      {{ form.as_p }}
+      <p>
+        <input type="submit" value="{% trans "Make Project Ad-Free" %}">
+      </p>
+    </form>
+  {% else %}
+    <p>
+      {% blocktrans trimmed with gold_level=gold_user.get_level_display %}
+        You have already adopted all the projects you can with your current Gold Membership of {{ gold_level }}.
+      {% endblocktrans %}
+    </p>
+  {% endif %}
 
 {% endblock %}

--- a/readthedocs/gold/templates/gold/projects.html
+++ b/readthedocs/gold/templates/gold/projects.html
@@ -29,7 +29,7 @@
         <span>(<a href="{% url "gold_projects_remove" project.slug %}">{% trans "Remove Ad-Free Status" %}</a>)</span>
       </li>
     {% empty %}
-      <p>{% trans 'You have not adopted any projects.' %}</p>
+      <p>{% trans 'No projects are currently ad-free.' %}</p>
     {% endfor %}
   </ul>
 

--- a/readthedocs/gold/templates/gold/subscription_confirm_delete.html
+++ b/readthedocs/gold/templates/gold/subscription_confirm_delete.html
@@ -3,19 +3,19 @@
 
 {% block profile-admin-gold-edit %}active{% endblock %}
 
-{% block title %}Cancel Gold{% endblock %}
+{% block title %}Cancel Gold membership{% endblock %}
 
 {% block edit_content %}
-  <h2>Cancel Gold Subscription</h2>
+  <h2>Cancel Gold membership</h2>
 
   <p>
     {% blocktrans trimmed %}
-      Are you sure you want to cancel your subscription?
+      Are you sure you want to cancel your Gold membership?
     {% endblocktrans %}
   </p>
 
   <form  method="post" action="{% url "gold_cancel" %}">
     {% csrf_token %}
-    <input type="submit" value="{% trans "Cancel Subscription" %}">
+    <input type="submit" value="{% trans "Cancel Gold membership" %}">
   </form>
 {% endblock %}

--- a/readthedocs/gold/templates/gold/subscription_detail.html
+++ b/readthedocs/gold/templates/gold/subscription_detail.html
@@ -4,7 +4,7 @@
 
 {% block profile-admin-gold-edit %}active{% endblock %}
 
-{% block title %}{% trans "Gold Subscription" %}{% endblock %}
+{% block title %}{% trans "Gold Membership" %}{% endblock %}
 
 {% block extra_scripts %}
   <script src="https://js.stripe.com/v2/" type="text/javascript"></script>
@@ -28,7 +28,7 @@ $(document).ready(function () {
 
 {% block edit_content %}
   <div class="gold-subscription">
-    <h2>{% trans "Gold Subscription" %}</h2>
+    <h2>{% trans "Gold Membership" %}</h2>
 
     <p>
       {% blocktrans trimmed %}
@@ -47,11 +47,11 @@ $(document).ready(function () {
     </p>
 
     <form method="get" action="{% url "gold_subscription" %}" class="subscription-update">
-      <button>{% trans "Update Subscription" %}</button>
+      <button>{% trans "Update membership" %}</button>
     </form>
 
     <form method="get" action="{% url "gold_cancel" %}" class="subscription-cancel">
-      <button>{% trans "Cancel Subscription" %}</button>
+      <button>{% trans "Cancel membership" %}</button>
     </form>
 
     <h3>{% trans "Gold projects" %}</h3>

--- a/readthedocs/gold/templates/gold/subscription_detail.html
+++ b/readthedocs/gold/templates/gold/subscription_detail.html
@@ -54,19 +54,11 @@ $(document).ready(function () {
       <button>{% trans "Cancel Subscription" %}</button>
     </form>
 
-    {% if golduser.can_sponsor_projects %}
-      <h3>{% trans "Projects" %}</h3>
-      <p class="subscription-projects">
-        {% blocktrans trimmed count projects=golduser.num_supported_projects %}
-          You can adopt one project with your subscription.
-        {% plural %}
-          You can adopt {{ projects }} projects with your subscription.
-        {% endblocktrans %}
-      </p>
+    <h3>{% trans "Gold projects" %}</h3>
+    <p class="subscription-projects">{% trans 'Choose projects you would like to make ad-free.' %}</p>
 
-      <form method="get" action="{% url "gold_projects" %}" class="subscription-projects">
-        <button>{% trans "Select Projects" %}</button>
-      </form>
-    {% endif %}
+    <form method="get" action="{% url "gold_projects" %}" class="subscription-projects">
+      <button>{% trans "Select Projects" %}</button>
+    </form>
   </div>
 {% endblock %}

--- a/readthedocs/gold/templates/gold/subscription_form.html
+++ b/readthedocs/gold/templates/gold/subscription_form.html
@@ -46,7 +46,7 @@ $(document).ready(function () {
 
     <p>
     {% blocktrans trimmed %}
-      Becoming a Gold Member makes Read the Docs ad-free for as long as you are logged-in.
+      Becoming a Gold Member makes Read the Docs ad-free when you are logged-in.
       Gold Members may also completely remove advertising for all visitors to their projects.
     {% endblocktrans %}
     </p>

--- a/readthedocs/gold/templates/gold/subscription_form.html
+++ b/readthedocs/gold/templates/gold/subscription_form.html
@@ -43,51 +43,34 @@ $(document).ready(function () {
         product.
       {% endblocktrans %}
     </p>
+
     <p>
     {% blocktrans trimmed %}
-      If you are an individual,
-      feel free to give whatever feels right for the value you get out of Read the Docs.
+      Becoming a Gold Member makes Read the Docs ad-free for as long as you are logged-in.
+      Gold Members may also completely remove advertising for all visitors to their projects.
     {% endblocktrans %}
     </p>
+
+    <ul class="donate-about">
+      <li>{% trans 'For small businesses or personal projects, we ask for $5 per month to remove ads from a project.' %}</li>
+      <li>{% trans 'For corporate supported open source projects, we ask for a $50 membership in order to cover our support and operations costs.' %}</li>
+    </ul>
+
     <p>
     {% blocktrans trimmed %}
       If you are a company using Read the Docs,
       please consider <a href="https://readthedocs.com/">Read the Docs for Business</a>.
       This will help us cover our costs,
       and provide you with a better experience on the site.
-      If you aren't able to do that,
-      we suggest giving at least $20/month to help cover our support and operations costs.
     {% endblocktrans %}
     </p>
 
-    <p>{% trans 'Becoming a Gold Member also makes Read the Docs ad-free for as long as you are logged-in.' %}</p>
-
     <p>
       {% blocktrans trimmed %}
-        You can also make one-time donations on our <a href="https://readthedocs.org/sustainability/">sustainability</a> page.
+        For any questions about our Gold Membership program,
+        please <a href="mailto:rev@readthedocs.org?subject=Gold%20membership%20questions">email us</a>.
       {% endblocktrans %}
     </p>
-
-    {% if domains.count %}
-    <h3>Domains</h3>
-    <p>
-      {% blocktrans trimmed %}
-      We ask that folks who use custom Domains give Read the Docs $5 per domain they are using.
-      This is optional, but it really does help us maintain the site going forward.
-      {% endblocktrans %}
-    </p>
-
-    <p>
-      You are currently using {{ domains.count }} domains:
-
-      <ul class="donate-about">
-      {% for domain in domains %}
-        <li>{{ domain.domain }} ({{ domain.project.name }})</li>
-      {% endfor %}
-      </ul>
-    </p>
-
-    {% endif %}
 
     {% trans "Become a Gold Member" as subscription_title %}
     {% if golduser %}

--- a/readthedocs/gold/templates/gold/subscription_form.html
+++ b/readthedocs/gold/templates/gold/subscription_form.html
@@ -34,7 +34,7 @@ $(document).ready(function () {
 
 {% block edit_content %}
   <div>
-    <h2>Read the Docs Gold</h2>
+    <h2>{% trans 'Read the Docs Gold Membership' %}</h2>
 
     <p>
       {% blocktrans trimmed %}
@@ -46,8 +46,8 @@ $(document).ready(function () {
 
     <p>
     {% blocktrans trimmed %}
-      Becoming a Gold Member makes Read the Docs ad-free when you are logged-in.
-      Gold Members may also completely remove advertising for all visitors to their projects.
+      Becoming a Gold member makes Read the Docs ad-free when you are logged-in.
+      Gold members may also completely remove advertising for all visitors to their projects.
     {% endblocktrans %}
     </p>
 
@@ -67,12 +67,12 @@ $(document).ready(function () {
 
     <p>
       {% blocktrans trimmed %}
-        For any questions about our Gold Membership program,
+        For any questions about our Gold membership program,
         please <a href="mailto:rev@readthedocs.org?subject=Gold%20membership%20questions">email us</a>.
       {% endblocktrans %}
     </p>
 
-    {% trans "Become a Gold Member" as subscription_title %}
+    {% trans "Become a Gold member" as subscription_title %}
     {% if golduser %}
       {% trans "Update Your Subscription" as subscription_title %}
     {% endif %}

--- a/readthedocs/gold/views.py
+++ b/readthedocs/gold/views.py
@@ -103,10 +103,6 @@ def projects(request):
     gold_user = get_object_or_404(GoldUser, user=request.user)
     gold_projects = gold_user.projects.all()
 
-    if not gold_user.can_sponsor_projects():
-        messages.error(request, _('New gold users are no longer allowed to sponsor projects'))
-        return HttpResponseRedirect(reverse('gold_detail'))
-
     if request.method == 'POST':
         form = GoldProjectForm(
             active_user=request.user,

--- a/readthedocs/rtd_tests/tests/test_gold.py
+++ b/readthedocs/rtd_tests/tests/test_gold.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from datetime import timedelta
-
 from django.test import TestCase
 from django.urls import reverse
 from django_dynamic_fixture import fixture, get
@@ -21,7 +18,6 @@ class GoldViewTests(TestCase):
             GoldUser,
             user=self.user,
             level=LEVEL_CHOICES[0][0],
-            pub_date=GoldUser.SPONSOR_PROJECT_CUTOFF - timedelta(days=1),
         )
 
         self.client.login(username='owner', password='test')
@@ -30,22 +26,6 @@ class GoldViewTests(TestCase):
         self.assertEqual(self.golduser.projects.count(), 0)
         resp = self.client.post(reverse('gold_projects'), data={'project': 'test'})
         self.assertEqual(self.golduser.projects.count(), 1)
-        self.assertEqual(resp.status_code, 302)
-
-    def test_adding_projects_after_cutoff(self):
-        user = create_user(username='testuser', password='testtest')
-        self.client.login(username='testuser', password='testtest')
-        after_cutoff_golduser = get(
-            GoldUser,
-            user=user,
-            level=LEVEL_CHOICES[0][0],
-            pub_date=GoldUser.SPONSOR_PROJECT_CUTOFF + timedelta(days=1),
-        )
-        self.assertEqual(after_cutoff_golduser.projects.count(), 0)
-
-        # Ensure no gold project is created
-        resp = self.client.post(reverse('gold_projects'), data={'project': 'test'})
-        self.assertEqual(after_cutoff_golduser.projects.count(), 0)
         self.assertEqual(resp.status_code, 302)
 
     def test_too_many_projects(self):

--- a/readthedocs/templates/profiles/base_profile_edit.html
+++ b/readthedocs/templates/profiles/base_profile_edit.html
@@ -51,7 +51,7 @@
           <li class="{% block profile-admin-change-email %}{% endblock %}"><a href="{% url 'account_email' %}">{% trans "Change Email" %}</a></li>
           <li class="{% block profile-admin-tokens %}{% endblock %}"><a href="{% url 'profiles_tokens' %}">{% trans "API Tokens" %}</a></li>
           <li class="{% block profile-admin-delete-account %}{% endblock %}"><a href="{% url 'delete_account' %}">{% trans "Delete Account" %}</a></li>
-          <li class="{% block profile-admin-gold-edit %}{% endblock %}"><a href="{% url 'gold_detail' %}">{% trans "Gold" %}</a></li>
+          <li class="{% block profile-admin-gold-edit %}{% endblock %}"><a href="{% url 'gold_detail' %}">{% trans "Gold Membership" %}</a></li>
           {% if USE_PROMOS %}
             <li class="{% block profile-admin-advertising %}{% endblock %}"><a href="{% url 'account_advertising' %}">{% trans "Advertising" %}</a></li>
           {% endif %}

--- a/readthedocs/templates/profiles/private/advertising_profile.html
+++ b/readthedocs/templates/profiles/private/advertising_profile.html
@@ -13,7 +13,7 @@
   {% if request.user.gold.exists or request.user.goldonce.exists %}
     <p>
       {% blocktrans trimmed %}
-        Since you are a Gold Member or Supporter, you are <strong>ad-free</strong> for as long as you are logged-in.
+        Since you are a Gold member or Supporter, you are <strong>ad-free</strong> for as long as you are logged-in.
         Thank you for supporting Read the Docs.
       {% endblocktrans%}
     </p>
@@ -39,7 +39,7 @@
       {% url "gold_detail" as gold_detail %}
       {% url "donate" as donate_url %}
       {% blocktrans trimmed %}
-        You can <strong>go ad-free</strong> by becoming a <a href="{{ gold_detail }}">Gold Member</a> or <a href="{{ donate_url }}">Supporter</a> of Read the Docs</a>.
+        You can <strong>go ad-free</strong> by becoming a <a href="{{ gold_detail }}">Gold member</a> or <a href="{{ donate_url }}">Supporter</a> of Read the Docs</a>.
       {% endblocktrans %}
     </p>
 

--- a/readthedocs/templates/projects/project_advertising.html
+++ b/readthedocs/templates/projects/project_advertising.html
@@ -79,7 +79,7 @@
     <li class="module-item">
       {% url "gold_detail" as gold_detail %}
       {% blocktrans trimmed %}
-        By becoming a <a href="{{ gold_detail }}">Gold Member</a> to Read the Docs,
+        By becoming a <a href="{{ gold_detail }}">Gold member</a> to Read the Docs,
         you may remove advertising from your projects for all visitors.
       {% endblocktrans %}
     </li>
@@ -95,7 +95,7 @@
     <li class="module-item">
       {% blocktrans trimmed %}
         If you would like to completely remove advertising from your open source project,
-        but both Read the Docs for Business and our Gold Memberships don't seem like the right fit,
+        but both Read the Docs for Business and our Gold memberships don't seem like the right fit,
         please <a href="mailto:ads@readthedocs.org?subject=Alternatives%20to%20advertising">get in touch</a>
         to discuss alternatives to advertising.
       {% endblocktrans %}
@@ -113,7 +113,7 @@
       {% blocktrans trimmed %}
         If you are a company hosting commercial documentation on our community site,
         we do not allow removing paid advertisements on your documentation.
-        Please consider Read the Docs for Business or a Gold Membership.
+        Please consider Read the Docs for Business or a Gold membership.
       {% endblocktrans %}
       </small>
     </p>

--- a/readthedocs/templates/projects/project_advertising.html
+++ b/readthedocs/templates/projects/project_advertising.html
@@ -77,6 +77,14 @@
     </li>
 
     <li class="module-item">
+      {% url "gold_detail" as gold_detail %}
+      {% blocktrans trimmed %}
+        By becoming a <a href="{{ gold_detail }}">Gold Member</a> to Read the Docs,
+        you may remove advertising from your projects for all visitors.
+      {% endblocktrans %}
+    </li>
+
+    <li class="module-item">
       {% blocktrans trimmed %}
         Project owners can <a href="#removing-paid-advertising">opt out of paid advertisements</a>
         for their projects.
@@ -87,7 +95,7 @@
     <li class="module-item">
       {% blocktrans trimmed %}
         If you would like to completely remove advertising from your open source project,
-        but Read the Docs for Business doesn't seem like the right fit,
+        but both Read the Docs for Business and our Gold Memberships don't seem like the right fit,
         please <a href="mailto:ads@readthedocs.org?subject=Alternatives%20to%20advertising">get in touch</a>
         to discuss alternatives to advertising.
       {% endblocktrans %}
@@ -104,7 +112,8 @@
       <small>
       {% blocktrans trimmed %}
         If you are a company hosting commercial documentation on our community site,
-        we do not allow removing sponsor advertisements on your documentation.
+        we do not allow removing paid advertisements on your documentation.
+        Please consider Read the Docs for Business or a Gold Membership.
       {% endblocktrans %}
       </small>
     </p>

--- a/readthedocs/templates/projects/project_dashboard.html
+++ b/readthedocs/templates/projects/project_dashboard.html
@@ -10,8 +10,9 @@
             Read the Docs depends on users like you to help us keep the site sustainable.
         </p>
         <p>
-            We now offer <a href="{% url "gold_detail" %}">Read the Docs Gold</a> to allow folks to support us. Gold subscriptions allow us to keep the site running, and improving all the time.
-            If you find value in Read the Docs, please consider getting a subscription.
+            We now offer <a href="{% url "gold_detail" %}">Read the Docs Gold membership</a> to allow folks to support us.
+            Gold members allow us to keep the site running, and improving all the time.
+            If you find value in Read the Docs, please consider becoming a member.
         </p>
 
         <form method="get" action="{% url "gold_detail" %}">

--- a/readthedocs/templates/support.html
+++ b/readthedocs/templates/support.html
@@ -28,7 +28,7 @@ Community Support
 
 Read the Docs is supported by community contributions and advertising.
 We hope to bring in enough money
-with our `Gold`_ and `Ethical Ads`_ programs to keep Read the Docs sustainable.
+with our `Gold membership`_ and `Ethical Ads`_ programs to keep Read the Docs sustainable.
 
 **All people answering your questions are doing it with their own time,
 so please be kind and provide as much information as possible.**
@@ -67,7 +67,7 @@ or read more at https://readthedocs.com/services/#open-source-support.
 
 .. _Stack Overflow: http://stackoverflow.com/questions/tagged/read-the-docs
 .. _Github Issue Tracker: https://github.com/readthedocs/readthedocs.org/issues
-.. _Gold: https://readthedocs.org/accounts/gold/
+.. _Gold membership: https://readthedocs.org/accounts/gold/
 .. _Ethical Ads: https://docs.readthedocs.io/page/advertising/ethical-advertising.html
 .. _Read the Docs for Business: https://readthedocs.com
 


### PR DESCRIPTION
- Be clear about this in the docs and gold app
- Re-enable the gold member screen to designate gold projects for all members
- $5/mo for personal or small biz and $50 for corporate

This mostly reverts #5628. The areas where I would most like feedback are in `subscription_detail.html`, `projects.html`, and `subscription_form.html`.

## Concerns

* There is absolutely nothing stopping a corporate OSS project from becoming a $5/mo member and removing ads. Only the text says they are supposed to pay more.
* While it isn't a big concern, we weren't quite as clear about gold removing all ads before although the screen totally did that in the past. It is possible that projects where we generate more than $5/mo in advertising suddenly go ad-free resulting in less revenue.

## Screenshots

### Becoming a gold member
![Screen Shot 2019-08-13 at 10 06 22 PM](https://user-images.githubusercontent.com/185043/62995713-a0edae80-be16-11e9-98fa-d13ea834ae53.png)

### Designating gold projects
![Screen Shot 2019-08-13 at 9 47 40 PM](https://user-images.githubusercontent.com/185043/62995716-a3e89f00-be16-11e9-88b5-38d460ad1a91.png)
