### PR TITLE
Fix CSS and how we were handling html in automation rule UI

### DIFF
--- a/media/css/core.css
+++ b/media/css/core.css
@@ -1293,7 +1293,6 @@ div.httpexchange div.highlight pre {
 
 
 /* Subprojects */
-
 div.module.project-subprojects li.subproject a.subproject-url:before {
     padding-right: .5em;
     font-family: FontAwesome;
@@ -1306,14 +1305,6 @@ div.module.project-subprojects li.subproject a.subproject-edit:before {
     font-weight: normal;
     content: "\f044";
 }
-
-/* Automation Rules */
-
-li.automation-rule input[type="submit"] {
-    font-family: FontAwesome;
-    font-weight: normal;
-}
-
 
 /* Pygments */
 div.highlight pre .hll { background-color: #ffffcc }

--- a/readthedocs/projects/static-src/projects/css/admin.less
+++ b/readthedocs/projects/static-src/projects/css/admin.less
@@ -16,3 +16,25 @@
       }
     }
 }
+
+// Automation rules
+#content .module-list.automation-rules .automation-rule button {
+    margin: .25em;
+
+    > span {
+        display: none;
+    }
+
+    &:before {
+        font-family: FontAwesome;
+        font-weight: normal;
+    }
+
+    &.automation-rule-up:before {
+        content: "\f062";
+    }
+
+    &.automation-rule-down:before {
+        content: "\f063";
+    }
+}

--- a/readthedocs/projects/static/projects/css/admin.css
+++ b/readthedocs/projects/static/projects/css/admin.css
@@ -13,3 +13,19 @@
   display: inline-block;
   margin: 1em 0em 0em 0em;
 }
+#content .module-list.automation-rules .automation-rule button {
+  margin: .25em;
+}
+#content .module-list.automation-rules .automation-rule button > span {
+  display: none;
+}
+#content .module-list.automation-rules .automation-rule button:before {
+  font-family: FontAwesome;
+  font-weight: normal;
+}
+#content .module-list.automation-rules .automation-rule button.automation-rule-up:before {
+  content: "\f062";
+}
+#content .module-list.automation-rules .automation-rule button.automation-rule-down:before {
+  content: "\f063";
+}

--- a/readthedocs/templates/builds/versionautomationrule_list.html
+++ b/readthedocs/templates/builds/versionautomationrule_list.html
@@ -1,8 +1,13 @@
 {% extends "projects/project_edit_base.html" %}
 
 {% load i18n %}
+{% load static %}
 
 {% block title %}{% trans "Automation Rules" %}{% endblock %}
+
+{% block extra_links %}
+  <link rel="stylesheet" type="text/css" href="{% static "projects/css/admin.css" %}" />
+{% endblock %}
 
 {% block nav-dashboard %} class="active"{% endblock %}
 
@@ -30,7 +35,7 @@
     </ul>
   </div>
 
-  <div class="module-list">
+  <div class="module-list automation-rules">
     <div class="module-list-wrapper">
       <ul>
         {% for rule in object_list %}
@@ -46,7 +51,9 @@
                 <li class="automation-rule">
                   <form method="post" action="{% url 'projects_automation_rule_move' project_slug=project.slug automation_rule_pk=rule.pk steps=-1 %}">
                     {% csrf_token %}
-                    <input aria-label="{% trans 'Move up' %}" title="{% trans 'Move up' %}" type="submit" value="&#xf062">
+                    <button aria-label="{% trans 'Move up' %}" title="{% trans 'Move up' %}" class="automation-rule-up">
+                      <span>{% trans 'Move up' %}</span>
+                    </button>
                   </form>
                 </li>
               {% endif %}
@@ -55,7 +62,9 @@
                 <li class="automation-rule">
                   <form method="post" action="{% url 'projects_automation_rule_move' project_slug=project.slug automation_rule_pk=rule.pk steps=1 %}">
                     {% csrf_token %}
-                    <input aria-label="{% trans 'Move down' %}" title="{% trans 'Move down' %}" type="submit" value="&#xf063">
+                    <button aria-label="{% trans 'Move down' %}" title="{% trans 'Move down' %}" class="automation-rule-down">
+                      <span>{% trans 'Move down' %}</span>
+                    </button>
                   </form>
                 </li>
               {% endif %}


### PR DESCRIPTION
Remove hard coded values in HTML for font awesome and override the
values with CSS instead.

The problem with how the underlying PR is written is that normally all of this is done with CSS, the values are not hard coded in the HTML. We can't override this on commercial styling as easy when we hardcode the value into HTML. This is a better example of how to do CSS, classes on the module and module elements, and how to add a font awesome icon to a button.