### PR TITLE
Add the private spamfighting module to INSTALLED_APPS

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -154,6 +154,7 @@ class CommunityBaseSettings(Settings):
             apps.append('django_countries')
             apps.append('readthedocsext.donate')
             apps.append('readthedocsext.embed')
+            apps.append('readthedocsext.spamfighting')
         return apps
 
     @property


### PR DESCRIPTION
This module has to be in `INSTALLED_APPS` for any celery tasks to run.