### PR TITLE
Add more supported field to APIv3 docs

### DIFF
--- a/docs/api/v3.rst
+++ b/docs/api/v3.rst
@@ -234,7 +234,18 @@ Project update
 
         {
             "name": "New name for the project",
-            "default_version": "v0.27.0"
+            "repository": {
+                "url": "https://github.com/readthedocs/readthedocs.org",
+                "type": "git"
+            },
+            "language": "ja",
+            "programming_language": "py",
+            "homepage": "https://readthedocs.org/",
+            "default_version": "v0.27.0",
+            "default_branch": "develop",
+            "analytics_code": "UA000000",
+            "single_version": false,
+
         }
 
     :statuscode 204: Updated successfully


### PR DESCRIPTION
Only "Project Update" is updated. I didn't find more cases where we need to expand our docs to show all the available fields.

Closes #6385