### PR TITLE
Update install docs

### DIFF
--- a/docs/development/install.rst
+++ b/docs/development/install.rst
@@ -2,11 +2,10 @@ Installation
 ============
 
 .. meta::
-   :description lang=en: Install a local instance of Read the Docs on your own servers with our step by step guide.
-
+   :description lang=en: Install a local development instance of Read the Docs with our step by step guide.
 
 Here is a step by step guide on how to install Read the Docs.
-It will get you to a point of having a local running instance.
+It will configure a local instance that can build and host documentation.
 
 Requirements
 ------------
@@ -16,15 +15,14 @@ Using a virtual environment is strongly recommended,
 since it will help you to avoid clutter in your system-wide libraries.
 
 .. warning::
+    Python 3.7 and newer are not currently supported. Some dependencies of Read
+    the Docs do not work with these versions. Python 3.6 is the latest supported
+    Python version.
 
-    Currently Read the Docs is using ``Django 1.11.x`` and this version of Django
-    has a `bug`_ which breaks database migrations if you are using ``sqlite 3.26.0 or Newer``.
-    So, we recommend using ``sqlite < 3.26.0`` to run Read the Docs properly on your machine.
-
-Additionally Read the Docs depends on:
+Additionally, Read the Docs depends on:
 
 * `Git`_ (version >=2.17.0)
-* `Mercurial`_ (only if you need to work with mercurial repositories)
+* `Mercurial`_ (only if you need to work with Mercurial repositories)
 * `Pip`_ (version >1.5)
 * `Redis`_
 * `Elasticsearch`_ (only if you want full support for searching inside the site)
@@ -33,47 +31,143 @@ Additionally Read the Docs depends on:
 
 .. note::
 
-    You can import Python 2.x or 3.x projects in RTD, make sure you install the
-    appropriate Python version (2.x or 3.x) with virtualenv.
+    To build Python 2.x or 3.x projects in Read the Docs, make sure you install
+    the appropriate Python version (2.x or 3.x) with virtualenv.
 
-In order to get all the dependencies successfully installed,
-you need these libraries.
+In order to install all the dependencies successfully, you need additional
+libraries:
 
 .. tabs::
 
    .. tab:: Mac OS
 
-      If you are having trouble on OS X Mavericks
-      (or possibly other versions of OS X) with building ``lxml``,
-      you probably might need to use Homebrew_ to ``brew install libxml2``,
-      and invoke the install with::
+      If you are having trouble on OS X Mavericks (or possibly other versions of
+      MacOS) building ``lxml``, you might need to use Homebrew_ to upgrade the
+      XML library:
 
-          CFLAGS=-I/usr/local/opt/libxml2/include/libxml2 \
-          LDFLAGS=-L/usr/local/opt/libxml2/lib \
-          pip install -r requirements.txt
+      .. code:: console
 
-   .. tab:: Ubuntu
+         $ brew install libxml2
+         $ export CFLAGS=-I/usr/local/opt/libxml2/include/libxml2
+         $ export LDFLAGS=-L/usr/local/opt/libxml2/lib
+         $ pip install -r requirements.txt
 
-      Install::
+   .. tab:: Ubuntu 18.04
 
-         sudo apt-get install build-essential
-         sudo apt-get install python-dev python-pip python-setuptools
-         sudo apt-get install libxml2-dev libxslt1-dev zlib1g-dev
+      .. note::
+         Ubuntu 18.04 LTS is the only version of Ubuntu that the core team
+         supports. Newer releases should work, however might require slightly
+         different packages and/or additional steps.
 
-      If you don't have redis installed yet, you can do it with::
+      Install the needed development libraries and headers with:
 
-         sudo apt-get install redis-server
+      .. code:: console
+
+         $ sudo apt-get install build-essential
+         $ sudo apt-get install python-dev python-pip python-setuptools
+         $ sudo apt-get install libxml2-dev libxslt1-dev zlib1g-dev
+
+      If you don't have redis installed yet, you can do it with:
+
+      .. code:: console
+
+         $ sudo apt-get install redis-server
 
    .. tab:: CentOS/RHEL 7
 
-      Install::
+      .. note::
+         CentOS/RHEL and variants are not officially supported by the core team.
 
-         sudo yum install python-devel python-pip libxml2-devel libxslt-devel
+      Install the needed development libraries and headers with:
+
+      .. code:: console
+
+         $ sudo yum install python-devel python-pip libxml2-devel libxslt-devel
 
    .. tab:: Other OS
 
