### PR TITLE
Don't log BuildEnvironmentWarning as error

### DIFF
--- a/readthedocs/vcs_support/base.py
+++ b/readthedocs/vcs_support/base.py
@@ -1,9 +1,8 @@
-# -*- coding: utf-8 -*-
-
 """Base classes for VCS backends."""
 import logging
 import os
 import shutil
+
 from readthedocs.doc_builder.exceptions import BuildEnvironmentWarning
 from readthedocs.projects.exceptions import RepositoryError
 

--- a/readthedocs/vcs_support/base.py
+++ b/readthedocs/vcs_support/base.py
@@ -4,6 +4,8 @@
 import logging
 import os
 import shutil
+from readthedocs.doc_builder.exceptions import BuildEnvironmentWarning
+from readthedocs.projects.exceptions import RepositoryError
 
 
 log = logging.getLogger(__name__)
@@ -102,7 +104,13 @@ class BaseVCS:
             'shell': False,
         })
 
-        build_cmd = self.environment.run(*cmd, **kwargs)
+        try:
+            build_cmd = self.environment.run(*cmd, **kwargs)
+        except BuildEnvironmentWarning as e:
+            # Re raise as RepositoryError,
+            # so isn't logged as ERROR.
+            raise RepositoryError(str(e))
+
         # Return a tuple to keep compatibility
         return (build_cmd.exit_code, build_cmd.output, build_cmd.error)
 


### PR DESCRIPTION
Turns out we are logging this manually
https://github.com/readthedocs/readthedocs.org/blob/00ab116ec09e75b74c20c1abdc7b9a9a47d9e673/readthedocs/projects/tasks.py#L254-L265

Closes #4590