### PR TITLE
Set privacy level explicitly

### DIFF
--- a/readthedocs/proxito/tests/base.py
+++ b/readthedocs/proxito/tests/base.py
@@ -23,8 +23,11 @@ class BaseDocServing(TestCase):
         self.eric.set_password('eric')
         self.eric.save()
         self.project = fixture.get(
-            Project, slug='project', privacy_level='project',
-            version_privacy_level='project', users=[self.eric],
+            Project,
+            slug='project',
+            privacy_level=PUBLIC,
+            version_privacy_level=PUBLIC,
+            users=[self.eric],
             main_language_project=None,
         )
         self.project.versions.update(privacy_level=PUBLIC)

--- a/readthedocs/proxito/tests/base.py
+++ b/readthedocs/proxito/tests/base.py
@@ -6,6 +6,7 @@ from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test.utils import override_settings
 
+from readthedocs.projects.constants import PUBLIC
 from readthedocs.projects.models import Project
 
 
@@ -26,31 +27,43 @@ class BaseDocServing(TestCase):
             version_privacy_level='project', users=[self.eric],
             main_language_project=None,
         )
+        self.project.versions.update(privacy_level=PUBLIC)
+
         self.subproject = fixture.get(
             Project,
             slug='subproject',
             users=[self.eric],
             main_language_project=None,
+            privacy_level=PUBLIC,
         )
+        self.subproject.versions.update(privacy_level=PUBLIC)
         self.project.add_subproject(self.subproject)
         self.translation = fixture.get(
             Project,
             language='es',
             slug='translation',
             users=[self.eric],
+            privacy_level=PUBLIC,
             main_language_project=self.project,
         )
+        self.translation.versions.update(privacy_level=PUBLIC)
+
         self.subproject_translation = fixture.get(
             Project,
             language='es',
             slug='subproject-translation',
             users=[self.eric],
             main_language_project=self.subproject,
+            privacy_level=PUBLIC,
         )
+        self.subproject_translation.versions.update(privacy_level=PUBLIC)
+
         self.subproject_alias = fixture.get(
             Project,
             language='en',
             slug='subproject-alias',
             users=[self.eric],
+            privacy_level=PUBLIC,
         )
+        self.subproject_alias.versions.update(privacy_level=PUBLIC)
         self.project.add_subproject(self.subproject_alias, alias='this-is-an-alias')

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -280,15 +280,22 @@ class TestAdditionalDocViews(BaseDocServing):
         translation = fixture.get(
             Project,
             main_language_project=self.project,
-            language='translation-es'
+            language='translation-es',
+            privacy_level=constants.PUBLIC,
         )
+        translation.versions.update(privacy_level=constants.PUBLIC)
         # sitemap hreflang should follow correct format.
         # ref: https://en.wikipedia.org/wiki/Hreflang#Common_Mistakes
         hreflang_test_translation_project = fixture.get(
             Project,
             main_language_project=self.project,
-            language='zh_CN'
+            language='zh_CN',
+            privacy_level=constants.PUBLIC,
         )
+        hreflang_test_translation_project.versions.update(
+            privacy_level=constants.PUBLIC,
+        )
+
         response = self.client.get(
             reverse('sitemap_xml'),
             HTTP_HOST='project.readthedocs.io',


### PR DESCRIPTION
This is needed to fix tests in the corporate site
where all versions are private by default.

Some tests expect them to be public.