### PR TITLE
Move out authorization from FooterHTML view

### DIFF
--- a/readthedocs/api/v2/permissions.py
+++ b/readthedocs/api/v2/permissions.py
@@ -86,13 +86,12 @@ class APIRestrictedPermission(permissions.BasePermission):
         )
 
 
-class FooterHTMLRestrictedPermission(permissions.BasePermission):
+class IsAuthorizedToViewVersion(permissions.BasePermission):
 
     """
-    Permission class used in the FooterHTML view.
+    Checks if the user from the request has permissions to see the version.
 
-    This checks if the user from the request has permissions
-    to see the version.
+    This permission class used in the FooterHTML view.
 
     .. note::
 

--- a/readthedocs/api/v2/permissions.py
+++ b/readthedocs/api/v2/permissions.py
@@ -106,7 +106,7 @@ class FooterHTMLRestrictedPermission(permissions.BasePermission):
         has_access = (
             Version.objects
             .public(
-                user=self.request.user,
+                user=request.user,
                 project=project,
                 only_active=False,
             )

--- a/readthedocs/api/v2/views/footer_views.py
+++ b/readthedocs/api/v2/views/footer_views.py
@@ -8,7 +8,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_jsonp.renderers import JSONPRenderer
 
-from readthedocs.api.v2.permissions import FooterHTMLRestrictedPermission
+from readthedocs.api.v2.permissions import IsAuthorizedToViewVersion
 from readthedocs.api.v2.signals import footer_response
 from readthedocs.builds.constants import LATEST, TAG
 from readthedocs.builds.models import Version
@@ -76,7 +76,7 @@ class FooterHTML(APIView):
     """
 
     http_method_names = ['get']
-    permission_classes = [FooterHTMLRestrictedPermission]
+    permission_classes = [IsAuthorizedToViewVersion]
     renderer_classes = [JSONRenderer, JSONPRenderer]
 
     def _get_project(self):

--- a/readthedocs/api/v2/views/footer_views.py
+++ b/readthedocs/api/v2/views/footer_views.py
@@ -3,12 +3,12 @@
 from django.conf import settings
 from django.shortcuts import get_object_or_404
 from django.template import loader as template_loader
-from rest_framework.permissions import AllowAny
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_jsonp.renderers import JSONPRenderer
 
+from readthedocs.api.v2.permissions import FooterHTMLRestrictedPermission
 from readthedocs.api.v2.signals import footer_response
 from readthedocs.builds.constants import LATEST, TAG
 from readthedocs.builds.models import Version
@@ -76,7 +76,7 @@ class FooterHTML(APIView):
     """
 
     http_method_names = ['get']
-    permission_classes = [AllowAny]
+    permission_classes = [FooterHTMLRestrictedPermission]
     renderer_classes = [JSONRenderer, JSONPRenderer]
 
     def _get_project(self):
@@ -102,17 +102,22 @@ class FooterHTML(APIView):
             if version_slug == '':
                 version_slug = LATEST
 
+            project = self._get_project()
             version = get_object_or_404(
-                Version.objects.public(
-                    user=self.request.user,
-                    project=self._get_project(),
-                    only_active=False,
-                ),
+                project.versions.all(),
                 slug__iexact=version_slug,
             )
             setattr(self, cache_key, version)
 
         return version
+
+    def _get_all_versions_sorted(self):
+        """Get all versions that the user has access, sorted."""
+        project = self._get_project()
+        versions = project.ordered_active_versions(
+            user=self.request.user,
+        )
+        return versions
 
     def _get_context(self):
         theme = self.request.GET.get('theme', False)
@@ -142,9 +147,7 @@ class FooterHTML(APIView):
             'path': path,
             'downloads': version.get_downloads(pretty=True),
             'current_version': version.verbose_name,
-            'versions': project.ordered_active_versions(
-                user=self.request.user,
-            ),
+            'versions': self._get_all_versions_sorted(),
             'main_project': main_project,
             'translations': main_project.translations.all(),
             'current_language': project.language,

--- a/readthedocs/api/v2/views/footer_views.py
+++ b/readthedocs/api/v2/views/footer_views.py
@@ -111,7 +111,7 @@ class FooterHTML(APIView):
 
         return version
 
-    def _get_all_versions_sorted(self):
+    def _get_active_versions_sorted(self):
         """Get all versions that the user has access, sorted."""
         project = self._get_project()
         versions = project.ordered_active_versions(
@@ -147,7 +147,7 @@ class FooterHTML(APIView):
             'path': path,
             'downloads': version.get_downloads(pretty=True),
             'current_version': version.verbose_name,
-            'versions': self._get_all_versions_sorted(),
+            'versions': self._get_active_versions_sorted(),
             'main_project': main_project,
             'translations': main_project.translations.all(),
             'current_language': project.language,

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -951,6 +951,12 @@ class Project(models.Model):
         )
 
     def ordered_active_versions(self, **kwargs):
+        """
+        Get all active versions, sorted.
+
+        :param kwargs: All kwargs are passed down to the
+                       `Version.internal.public` queryset.
+        """
         from readthedocs.builds.models import Version
         kwargs.update(
             {
@@ -959,8 +965,7 @@ class Project(models.Model):
             },
         )
         versions = (
-            Version.internal
-            .public(**kwargs)
+            Version.internal.public(**kwargs)
             .select_related(
                 'project',
                 'project__main_language_project',

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -950,28 +950,33 @@ class Project(models.Model):
             versions.filter(active=True, uploaded=True)
         )
 
-    def ordered_active_versions(self, user=None):
+    def ordered_active_versions(self, **kwargs):
         from readthedocs.builds.models import Version
-        kwargs = {
-            'project': self,
-            'only_active': True,
-        }
-        if user:
-            kwargs['user'] = user
-        versions = Version.internal.public(**kwargs).select_related(
-            'project',
-            'project__main_language_project',
-        ).prefetch_related(
-            Prefetch(
-                'project__superprojects',
-                ProjectRelationship.objects.all().select_related('parent'),
-                to_attr='_superprojects',
-            ),
-            Prefetch(
-                'project__domains',
-                Domain.objects.filter(canonical=True),
-                to_attr='_canonical_domains',
-            ),
+        kwargs.update(
+            {
+                'project': self,
+                'only_active': True,
+            },
+        )
+        versions = (
+            Version.internal
+            .public(**kwargs)
+            .select_related(
+                'project',
+                'project__main_language_project',
+            )
+            .prefetch_related(
+                Prefetch(
+                    'project__superprojects',
+                    ProjectRelationship.objects.all().select_related('parent'),
+                    to_attr='_superprojects',
+                ),
+                Prefetch(
+                    'project__domains',
+                    Domain.objects.filter(canonical=True),
+                    to_attr='_canonical_domains',
+                ),
+            )
         )
         return sort_version_aware(versions)
 


### PR DESCRIPTION
This allow us to override the authorization from the corporate site.

Everything that makes use of `request.user` now can be overridden :)