### PR TITLE
Use sync instead of copy for blob storage

### DIFF
--- a/readthedocs/builds/storage.py
+++ b/readthedocs/builds/storage.py
@@ -91,12 +91,14 @@ class BuildMediaStorageMixin:
         """
         Sync a directory recursively to storage.
 
-        Overwrites files in remote storage where a file in ``source`` exists (no timstamp checking done).
+        Overwrites files in remote storage with files from ``source`` (no timstamp/hash checking).
         Removes files and folders in remote storage that are not present in ``source``.
 
         :param source: the source path on the local disk
         :param destination: the destination path in storage
         """
+        if destination in ('', '/'):
+            raise SuspiciousFileOperation('Syncing all storage cannot be right')
 
         log.debug(
             'Syncing to media storage. source=%s destination=%s',
@@ -123,7 +125,9 @@ class BuildMediaStorageMixin:
                 self.delete_directory(self.join(destination, folder))
         for filename in dest_files:
             if filename not in copied_files:
-                self.delete(self.join(destination, filename))
+                filepath = self.join(destination, filename)
+                log.debug('Deleting file from media storage. file=%s', filepath)
+                self.delete(filepath)
 
     def join(self, directory, filepath):
         return safe_join(directory, filepath)

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -847,7 +847,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
                 },
             )
             try:
-                storage.copy_directory(from_path, to_path)
+                storage.sync_directory(from_path, to_path)
             except Exception:
                 # Ideally this should just be an IOError
                 # but some storage backends unfortunately throw other errors

--- a/readthedocs/rtd_tests/tests/test_build_storage.py
+++ b/readthedocs/rtd_tests/tests/test_build_storage.py
@@ -18,6 +18,25 @@ class TestBuildMediaStorage(TestCase):
     def tearDown(self):
         shutil.rmtree(self.test_media_dir, ignore_errors=True)
 
+    def assertFileTree(self, source, tree):
+        """
+        Recursively check that ``source`` from storage has the same file tree as ``tree``.
+
+        :param source: source path in storage
+        :param tree: a list of strings representing files
+                     or tuples (string, list) representing directories.
+        """
+        dirs_tree = [e for e in tree if not isinstance(e, str)]
+
+        dirs, files = self.storage.listdir(source)
+        expected_dirs = [e[0] for e in dirs_tree]
+        expected_files = [e for e in tree if isinstance(e, str)]
+        self.assertCountEqual(dirs, expected_dirs)
+        self.assertCountEqual(files, expected_files)
+
+        for folder, files in dirs_tree:
+            self.assertFileTree(self.storage.join(source, folder), files)
+
     def test_copy_directory(self):
         self.assertFalse(self.storage.exists('files/test.html'))
 
@@ -26,6 +45,39 @@ class TestBuildMediaStorage(TestCase):
         self.assertTrue(self.storage.exists('files/conf.py'))
         self.assertTrue(self.storage.exists('files/api.fjson'))
         self.assertTrue(self.storage.exists('files/api/index.html'))
+
+    def test_sync_directory(self):
+        tmp_files_dir = os.path.join(tempfile.mkdtemp(), 'files')
+        shutil.copytree(files_dir, tmp_files_dir)
+        storage_dir = 'files'
+
+        tree = [
+            ('api', ['index.html']),
+            'api.fjson',
+            'conf.py',
+            'test.html',
+        ]
+        self.storage.sync_directory(tmp_files_dir, storage_dir)
+        self.assertFileTree(storage_dir, tree)
+
+        tree = [
+            ('api', ['index.html']),
+            'conf.py',
+            'test.html',
+        ]
+        os.remove(os.path.join(tmp_files_dir, 'api.fjson'))
+        self.storage.sync_directory(tmp_files_dir, storage_dir)
+        self.assertFileTree(storage_dir, tree)
+
+        tree = [
+            # Cloud storage generally doesn't consider empty directories to exist
+            ('api', []),
+            'conf.py',
+            'test.html',
+        ]
+        shutil.rmtree(os.path.join(tmp_files_dir, 'api'))
+        self.storage.sync_directory(tmp_files_dir, storage_dir)
+        self.assertFileTree(storage_dir, tree)
 
     def test_delete_directory(self):
         self.storage.copy_directory(files_dir, 'files')


### PR DESCRIPTION
We use `rsync` for our _normal_ storage, but for blob storage we are just doing a copy.

Full explanation at https://github.com/readthedocs/readthedocs.org/pull/6186#issuecomment-542496770

This is _heavily borrowed_ from a snippet from @davidfischer  :)

Fixes #6069
Closes #6186