### PR TITLE
Use github actions to trigger tests in corporate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,5 +15,5 @@ jobs:
       run: |
         curl --request POST \
         --url https://circleci.com/api/v1.1/project/github/${{ secrets.CORPORATE_REPO }}/tree/master \
-        --user '${{ secrets.CIRCLECI_USER }}' \
+        --user '${{ secrets.CIRCLECI_USER_TOKEN }}:' \
         --data 'build_parameters[CIRCLE_JOB]=${{ secrets.CIRCLECI_JOB }}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Trigger tests in corporate
+      run: |
+        curl --request POST \
+        --url https://circleci.com/api/v1.1/project/github/${{ secrets.CORPORATE_REPO }}/tree/master \
+        --user '${{ secrets.CIRCLECI_USER }}' \
+        --data 'build_parameters[CIRCLE_JOB]=${{ secrets.CIRCLECI_JOB }}'


### PR DESCRIPTION
Secrets are set in https://github.com/readthedocs/readthedocs.org/settings/secrets only users with write access can see/edit them 

https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets

Docs from circle

https://circleci.com/docs/2.0/api-job-trigger/