### PR TITLE
Dont link to dashboard from footer

### DIFF
--- a/readthedocs/api/v2/views/footer_views.py
+++ b/readthedocs/api/v2/views/footer_views.py
@@ -44,7 +44,9 @@ def get_version_compare_data(project, base_version=None):
         'is_highest': True,
     }
     if highest_version_obj:
-        ret_val['url'] = highest_version_obj.get_absolute_url()
+        # Never link to the dashboard,
+        # users reading the docs may don't have access to the dashboard.
+        ret_val['url'] = highest_version_obj.get_absolute_url(link_to_dashboard=False)
         ret_val['slug'] = highest_version_obj.slug
     if base_version and base_version.slug != LATEST:
         try:

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -77,7 +77,6 @@ from readthedocs.projects.constants import (
 from readthedocs.projects.models import APIProject, Project
 from readthedocs.projects.version_handling import determine_stable_version
 
-
 log = logging.getLogger(__name__)
 
 
@@ -289,7 +288,13 @@ class Version(models.Model):
         )
         return self.identifier
 
-    def get_absolute_url(self):
+    def get_absolute_url(self, link_to_dashboard=True):
+        """
+        Get absolute url to the docs of the version.
+
+        :param link_to_dashboard: If `False` we never try to link to the dashboard,
+                                  we link to the docs even if they result in a 404.
+        """
         # Hack external versions for now.
         # TODO: We can integrate them into the resolver
         # but this is much simpler to handle since we only link them a couple places for now
@@ -299,7 +304,7 @@ class Version(models.Model):
                 f'{self.project.slug}/{self.slug}/index.html'
             return url
 
-        if not self.built and not self.uploaded:
+        if not self.built and not self.uploaded and link_to_dashboard:
             return reverse(
                 'project_version_detail',
                 kwargs={

--- a/readthedocs/rtd_tests/tests/test_footer.py
+++ b/readthedocs/rtd_tests/tests/test_footer.py
@@ -240,11 +240,12 @@ class TestFooterPerformance(APITestCase):
 
     # The expected number of queries for generating the footer
     # This shouldn't increase unless we modify the footer API
-    EXPECTED_QUERIES = 9
+    EXPECTED_QUERIES = 13
 
     def setUp(self):
         self.pip = Project.objects.get(slug='pip')
         self.pip.versions.create_latest()
+        self.pip.versions.update(built=True)
 
     def render(self):
         request = self.factory.get(self.url)

--- a/readthedocs/rtd_tests/tests/test_footer.py
+++ b/readthedocs/rtd_tests/tests/test_footer.py
@@ -1,6 +1,7 @@
 import mock
 from django.contrib.sessions.backends.base import SessionBase
 from django.test import TestCase
+from django.test.utils import override_settings
 from rest_framework.test import APIRequestFactory, APITestCase
 
 from readthedocs.api.v2.views.footer_views import (
@@ -114,6 +115,10 @@ class Testmaker(APITestCase):
         self.assertNotIn('Edit', response.data['html'])
 
 
+@override_settings(
+    USE_SUBDOMAIN=True,
+    PUBLIC_DOMAIN='readthedocs.io',
+)
 class TestVersionCompareFooter(TestCase):
     fixtures = ['test_data']
 
@@ -124,7 +129,7 @@ class TestVersionCompareFooter(TestCase):
         base_version = self.pip.get_stable_version()
         valid_data = {
             'project': 'Version 0.8.1 of Pip (19)',
-            'url': '/dashboard/pip/version/0.8.1/',
+            'url': 'http://pip.readthedocs.io/en/0.8.1/',
             'slug': '0.8.1',
             'version': '0.8.1',
             'is_highest': True,
@@ -136,7 +141,7 @@ class TestVersionCompareFooter(TestCase):
         base_version = self.pip.versions.get(slug='0.8')
         valid_data = {
             'project': 'Version 0.8.1 of Pip (19)',
-            'url': '/dashboard/pip/version/0.8.1/',
+            'url': 'http://pip.readthedocs.io/en/0.8.1/',
             'slug': '0.8.1',
             'version': '0.8.1',
             'is_highest': False,
@@ -149,7 +154,7 @@ class TestVersionCompareFooter(TestCase):
         base_version = self.pip.versions.get(slug=LATEST)
         valid_data = {
             'project': 'Version 0.8.1 of Pip (19)',
-            'url': '/dashboard/pip/version/0.8.1/',
+            'url': 'http://pip.readthedocs.io/en/0.8.1/',
             'slug': '0.8.1',
             'version': '0.8.1',
             'is_highest': True,
@@ -177,7 +182,7 @@ class TestVersionCompareFooter(TestCase):
         base_version = self.pip.versions.get(slug='0.8.1')
         valid_data = {
             'project': 'Version 1.0.0 of Pip ({})'.format(version.pk),
-            'url': '/dashboard/pip/version/1.0.0/',
+            'url': 'http://pip.readthedocs.io/en/1.0.0/',
             'slug': '1.0.0',
             'version': '1.0.0',
             'is_highest': False,
@@ -191,7 +196,7 @@ class TestVersionCompareFooter(TestCase):
         base_version = self.pip.versions.get(slug='0.8.1')
         valid_data = {
             'project': 'Version 0.8.1 of Pip (19)',
-            'url': '/dashboard/pip/version/0.8.1/',
+            'url': 'http://pip.readthedocs.io/en/0.8.1/',
             'slug': '0.8.1',
             'version': '0.8.1',
             'is_highest': True,
@@ -202,7 +207,7 @@ class TestVersionCompareFooter(TestCase):
         base_version = self.pip.versions.get(slug='0.8')
         valid_data = {
             'project': 'Version 0.8.1 of Pip (19)',
-            'url': '/dashboard/pip/version/0.8.1/',
+            'url': 'http://pip.readthedocs.io/en/0.8.1/',
             'slug': '0.8.1',
             'version': '0.8.1',
             'is_highest': False,
@@ -219,7 +224,7 @@ class TestVersionCompareFooter(TestCase):
         )
         valid_data = {
             'project': 'Version 2.0.0 of Pip ({})'.format(version.pk),
-            'url': '/dashboard/pip/version/2.0.0/',
+            'url': 'http://pip.readthedocs.io/en/2.0.0/',
             'slug': '2.0.0',
             'version': '2.0.0',
             'is_highest': False,


### PR DESCRIPTION
We use the `get_absolute_url` in other parts of the code
where it makes sense to link to the dashboard.
So I'm adding an additional parameter.

Closes #6137