### PR TITLE
Require login for old redirect

### DIFF
--- a/readthedocs/projects/urls/private.py
+++ b/readthedocs/projects/urls/private.py
@@ -1,6 +1,7 @@
 """Project URLs for authenticated users."""
 
 from django.conf.urls import url
+from django.contrib.auth.decorators import login_required
 from django.views.generic.base import RedirectView
 
 from readthedocs.constants import pattern_opts
@@ -45,7 +46,9 @@ urlpatterns = [
     ),
     url(
         r'^(?P<project_slug>[-\w]+)/$',
-        RedirectView.as_view(pattern_name='projects_detail', permanent=True),
+        login_required(
+            RedirectView.as_view(pattern_name='projects_detail', permanent=True),
+        ),
         name='projects_manage',
     ),
     url(

--- a/readthedocs/rtd_tests/tests/test_privacy_urls.py
+++ b/readthedocs/rtd_tests/tests/test_privacy_urls.py
@@ -311,11 +311,6 @@ class PrivateProjectUnauthAccessTest(PrivateProjectMixin, TestCase):
     # Auth protected
     default_status_code = 302
 
-    response_data = {
-        # Old url, it redirects to a view that doesn't requires login.
-        '/dashboard/pip/': {'status_code': 301},
-    }
-
     def login(self):
         pass
 


### PR DESCRIPTION
It was redirecting to a page that has login,
but on .com we put everything under a login,
so tests here fail.

I'm doing the change here so we don't have to deal
with fixing tests on .com.

Also, we could just remove this.