### PR TITLE
Add terms of service

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -163,6 +163,7 @@ of Read the Docs and the larger software documentation ecosystem.
 * **Policies & Process**:
   :doc:`security` |
   :doc:`Privacy policy <privacy-policy>` |
+  :doc:`Terms of service <terms-of-service>` |
   :doc:`DMCA takedown policy <dmca/index>` |
   :doc:`Policy for abandoned projects <abandoned-projects>` |
   :doc:`Release notes & changelog <changelog>`
@@ -195,6 +196,7 @@ of Read the Docs and the larger software documentation ecosystem.
 
    security
    privacy-policy
+   terms-of-service
    dmca/index
    abandoned-projects
    changelog

--- a/docs/privacy-policy.rst
+++ b/docs/privacy-policy.rst
@@ -4,7 +4,7 @@
 Privacy Policy
 ==============
 
-Effective date: **August 1, 2019**
+Effective date: **September  30, 2019**
 
 Welcome to Read the Docs.
 At Read the Docs, we believe in protecting the privacy of our
@@ -30,21 +30,23 @@ Our services
 Read the Docs is made up of:
 
 readthedocs.org ("Read the Docs Community")
-    This is a website aimed at documentation authors writing and building
-    software documentation. This Privacy Policy applies to this site
-    in full without reservation.
+    This is a website aimed at documentation authors and project maintainers
+    writing and distributing technical documentation.
+    This Privacy Policy applies to this site in full without reservation.
 
 readthedocs.com ("Read the Docs for Business")
     This website is a commercial hosted offering for hosting private
     documentation for corporate clients.
-    It is governed by this privacy policy but also separate
-    `terms <https://readthedocs.com/terms/>`_.
+    This Privacy Policy applies to this site in full without reservation.
 
 readthedocs.io, readthedocs-hosted.com, and other domains ("Documentation Sites")
-    These websites are where Read the Docs hosts documentation on
-    behalf of documentation authors. A best effort is made to apply
+    These websites are where Read the Docs hosts documentation (":ref:`User-Generated Content <terms-of-service:User-Generated Content>`")
+    on behalf of documentation authors.
+    A best effort is made to apply
     this Privacy Policy to these sites but the documentation
     may contain content and files created by documentation authors.
+
+All use of Read the Docs is subject to this Privacy Policy, together with our :doc:`Terms of service <terms-of-service>`.
 
 
 What information Read the Docs collects and why
@@ -114,6 +116,9 @@ Documentation Sites hosted on Read the Docs are public,
 anyone (including us) may view their contents.
 If you have included private or sensitive information in your Documentation Site,
 such as email addresses, that information may be indexed by search engines or used by third parties.
+
+Read the Docs for Business may host :ref:`private projects <terms-of-service:Private projects>` which we treat as confidential
+and we only access them for support reasons, with your consent, or if required to for security reasons
 
 If you're a **child under the age of 13**, you may not have an account on Read the Docs.
 Read the Docs does not knowingly collect information from or direct any of our content specifically to children under 13.

--- a/docs/terms-of-service.rst
+++ b/docs/terms-of-service.rst
@@ -288,7 +288,7 @@ Intellectual property notice
 ----------------------------
 
 **Short version:** *We own the Service and all of our Content.
-In order for you to use our content, we give you certain rights to it,
+In order for you to use our Content, we give you certain rights to it,
 but you may only use our content in the way we have allowed.*
 
 Read the Docs' rights to content

--- a/docs/terms-of-service.rst
+++ b/docs/terms-of-service.rst
@@ -348,12 +348,12 @@ and may not be appropriate for some high-bandwidth uses or other prohibited uses
 Read the Docs reserves the right at all times to reclaim any Read the Docs subdomain without liability.
 
 
-Third Party Applications
+Third party applications
 ---------------------------
 
 **Short version:** *You need to follow certain rules if you create an application for other Users.*
 
-Creating Applications
+Creating applications
 ~~~~~~~~~~~~~~~~~~~~~
 
 If you create a third-party application or other developer product that collects User Personal Information
@@ -497,7 +497,7 @@ Communications with Read the Docs
 
 **Short version:** *We use email and other electronic means to stay in touch with our users.*
 
-Electronic Communication Required
+Electronic communication required
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For contractual purposes, you:

--- a/docs/terms-of-service.rst
+++ b/docs/terms-of-service.rst
@@ -61,7 +61,7 @@ readthedocs.org ("Read the Docs Community")
     writing and distributing technical documentation.
 
 readthedocs.com ("Read the Docs for Business")
-    This website is a commercial hosted offering for hosting private
+    This Website is a commercial hosted offering for hosting private
     documentation for corporate clients.
 
 readthedocs.io, readthedocs-hosted.com, and other domains ("Documentation Sites")

