### PR TITLE
Improve CORS configuration

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -403,16 +403,19 @@ class CommunityBaseSettings(Settings):
         r'^http://(.+)\.readthedocs\.io$',
         r'^https://(.+)\.readthedocs\.io$',
     )
-    # So people can post to their accounts
+
+    # We need to allow credentials (cookies) to identify the user and remove ads
+    # if it's Gold member. Note: in Django 2.1 the ``SESSION_COOKIE_SAMESITE``
+    # setting was added, set to 'Lax' by default, which will prevent Django's
+    # session cookie being sent cross-domain. Change it to None to bypass this
+    # security restriction.
     CORS_ALLOW_CREDENTIALS = True
-    CORS_ALLOW_HEADERS = (
-        'x-requested-with',
-        'content-type',
-        'accept',
-        'origin',
-        'authorization',
-        'x-csrftoken'
-    )
+
+    CORS_ALLOW_METHODS = [
+        'GET',
+        'OPTIONS',
+        'HEAD',
+    ]
 
     # RTD Settings
     REPO_LOCK_SECONDS = 30


### PR DESCRIPTION
The goal of this commit is to allow access to our resources from different hosts:

* everything coming from `*.readthedocs.io`
* everything hitting any URL under `/api/` if it's safe method, no matter the host where the request comes from

Compared with the previous implementation, this reduces the number of queries to our database since we are not checking that the host where the request was made is a known Domain for us.

Besides, this opens access to `/api/v3` as well.

Be careful when reviewing this PR since it may be opening our API too widely. I'd appreciate comments on this.

> As a note, currently we are not allowing one reported use case: "create a landing page on GitHub pages (project.github.io/) and make an API query to get the active versions (readthedocs.org/api/v2/)"

Closes #6154 