### PR TITLE
Update intersphinx mapping with canonical sources

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,8 +54,8 @@ release = version
 exclude_patterns = ['_build']
 default_role = 'obj'
 intersphinx_mapping = {
-    'python': ('https://python.readthedocs.io/en/latest/', None),
-    'django': ('https://django.readthedocs.io/en/1.11.x/', None),
+    'python': ('https://docs.python.org/3.6/', None),
+    'django': ('https://docs.djangoproject.com/en/1.11/', 'https://docs.djangoproject.com/en/1.11/_objects/'),
     'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
 }
 htmlhelp_basename = 'ReadTheDocsdoc'


### PR DESCRIPTION
As far as I can tell, neither the Python Intersphinx mapping nor the Django one are used in our docs. We are planning an upcoming Intersphinx guide and/or blog so this should be helpful for that.