### PR TITLE
Change the default of proxied_api_host to api_host

### DIFF
--- a/readthedocs/core/static-src/core/js/doc-embed/footer.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/footer.js
@@ -65,7 +65,7 @@ function init() {
     // Check for new logic around proxying requests.
     // ``proxied_api_host`` won't exist on existing built docs,
     // so default to ``api_host`` in those cases
-    real_api_host = rtd.api_host
+    var real_api_host = rtd.api_host;
     if ("proxied_api_host" in rtd) {
         real_api_host = rtd.proxied_api_host
     }

--- a/readthedocs/core/static-src/core/js/doc-embed/footer.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/footer.js
@@ -67,7 +67,7 @@ function init() {
     // so default to ``api_host`` in those cases
     var real_api_host = rtd.api_host;
     if ("proxied_api_host" in rtd) {
-        real_api_host = rtd.proxied_api_host
+        real_api_host = rtd.proxied_api_host;
     }
 
     // Get footer HTML from API and inject it into the page.

--- a/readthedocs/core/static-src/core/js/doc-embed/footer.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/footer.js
@@ -62,9 +62,18 @@ function init() {
         get_data['subproject'] = true;
     }
 
+    // Check for new logic around proxying requests.
+    // ``proxied_api_host`` won't exist on existing built docs,
+    // so default to ``api_host`` in those cases
+    if ("proxied_api_host" in rtd) {
+        api_host = rtd.proxied_api_host
+    } else {
+        api_host = rtd.api_host
+    }
+
     // Get footer HTML from API and inject it into the page.
     $.ajax({
-        url: rtd.proxied_api_host + "/api/v2/footer_html/",
+        url: api_host + "/api/v2/footer_html/",
         crossDomain: true,
         xhrFields: {
             withCredentials: true,

--- a/readthedocs/core/static-src/core/js/doc-embed/footer.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/footer.js
@@ -65,15 +65,14 @@ function init() {
     // Check for new logic around proxying requests.
     // ``proxied_api_host`` won't exist on existing built docs,
     // so default to ``api_host`` in those cases
+    real_api_host = rtd.api_host
     if ("proxied_api_host" in rtd) {
-        api_host = rtd.proxied_api_host
-    } else {
-        api_host = rtd.api_host
+        real_api_host = rtd.proxied_api_host
     }
 
     // Get footer HTML from API and inject it into the page.
     $.ajax({
-        url: api_host + "/api/v2/footer_html/",
+        url: real_api_host + "/api/v2/footer_html/",
         crossDomain: true,
         xhrFields: {
             withCredentials: true,

--- a/readthedocs/core/static-src/core/js/doc-embed/rtd-data.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/rtd-data.js
@@ -53,7 +53,6 @@ function get() {
 
     var defaults = {
         api_host: 'https://readthedocs.org',
-        proxied_api_host: 'https://readthedocs.org',
         ad_free: false,
     };
 


### PR DESCRIPTION
This allows us to respect the ``api_host`` that might be configured
in pre-built documentation.
Previously these would all default to ``readthedocs.org``,
which isn't great for local dev or custom installs.