### PR TITLE
Override production domain explicitly

### DIFF
--- a/readthedocs/rtd_tests/tests/test_version.py
+++ b/readthedocs/rtd_tests/tests/test_version.py
@@ -1,7 +1,8 @@
 from django.test import TestCase
+from django.test.utils import override_settings
 from django_dynamic_fixture import get
 
-from readthedocs.builds.constants import EXTERNAL, BRANCH, TAG
+from readthedocs.builds.constants import BRANCH, EXTERNAL, TAG
 from readthedocs.builds.models import Version
 from readthedocs.projects.models import Project
 
@@ -83,6 +84,7 @@ class TestVersionModel(VersionMixin, TestCase):
     def test_version_supports_wipe(self):
         self.assertTrue(self.branch_version.supports_wipe)
 
+    @override_settings(PRODUCTION_DOMAIN='readthedocs.org')
     def test_get_downloads(self):
         self.assertDictEqual(self.branch_version.get_downloads(), {})
 


### PR DESCRIPTION
This fixes tests in .com where it's readthedocs.com instead.