### PR TITLE
chore: Add restructuredtext-lint linter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   - bower install
 script:
   - ./scripts/travis/run_tests.sh
-  - rst-lint find $directory -type f -name "*.rst"
+  - rst-lint doc/*.rst
 notifications:
   slack:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ cache:
 install:
   - ./scripts/travis/install_elasticsearch.sh
   - pip install tox-travis
+  - pip install restructuredtext-lint
   - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash
   - source ~/.nvm/nvm.sh
   - nvm install --lts
@@ -34,6 +35,7 @@ install:
   - bower install
 script:
   - ./scripts/travis/run_tests.sh
+  - rst-lint find $directory -type f -name "*.rst"
 notifications:
   slack:
     rooms:


### PR DESCRIPTION
Ref https://github.com/readthedocs/readthedocs.org/issues/5876.

No restructuredtext linting for vale-linter. Feel free closing if that linter is useless for readthedocs.