### PR TITLE
Do not use --cache-dir for pip if CLEAN_AFTER_BUILD is enabled

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -132,18 +132,16 @@ class PythonEnvironment:
         need to cache anything.
         """
         if (
-            not settings.RTD_CLEAN_AFTER_BUILD and
-            not self.project.has_feature(Feature.CLEAN_AFTER_BUILD)
+            settings.RTD_CLEAN_AFTER_BUILD or
+            self.project.has_feature(Feature.CLEAN_AFTER_BUILD)
         ):
             return [
-                '--cache-dir',
-                self.project.pip_cache_path,
+                '--no-cache-dir',
             ]
-
         return [
-            '--no-cache-dir',
+            '--cache-dir',
+            self.project.pip_cache_path,
         ]
-
 
     def venv_bin(self, filename=None):
         """


### PR DESCRIPTION
Avoid caching `pip` packages if we are using CLEAN_AFTER_BUILD.

This PR decide when to use `--cache-dir` or `--no-cache-dir` based on this setting.

@stsewd what do you think about this? If you think it's OK, I will fix the tests tomorrow.

Related https://github.com/readthedocs/readthedocs.org/pull/6236#issuecomment-537597611