### PR TITLE
Remove global pip cache

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -945,9 +945,6 @@ class DockerBuildEnvironment(BuildEnvironment):
 
         It uses Docker Volume if running on a docker-compose. Otherwise, it
         returns just a regular mountpoint path.
-
-        Besides, it binds the ``GLOBAL_PIP_CACHE`` if it's set and we are under
-        ``DEBUG`` mode.
         """
         if getattr(settings, 'RTD_DOCKER_COMPOSE', False):
             from pathlib import Path
@@ -964,14 +961,6 @@ class DockerBuildEnvironment(BuildEnvironment):
                     'mode': 'rw',
                 },
             }
-
-        if settings.GLOBAL_PIP_CACHE and settings.DEBUG:
-            binds.update({
-                self.project.pip_cache_path: {
-                    'bind': self.project.pip_cache_path,
-                    'mode': 'rw',
-                },
-            })
 
         return binds
 

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -663,8 +663,6 @@ class Project(models.Model):
     @property
     def pip_cache_path(self):
         """Path to pip cache."""
-        if settings.GLOBAL_PIP_CACHE and settings.DEBUG:
-            return settings.GLOBAL_PIP_CACHE
         return os.path.join(self.doc_path, '.cache', 'pip')
 
     #

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -275,7 +275,6 @@ class CommunityBaseSettings(Settings):
         }
     }
     CACHE_MIDDLEWARE_SECONDS = 60
-    GLOBAL_PIP_CACHE = False
 
     # I18n
     TIME_ZONE = 'UTC'


### PR DESCRIPTION
This is not working anymore and it can be superseded by a docker container with devpi instead (see #6340).