### PR TITLE
Add support for a RC1 image with Python 3.8

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -367,6 +367,9 @@ class CommunityBaseSettings(Settings):
         'readthedocs/build:5.0': {
             'python': {'supported_versions': [2, 2.7, 3, 3.5, 3.6, 3.7, 'pypy3.5']},
         },
+        'readthedocs/build:6.0rc1': {
+            'python': {'supported_versions': [2, 2.7, 3, 3.5, 3.6, 3.7, 3.8, 'pypy3.5']},
+        },
     }
 
     # Alias tagged via ``docker tag`` on the build servers


### PR DESCRIPTION
This PR add support to start testing a RC1 Docker image with support for 3.8.

Related #6324 https://github.com/readthedocs/readthedocs-docker-images/pull/111