-      On other operating systems no further dependencies are required,
-      or you need to find the proper equivalent libraries.
+      Other operating systems and distributions might require additional steps
+      to install Read the Docs. These are outside the scope of this document and
+      are not officially supported by the core team.
+
+Database
+~~~~~~~~
+
+By default, SQLite is used as the database backend and does not need any
+additional configuration or setup steps. You will need to set up a database if
+you run into problems during database migrations, or if you are using an
+unsupported database.
+
+.. tabs::
+
+    .. tab:: SQLite
+
+        .. warning::
+            Read the Docs uses ``Django 1.11.x``, which has a `bug`_ that breaks
+            database migrations if an unsupported version of the SQLite library
+            is used. SQLite versions ``3.26.0`` and newer are not supported.
+
+        If an unsupported version of the SQLite library is installed, you will
+        need to configure a different database or install an older version of
+        SQLite. We recommend installing PostgreSQL.
+
+    .. tab:: PostgreSQL
+
+        PostgreSQL is the recommended database backend, however SQLite will work
+        for most development cases. You'll need to make sure you have the
+        necessary Python PostgreSQL dependencies and the correct database
+        settings configured in order to use a PostgreSQL server instance.
+
+        .. tabs::
+
+            .. tab:: On your host system
+
+                Installation of PostgreSQL on your host system is outside the
+                scope of this document. Most operating systems or Linux
+                distributions have an easily installable version of PostgreSQL
+                server.
+
+            .. tab:: Docker
+
+                If you have Docker installed already, you can run a server
+                inside a container.
+
+                .. warning::
+                    This example is not meant as a thorough installation guide
+                    and is only recommended for development purposes.
+
+                .. code:: console
+
+                    $ docker pull postgres:10-alpine
+                    $ docker run -d --name postgres -p 5432:5432 postgres:10-alpine
+                    $ docker exec postgres createuser -h 127.0.0.1 -U postgres docs
+                    $ docker exec postgres createdb -h 127.0.0.1 -U postgres -O docs docs
+
+                To connect to the server:
+
+                :Host: ``127.0.0.1``
+                :User: ``docs``
+                :Database: ``docs``
+                :Password: None
+
+        You'll need to install the ``psycopg2`` Python package to allow Django to
+        use the database:
+
+        .. code:: console
+
+            $ python -m pip install psycopg2
+
+        This requires the PostgreSQL client libraries to be installed on your
+        system. If you do not have these, you can instead use:
+
+        .. code:: console
+
+            $ python -m pip install psycopg2-binary
+
+        Finally, you'll need to change the :std:setting:`DATABASES` Django
+        setting using a ``local_settings.py`` file after cloning the Read the
+        Docs repository. Configure this setting to use your new PostgreSQL
+        instance before configuring a user or running migrations.
 
 
 .. _Python 3.6: http://www.python.org/
@@ -90,37 +184,51 @@ you need these libraries.
 Get and run Read the Docs
 -------------------------
 
-Clone the repository somewhere on your disk and enter to the repository::
+Clone the repository somewhere on your disk and enter to the repository:
 
-    git clone --recurse-submodules https://github.com/readthedocs/readthedocs.org.git
-    cd readthedocs.org
+.. code:: console
 
-Create a virtual environment and activate it::
+    $ git clone --recurse-submodules https://github.com/readthedocs/readthedocs.org.git
+    $ cd readthedocs.org
 
-    virtualenv --python=python3 venv
-    source venv/bin/activate
+Create a virtual environment and activate it:
+
+.. code:: console
+
+    $ virtualenv --python=python3 venv
+    $ source venv/bin/activate
 
 Next, install the dependencies using ``pip``
-(make sure you are inside of the virtual environment)::
+(make sure you are inside of the virtual environment):
 
-    pip install -r requirements.txt
+.. code:: console
+
+    $ pip install -r requirements.txt
 
 This may take a while, so go grab a beverage.
-When it's done, build the database::
+When it's done, build the database:
 
-    python manage.py migrate
+.. code:: console
 
-Then create a superuser account for Django::
+    $ python manage.py migrate
 
-    python manage.py createsuperuser
+Then create a superuser account for Django:
 
-Now let's properly generate the static assets::
+.. code:: console
 
-    python manage.py collectstatic
+    $ python manage.py createsuperuser
 
-Now you can optionally load a couple users and test projects::
+Now let's properly generate the static assets:
 
-    python manage.py loaddata test_data
+.. code:: console
+
+    $ python manage.py collectstatic
+
+Now you can optionally load a couple users and test projects:
+
+.. code:: console
+
+    $ python manage.py loaddata test_data
 
 .. note::
 
@@ -131,26 +239,30 @@ Now you can optionally load a couple users and test projects::
     create an ``EmailAddress`` entry for the user, then you can use ``shell_plus`` to
     update the object with ``primary=True``, ``verified=True``.
 
-Finally, you're ready to start the web server::
+Finally, you're ready to start the web server:
 
-    python manage.py runserver
+.. code:: console
 
-Visit http://127.0.0.1:8000/ in your browser to see how it looks;
-you can use the admin interface via http://127.0.0.1:8000/admin
+    $ python manage.py runserver
+
+Visit http://localhost:8000/ in your browser to see how it looks.
+You can use the admin interface via http://localhost:8000/admin
 (logging in with the superuser account you just created).
 
 For builds to properly work as expected,
 it is necessary that the port you're serving on
