### PR TITLE
Allow project badges for private version

### DIFF
--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -1,5 +1,6 @@
 """Public project views."""
 
+import hashlib
 import json
 import logging
 import mimetypes
@@ -17,8 +18,11 @@ from django.db.models import prefetch_related_objects
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render, redirect
 from django.urls import reverse
+from django.views import View
 from django.views.decorators.cache import never_cache
 from django.views.generic import DetailView, ListView
+from django.utils.crypto import constant_time_compare
+from django.utils.encoding import force_bytes
 from taggit.models import Tag
 
 from readthedocs.analytics.tasks import analytics_event
@@ -30,6 +34,7 @@ from readthedocs.projects.models import Project
 from readthedocs.projects.templatetags.projects_tags import sort_version_aware
 
 from .base import ProjectOnboardMixin
+from ..constants import PRIVATE
 
 
 log = logging.getLogger(__name__)
@@ -108,11 +113,10 @@ class ProjectDetailView(BuildTriggerMixin, ProjectOnboardMixin, DetailView):
 
         version_slug = project.get_default_version()
 
-        context['badge_url'] = '{}://{}{}?version={}'.format(
-            protocol,
-            settings.PRODUCTION_DOMAIN,
-            reverse('project_badge', args=[project.slug]),
-            project.get_default_version(),
+        context['badge_url'] = ProjectBadgeView.get_badge_url(
+            project.slug,
+            version_slug,
+            protocol=protocol,
         )
         context['site_url'] = '{url}?badge={version}'.format(
             url=project.get_docs_url(version_slug),
@@ -122,59 +126,131 @@ class ProjectDetailView(BuildTriggerMixin, ProjectOnboardMixin, DetailView):
         return context
 
 
-@never_cache
-def project_badge(request, project_slug):
-    """Return a sweet badge for the project."""
-    style = request.GET.get('style', 'flat')
-    if style not in (
+class ProjectBadgeView(View):
+
+    """
+    Return a sweet badge for the project.
+
+    Query parameters:
+
+    * ``version`` the version for the project (latest [default], stable, etc.)
+    * ``style`` the style of the badge (flat [default], plastic, etc.)
+    * ``token`` a project-specific token needed to access private versions
+    """
+
+    http_method_names = ['get', 'head', 'options']
+    STATUS_UNKNOWN = 'unknown'
+    STATUS_PASSING = 'passing'
+    STATUS_FAILING = 'failing'
+    STATUSES = (STATUS_FAILING, STATUS_PASSING, STATUS_UNKNOWN)
+
+    def get(self, request, project_slug, *args, **kwargs):
+        status = self.STATUS_UNKNOWN
+        token = request.GET.get('token')
+        version_slug = request.GET.get('version', LATEST)
+        version = None
+
+        if token:
+            version_to_check = Version.objects.filter(
+                project__slug=project_slug,
+                slug=version_slug,
+            ).first()
+            if version_to_check and self.verify_project_token(token, project_slug):
+                version = version_to_check
+        else:
+            version = Version.objects.public(request.user).filter(
+                project__slug=project_slug,
+                slug=version_slug,
+            ).first()
+
+        if version:
+            last_build = version.builds.filter(
+                type='html',
+                state='finished',
+            ).order_by('-date').first()
+            if last_build:
+                if last_build.success:
+                    status = self.STATUS_PASSING
+                else:
+                    status = self.STATUS_FAILING
+
+        return self.serve_badge(request, status)
+
+    def get_style(self, request):
+        style = request.GET.get('style', 'flat')
+        if style not in (
             'flat',
             'plastic',
             'flat-square',
             'for-the-badge',
             'social',
-    ):
-        style = 'flat'
+        ):
+            style = 'flat'
 
-    # Get the local path to the badge files
-    badge_path = os.path.join(
-        os.path.dirname(__file__),
-        '..',
-        'static',
-        'projects',
-        'badges',
-        '%s-' + style + '.svg',
-    )
+        return style
 
-    version_slug = request.GET.get('version', LATEST)
-    file_path = badge_path % 'unknown'
+    def serve_badge(self, request, status):
+        style = self.get_style(request)
+        if status not in self.STATUSES:
+            status = self.STATUS_UNKNOWN
 
-    version = Version.objects.public(request.user).filter(
-        project__slug=project_slug,
-        slug=version_slug,
-    ).first()
-
-    if version:
-        last_build = version.builds.filter(
-            type='html',
-            state='finished',
-        ).order_by('-date').first()
-        if last_build:
-            if last_build.success:
-                file_path = badge_path % 'passing'
-            else:
-                file_path = badge_path % 'failing'
-
-    try:
-        with open(file_path) as fd:
-            return HttpResponse(
-                fd.read(),
-                content_type='image/svg+xml',
-            )
-    except (IOError, OSError):
-        log.exception(
-            'Failed to read local filesystem while serving a docs badge',
+        badge_path = os.path.join(
+            os.path.dirname(__file__),
+            '..',
+            'static',
+            'projects',
+            'badges',
+            f'{status}-{style}.svg',
         )
-        return HttpResponse(status=503)
+
+        try:
+            with open(badge_path) as fd:
+                return HttpResponse(
+                    fd.read(),
+                    content_type='image/svg+xml',
+                )
+        except (IOError, OSError):
+            log.exception(
+                'Failed to read local filesystem while serving a docs badge',
+            )
+            return HttpResponse(status=503)
+
+    @classmethod
+    def get_badge_url(cls, project_slug, version_slug, protocol='https'):
+        url = '{}://{}{}?version={}'.format(
+            protocol,
+            settings.PRODUCTION_DOMAIN,
+            reverse('project_badge', args=[project_slug]),
+            version_slug,
+        )
+
+        # Append a token for private versions
+        version = Version.objects.filter(
+            project__slug=project_slug,
+            slug=version_slug,
+        ).first()
+        if version and version.privacy_level == PRIVATE:
+            token = cls.get_project_token(project_slug)
+            url += f'&token={token}'
+
+        return url
+
+    @classmethod
+    def get_project_token(cls, project_slug):
+        salt = b"readthedocs.projects.views.public.ProjectBadgeView"
+        hash_id = hashlib.sha256()
+        hash_id.update(force_bytes(settings.SECRET_KEY))
+        hash_id.update(salt)
+        hash_id.update(force_bytes(project_slug))
+        return hash_id.hexdigest()
+
+    @classmethod
+    def verify_project_token(cls, token, project_slug):
+        expected_token = cls.get_project_token(project_slug)
+        return constant_time_compare(token, expected_token)
+
+
+project_badge = never_cache(ProjectBadgeView.as_view())
 
 
 def project_downloads(request, project_slug):

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -20,6 +20,7 @@ from readthedocs.projects.constants import PUBLIC
 from readthedocs.projects.exceptions import ProjectSpamError
 from readthedocs.projects.models import Domain, Project
 from readthedocs.projects.views.mixins import ProjectRelationMixin
+from readthedocs.projects.views.public import ProjectBadgeView
 from readthedocs.projects.views.private import ImportWizardView
 from readthedocs.rtd_tests.base import (
     MockBuildTestCase,
@@ -578,6 +579,15 @@ class TestBadges(TestCase):
         res = self.client.get(unknown_project_url, {'version': 'latest'})
         self.assertContains(res, 'unknown')
 
+        # Unknown version
+        res = self.client.get(self.badge_url, {'version': 'fake-version'})
+        self.assertContains(res, 'unknown')
+
+    def test_badge_caching(self):
+        res = self.client.get(self.badge_url, {'version': self.version.slug})
+        self.assertTrue('must-revalidate' in res['Cache-Control'])
+        self.assertTrue('no-cache' in res['Cache-Control'])
+
     def test_passing_badge(self):
         get(Build, project=self.project, version=self.version, success=True)
         res = self.client.get(self.badge_url, {'version': self.version.slug})
@@ -611,6 +621,36 @@ class TestBadges(TestCase):
         resp = self.client.get(badge_url, {'version': 'latest'})
         self.assertEqual(resp.status_code, 302)
         self.assertTrue('project-slug' in resp['location'])
+
+    def test_private_version(self):
+        # Set version to private
+        self.version.privacy_level = 'private'
+        self.version.save()
+
+        # Without a token, badge is unknown
+        get(Build, project=self.project, version=self.version, success=True)
+        res = self.client.get(self.badge_url, {'version': self.version.slug})
+        self.assertContains(res, 'unknown')
+
+        # With an invalid token, the badge is unknown
+        res = self.client.get(
+            self.badge_url,
+            {
+                'token': ProjectBadgeView.get_project_token('invalid-project'),
+                'version': self.version.slug,
+            }
+        )
+        self.assertContains(res, 'unknown')
+
+        # With a valid token, the badge should work correctly
+        res = self.client.get(
+            self.badge_url,
+            {
+                'token': ProjectBadgeView.get_project_token(self.project.slug),
+                'version': self.version.slug,
+            }
+        )
+        self.assertContains(res, 'passing')
 
 
 class TestTags(TestCase):


### PR DESCRIPTION
- Refactored the badge view into a class-based view
- Private versions require a token. This PR also adds the token to the badge examples/directions in the dashboard for private versions. This PR doesn't do anything for protected versions. Should it?
- Token is generated from the project_slug and the secret key which has a few implications:
  * A token can't be invalidated without changing the project slug or secret key. If somebody leaks their token, it's basically leaked. All it leaks is the status of the build, but it does leak information. 
  * The token is *not* based on the version so leaking the token for a project would leak the existence of *all* versions for that project. However, this makes changing the badge to show a different version as easy as changing the `?version=latest` parameter.