### PR TITLE
Small optimization to not compute the highest version when it isn't displayed

### DIFF
--- a/readthedocs/api/v2/views/footer_views.py
+++ b/readthedocs/api/v2/views/footer_views.py
@@ -26,6 +26,9 @@ def get_version_compare_data(project, base_version=None):
     :param base_version: We assert whether or not the base_version is also the
                          highest version in the resulting "is_highest" value.
     """
+    if not project.show_version_warning:
+        return {'is_highest': False}
+
     versions_qs = (
         Version.internal.public(project=project)
         .filter(built=True, active=True)

--- a/readthedocs/rtd_tests/tests/test_api_version_compare.py
+++ b/readthedocs/rtd_tests/tests/test_api_version_compare.py
@@ -8,6 +8,9 @@ from readthedocs.projects.models import Project
 class VersionCompareTests(TestCase):
     fixtures = ['eric.json', 'test_data.json']
 
+    def setUp(self):
+        Project.objects.update(show_version_warning=True)
+
     def test_not_highest(self):
         project = Project.objects.get(slug='read-the-docs')
         version = project.versions.get(slug='0.2.1')


### PR DESCRIPTION
We added a setting about whether to show this to the user or not,
but always calculated the data regardless of the setting.

@humitos does this break your extension, or is it respecting this setting also? 