--- a/docs/terms-of-service.rst
+++ b/docs/terms-of-service.rst
@@ -652,4 +652,5 @@ including any confidentiality or nondisclosure agreements.
 
 Questions
 ~~~~~~~~~
-Questions about the Terms of Service? `Contact us <mailto:support@readthedocs.org>`_.
+
+Questions about the Terms of Service? `Get in touch <mailto:support@readthedocs.org>`_.

--- a/docs/terms-of-service.rst
+++ b/docs/terms-of-service.rst
@@ -289,7 +289,7 @@ Intellectual property notice
 
 **Short version:** *We own the Service and all of our Content.
 In order for you to use our Content, we give you certain rights to it,
-but you may only use our content in the way we have allowed.*
+but you may only use our Content in the way we have allowed.*
 
 Read the Docs' rights to content
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/terms-of-service.rst
+++ b/docs/terms-of-service.rst
@@ -57,7 +57,7 @@ Our services
 Read the Docs is made up of the following Websites:
 
 readthedocs.org ("Read the Docs Community")
-    This is a website aimed at documentation authors and project maintainers
+    This Website is used by documentation authors and project maintainers for
     writing and distributing technical documentation.
 
 readthedocs.com ("Read the Docs for Business")

--- a/docs/terms-of-service.rst
+++ b/docs/terms-of-service.rst
@@ -54,7 +54,7 @@ There's not going to be a test on it, but it's still useful information.*
 Our services
 ~~~~~~~~~~~~
 
-Read the Docs is made up of:
+Read the Docs is made up of the following Websites:
 
 readthedocs.org ("Read the Docs Community")
     This is a website aimed at documentation authors and project maintainers

--- a/docs/terms-of-service.rst
+++ b/docs/terms-of-service.rst
@@ -287,7 +287,7 @@ We will terminate the Accounts of repeat infringers of this policy.
 Intellectual property notice
 ----------------------------
 
-**Short version:** *We own the service and all of our content.
+**Short version:** *We own the Service and all of our Content.
 In order for you to use our content, we give you certain rights to it,
 but you may only use our content in the way we have allowed.*
 

--- a/docs/terms-of-service.rst
+++ b/docs/terms-of-service.rst
@@ -49,6 +49,12 @@ There's not going to be a test on it, but it's still useful information.*
    A "User Account" represents an individual User's authorization to log in to and use the Service and serves as a User's identity on Read the Docs.
    "Organizations" are shared workspaces that may be associated with a single entity or with one or more Users where multiple Users can collaborate across many projects at once.
    A User Account can be a member of any number of Organizations.
+8. "User Personal Information" is any information about one of our users which could,
+   alone or together with other information, personally identify him or her.
+   Information such as a user name and password, an email address,
+   a real name, and a photograph are examples of User Personal Information.
+   Our :doc:`privacy-policy` goes into more details on User Personal Information,
+   what data Read the Docs collects, and why we collect it.
 
 
 Our services
@@ -345,7 +351,6 @@ Each Read the Docs Account comes with the ability to host Documentation Sites.
 This hosting service is intended to host static web pages for All Users.
 Documentation Sites are subject to some specific bandwidth and usage limits,
 and may not be appropriate for some high-bandwidth uses or other prohibited uses.
-Read the Docs reserves the right at all times to reclaim any Read the Docs subdomain without liability.
 
 
 Third party applications

--- a/docs/terms-of-service.rst
+++ b/docs/terms-of-service.rst
@@ -65,7 +65,7 @@ readthedocs.com ("Read the Docs for Business")
     documentation for corporate clients.
 
 readthedocs.io, readthedocs-hosted.com, and other domains ("Documentation Sites")
-    These websites are where Read the Docs hosts documentation (":ref:`User-Generated Content <terms-of-service:User-Generated Content>`")
+    These Websites are where Read the Docs hosts :ref:`terms-of-service:User-Generated Content`
     on behalf of documentation authors.
 
 

