### PR TITLE
Remove files from storage and delete indexes from ES when no longer needed

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -322,11 +322,6 @@ class Version(models.Model):
             task=tasks.symlink_project,
             args=[self.project.pk],
         )
-
-        # These resources are not used when a version is inactive
-        if not self.active:
-            tasks.clean_project_resources(self.project, self)
-
         return obj
 
     def delete(self, *args, **kwargs):  # pylint: disable=arguments-differ

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -480,6 +480,7 @@ class Project(models.Model):
             args=[(self.doc_path,)],
         )
 
+        # Remove extra resources
         tasks.clean_project_resources(self)
 
         super().delete(*args, **kwargs)

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -480,16 +480,7 @@ class Project(models.Model):
             args=[(self.doc_path,)],
         )
 
-        # Remove build artifacts from storage
-        storage_paths = []
-        for type_ in MEDIA_TYPES:
-            storage_paths.append(
-                '{}/{}'.format(
-                    type_,
-                    self.slug,
-                )
-            )
-        tasks.remove_build_storage_paths.delay(storage_paths)
+        tasks.clean_project_resources(self)
 
         super().delete(*args, **kwargs)
 
@@ -533,6 +524,19 @@ class Project(models.Model):
                     (api.project(self.pk).subprojects().get()['subprojects'])]
         return [(proj.child.slug, proj.child.get_docs_url())
                 for proj in self.subprojects.all()]
+
+    def get_storage_paths(self):
+        """
+        Get the paths of all artifacts used by the project.
+
+        :return: the path to an item in storage
+                 (can be used with ``storage.url`` to get the URL).
+        """
+        storage_paths = [
+            f'{type_}/{self.slug}'
+            for type_ in MEDIA_TYPES
+        ]
+        return storage_paths
 
     def get_storage_path(
             self,

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1847,8 +1847,7 @@ def remove_build_storage_paths(paths):
 
 @app.task(queue='web')
 def remove_search_indexes(project_slug, version_slug=None):
-    """Wrapper around `remove_indexed_files to make it a task."""
-    # Remove ES indexes
+    """Wrapper around ``remove_indexed_files`` to make it a task."""
     remove_indexed_files(
         model=HTMLFile,
         project_slug=project_slug,
@@ -1875,7 +1874,7 @@ def clean_project_resources(project, version=None):
     # Remove storage paths
     storage_paths = []
     if version:
-        version.get_storage_paths()
+        storage_paths = version.get_storage_paths()
     else:
         storage_paths = project.get_storage_paths()
     remove_build_storage_paths.delay(storage_paths)

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1844,6 +1844,26 @@ def remove_build_storage_paths(paths):
         storage.delete_directory(storage_path)
 
 
+def clean_project_resources(project, version=None):
+    """
+    Delete all extra resources used by `version` of `project`.
+
+    It removes:
+
+    - Artifacts from storage.
+    - Search indexes from ES.
+
+    :param version: Version instance. if isn't given,
+                    all resources of `project` will be deleted.
+    """
+    storage_paths = []
+    if version:
+        version.get_storage_paths()
+    else:
+        storage_paths = project.get_storage_paths()
+    remove_build_storage_paths.delay(storage_paths)
+
+
 @app.task(queue='web')
 def sync_callback(_, version_pk, commit, build, *args, **kwargs):
     """

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -203,6 +203,10 @@ class ProjectVersionDetail(ProjectVersionMixin, UpdateView):
                     task=tasks.remove_dirs,
                     args=[version.get_artifact_paths()],
                 )
+                tasks.clean_project_resources(
+                    version.project,
+                    version,
+                )
                 version.built = False
                 version.save()
         return HttpResponseRedirect(self.get_success_url())

--- a/readthedocs/rtd_tests/tests/test_build_forms.py
+++ b/readthedocs/rtd_tests/tests/test_build_forms.py
@@ -1,6 +1,7 @@
-# -*- coding: utf-8 -*-
-
+import mock
+from django.contrib.auth.models import User
 from django.test import TestCase
+from django.urls import reverse
 from django_dynamic_fixture import get
 
 from readthedocs.builds.forms import VersionForm
@@ -12,7 +13,8 @@ from readthedocs.projects.models import Project
 class TestVersionForm(TestCase):
 
     def setUp(self):
-        self.project = get(Project)
+        self.user = get(User)
+        self.project = get(Project, users=(self.user,))
 
     def test_default_version_is_active(self):
         version = get(
@@ -50,3 +52,35 @@ class TestVersionForm(TestCase):
         )
         self.assertFalse(form.is_valid())
         self.assertIn('active', form.errors)
+
+    @mock.patch('readthedocs.projects.tasks.clean_project_resources')
+    def test_resources_are_deleted_when_version_is_inactive(self, clean_project_resources):
+        version = get(
+            Version,
+            project=self.project,
+            active=True,
+        )
+
+        url = reverse('project_version_detail', args=(version.project.slug, version.slug))
+
+        self.client.force_login(self.user)
+
+        r = self.client.post(
+            url,
+            data={
+                'active': True,
+                'privacy_level': PRIVATE,
+            },
+        )
+        self.assertTrue(r.status_code, 200)
+        clean_project_resources.assert_not_called()
+
+        r = self.client.post(
+            url,
+            data={
+                'active': False,
+                'privacy_level': PRIVATE,
+            },
+        )
+        self.assertTrue(r.status_code, 200)
+        clean_project_resources.assert_called_once()

--- a/readthedocs/search/utils.py
+++ b/readthedocs/search/utils.py
@@ -43,18 +43,22 @@ def index_new_files(model, version, build):
         log.exception('Unable to index a subset of files. Continuing.')
 
 
-def remove_indexed_files(model, version, build):
+def remove_indexed_files(model, project_slug, version_slug=None, build_id=None):
     """
-    Remove files from the version from the search index.
+    Remove files from `version_slug` of `project_slug` from the search index.
 
-    This excludes files from the current build.
+    :param model: Class of the model to be deleted.
+    :param project_slug: Project slug.
+    :param version_slug: Version slug. If isn't given,
+                    all index from `project` are deleted.
+    :param build_id: Build id. If isn't given, all index from `version` are deleted.
     """
 
     if not DEDConfig.autosync_enabled():
         log.info(
             'Autosync disabled, skipping removal from the search index for: %s:%s',
-            version.project.slug,
-            version.slug,
+            project_slug,
+            version_slug,
         )
         return
 
@@ -62,16 +66,18 @@ def remove_indexed_files(model, version, build):
         document = list(registry.get_documents(models=[model]))[0]
         log.info(
             'Deleting old files from search index for: %s:%s',
-            version.project.slug,
-            version.slug,
+            project_slug,
+            version_slug,
         )
-        (
+        documents = (
             document().search()
-            .filter('term', project=version.project.slug)
-            .filter('term', version=version.slug)
-            .exclude('term', build=build)
-            .delete()
+            .filter('term', project=project_slug)
         )
+        if version_slug:
+            documents.filter('term', version=version_slug)
+        if build_id:
+            documents.exclude('term', build=build_id)
+        documents.delete()
     except Exception:
         log.exception('Unable to delete a subset of files. Continuing.')
 


### PR DESCRIPTION
Currently, we are not removing files from storage when a version is deactivated. And we are not removing indexes from ES when a project/version is deleted or a version is deactivated.

Have to refactor `remove_indexed_files` to accept a slug instead of an instance, so we avoid having to make a query.