### PR TITLE
Fixed remove_search_analytics issue

### DIFF
--- a/docs/guides/feature-flags.rst
+++ b/docs/guides/feature-flags.rst
@@ -36,5 +36,3 @@ e.g. python-reno release notes manager is known to do that
 ``USE_TESTING_BUILD_IMAGE``: :featureflags:`USE_TESTING_BUILD_IMAGE`
 
 ``EXTERNAL_VERSION_BUILD``: :featureflags:`EXTERNAL_VERSION_BUILD`
-
-``SEARCH_ANALYTICS``: :featureflags:`SEARCH_ANALYTICS`

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1480,7 +1480,6 @@ class Feature(models.Model):
     EXTERNAL_VERSION_BUILD = 'external_version_build'
     UPDATE_CONDA_STARTUP = 'update_conda_startup'
     CONDA_APPEND_CORE_REQUIREMENTS = 'conda_append_core_requirements'
-    SEARCH_ANALYTICS = 'search_analytics'
 
     FEATURES = (
         (USE_SPHINX_LATEST, _('Use latest version of Sphinx')),
@@ -1532,10 +1531,7 @@ class Feature(models.Model):
             CONDA_APPEND_CORE_REQUIREMENTS,
             _('Append Read the Docs core requirements to environment.yml file'),
         ),
-        (
-            SEARCH_ANALYTICS,
-            _('Enable search analytics'),
-        )
+
     )
 
     projects = models.ManyToManyField(

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -1006,12 +1006,6 @@ class SearchAnalytics(ProjectAdminMixin, PrivateViewMixin, TemplateView):
         context = super().get_context_data(**kwargs)
         project = self.get_project()
 
-        context['show_analytics'] = project.has_feature(
-            Feature.SEARCH_ANALYTICS,
-        )
-        if not context['show_analytics']:
-            return context
-
         # data for plotting the line-chart
         query_count_of_1_month = SearchQuery.generate_queries_count_of_one_month(
             project.slug,

--- a/readthedocs/rtd_tests/tests/test_views.py
+++ b/readthedocs/rtd_tests/tests/test_views.py
@@ -278,7 +278,7 @@ class TestSearchAnalyticsView(TestCase):
         test_time = timezone.datetime(2019, 8, 2, 12, 0)
         self.test_time = timezone.make_aware(test_time)
 
-        get(Feature, projects=[self.pip], feature_id=Feature.SEARCH_ANALYTICS)
+        get(Feature, projects=[self.pip])
 
     def test_top_queries(self):
         with mock.patch('django.utils.timezone.now') as test_time:


### PR DESCRIPTION
This pull request references the issue [#6349](https://github.com/readthedocs/readthedocs.org/pull/6349).
Changes : 

- Removed SEARCH_ANALYTICS flag from feature-flags
- Removed SEARCH_ANALYTICS property from the Feature class under project/models.py
- Removed 'Enable search analytics' tuple from the Feature object.

Closes https://github.com/readthedocs/readthedocs.org/issues/6217