--- a/docs/terms-of-service.rst
+++ b/docs/terms-of-service.rst
@@ -1,0 +1,655 @@
+Read the Docs Terms of Service
+==============================
+
+Effective date: **September 30, 2019**
+
+Thank you for using Read the Docs! We're happy you're here.
+Please read this Terms of Service agreement carefully before accessing or using Read the Docs.
+Because it is such an important contract between us and our users,
+we have tried to make it as clear as possible.
+For your convenience, we have presented these terms in a short non-binding summary
+followed by the full legal terms.
+
+
+.. contents:: Table of contents
+   :local:
+   :backlinks: none
+   :depth: 1
+
+
+Definitions
+-----------
+
+**Short version:** *We use these basic terms throughout the agreement,
+and they have specific meanings.
+You should know what we mean when we use each of the terms.
+There's not going to be a test on it, but it's still useful information.*
+
+1. The "Agreement" refers, collectively, to all the terms, conditions, notices
+   contained or referenced in this document (the "Terms of Service" or the "Terms")
+   and all other operating rules, policies
+   (including our :doc:`privacy-policy`)
+   and procedures that we may publish from time to time on our sites.
+2. Our "Service" or "Services" refers to the applications, software, products, and services provided by Read the Docs
+   (see :ref:`Our services <terms-of-service:Our services>`).
+3. The "Website" or "Websites" refers to Read the Docs' websites located at
+   readthedocs.org, readthedocs.com, Documentation Sites,
+   and all content, services, and products provided by Read the Docs at or through those Websites.
+4. "The User," "You," and "Your" refer to the individual person, company, or organization that has visited or is using ours Websites or Services;
+   that accesses or uses any part of the Account; or that directs the use of the Account in the performance of its functions.
+   A User must be at least 13 years of age.
+5. "Read the Docs," "We," and "Us" refer to Read the Docs, Inc.,
+   as well as our affiliates, directors, subsidiaries, contractors, licensors, officers, agents, and employees.
+6. "Content" refers to content featured or displayed through the Websites,
+   including without limitation text, data, articles, images, photographs, graphics, software, applications, designs, features,
+   and other materials that are available on our Websites or otherwise available through our Services.
+   "Content" also includes Services. "User-Generated Content" is Content, written or otherwise, created or uploaded by our Users.
+   "Your Content" is Content that you create or own.
+7. An "Account" represents your legal relationship with Read the Docs.
+   A "User Account" represents an individual User's authorization to log in to and use the Service and serves as a User's identity on Read the Docs.
+   "Organizations" are shared workspaces that may be associated with a single entity or with one or more Users where multiple Users can collaborate across many projects at once.
+   A User Account can be a member of any number of Organizations.
+
+
+Our services
+~~~~~~~~~~~~
+
+Read the Docs is made up of:
+
+readthedocs.org ("Read the Docs Community")
+    This is a website aimed at documentation authors and project maintainers
+    writing and distributing technical documentation.
+
+readthedocs.com ("Read the Docs for Business")
+    This website is a commercial hosted offering for hosting private
+    documentation for corporate clients.
+
+readthedocs.io, readthedocs-hosted.com, and other domains ("Documentation Sites")
+    These websites are where Read the Docs hosts documentation (":ref:`User-Generated Content <terms-of-service:User-Generated Content>`")
+    on behalf of documentation authors.
+
+
+Account terms
+-------------
+
+**Short version:** *User Accounts and Organizations have different administrative controls;
+a human must create your Account; you must be 13 or over;
+and you must provide a valid email address.
+You alone are responsible for your Account and anything that happens while you are signed in to or using your Account.
+You are responsible for keeping your Account secure.*
+
+Account controls
+~~~~~~~~~~~~~~~~~~~
+
+Users
+    Subject to these Terms, you retain ultimate administrative control over your User Account and the Content within it.
+
+Organizations
+    The "owner" of an Organization that was created under these Terms has ultimate administrative control over that Organization and the Content within it.
+    Within our Services, an owner can manage User access to the Organization's data and projects.
+    An Organization may have multiple owners, but there must be at least one User Account designated as an owner of an Organization.
+    If you are the owner of an Organization under these Terms, we consider you responsible for the actions that are performed on or through that Organization.
+
+Required information
+~~~~~~~~~~~~~~~~~~~~
+
+You must provide a valid email address in order to complete the signup process.
+Any other information requested, such as your real name, is optional,
+unless you are accepting these terms on behalf of a legal entity (in which case we need more information about the legal entity)
+or if you opt for a :ref:`paid Account <terms-of-service:Payment>`, in which case additional information will be necessary for billing purposes.
+
+Account requirements
+~~~~~~~~~~~~~~~~~~~~
+
+We have a few simple rules for User Accounts on Read the Docs' Services.
+
+- You must be a human to create an Account.
+  Accounts registered by "bots" or other automated methods are not permitted.
+  We do permit machine accounts:
+- A machine account is an Account set up by an individual human who accepts the Terms on behalf of the Account,
+  provides a valid email address, and is responsible for its actions.
+  A machine account is used exclusively for performing automated tasks.
+  Multiple users may direct the actions of a machine account,
+  but the owner of the Account is ultimately responsible for the machine's actions.
+- You must be age 13 or older. While we are thrilled to see brilliant young developers and authors get excited by learning to program,
+  we must comply with United States law.
+  Read the Docs does not target our Services to children under 13,
+  and we do not permit any Users under 13 on our Service.
+  If we learn of any User under the age of 13,
+  we will have to close your account.
+  If you are a resident of a country outside the United States, your country's minimum age may be older;
+  in such a case, you are responsible for complying with your country's laws.
+- You may not use Read the Docs in violation of export control or sanctions laws of the United States or any other applicable jurisdiction.
+  You may not use Read the Docs if you are or are working on behalf of a `Specially Designated National (SDN)`_
+  or a person subject to similar blocking or denied party prohibitions administered by a U.S. government agency.
+  Read the Docs may allow persons in certain sanctioned countries or territories to access certain Read the Docs services pursuant to U.S. government authorizations.
+
+.. _Specially Designated National (SDN): https://www.treasury.gov/resource-center/sanctions/SDN-List/Pages/default.aspx
+
+User Account security
+~~~~~~~~~~~~~~~~~~~~~
+
+You are responsible for keeping your Account secure while you use our Service.
+
+- You are responsible for all content posted and activity that occurs under your Account.
+- You are responsible for maintaining the security of your Account and password.
+  Read the Docs cannot and will not be liable for any loss or damage from your failure to comply with this security obligation.
+- You will promptly :doc:`notify Read the Docs </security>` if you become aware of any unauthorized use of,
+  or access to, our Services through your Account, including any unauthorized use of your password or Account.
+
+Additional terms
+~~~~~~~~~~~~~~~~
+
+In some situations, third parties' terms may apply to your use of Read the Docs.
+For example, you may be a member of an organization on Read the Docs with its own terms or license agreements;
+or you may download an application that integrates with Read the Docs.
+Please be aware that while these Terms are our full agreement with you, other parties' terms govern their relationships with you.
+
+
+Acceptable use
+--------------
+
+**Short version:** *Read the Docs hosts a wide variety of collaborative projects from all over the world,
+and that collaboration only works when our users are able to work together in good faith.
+While using the service, you must follow the terms of this section,
+which include some restrictions on content you can post, conduct on the service, and other limitations.
+In short, be excellent to each other.*
+
+Your use of our Websites and Services must not violate any applicable laws,
+including copyright or trademark laws, export control or sanctions laws, or other laws in your jurisdiction.
+You are responsible for making sure that your use of the Service is in compliance with laws and any applicable regulations.
+
+
+User-Generated Content
+----------------------
+
+**Short version:** *You own content you create, but you allow us certain rights to it,
+so that we can display and share the content and documentation you post.
+You still have control over your content, and responsibility for it,
+and the rights you grant us are limited to those we need to provide the service.
+We have the right to remove content or close Accounts if we need to.*
+
+Responsibility for User-Generated Content
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You may create or upload User-Generated Content while using the Service.
+You are solely responsible for the content of, and for any harm resulting from,
+any User-Generated Content that you post, upload, link to or otherwise make available via the Service,
+regardless of the form of that Content.
+We are not responsible for any public display or misuse of your User-Generated Content.
+
+Read the Docs may remove Content
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+We do not pre-screen User-Generated Content, but we have the right (though not the obligation)
+to refuse or remove any User-Generated Content that, in our sole discretion,
+violates any Read the Docs terms or policies.
+
+Ownership of Content, right to post, and license grants
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You retain ownership of and responsibility for Your Content.
+If you're posting anything you did not create yourself or do not own the rights to,
+you agree that you are responsible for any Content you post;
+that you will only submit Content that you have the right to post;
+and that you will fully comply with any third party licenses relating to Content you post.
+
+Because you retain ownership of and responsibility for Your Content,
+we need you to grant us — and other Read the Docs Users — certain legal permissions,
+listed below (in :ref:`License grant to us <terms-of-service:License grant to us>`,
+:ref:`License grant to other users <terms-of-service:License grant to other users>` and
+:ref:`Moral rights <terms-of-service:Moral rights>`). These license grants apply to Your Content.
+If you upload Content that already comes with a license granting Read the Docs the permissions we need to run our Service,
+no additional license is required.
+You understand that you will not receive any payment for any of the rights granted.
+The licenses you grant to us will end when you remove Your Content from our servers.
+
+License grant to us
+~~~~~~~~~~~~~~~~~~~
+
+We need the legal right to do things like host Your Content, publish it, and share it.
+You grant us and our legal successors the right to store, parse, and display Your Content,
+and make incidental copies as necessary to render the Website and provide the Service.
+This includes the right to do things like copy it to our database and make backups;
+show it to you and other users; parse it into a search index or otherwise analyze it on our servers;
+share it with other users; and perform it, in case Your Content is something like music or video.
+
+This license does not grant Read the Docs the right to sell Your Content
+or otherwise distribute or use it outside of our provision of the Service.
+
+License grant to other users
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Any User-Generated Content you post publicly may be viewed by others.
+By setting your projects to be viewed publicly, you agree to allow others to view your Content.
+
+On Read the Docs Community, all Content is public.
+
+Moral rights
+~~~~~~~~~~~~
+You retain all moral rights to Your Content that you upload,
+publish, or submit to any part of our Services,
+including the rights of integrity and attribution.
+However, you waive these rights and agree not to assert them against us,
+to enable us to reasonably exercise the rights granted in :ref:`License grant to us <terms-of-service:License grant to us>`, but not otherwise.
+
+To the extent this agreement is not enforceable by applicable law,
+you grant Read the Docs the rights we need to use Your Content without attribution and to make reasonable adaptations of Your Content
+as necessary to render our Websites and provide our Services.
+
+
+Private projects
+----------------
+
+**Short version:** *You may connect Read the Docs for Business to your private repositories or host documentation privately.
+We treat the content of these private projects as confidential,
+and we only access it for support reasons, with your consent, or if required to for security reasons.*
+
+Confidentiality of private projects
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Read the Docs considers the contents of private projects to be confidential to you.
+Read the Docs will protect the contents of private projects from unauthorized use,
+access, or disclosure in the same manner that we would use to protect our own confidential information of a similar nature
+and in no event with less than a reasonable degree of care.
+
+Access
+~~~~~~
+
+Read the Docs employees may only access the content of your private projects in the following situations:
+
+- With your consent and knowledge, for support reasons.
+  If Read the Docs accesses a private project for support reasons,
+  we will only do so with the owner's consent and knowledge.
+- When access is required for security reasons,
+  including when access is required to maintain ongoing confidentiality,
+  integrity, availability and resilience of Read the Docs' systems and Services.
+
+Exclusions
+~~~~~~~~~~
+
+If we have reason to believe the contents of a private project are in violation of the law or of these Terms,
+we have the right to access, review, and remove them.
+Additionally, we may be :ref:`compelled by law <privacy-policy:How we respond to compelled disclosure>`
+to disclose the contents of your private projects.
+
+
+Copyright infringement and DMCA policy
+--------------------------------------
+
+If you believe that content on our website violates your copyright or other rights,
+please contact us in accordance with our :doc:`Digital Millennium Copyright Act Policy </dmca/index>`.
+There may be legal consequences for sending a false or frivolous takedown notice.
+Before sending a takedown request, you must consider legal uses such as fair use and licensed uses.
+
+We will terminate the Accounts of repeat infringers of this policy.
+
+
+Intellectual property notice
+----------------------------
+
+**Short version:** *We own the service and all of our content.
+In order for you to use our content, we give you certain rights to it,
+but you may only use our content in the way we have allowed.*
+
+Read the Docs' rights to content
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Read the Docs and our licensors, vendors, agents, and/or our content providers
+retain ownership of all intellectual property rights of any kind related to our Websites and Services.
+We reserve all rights that are not expressly granted to you under this Agreement or by law.
+
+Read the Docs trademarks and logos
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you'd like to use Read the Docs's trademarks,
+you must follow all of our `trademark guidelines`_.
+
+.. _trademark guidelines: https://read-the-docs-guidelines.readthedocs-hosted.com/
+
+
+API terms
+---------
+
+**Short version:** *You agree to these Terms of Service,
+plus this Section, when using any of Read the Docs' APIs (Application Provider Interface),
+including use of the API through a third party product that accesses Read the Docs.*
+
+No abuse or overuse of the API
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Abuse or excessively frequent requests to Read the Docs via the API may result in the temporary or permanent suspension of your Account's access to the API.
+Read the Docs, in our sole discretion, will determine abuse or excessive usage of the API.
+We will make a reasonable attempt to warn you via email prior to suspension.
+
+You may not share API tokens to exceed Read the Docs' rate limitations.
+
+You may not use the API to download data or Content from Read the Docs for spamming purposes,
+including for the purposes of selling Read the Docs users' personal information, such as to recruiters, headhunters, and job boards.
+
+All use of the Read the Docs API is subject to these Terms of Service and our :doc:`privacy-policy`.
+
+Read the Docs may offer subscription-based access to our API for those Users who require high-throughput access
+or access that would result in resale of Read the Docs' Service.
+
+
+Additional terms for Documentation Sites
+----------------------------------------
+
+**Short version:** *Documentation Sites on Read the Docs are subject to certain rules,
+in addition to the rest of the Terms.*
+
+Documentation Sites
+~~~~~~~~~~~~~~~~~~~
+
+Each Read the Docs Account comes with the ability to host Documentation Sites.
+This hosting service is intended to host static web pages for All Users.
+Documentation Sites are subject to some specific bandwidth and usage limits,
+and may not be appropriate for some high-bandwidth uses or other prohibited uses.
+Read the Docs reserves the right at all times to reclaim any Read the Docs subdomain without liability.
+
+
+Third Party Applications
+---------------------------
+
+**Short version:** *You need to follow certain rules if you create an application for other Users.*
+
+Creating Applications
+~~~~~~~~~~~~~~~~~~~~~
+
+If you create a third-party application or other developer product that collects User Personal Information
+or User-Generated Content and integrates with the Service through Read the Docs' API,
+OAuth mechanism, or otherwise ("Developer Product"), and make it available for other Users,
+then you must comply with the following requirements:
+
+- You must comply with this Agreement and our :doc:`privacy-policy`.
+- Except as otherwise permitted, such as by law or by a license,
+  you must limit your usage of the User Personal Information or User-Generated Content you collect
+  to that purpose for which the User has authorized its collection.
+- You must take all reasonable security measures appropriate to the risks,
+  such as against accidental or unlawful destruction, or accidental loss, alteration,
+  unauthorized disclosure or access, presented by processing the User Personal Information or User-Generated Content.
+- You must not hold yourself out as collecting any User Personal Information or User-Generated Content on Read the Docs' behalf,
+  and provide sufficient notice of your privacy practices to the User, such as by posting a privacy policy.
+- You must provide Users with a method of deleting any User Personal Information or User-Generated Content
+  you have collected through Read the Docs after it is no longer needed for the limited and specified purposes
+  for which the User authorized its collection,
+  except where retention is required by law or otherwise permitted, such as through a license.
+
+
+Advertising on Documentation Sites
+----------------------------------
+
+**Short version:** *We do not generally prohibit use of Documentation Sites for advertising.
+However, we expect our users to follow certain limitations,
+so Read the Docs does not become a spam haven. No one wants that.*
+
+Our advertising
+~~~~~~~~~~~~~~~
+
+We host advertising on Documentation Sites on Read the Docs Community.
+This advertising is first-party advertising hosted by Read the Docs.
+We **do not** run any code from advertisers and all ad images are hosted
+on Read the Docs' servers. For more details, see our document on
+:doc:`advertising/advertising-details`.
+
+Acceptable advertising on Documentation Sites
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+We offer Documentation Sites primarily as a showcase for personal and organizational projects.
+Some project monetization efforts are permitted on Documentation Sites, such as donation buttons and crowdfunding links.
+
+Spamming and inappropriate use of Read the Docs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Advertising Content, like all Content, must not violate the law or these Terms of Use,
+for example through excessive bulk activity such as spamming.
+We reserve the right to remove any projects that, in our sole discretion,
+violate any Read the Docs terms or policies.
+
+
+Payment
+-------
+
+**Short version:** *You are responsible for any fees associated with your use of Read the Docs.
+We are responsible for communicating those fees to you clearly and accurately,
+and letting you know well in advance if those prices change.*
+
+Pricing
+~~~~~~~
+
+Our pricing and payment terms are available at https://readthedocs.com/pricing/.
+If you agree to a subscription price, that will remain your price for the duration of the payment term;
+however, prices are subject to change at the end of a payment term.
+
+
+Upgrades, downgrades, and changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- We will immediately bill you when you upgrade from the free plan to any paying plan
+  (either Read the Docs for Business or a Gold membership).
+- If you change from a monthly billing plan to a yearly billing plan,
+  Read the Docs will bill you for a full year at the next monthly billing date.
+- If you upgrade to a higher level of service, we will bill you for the upgraded plan immediately.
+- You may change your level of service at any time by going into your billing settings.
+  If you choose to downgrade your Account, you may lose access to Content, features, or capacity of your Account.
+
+Billing schedule; no refunds
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- For monthly or yearly payment plans, the Service is billed in advance on a monthly or yearly basis respectively and is non-refundable.
+  There will be no refunds or credits for partial months of service, downgrade refunds, or refunds for months unused with an open Account;
+  however, the service will remain active for the length of the paid billing period.
+- Exceptions to these rules are at Read the Docs' sole discretion.
+
+Authorization
+~~~~~~~~~~~~~
+
+By agreeing to these Terms,
+you are giving us permission to charge your on-file credit card,
+PayPal account, or other approved methods of payment for fees that you authorize for Read the Docs.
+
+Responsibility for payment
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You are responsible for all fees, including taxes, associated with your use of the Service.
+By using the Service, you agree to pay Read the Docs any charge incurred in connection with your use of the Service.
+If you dispute the matter, `contact us <mailto:support@readthedocs.org>`_.
+You are responsible for providing us with a valid means of payment for paid Accounts.
+Free Accounts are not required to provide payment information.
+
+Cancellation and termination
+----------------------------
+
+**Short version:** *You may close your Account at any time.
+If you do, we'll treat your information responsibly.*
+
+Account cancellation
+~~~~~~~~~~~~~~~~~~~~
+
+It is your responsibility to properly cancel your Account with Read the Docs.
+You can cancel your Account at any time by going into your Settings in the global navigation bar at the top of the screen.
+We are not able to cancel Accounts in response to an email or phone request.
+
+Upon cancellation
+~~~~~~~~~~~~~~~~~
+
+We will retain and use your information as necessary to comply with our legal obligations,
+resolve disputes, and enforce our agreements, but barring legal requirements,
+we will delete your full profile and the Content of your repositories within 90 days of cancellation or termination.
+This information can not be recovered once your Account is cancelled.
+
+Read the Docs may terminate
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Read the Docs has the right to suspend or terminate your access to all or any part of the Website at any time,
+with or without cause, with or without notice, effective immediately.
+Read the Docs reserves the right to refuse service to anyone for any reason at any time.
+
+Survival
+~~~~~~~~
+
+All provisions of this Agreement which, by their nature, should survive termination *will* survive termination --
+including, without limitation: ownership provisions, warranty disclaimers, indemnity, and limitations of liability.
+
+
+Communications with Read the Docs
+---------------------------------
+
+**Short version:** *We use email and other electronic means to stay in touch with our users.*
+
+Electronic Communication Required
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For contractual purposes, you:
+
+1. Consent to receive communications from us in an electronic form via the email address you have submitted or via the Service
+2. Agree that all Terms of Service, agreements, notices, disclosures, and other communications
+   that we provide to you electronically satisfy any legal requirement that those communications would satisfy if they were on paper.
+   This section does not affect your non-waivable rights.
+
+Legal notice to Read the Docs must be in writing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Communications made through email or Read the Docs' support system
+will not constitute legal notice to Read the Docs or any of its officers, employees, agents or representatives
+in any situation where notice to Read the Docs is required by contract or any law or regulation.
+Legal notice to Read the Docs must be in writing.
+
+No phone support
+~~~~~~~~~~~~~~~~
+
+Read the Docs only offers support via email, in-Service communications,
+and electronic messages. We do not offer telephone support.
+
+
+Disclaimer of warranties
+------------------------
+
+**Short version:** *We provide our service as is, and we make no promises or guarantees about this service.
+Please read this section carefully; you should understand what to expect.*
+
+Read the Docs provides the Website and the Service "as is" and "as available,"
+without warranty of any kind.
+Without limiting this, we expressly disclaim all warranties, whether express, implied or statutory,
+regarding the Website and the Service including without limitation any warranty of merchantability,
+fitness for a particular purpose, title, security, accuracy and non-infringement.
+
+Read the Docs does not warrant that the Service will meet your requirements;
+that the Service will be uninterrupted, timely, secure, or error-free;
+that the information provided through the Service is accurate, reliable or correct;
+that any defects or errors will be corrected;
+that the Service will be available at any particular time or location;
+or that the Service is free of viruses or other harmful components.
+You assume full responsibility and risk of loss resulting from your downloading
+and/or use of files, information, content or other material obtained from the Service.
+
+
+Limitation of liability
+-----------------------
+
+**Short version:** *We will not be liable for damages or losses arising from your use or inability to use the Service or otherwise arising under this agreement.
+Please read this section carefully; it limits our obligations to you.*
+
+You understand and agree that we will not be liable to you or any third party for any loss of profits,
+use, goodwill, or data, or for any incidental, indirect, special, consequential or exemplary damages, however arising, that result from:
+
+- the use, disclosure, or display of your User-Generated Content;
+- your use or inability to use the Service;
+- any modification, price change, suspension or discontinuance of the Service;
+- the Service generally or the software or systems that make the Service available;
+- unauthorized access to or alterations of your transmissions or data;
+- statements or conduct of any third party on the Service;
+- any other user interactions that you input or receive through your use of the Service; or
+- any other matter relating to the Service.
+
+Our liability is limited whether or not we have been informed of the possibility of such damages,
+and even if a remedy set forth in this Agreement is found to have failed of its essential purpose.
+We will have no liability for any failure or delay due to matters beyond our reasonable control.
+
+Release and indemnification
+---------------------------
+
+**Short version:** *You are responsible for your use of the service.
+If you harm someone else or get into a dispute with someone else, we will not be involved.*
+
+If you have a dispute with one or more Users,
+you agree to release Read the Docs from any and all claims, demands and damages (actual and consequential) of every kind and nature,
+known and unknown, arising out of or in any way connected with such disputes.
+
+You agree to indemnify us, defend us, and hold us harmless from and against any and all claims,
+liabilities, and expenses, including attorneys' fees, arising out of your use of the Website and the Service,
+including but not limited to your violation of this Agreement,
+provided that Read the Docs:
+
+1. Promptly gives you written notice of the claim, demand, suit or proceeding
+2. Gives you sole control of the defense and settlement of the claim, demand, suit or proceeding
+   (provided that you may not settle any claim, demand, suit or proceeding unless the settlement unconditionally releases Read the Docs of all liability)
+3. Provides to you all reasonable assistance, at your expense.
+
+Changes to these terms
+----------------------
+
+**Short version:** *We want our users to be informed of important changes to our terms,
+but some changes aren't that important — we don't want to bother you every time we fix a typo.
+So while we may modify this agreement at any time,
+we will notify users of any changes that affect your rights and give you time to adjust to them.*
+
+We reserve the right, at our sole discretion, to amend these Terms of Service at any time
+and will update these Terms of Service in the event of any such amendments.
+We will notify our Users of material changes to this Agreement, such as price changes,
+at least 30 days prior to the change taking effect by posting a notice on our Website.
+For non-material modifications, your continued use of the Website constitutes agreement to our revisions of these Terms of Service.
+
+We reserve the right at any time and from time to time to modify or discontinue,
+temporarily or permanently, the Website (or any part of it) with or without notice.
+
+
+Miscellaneous
+-------------
+
+Governing law
+~~~~~~~~~~~~~
+
+Except to the extent applicable law provides otherwise,
+this Agreement between you and Read the Docs and any access to or use of our Websites or our Services
+are governed by the federal laws of the United States of America
+and the laws of the State of Oregon, without regard to conflict of law provisions.
+
+Non-assignability
+~~~~~~~~~~~~~~~~~
+
+Read the Docs may assign or delegate these Terms of Service and/or our :doc:`privacy-policy`,
+in whole or in part, to any person or entity at any time with or without your consent,
+including the license grant in :ref:`License grant to us <terms-of-service:License grant to us>`.
+You may not assign or delegate any rights or obligations under the Terms of Service or Privacy Policy without our prior written consent,
+and any unauthorized assignment and delegation by you is void.
+
+Section headings and summaries
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Throughout this Agreement, each section includes titles and brief summaries of the following terms and conditions.
+These section titles and brief summaries are not legally binding.
+
+Severability, no waiver, and survival
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If any part of this Agreement is held invalid or unenforceable,
+that portion of the Agreement will be construed to reflect the parties' original intent.
+The remaining portions will remain in full force and effect.
+Any failure on the part of Read the Docs to enforce any provision of this Agreement will not be considered a waiver of our right to enforce such provision.
+Our rights under this Agreement will survive any termination of this Agreement.
+
+Amendments; complete agreement
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This Agreement may only be modified by a written amendment signed by an authorized representative of Read the Docs,
+or by the posting by Read the Docs of a revised version in accordance with :ref:`Changes to these terms <terms-of-service:Changes to these terms>`.
+These Terms of Service, together with our :doc:`privacy-policy`,
+represent the complete and exclusive statement of the agreement between you and us.
+This Agreement supersedes any proposal or prior agreement oral or written,
+and any other communications between you and Read the Docs relating to the subject matter of these terms
+including any confidentiality or nondisclosure agreements.
+
+Questions
+~~~~~~~~~
+Questions about the Terms of Service? `Contact us <mailto:support@readthedocs.org>`_.


