### PR TITLE
Remove .cache directory when CLEAN_AFTER_BUILD feature is enabled

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1517,7 +1517,7 @@ def clean_build(version_pk):
     # because we are syncing the servers with an async task.
     del_dirs = [
         os.path.join(version.project.doc_path, dir_, version.slug)
-        for dir_ in ('checkouts', 'envs', 'conda')
+        for dir_ in ('checkouts', 'envs', 'conda', '.cache')
     ]
     try:
         with version.project.repo_nonblockinglock(version):


### PR DESCRIPTION
Disk space is growing up without limit in `build04`.

We do have a solution for this by `CLEAN_AFTER_BUILD` feature/setting, but it does not remove `.cache` nor `artifacts`.

This PR add `.cache` as a directory to be removed as well.

`artifacts` is not possible to remove just yet because how the pull sync system works (webs need to pull these files from the builders before it removes them)