### PR TITLE
Support 6.0rc1 build image

### DIFF
--- a/readthedocs/rtd_tests/tests/test_config_integration.py
+++ b/readthedocs/rtd_tests/tests/test_config_integration.py
@@ -75,6 +75,7 @@ class LoadConfigTests(TestCase):
             Project,
             main_language_project=None,
             install_project=False,
+            container_image=None,
         )
         self.version = get(Version, project=self.project)
 

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -367,6 +367,9 @@ class CommunityBaseSettings(Settings):
         'readthedocs/build:5.0': {
             'python': {'supported_versions': [2, 2.7, 3, 3.5, 3.6, 3.7, 'pypy3.5']},
         },
+        'readthedocs/build:6.0rc1': {
+            'python': {'supported_versions': [2, 2.7, 3, 3.5, 3.6, 3.7, 3.8, 'pypy3.5']},
+        },
     }
 
     # Alias tagged via ``docker tag`` on the build servers


### PR DESCRIPTION
This is basically the same as https://github.com/readthedocs/readthedocs.org/pull/6327, with tests fixed.

Users get python 3.8 only if they have `python: 3` as version (not if they have `python: 3.x`) or aren't using a configuration file and have `python3` set on the web UI.

https://github.com/readthedocs/readthedocs-docker-images/pull/111 is needed.