### PR TITLE
Allow to extend El Proxito views from commercial

### DIFF
--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -83,15 +83,9 @@ class ServeDocsBase(ServeDocsMixin, View):
         #     language=lang_slug, version_slug=version_slug, path=filename
         # )
 
-        # Don't do auth checks
-        # try:
-        #     Version.objects.public(user=request.user, project=final_project).get(slug=version_slug)  # noqa
-        # except Version.DoesNotExist:
-        #     # Properly raise a 404 if the version doesn't exist (or is inactive) and
-        #     # a 401 if it does
-        #     if final_project.versions.filter(slug=version_slug, active=True).exists():
-        #         return _serve_401(request, final_project)
-        #     raise Http404('Version does not exist.')
+        # Check user permissions and return an unauthed response if needed
+        if not self.allowed_user(request, final_project, version_slug):
+            return self.get_unauthed_response(request, final_project)
 
         storage_path = final_project.get_storage_path(
             type_='html', version_slug=version_slug, include_file=False
@@ -104,6 +98,9 @@ class ServeDocsBase(ServeDocsMixin, View):
             path += 'index.html'
 
         return self._serve_docs(request, final_project=final_project, path=path)
+
+    def allowed_user(self, *args, **kwargs):
+        return True
 
 
 class ServeDocs(SettingsOverrideObject):


### PR DESCRIPTION
This is useful in commercial site to override `allowed_user` method to the required auth checks and decide if the file should be served to the user or not.

In the community site, this method should always return `True` since all projects/versions are public.

This is all the code changes required in the community site. Feel free to suggest a better pattern or better names for the methods.

This PR is based on #6396 