### PR TITLE
Show predefined match on automation rules admin

### DIFF
--- a/readthedocs/builds/admin.py
+++ b/readthedocs/builds/admin.py
@@ -201,6 +201,7 @@ class VersionAutomationRuleAdmin(PolymorphicParentModelAdmin, admin.ModelAdmin):
         'id',
         'project',
         'priority',
+        'predefined_match_arg',
         'match_arg',
         'action',
         'version_type',


### PR DESCRIPTION
Right now we just see empty rules when a project is using predefined matches