### PR TITLE
remove /projects/

### DIFF
--- a/readthedocs/projects/urls/public.py
+++ b/readthedocs/projects/urls/public.py
@@ -5,7 +5,7 @@ from django.conf.urls import url
 from readthedocs.builds import views as build_views
 from readthedocs.constants import pattern_opts
 from readthedocs.projects.views import public
-from readthedocs.projects.views.public import ProjectDetailView, ProjectIndex
+from readthedocs.projects.views.public import ProjectDetailView, ProjectTagIndex
 from readthedocs.search import views as search_views
 
 
@@ -73,7 +73,7 @@ urlpatterns = [
     ),
     url(
         r'^tags/(?P<tag>[-\w]+)/$',
-        ProjectIndex.as_view(),
+        ProjectTagIndex.as_view(),
         name='projects_tag_detail',
     ),
 ]

--- a/readthedocs/projects/urls/public.py
+++ b/readthedocs/projects/urls/public.py
@@ -11,11 +11,6 @@ from readthedocs.search import views as search_views
 
 urlpatterns = [
     url(
-        r'^$',
-        ProjectIndex.as_view(),
-        name='projects_list',
-    ),
-    url(
         r'^(?P<invalid_project_slug>{project_slug}_{project_slug})/'.format(**pattern_opts),
         public.project_redirect,
         name='project_redirect',

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -37,7 +37,7 @@ search_log = logging.getLogger(__name__ + '.search')
 mimetypes.add_type('application/epub+zip', '.epub')
 
 
-class ProjectIndex(ListView):
+class ProjectTagIndex(ListView):
 
     """List view of public :py:class:`Project` instances."""
 
@@ -47,11 +47,8 @@ class ProjectIndex(ListView):
         queryset = Project.objects.public(self.request.user)
         queryset = queryset.exclude(users__profile__banned=True)
 
-        if self.kwargs.get('tag'):
-            self.tag = get_object_or_404(Tag, slug=self.kwargs.get('tag'))
-            queryset = queryset.filter(tags__slug__in=[self.tag.slug])
-        else:
-            self.tag = None
+        self.tag = get_object_or_404(Tag, slug=self.kwargs.get('tag'))
+        queryset = queryset.filter(tags__slug__in=[self.tag.slug])
 
         if self.kwargs.get('username'):
             self.user = get_object_or_404(


### PR DESCRIPTION
Fixes #6221

I am relatively new to development with Django but to remove the publicly accessible `/projects` path, only a small amount of removals seemed to be required.

I did not remove the [ProjectIndex](https://github.com/readthedocs/readthedocs.org/blob/1ce31662650d6defa434587ec0325f044052ee72/readthedocs/projects/views/public.py#L40 ) class, as it seems that the tags functionality is dependant on it. If you're happy for the tags to go, I will be happy to update my PR.

I did not remove the [project_urls](https://github.com/readthedocs/readthedocs.org/blob/1ce31662650d6defa434587ec0325f044052ee72/readthedocs/urls.py#L56-L58) section, as clicking on a project as a logged in user takes you to a `/projects/<project_name>` route.

Please let me know how I did in meeting your expectations and let me know if I can do any better.

