### PR TITLE
Fix inactive version list not showing when no resuts returned

### DIFF
--- a/readthedocs/templates/projects/project_version_list.html
+++ b/readthedocs/templates/projects/project_version_list.html
@@ -126,6 +126,8 @@ Versions
                     </li>
                   {% endblock inactive-versions %}
 
+                {% empty %}
+                <li class="module-item quiet">{% trans "No versions found" %}</li>
                 {% endfor %}
               </ul>
             </div>

--- a/readthedocs/templates/projects/project_version_list.html
+++ b/readthedocs/templates/projects/project_version_list.html
@@ -76,7 +76,7 @@ Versions
     <div class="module project-versions-inactive">
       <div class="module-wrapper">
 
-        {% if inactive_versions %}
+        {% if inactive_versions or request.GET.version_filter %}
           <div class="module-header">
             <h1>{% trans "Activate a version" %}</h1>
             <p>{% trans "Active versions are built whenever new code is pushed to that branch or tag." %}</p>


### PR DESCRIPTION
Previously it would hide the UI when users search
for a term with no matching versions