### PR TITLE
Add setting for always cleaning the build post-build

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1507,7 +1507,10 @@ def clean_build(version_pk):
     except Exception:
         log.exception('Error while fetching the version from the api')
         return False
-    if not version.project.has_feature(Feature.CLEAN_AFTER_BUILD):
+    if (
+        not settings.RTD_CLEAN_AFTER_BUILD and
+        not version.project.has_feature(Feature.CLEAN_AFTER_BUILD)
+    ):
         log.info(
             'Skipping build files deletetion for version: %s',
             version_pk,

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -79,6 +79,7 @@ class CommunityBaseSettings(Settings):
     RTD_LATEST_VERBOSE_NAME = 'latest'
     RTD_STABLE = 'stable'
     RTD_STABLE_VERBOSE_NAME = 'stable'
+    RTD_CLEAN_AFTER_BUILD = False
 
     # Database and API hitting settings
     DONT_HIT_API = False


### PR DESCRIPTION
This is the next phase in testing smaller disks on our build servers. It
makes the `CLEAN_AFTER_BUILD` feature flag into a server-wide setting,
allowing us to test the artifact-less build server on our normal build
queue.