### PR TITLE
Use media availability instead of querying the filesystem

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -379,17 +379,18 @@ class Version(models.Model):
         def prettify(k):
             return k if pretty else k.lower()
 
-        if project.has_pdf(self.slug, version_type=self.type):
+        if self.has_pdf:
             data[prettify('PDF')] = project.get_production_media_url(
                 'pdf',
                 self.slug,
             )
-        if project.has_htmlzip(self.slug, version_type=self.type):
+
+        if self.has_htmlzip:
             data[prettify('HTML')] = project.get_production_media_url(
                 'htmlzip',
                 self.slug,
             )
-        if project.has_epub(self.slug, version_type=self.type):
+        if self.has_epub:
             data[prettify('Epub')] = project.get_production_media_url(
                 'epub',
                 self.slug,

--- a/readthedocs/rtd_tests/tests/test_footer.py
+++ b/readthedocs/rtd_tests/tests/test_footer.py
@@ -12,7 +12,6 @@ from readthedocs.builds.constants import BRANCH, LATEST, TAG
 from readthedocs.builds.models import Version
 from readthedocs.core.middleware import FooterNoSessionMiddleware
 from readthedocs.projects.models import Project
-from readthedocs.rtd_tests.mocks.paths import fake_paths_by_regex
 
 
 class Testmaker(APITestCase):
@@ -74,23 +73,25 @@ class Testmaker(APITestCase):
             self.assertEqual(r.data['version_compare'], {'MOCKED': True})
 
     def test_pdf_build_mentioned_in_footer(self):
-        with fake_paths_by_regex(r'\.pdf$'):
-            response = self.render()
+        self.latest.has_pdf = True
+        self.latest.save()
+
+        response = self.render()
         self.assertIn('pdf', response.data['html'])
 
     def test_pdf_not_mentioned_in_footer_when_doesnt_exists(self):
-        with fake_paths_by_regex(r'\.pdf$', exists=False):
-            response = self.render()
+        response = self.render()
         self.assertNotIn('pdf', response.data['html'])
 
     def test_epub_build_mentioned_in_footer(self):
-        with fake_paths_by_regex(r'\.epub$'):
-            response = self.render()
+        self.latest.has_epub = True
+        self.latest.save()
+
+        response = self.render()
         self.assertIn('epub', response.data['html'])
 
     def test_epub_not_mentioned_in_footer_when_doesnt_exists(self):
-        with fake_paths_by_regex(r'\.epub$', exists=False):
-            response = self.render()
+        response = self.render()
         self.assertNotIn('epub', response.data['html'])
 
     def test_no_session_logged_out(self):

--- a/readthedocs/rtd_tests/tests/test_version.py
+++ b/readthedocs/rtd_tests/tests/test_version.py
@@ -82,3 +82,15 @@ class TestVersionModel(VersionMixin, TestCase):
 
     def test_version_supports_wipe(self):
         self.assertTrue(self.branch_version.supports_wipe)
+
+    def test_get_downloads(self):
+        self.assertDictEqual(self.branch_version.get_downloads(), {})
+
+        self.branch_version.has_pdf = True
+        self.branch_version.has_epub = True
+        self.branch_version.save()
+        expected = {
+            'epub': '//readthedocs.org/projects/pip/downloads/epub/stable/',
+            'pdf': '//readthedocs.org/projects/pip/downloads/pdf/stable/',
+        }
+        self.assertDictEqual(self.branch_version.get_downloads(), expected)


### PR DESCRIPTION
This change allows us to query the database instead of the file system or remote storage to get whether a version has a download of a specific type.

Currently, we rely on the presence of a file existing at a certain filesystem or storage path to determine whether media/downloads are available. As we move toward storage being an abstraction on top of the filesystem where it is possibly remote (eg. Cloud storage) we don't want to have to query remote storage to know whether a version has a PDF.

Instead, we started caching whether a version has builds of a specific type (eg. a PDF, ePub) and storing it on the `Version` model. After we started storing that data, a script was run to store the results for all previously built versions.

This builds on work in https://github.com/readthedocs/readthedocs.org/pull/6278

## Future work

There's some additional work I didn't add into this PR to keep it minimal. However, we could add this cleanup if desired:

* Remove the `Project.get_downloads` method which gets project downloads for the default version. As far as I can tell, this is not used.
* Remove the `Project.has_pdf`, `Project.has_epub`, and `Project.has_htmlzip` methods. These do not appear to be used anymore. Alternatively, these could be changed to get the version object and query it instead of hitting the filesystem/storage. I think it really depends on whether we want to maintain this API.