### PR TITLE
Do not expose env variables on external versions

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -12,6 +12,7 @@ import yaml
 
 from django.conf import settings
 
+from readthedocs.builds.constants import EXTERNAL
 from readthedocs.config import PIP, SETUPTOOLS, ParseError, parse as parse_yaml
 from readthedocs.config.models import PythonInstall, PythonInstallRequirements
 from readthedocs.doc_builder.config import load_yaml_config
@@ -234,7 +235,11 @@ class PythonEnvironment:
         it returns sha256 hash of empty string.
         """
         m = hashlib.sha256()
+
         env_vars = self.version.project.environment_variables
+        if self.version.type == EXTERNAL:
+            env_vars = {}
+
         for variable, value in env_vars.items():
             hash_str = f'_{variable}_{value}_'
             m.update(hash_str.encode('utf-8'))

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -730,8 +730,11 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
                 ),
             })
 
-        # Update environment from Project's specific environment variables
-        env.update(self.project.environment_variables)
+        # Update environment from Project's specific environment variables,
+        # avoiding to expose environment variables if the version is external
+        # for security reasons.
+        if self.version.type != EXTERNAL:
+            env.update(self.project.environment_variables)
 
         return env
 


### PR DESCRIPTION
This avoid exposing potential secrets when a PR is opened.