### PR TITLE
Use trigger_build for update_repos command

### DIFF
--- a/readthedocs/core/management/commands/update_repos.py
+++ b/readthedocs/core/management/commands/update_repos.py
@@ -64,19 +64,7 @@ class Command(BaseCommand):
                             active=True,
                             uploaded=False,
                     ):
-
-                        build = Build.objects.create(
-                            project=version.project,
-                            version=version,
-                            type='html',
-                            state='triggered',
-                        )
-
-                        # pylint: disable=no-value-for-parameter
-                        tasks.update_docs_task(
-                            version.pk,
-                            build_pk=build.pk,
-                        )
+                        trigger_build(project=version.project, version=version)
                 elif version == INTERNAL:
                     log.info('Updating all internal versions for %s', slug)
                     for version in Version.internal.filter(
@@ -84,20 +72,7 @@ class Command(BaseCommand):
                             active=True,
                             uploaded=False,
                     ):
-
-                        build = Build.objects.create(
-                            project=version.project,
-                            version=version,
-                            type='html',
-                            state='triggered',
-                        )
-
-                        # pylint: disable=no-value-for-parameter
-                        tasks.update_docs_task(
-                            version.project_id,
-                            build_pk=build.pk,
-                            version_pk=version.pk,
-                        )
+                        trigger_build(project=version.project, version=version)
                 elif version == EXTERNAL:
                     log.info('Updating all external versions for %s', slug)
                     for version in Version.external.filter(
@@ -105,20 +80,7 @@ class Command(BaseCommand):
                             active=True,
                             uploaded=False,
                     ):
-
-                        build = Build.objects.create(
-                            project=version.project,
-                            version=version,
-                            type='html',
-                            state='triggered',
-                        )
-
-                        # pylint: disable=no-value-for-parameter
-                        tasks.update_docs_task(
-                            version.project_id,
-                            build_pk=build.pk,
-                            version_pk=version.pk,
-                        )
+                        trigger_build(project=version.project, version=version)
                 else:
                     p = Project.all_objects.get(slug=slug)
                     log.info('Building %s', p)
@@ -130,18 +92,11 @@ class Command(BaseCommand):
                         active=True,
                         uploaded=False,
                 ):
-                    # pylint: disable=no-value-for-parameter
-                    tasks.update_docs_task(
-                        version.pk,
-                        force=force,
-                    )
-            else:
+                    trigger_build(project=version.project, version=version)
+
                 log.info('Updating all docs')
                 for project in Project.objects.all():
                     # pylint: disable=no-value-for-parameter
                     default_version = project.get_default_version()
                     version = project.versions.get(slug=default_version)
-                    tasks.update_docs_task(
-                        version.pk,
-                        force=force,
-                    )
+                    trigger_build(project=version.project, version=version)

--- a/readthedocs/core/management/commands/update_repos.py
+++ b/readthedocs/core/management/commands/update_repos.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 Custom management command to rebuild documentation for all projects.
 
@@ -11,11 +9,9 @@ import logging
 from django.core.management.base import BaseCommand
 
 from readthedocs.builds.constants import EXTERNAL, INTERNAL
-from readthedocs.builds.models import Build, Version
+from readthedocs.builds.models import Version
 from readthedocs.core.utils import trigger_build
-from readthedocs.projects import tasks
 from readthedocs.projects.models import Project
-
 
 log = logging.getLogger(__name__)
 

--- a/readthedocs/core/management/commands/update_repos.py
+++ b/readthedocs/core/management/commands/update_repos.py
@@ -90,6 +90,7 @@ class Command(BaseCommand):
                 ):
                     trigger_build(project=version.project, version=version)
 
+            else:
                 log.info('Updating all docs')
                 for project in Project.objects.all():
                     # pylint: disable=no-value-for-parameter


### PR DESCRIPTION
Use `trigger_build` (that will use Celery if enabled) when importing a Project (import_project_from_live) or updating documentation (update_repos) via manage commands.