### PR TITLE
Use django-cacheops to speed up serving docs and support DB going down

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,6 +144,9 @@ services:
       - storage
     command: ["/usr/local/bin/create-containers.sh"]
 
+  cacheops:
+    image: redis:3.2.7
+
   cache:
     image: redis:3.2.7
 

--- a/docker/settings/proxito.py
+++ b/docker/settings/proxito.py
@@ -4,6 +4,30 @@ from .docker_compose import DockerBaseSettings
 class ProxitoDevSettings(DockerBaseSettings):
     ROOT_URLCONF = 'readthedocs.proxito.urls'
 
+    CACHEOPS_TIMEOUT = 60 * 60
+    CACHEOPS_OPS = {'get', 'fetch'}
+    CACHEOPS = {
+        # readthedocs.projects.*
+        'projects.project': {
+            'ops': CACHEOPS_OPS,
+            'timeout': CACHEOPS_TIMEOUT,
+        },
+        'projects.projectrelationship': {
+            'ops': CACHEOPS_OPS,
+            'timeout': CACHEOPS_TIMEOUT,
+        },
+        'projects.domain': {
+            'ops': CACHEOPS_OPS,
+            'timeout': CACHEOPS_TIMEOUT,
+        },
+
+        # readthedocs.builds.*
+        'builds.version': {
+            'ops': CACHEOPS_OPS,
+            'timeout': CACHEOPS_TIMEOUT,
+        },
+    }
+
     @property
     def MIDDLEWARE(self):  # noqa
         classes = list(super().MIDDLEWARE)

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -124,6 +124,7 @@ class CommunityBaseSettings(Settings):
             'django_elasticsearch_dsl',
             'django_filters',
             'polymorphic',
+            'cacheops',
 
             # our apps
             'readthedocs.projects',

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -67,6 +67,31 @@ class DockerBaseSettings(CommunityDevSettings):
         }
     }
 
+    CACHEOPS_REDIS = 'redis://cacheops:6379/0'
+    CACHEOPS_TIMEOUT = 60 * 60
+    CACHEOPS = {
+        # readthedocs.projects.*
+        'projects.project': {
+            'ops': (),
+            'timeout': CACHEOPS_TIMEOUT,
+        },
+        'projects.projectrelationship': {
+            'ops': (),
+            'timeout': CACHEOPS_TIMEOUT,
+        },
+        'projects.domain': {
+            'ops': (),
+            'timeout': CACHEOPS_TIMEOUT,
+        },
+
+        # readthedocs.builds.*
+        'builds.version': {
+            'ops': (),
+            'timeout': CACHEOPS_TIMEOUT,
+        },
+    }
+    CACHEOPS_DEGRADE_ON_FAILURE = True
+
     BROKER_URL = "redis://cache:6379/0"
     CELERY_RESULT_BACKEND = "redis://cache:6379/0"
     CELERY_RESULT_SERIALIZER = "json"

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -111,3 +111,5 @@ django-storages==1.7.2
 
 # Required only in development and linting
 django-debug-toolbar==2.0
+
+django-cacheops==4.2


### PR DESCRIPTION
`django-cacheops` allows us to cache querysets into a redis backend in a
granular way. We can define which models we want to cache and we can
specify which instances (el proxito, web, workers, etc) will use this
cache and which of them will invalidate it.

This initial approach configure El Proxito to make usage of this cache
when performing queries and configure Web/Celery/Build instances only
to invalidate the cache when a model changed.

This setup allows us to serve docs faster but also keep serving docs
during `CACHEOPS_TIMEOUT` seconds even when the DB goes down.

Because the way it's configured now (web is not using the cache), when
the DB goes down, the footer API call will fail and the flyout menu
won't be replaced properly. We could change this if we want by
performing Manual caching on that view or by enabling cacheops in Web
instance as well.