### PR TITLE
Use /data inside Azurite container to persist data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,7 +132,7 @@ services:
       - azurite_data:/data
     ports:
       - "10000:10000"
-    command: ["azurite-blob", "--silent", "--blobPort", "10000", "--blobHost", "0.0.0.0"]
+    command: ["azurite-blob", "--silent", "--blobPort", "10000", "--blobHost", "0.0.0.0", "--location", "/data"]
 
   azure-cli:
     image: microsoft/azure-cli


### PR DESCRIPTION
I missed the `--location` argument on Azurite container to persist data after the container is removed. This PR adds that argument and make data to be persistent.