### PR DESCRIPTION
**As this changes the terms of service for Read the Docs, it should not be merged without approval of either @agjohnson, @ericholscher, or both**

This PR adds a terms of service for Read the Docs, Read the Docs for Business, and Documentation Sites. It updates the Privacy Policy to link to the terms.

* I wrote the terms with the intention that they apply to Read the Docs for Business
* I followed [sentence case](https://docs.readthedocs.io/en/stable/development/docs.html#titles) for non-H1 headings except when a term was from the definitions section
* These terms were heavily influenced (see: borrowed or lifted) from [GitHub's CC-0 licensed site policies](https://github.com/github/site-policy/)
* GitHub's terms had a whole sub-document on serving legal notice. Since we don't have that in place, I removed much of it.
* The terms are "governed by the federal laws of the United States of America and the laws of the State of Oregon" 
* If you are casually reviewing this, I think a second set of eyes on the Payments/Refunds section specifically wouldn't be bad
* I tentatively put the date on the terms/privacy policy for the end of the month but this can be adjusted if and when this is merged.

## Future work

- Link to this terms of service from the footer of readthedocs.org. Since our links usually link to the "stable" version of the docs, we should wait until this is released to add that link.
- Link to this ToS from the footer of readthedocs.com and replace the [existing terms](https://readthedocs.com/terms/).
- Consider linking to this from the flyout menu on Documentation Sites