### PR TITLE
Better ES settings on docker-compose

### DIFF
--- a/docker-compose-search.yml
+++ b/docker-compose-search.yml
@@ -31,6 +31,7 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
     environment:
       - discovery.type=single-node
+      - node.name=search
       - cluster.routing.allocation.disk.threshold_enabled=false
       - cluster.info.update.interval=30m
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"

--- a/docker-compose-search.yml
+++ b/docker-compose-search.yml
@@ -31,6 +31,8 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
     environment:
       - discovery.type=single-node
+      - cluster.routing.allocation.disk.threshold_enabled=false
+      - cluster.info.update.interval=30m
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     volumes:
       - search_data:/usr/share/elasticsearch/data


### PR DESCRIPTION
- Disable check for allocation which is not needed on development
- Set a better name to the node

This avoid the cluster going read-only mode because not "enough" space on disk,

```
search_1     | [2019-12-05T16:38:02,390][WARN ][o.e.c.r.a.DiskThresholdMonitor] [1qOjoH7] flood stage disk watermark [95%] exceeded on [1qOjoH7qRX2hXuMCo80xOg][1qOjoH7][/usr/share/elasticsearch/data/nodes/0] free: 4.2gb[4.7%], all indices on this node will be marked read-only
```