### PR TITLE
Add AuthenticationMiddleware to El Proxito tests

### DIFF
--- a/readthedocs/proxito/tests/base.py
+++ b/readthedocs/proxito/tests/base.py
@@ -13,7 +13,13 @@ from readthedocs.projects.models import Project
 @override_settings(
     PUBLIC_DOMAIN='dev.readthedocs.io',
     ROOT_URLCONF='readthedocs.proxito.urls',
-    MIDDLEWARE=['readthedocs.proxito.middleware.ProxitoMiddleware'],
+    MIDDLEWARE=[
+        # Auth middleware is required since some views uses ``request.user``
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+
+        'readthedocs.proxito.middleware.ProxitoMiddleware',
+    ],
     USE_SUBDOMAIN=True,
 )
 class BaseDocServing(TestCase):


### PR DESCRIPTION
This middleware is required to run the tests in Corporate because the `allowed_user` method uses `request.user` to make the decision.

I'm not sure if there is a better way to do this by overriding one of this setting in the corporate site. We have been skipping these kind of tests, but I think El Proxito is important in corporate and it's better to run these tests as well.