### PR TITLE
Redirect index files in proxito instead of serving

### DIFF
--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -189,17 +189,32 @@ class TestAdditionalDocViews(BaseDocServing):
     def test_directory_indexes(self, storage_mock):
         self.project.versions.update(active=True, built=True)
         storage_mock()().exists.return_value = True
-        storage_mock()().open().read.return_value = 'foo'
         # Confirm we've serving from storage for the `index-exists/index.html` file
         response = self.client.get(
             reverse('serve_error_404', kwargs={'proxito_path': '/en/latest/index-exists'}),
             HTTP_HOST='project.readthedocs.io',
         )
         self.assertEqual(
-            response.content, b'foo'
+            response.status_code, 302
         )
         self.assertEqual(
-            response.status_code, 200
+            response['location'], '/en/latest/index-exists/index.html',
+        )
+
+    @mock.patch('readthedocs.proxito.views.get_storage_class')
+    def test_directory_indexes_get_args(self, storage_mock):
+        self.project.versions.update(active=True, built=True)
+        storage_mock()().exists.return_value = True
+        # Confirm we've serving from storage for the `index-exists/index.html` file
+        response = self.client.get(
+            reverse('serve_error_404', kwargs={'proxito_path': '/en/latest/index-exists?foo=bar'}),
+            HTTP_HOST='project.readthedocs.io',
+        )
+        self.assertEqual(
+            response.status_code, 302
+        )
+        self.assertEqual(
+            response['location'], '/en/latest/index-exists/index.html?foo=bar',
         )
 
     @mock.patch('readthedocs.proxito.views.get_storage_class')

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -231,7 +231,7 @@ class TestAdditionalDocViews(BaseDocServing):
             response.status_code, 302
         )
         self.assertEqual(
-            response['location'], '/en/latest/index-exists/index.html?foo=bar',
+            response['location'], '/en/latest/index-exists/?foo=bar',
         )
 
     @mock.patch('readthedocs.proxito.views.get_storage_class')

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -198,7 +198,24 @@ class TestAdditionalDocViews(BaseDocServing):
             response.status_code, 302
         )
         self.assertEqual(
-            response['location'], '/en/latest/index-exists/index.html',
+            response['location'], '/en/latest/index-exists/',
+        )
+
+    @mock.patch('readthedocs.proxito.views.get_storage_class')
+    def test_directory_indexes_readme_serving(self, storage_mock):
+        self.project.versions.update(active=True, built=True)
+
+        storage_mock()().exists.side_effect = [False, True]
+        # Confirm we've serving from storage for the `index-exists/index.html` file
+        response = self.client.get(
+            reverse('serve_error_404', kwargs={'proxito_path': '/en/latest/readme-exists'}),
+            HTTP_HOST='project.readthedocs.io',
+        )
+        self.assertEqual(
+            response.status_code, 302
+        )
+        self.assertEqual(
+            response['location'], '/en/latest/readme-exists/README.html',
         )
 
     @mock.patch('readthedocs.proxito.views.get_storage_class')

--- a/readthedocs/proxito/views.py
+++ b/readthedocs/proxito/views.py
@@ -394,7 +394,7 @@ def serve_error_404(request, proxito_path, template_name='404.html'):
             parts = urlparse(proxito_path)
             if tryfile == 'README.html':
                 new_path = os.path.join(parts.path, tryfile)
-            else: 
+            else:
                 new_path = parts.path + '/'
             new_parts = parts._replace(path=new_path)
             resp = HttpResponseRedirect(new_parts.geturl())

--- a/readthedocs/proxito/views.py
+++ b/readthedocs/proxito/views.py
@@ -385,12 +385,12 @@ def serve_error_404(request, proxito_path, template_name='404.html'):
         )
         if storage.exists(storage_filename_path):
             log.info(
-                'Serving index file: project=%s version=%s, url=%s',
+                'Redirecting to index file: project=%s version=%s, url=%s',
                 final_project.slug,
                 version_slug,
                 storage_filename_path,
             )
-            resp = HttpResponse(storage.open(storage_filename_path).read())
+            resp = HttpResponseRedirect(os.path.join(filename, tryfile))
             return resp
 
     # If that doesn't work, attempt to serve the 404 of the current version (version_slug)

--- a/readthedocs/proxito/views.py
+++ b/readthedocs/proxito/views.py
@@ -390,7 +390,11 @@ def serve_error_404(request, proxito_path, template_name='404.html'):
                 version_slug,
                 storage_filename_path,
             )
-            resp = HttpResponseRedirect(os.path.join(filename, tryfile))
+            # Use urlparse so that we maintain GET args in our redirect
+            parts = urlparse(proxito_path)
+            new_path = os.path.join(parts.path, tryfile)
+            new_parts = parts._replace(path=new_path)
+            resp = HttpResponseRedirect(new_parts.geturl())
             return resp
 
     # If that doesn't work, attempt to serve the 404 of the current version (version_slug)

--- a/readthedocs/proxito/views.py
+++ b/readthedocs/proxito/views.py
@@ -392,7 +392,10 @@ def serve_error_404(request, proxito_path, template_name='404.html'):
             )
             # Use urlparse so that we maintain GET args in our redirect
             parts = urlparse(proxito_path)
-            new_path = os.path.join(parts.path, tryfile)
+            if tryfile == 'README.html':
+                new_path = os.path.join(parts.path, tryfile)
+            else: 
+                new_path = parts.path + '/'
             new_parts = parts._replace(path=new_path)
             resp = HttpResponseRedirect(new_parts.geturl())
             return resp


### PR DESCRIPTION
This lets us just return a redirect if the file exists. This matches the
existing nginx behavior, except it actually appends the index filename
instead of just a slash.

I'm not sure which is better, but this is more explicit which feels good.