### PR TITLE
Default to None when using the Serializer as Form for BrowsableAPI

### DIFF
--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -557,8 +557,11 @@ class SubprojectCreateSerializer(FlexFieldsModelSerializer):
 
     def __init__(self, *args, **kwargs):
         # Initialize the instance with the parent Project to be used in the
-        # serializer validation.
-        self.parent_project = kwargs.pop('parent')
+        # serializer validation. When this Serializer is rendered as a Form in
+        # BrowsableAPIRenderer, it's not initialized with the ``parent``, so we
+        # default to ``None`` because we don't need it at that point.
+        self.parent_project = kwargs.pop('parent', None)
+
         super().__init__(*args, **kwargs)
 
     def validate_child(self, value):


### PR DESCRIPTION
Fix a small issue that we noticed when deploying.

Accessing the subproject list returns a 500: https://readthedocs.org/api/v3/projects/test-builds/subprojects/