-(i.e. ``python manage.py runserver 0.0.0.0:8080``)
+(i.e. ``python manage.py runserver 8000``)
 matches the port defined in ``PRODUCTION_DOMAIN``.
 You can use ``readthedocs/settings/local_settings.py`` to modify this
 (by default, it's ``localhost:8000``).
 
-While the web server is running,
-you can build the documentation for the latest version of any project using the ``update_repos`` command.
-For example to update the ``pip`` repo::
+While the web server is running, you can build the documentation for the latest
+version of any project using the ``update_repos`` command. For example to
+update the ``pip`` repo:
 
-    python manage.py update_repos pip
+.. code:: console
+
+    $ python manage.py update_repos pip
 
 .. note::
 
@@ -158,29 +270,50 @@ For example to update the ``pip`` repo::
     it is probably because of some missing libraries for ``pdf`` and ``epub`` generation.
     You can uncheck this on the advanced settings of your project.
 
-What's available
-----------------
+Next steps
+----------
 
 After registering with the site (or creating yourself a superuser account),
 you will be able to log in and view the `dashboard <http://localhost:8000/dashboard/>`_.
+You are now ready to start building docs and contributing to Read the Docs!
 
 Importing your docs
 ~~~~~~~~~~~~~~~~~~~
 
-One of the goals of readthedocs.org is to make it easy for any open source developer to get high quality hosted docs with great visibility!
-Simply provide us with the clone URL to your repo, we'll pull your code, extract your docs, and build them!
+You can start testing your instance by building some of the example
+documentation projects that were configured when you imported the fixture data,
+or you can import new projects. You can also import and Sphinx or Mkdocs
+project, especially projects that have already set up their repository on
+https://readthedocs.org.
 
-We make available a post-commit webhook that can be configured to update the docs whenever you commit to your repo.
-See our :doc:`/intro/import-guide` page to learn more.
+Contributing
+~~~~~~~~~~~~
 
-Further steps
--------------
+By now you can trigger builds on your local environment, and should be able to
+make changes to most of Read the Docs. See our docs on :doc:`contributing to
+Read the Docs </contribute>` for more information on how to help.
 
-By now you can trigger builds on your local environment,
-to encapsulate the build process inside a Docker container,
-see :doc:`buildenvironments`.
+Additionally, there is more configuration you can do if you would like to
+contribute to all parts of Read the Docs.
 
-For building this documentation,
-see :doc:`docs`.
+Use Docker for builds
+    By default, Read the Docs will use your local environment and your system
+    binaries to build projects. However, this means that you can only use Python
+    versions that you have installed on your host system, and it means that PDF
+    output likely doesn't work unless you have all of the LaTeX dependencies
+    installed.
 
-And for setting up for the front end development, see :doc:`front-end`.
+    To build projects inside using Docker, and more closely replicate how Read
+    the Docs builds projects for our community site, see
+    :doc:`buildenvironments`.
+
+Index to Elasticsearch
+    Search results might be different on your instance if you did not set up
+    `Elasticsearch`_. Follow the :doc:`search development guide </development/search>`
+    for more instruction.
+
+Make front end and UI changes
+    To set up for front end development, see :doc:`front-end`.
+
+Make documentation updates
+    To contribute to this documentation, see :doc:`docs`.

--- a/requirements/docs-lint.txt
+++ b/requirements/docs-lint.txt
@@ -1,5 +1,2 @@
-# Use <2.x until we fix some issues in our theme.
-# Some things are not rendering properly and sidebar shows titles in gray.
-Sphinx==1.8.5  # pyup: <2.0.0
-
+Sphinx==2.2.0
 rstcheck==3.3.1

--- a/requirements/local-docs-build.txt
+++ b/requirements/local-docs-build.txt
@@ -10,6 +10,7 @@
 # AttributeError: 'str' object has no attribute 'rawsource'
 docutils==0.14  # pyup: ignore
 
+sphinx==2.2
 sphinx_rtd_theme==0.4.3
 sphinx-tabs==1.1.13
 # Required to avoid Transifex error with reserved slug


### PR DESCRIPTION
I walked through these docs again and hit more issues on new Ubuntu release
(SQLite and Python 3.7)

* Clean up copy on install docs
* Notes Python 3.6 is required, no 3.7+
* Convert literal blocks to code console blocks
* Add directions for using PostgreSQL, guide users away from SQLite
* Drop a block at the end that didn't sound like it belonged in the install
docs

Requires Sphinx 2+ and a yet-to-be-release sphinx-rtd-theme. This is mostly
to deal with the code console prefix, our theme will make these not part of
the selection.

Refs readthedocs/sphinx_rtd_theme#845
Requires a release of the sphinx theme