### PR TITLE
Customize default build media storage for the FS

### DIFF
--- a/readthedocs/builds/storage.py
+++ b/readthedocs/builds/storage.py
@@ -114,13 +114,11 @@ class BuildMediaFileSystemStorage(BuildMediaStorageMixin, FileSystemStorage):
         location = kwargs.pop('location', None)
 
         if not location:
-            # If no location was passed:
-            # - Use PRODUCTION_MEDIA_ARTIFACTS if it exists
-            # - Fallback to MEDIA_ROOT
-            if Path(settings.PRODUCTION_MEDIA_ARTIFACTS).exists():
-                location = settings.PRODUCTION_MEDIA_ARTIFACTS
-            else:
+            # Mirrors the logic of getting the production media path
+            if settings.DEFAULT_PRIVACY_LEVEL == 'public' or settings.DEBUG:
                 location = settings.MEDIA_ROOT
+            else:
+                location = settings.PRODUCTION_MEDIA_ARTIFACTS
 
         super().__init__(location)
 

--- a/readthedocs/builds/storage.py
+++ b/readthedocs/builds/storage.py
@@ -1,6 +1,7 @@
 import logging
 from pathlib import Path
 
+from django.conf import settings
 from django.core.exceptions import SuspiciousFileOperation
 from django.core.files.storage import FileSystemStorage
 from storages.utils import safe_join, get_available_overwrite_name
@@ -107,7 +108,21 @@ class BuildMediaStorageMixin:
 
 class BuildMediaFileSystemStorage(BuildMediaStorageMixin, FileSystemStorage):
 
-    """Storage subclass that writes build artifacts under MEDIA_ROOT."""
+    """Storage subclass that writes build artifacts in PRODUCTION_MEDIA_ARTIFACTS or MEDIA_ROOT."""
+
+    def __init__(self, **kwargs):
+        location = kwargs.pop('location', None)
+
+        if not location:
+            # If no location was passed:
+            # - Use PRODUCTION_MEDIA_ARTIFACTS if it exists
+            # - Fallback to MEDIA_ROOT
+            if Path(settings.PRODUCTION_MEDIA_ARTIFACTS).exists():
+                location = settings.PRODUCTION_MEDIA_ARTIFACTS
+            else:
+                location = settings.MEDIA_ROOT
+
+        super().__init__(location)
 
     def get_available_name(self, name, max_length=None):
         """


### PR DESCRIPTION
Edit: closely mirror the logic to get the production media path:

https://github.com/readthedocs/readthedocs.org/blob/557c875fa4d74e1cb69146e005375595f80adf91/readthedocs/projects/models.py#L584-L598