### PR TITLE
Filebased footer file cache

### DIFF
--- a/readthedocs/api/v2/views/footer_views.py
+++ b/readthedocs/api/v2/views/footer_views.py
@@ -18,7 +18,6 @@ from readthedocs.projects.version_handling import (
     parse_version_failsafe,
 )
 
-
 def get_version_compare_data(project, base_version=None):
     """
     Retrieve metadata about the highest version available for this project.

--- a/readthedocs/api/v2/views/footer_views.py
+++ b/readthedocs/api/v2/views/footer_views.py
@@ -18,6 +18,7 @@ from readthedocs.projects.version_handling import (
     parse_version_failsafe,
 )
 
+
 def get_version_compare_data(project, base_version=None):
     """
     Retrieve metadata about the highest version available for this project.

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -267,6 +267,10 @@ class CommunityBaseSettings(Settings):
         'default': {
             'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
             'PREFIX': 'docs',
+        },
+        'footer': {
+            'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+            'LOCATION': os.path.join(SITE_ROOT, 'readthedocs', 'api/v2/templates/restapi/footer.html' )
         }
     }
     CACHE_MIDDLEWARE_SECONDS = 60


### PR DESCRIPTION
Fixes https://github.com/readthedocs/readthedocs.org/issues/6126.

Footer attached files are accessed per ref, more than just view I think. Please feel free letting me know if memcache sounds cool.