### PR TITLE
Protection against ReDoS

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -1138,7 +1138,7 @@ class VersionAutomationRule(PolymorphicModel, TimeStampedModel):
 
 class RegexAutomationRule(VersionAutomationRule):
 
-    TIMEOUT = 2  # timeout in seconds
+    TIMEOUT = 1  # timeout in seconds
 
     allowed_actions = {
         VersionAutomationRule.ACTIVATE_VERSION_ACTION: actions.activate_version,

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -1156,6 +1156,9 @@ class RegexAutomationRule(VersionAutomationRule):
 
            We use the regex module with the timeout
            arg to avoid ReDoS.
+
+           We could use a finite state machine type of regex too,
+           but there isn't a stable library at the time of writting this code.
         """
         try:
             match = regex.search(

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -1138,7 +1138,7 @@ class VersionAutomationRule(PolymorphicModel, TimeStampedModel):
 
 class RegexAutomationRule(VersionAutomationRule):
 
-    TIMEOUT = 15  # timout in seconds
+    TIMEOUT = 2  # timeout in seconds
 
     allowed_actions = {
         VersionAutomationRule.ACTIVATE_VERSION_ACTION: actions.activate_version,

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -75,6 +75,7 @@ Unipath==1.1
 django-kombu==0.9.4
 mock==3.0.5
 stripe==2.37.2
+regex==2019.11.1
 
 # unicode-slugify==0.1.5 is not released on PyPI yet
 git+https://github.com/mozilla/unicode-slugify@b696c37#egg=unicode-slugify==0.1.5


### PR DESCRIPTION
The regex module is compatible with the re module (VERSION0 flag).
It is also faster.

```python
>>> import re
>>> import regex
>>> import timeit
>>> pattert = "(a+)+b"
>>> input = "a" * 25
>>> timeit.timeit(lambda: re.search(pattern, input), number=10)
32.332445038000515
>>> timeit.timeit(lambda: regex.search(pattern, input, flags=regex.VERSION0), number=10)
0.003861578001306043
>>> input = "a" * 10000
>>> regex.search(pattern, input, flags=regex.VERSION0, timeout=5)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/stsewd/.pyenv/versions/readthedocs.org/lib/python3.6/site-packages/regex/regex.py", line 266, in search
    concurrent, partial, timeout)
TimeoutError: regex timed out
```

I put the timeout to 15, maybe we can drop it to 5?