### PR TITLE
Use WORKDIR to cd into a directory in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,8 @@ RUN apt-get -y install \
 
 RUN pip3 install --upgrade pip
 
-RUN mkdir checkouts; cd checkouts
+RUN mkdir checkouts
+WORKDIR /usr/src/app/checkouts
 
 COPY requirements readthedocs.org/requirements
 


### PR DESCRIPTION
Minor fix to use WORKDIR instead of `cd` into the previous RUN command.