### PR TITLE
Allow to use a different base for static documents

### DIFF
--- a/readthedocs/core/symlink.py
+++ b/readthedocs/core/symlink.py
@@ -386,10 +386,11 @@ class Symlink:
 
 
 class PublicSymlinkBase(Symlink):
-    CNAME_ROOT = os.path.join(settings.SITE_ROOT, 'public_cname_root')
-    WEB_ROOT = os.path.join(settings.SITE_ROOT, 'public_web_root')
+    public_base = getattr(settings, 'PUBLIC_BASE', None) or settings.SITE_ROOT
+    CNAME_ROOT = os.path.join(public_base, 'public_cname_root')
+    WEB_ROOT = os.path.join(public_base, 'public_web_root')
     PROJECT_CNAME_ROOT = os.path.join(
-        settings.SITE_ROOT,
+        public_base,
         'public_cname_project',
     )
 
@@ -409,10 +410,11 @@ class PublicSymlinkBase(Symlink):
 
 
 class PrivateSymlinkBase(Symlink):
-    CNAME_ROOT = os.path.join(settings.SITE_ROOT, 'private_cname_root')
-    WEB_ROOT = os.path.join(settings.SITE_ROOT, 'private_web_root')
+    public_base = getattr(settings, 'PUBLIC_BASE', None) or settings.SITE_ROOT
+    CNAME_ROOT = os.path.join(public_base, 'private_cname_root')
+    WEB_ROOT = os.path.join(public_base, 'private_web_root')
     PROJECT_CNAME_ROOT = os.path.join(
-        settings.SITE_ROOT,
+        public_base,
         'private_cname_project',
     )
 


### PR DESCRIPTION
This change allows to configure a different base for data storage than the project root

This might be useful mainly when using this project in a docker environment using shared volumes betweeb builder tasks, main application and webserver or for deployment which requires a different layout than the standard one

I cannot find a place where the documentation for this setting could be located or whether any sensible test is doable, but I'm more than willing to add both 