### PR TITLE
Upgrade django-storages

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -106,8 +106,7 @@ django-cors-middleware==1.4.0
 user-agents==2.0
 
 # Utilities used to upload build media to cloud storage
-# 1.7.2 blows up on our servers because of azure changes
-django-storages==1.7.1  # pyup: <1.7.2
+django-storages==1.7.2
 
 # Required only in development and linting
 django-debug-toolbar==2.0


### PR DESCRIPTION
1.7.2 fixes an issue on Azure with filenames that contain spaces.

Closes #6328 
Needs https://github.com/readthedocs/readthedocs-ext/pull/266