### PR TITLE
Turn off elasticsearch log

### DIFF
--- a/docker-compose-search.yml
+++ b/docker-compose-search.yml
@@ -34,3 +34,8 @@ services:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     volumes:
       - search_data:/usr/share/elasticsearch/data
+
+    # Remove elasticsearch log since it's useless and shows periodic
+    # "flood stage disk watermark exceeded" all the time
+    logging:
+      driver: none


### PR DESCRIPTION
This log is useless and shows all the time:
```
search_1    | [2019-12-05T11:44:43,321][WARN ][o.e.c.r.a.DiskThresholdMonitor] [_QIwyaJ] flood stage disk watermark [95%] exceeded on [_QIwyaJjQD-m2Y-9zjrHog][_QIwyaJ][/usr/share/elasticsearch/data/nodes/0] free: 4.2gb[4.8%], all indices on this node will be marked read-only
```