### PR TITLE
Translations: fix plural forms

### DIFF
--- a/docs/locale/ru/LC_MESSAGES/abandoned-projects.po
+++ b/docs/locale/ru/LC_MESSAGES/abandoned-projects.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../abandoned-projects.rst:2
 msgid "Policy for Abandoned Projects"

--- a/docs/locale/ru/LC_MESSAGES/alternate_domains.po
+++ b/docs/locale/ru/LC_MESSAGES/alternate_domains.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../alternate_domains.rst:2
 msgid "Alternate Domains"

--- a/docs/locale/ru/LC_MESSAGES/api/index.po
+++ b/docs/locale/ru/LC_MESSAGES/api/index.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 # 82d92117fc034b4993a34d6818df94d2
 #: ../../api/index.rst:2

--- a/docs/locale/ru/LC_MESSAGES/architecture.po
+++ b/docs/locale/ru/LC_MESSAGES/architecture.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../architecture.rst:2
 msgid "Architecture"

--- a/docs/locale/ru/LC_MESSAGES/automatic-redirects.po
+++ b/docs/locale/ru/LC_MESSAGES/automatic-redirects.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../automatic-redirects.rst:2
 msgid "Automatic Redirects"

--- a/docs/locale/ru/LC_MESSAGES/badges.po
+++ b/docs/locale/ru/LC_MESSAGES/badges.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../badges.rst:2
 msgid "Badges"

--- a/docs/locale/ru/LC_MESSAGES/builds.po
+++ b/docs/locale/ru/LC_MESSAGES/builds.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../builds.rst:2
 msgid "Build Process"

--- a/docs/locale/ru/LC_MESSAGES/canonical.po
+++ b/docs/locale/ru/LC_MESSAGES/canonical.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../canonical.rst:2
 msgid "Canonical URLs"

--- a/docs/locale/ru/LC_MESSAGES/changelog.po
+++ b/docs/locale/ru/LC_MESSAGES/changelog.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../changelog.rst:2
 msgid "Changelog"

--- a/docs/locale/ru/LC_MESSAGES/code-of-conduct.po
+++ b/docs/locale/ru/LC_MESSAGES/code-of-conduct.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../code-of-conduct.rst:2
 msgid "Code of Conduct"

--- a/docs/locale/ru/LC_MESSAGES/conda.po
+++ b/docs/locale/ru/LC_MESSAGES/conda.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../conda.rst:2
 msgid "Conda Support"

--- a/docs/locale/ru/LC_MESSAGES/contribute.po
+++ b/docs/locale/ru/LC_MESSAGES/contribute.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../contribute.rst:2
 msgid "Contributing to Read the Docs"

--- a/docs/locale/ru/LC_MESSAGES/custom_installs/customization.po
+++ b/docs/locale/ru/LC_MESSAGES/custom_installs/customization.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 # 9a4df253f71d409e8ec590353f2f7a15
 #: ../../custom_installs/customization.rst:2

--- a/docs/locale/ru/LC_MESSAGES/custom_installs/index.po
+++ b/docs/locale/ru/LC_MESSAGES/custom_installs/index.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 # e52de36f1bf24ee6a7fda490b7ec9ad8
 #: ../../custom_installs/index.rst:2

--- a/docs/locale/ru/LC_MESSAGES/design.po
+++ b/docs/locale/ru/LC_MESSAGES/design.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../design.rst:2
 msgid "Designing Read the Docs"

--- a/docs/locale/ru/LC_MESSAGES/docs.po
+++ b/docs/locale/ru/LC_MESSAGES/docs.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../docs.rst:2
 msgid "Building and Contributing to Documentation"

--- a/docs/locale/ru/LC_MESSAGES/embed.po
+++ b/docs/locale/ru/LC_MESSAGES/embed.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../embed.rst:2
 msgid "Embed API"

--- a/docs/locale/ru/LC_MESSAGES/faq.po
+++ b/docs/locale/ru/LC_MESSAGES/faq.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../faq.rst:2
 msgid "Frequently Asked Questions"

--- a/docs/locale/ru/LC_MESSAGES/features.po
+++ b/docs/locale/ru/LC_MESSAGES/features.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../features.rst:2
 msgid "Read the Docs features"

--- a/docs/locale/ru/LC_MESSAGES/getting_started.po
+++ b/docs/locale/ru/LC_MESSAGES/getting_started.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../getting_started.rst:2
 msgid "Getting Started"

--- a/docs/locale/ru/LC_MESSAGES/gsoc.po
+++ b/docs/locale/ru/LC_MESSAGES/gsoc.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../gsoc.rst:2
 msgid "Google Summer of Code"

--- a/docs/locale/ru/LC_MESSAGES/i18n.po
+++ b/docs/locale/ru/LC_MESSAGES/i18n.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../i18n.rst:2
 msgid "Internationalization"

--- a/docs/locale/ru/LC_MESSAGES/index.po
+++ b/docs/locale/ru/LC_MESSAGES/index.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../index.rst:2
 msgid "Welcome to Read The Docs"

--- a/docs/locale/ru/LC_MESSAGES/install.po
+++ b/docs/locale/ru/LC_MESSAGES/install.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../install.rst:2
 msgid "Installation"

--- a/docs/locale/ru/LC_MESSAGES/issue-labels.po
+++ b/docs/locale/ru/LC_MESSAGES/issue-labels.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../issue-labels.rst:2
 msgid "Overview of issue labels"

--- a/docs/locale/ru/LC_MESSAGES/localization.po
+++ b/docs/locale/ru/LC_MESSAGES/localization.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../localization.rst:2
 msgid "Localization of Documentation"

--- a/docs/locale/ru/LC_MESSAGES/open-source-philosophy.po
+++ b/docs/locale/ru/LC_MESSAGES/open-source-philosophy.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../open-source-philosophy.rst:2
 msgid "Read the Docs Open Source Philosophy"

--- a/docs/locale/ru/LC_MESSAGES/privacy-policy.po
+++ b/docs/locale/ru/LC_MESSAGES/privacy-policy.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../privacy-policy.rst:5
 msgid "Privacy Policy"

--- a/docs/locale/ru/LC_MESSAGES/privacy.po
+++ b/docs/locale/ru/LC_MESSAGES/privacy.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../privacy.rst:2
 msgid "Privacy Levels"

--- a/docs/locale/ru/LC_MESSAGES/security.po
+++ b/docs/locale/ru/LC_MESSAGES/security.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../security.rst:2
 msgid "Security"

--- a/docs/locale/ru/LC_MESSAGES/single_version.po
+++ b/docs/locale/ru/LC_MESSAGES/single_version.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../single_version.rst:2
 msgid "Single Version Documentation"

--- a/docs/locale/ru/LC_MESSAGES/sponsors.po
+++ b/docs/locale/ru/LC_MESSAGES/sponsors.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../sponsors.rst:2
 msgid "Sponsors of Read the Docs"

--- a/docs/locale/ru/LC_MESSAGES/story.po
+++ b/docs/locale/ru/LC_MESSAGES/story.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../story.rst:2
 msgid "The Story of Read the Docs"

--- a/docs/locale/ru/LC_MESSAGES/subprojects.po
+++ b/docs/locale/ru/LC_MESSAGES/subprojects.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../subprojects.rst:2
 msgid "Subprojects"

--- a/docs/locale/ru/LC_MESSAGES/support.po
+++ b/docs/locale/ru/LC_MESSAGES/support.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../support.rst:2
 msgid "Support"

--- a/docs/locale/ru/LC_MESSAGES/symlinks.po
+++ b/docs/locale/ru/LC_MESSAGES/symlinks.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../symlinks.rst:2
 msgid "How we use symlinks"

--- a/docs/locale/ru/LC_MESSAGES/team.po
+++ b/docs/locale/ru/LC_MESSAGES/team.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../team.rst:2
 msgid "Read the Docs Team"

--- a/docs/locale/ru/LC_MESSAGES/tests.po
+++ b/docs/locale/ru/LC_MESSAGES/tests.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../tests.rst:2
 msgid "Testing"

--- a/docs/locale/ru/LC_MESSAGES/user-defined-redirects.po
+++ b/docs/locale/ru/LC_MESSAGES/user-defined-redirects.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../user-defined-redirects.rst:2
 msgid "User-defined Redirects"

--- a/docs/locale/ru/LC_MESSAGES/vcs.po
+++ b/docs/locale/ru/LC_MESSAGES/vcs.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../vcs.rst:2
 msgid "Version Control System Integration"

--- a/docs/locale/ru/LC_MESSAGES/versions.po
+++ b/docs/locale/ru/LC_MESSAGES/versions.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../versions.rst:2
 msgid "Versions"

--- a/docs/locale/ru/LC_MESSAGES/webhooks.po
+++ b/docs/locale/ru/LC_MESSAGES/webhooks.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../webhooks.rst:2
 msgid "Webhooks"

--- a/docs/locale/ru/LC_MESSAGES/yaml-config.po
+++ b/docs/locale/ru/LC_MESSAGES/yaml-config.po
@@ -15,7 +15,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: ../../yaml-config.rst:2
 msgid "Read the Docs YAML Config"

--- a/readthedocs/locale/ar/LC_MESSAGES/django.po
+++ b/readthedocs/locale/ar/LC_MESSAGES/django.po
@@ -2300,7 +2300,7 @@ msgstr ""
 
 #: templates/notifications/send_notification_form.html:21
 #, python-format
-msgid "And 1 other recipient."
+msgid "And %(counter)s other recipient."
 msgid_plural "And %(counter)s other recipients..."
 msgstr[0] ""
 msgstr[1] ""

--- a/readthedocs/locale/ca/LC_MESSAGES/django.po
+++ b/readthedocs/locale/ca/LC_MESSAGES/django.po
@@ -2306,7 +2306,7 @@ msgstr ""
 
 #: templates/notifications/send_notification_form.html:21
 #, python-format
-msgid "And 1 other recipient."
+msgid "And %(counter)s other recipient."
 msgid_plural "And %(counter)s other recipients..."
 msgstr[0] ""
 msgstr[1] ""

--- a/readthedocs/locale/de/LC_MESSAGES/django.po
+++ b/readthedocs/locale/de/LC_MESSAGES/django.po
@@ -2316,7 +2316,7 @@ msgstr ""
 
 #: templates/notifications/send_notification_form.html:21
 #, python-format
-msgid "And 1 other recipient."
+msgid "And %(counter)s other recipient."
 msgid_plural "And %(counter)s other recipients..."
 msgstr[0] ""
 msgstr[1] ""

--- a/readthedocs/locale/en/LC_MESSAGES/django.po
+++ b/readthedocs/locale/en/LC_MESSAGES/django.po
@@ -2281,7 +2281,7 @@ msgstr ""
 
 #: templates/notifications/send_notification_form.html:21
 #, python-format
-msgid "And 1 other recipient."
+msgid "And %(counter)s other recipient."
 msgid_plural "And %(counter)s other recipients..."
 msgstr[0] ""
 msgstr[1] ""

--- a/readthedocs/locale/es/LC_MESSAGES/django.po
+++ b/readthedocs/locale/es/LC_MESSAGES/django.po
@@ -2365,7 +2365,7 @@ msgstr ""
 
 #: templates/notifications/send_notification_form.html:21
 #, python-format
-msgid "And 1 other recipient."
+msgid "And %(counter)s other recipient."
 msgid_plural "And %(counter)s other recipients..."
 msgstr[0] ""
 msgstr[1] ""

--- a/readthedocs/locale/eu/LC_MESSAGES/django.po
+++ b/readthedocs/locale/eu/LC_MESSAGES/django.po
@@ -2294,7 +2294,7 @@ msgstr ""
 
 #: templates/notifications/send_notification_form.html:21
 #, python-format
-msgid "And 1 other recipient."
+msgid "And %(counter)s other recipient."
 msgid_plural "And %(counter)s other recipients..."
 msgstr[0] ""
 msgstr[1] ""

--- a/readthedocs/locale/fr/LC_MESSAGES/django.po
+++ b/readthedocs/locale/fr/LC_MESSAGES/django.po
@@ -2441,7 +2441,7 @@ msgstr ""
 
 #: templates/notifications/send_notification_form.html:21
 #, python-format
-msgid "And 1 other recipient."
+msgid "And %(counter)s other recipient."
 msgid_plural "And %(counter)s other recipients..."
 msgstr[0] ""
 msgstr[1] ""

--- a/readthedocs/locale/gl/LC_MESSAGES/django.po
+++ b/readthedocs/locale/gl/LC_MESSAGES/django.po
@@ -2295,7 +2295,7 @@ msgstr ""
 
 #: templates/notifications/send_notification_form.html:21
 #, python-format
-msgid "And 1 other recipient."
+msgid "And %(counter)s other recipient."
 msgid_plural "And %(counter)s other recipients..."
 msgstr[0] ""
 msgstr[1] ""

--- a/readthedocs/locale/it/LC_MESSAGES/django.po
+++ b/readthedocs/locale/it/LC_MESSAGES/django.po
@@ -2361,7 +2361,7 @@ msgstr ""
 
 #: templates/notifications/send_notification_form.html:21
 #, python-format
-msgid "And 1 other recipient."
+msgid "And %(counter)s other recipient."
 msgid_plural "And %(counter)s other recipients..."
 msgstr[0] ""
 msgstr[1] ""

--- a/readthedocs/locale/ja/LC_MESSAGES/django.po
+++ b/readthedocs/locale/ja/LC_MESSAGES/django.po
@@ -2325,7 +2325,7 @@ msgstr ""
 
 #: templates/notifications/send_notification_form.html:21
 #, python-format
-msgid "And 1 other recipient."
+msgid "And %(counter)s other recipient."
 msgid_plural "And %(counter)s other recipients..."
 msgstr[0] ""
 

--- a/readthedocs/locale/nb/LC_MESSAGES/django.po
+++ b/readthedocs/locale/nb/LC_MESSAGES/django.po
@@ -2304,7 +2304,7 @@ msgstr ""
 
 #: templates/notifications/send_notification_form.html:21
 #, python-format
-msgid "And 1 other recipient."
+msgid "And %(counter)s other recipient."
 msgid_plural "And %(counter)s other recipients..."
 msgstr[0] ""
 msgstr[1] ""

--- a/readthedocs/locale/pl/LC_MESSAGES/django.po
+++ b/readthedocs/locale/pl/LC_MESSAGES/django.po
@@ -2305,7 +2305,7 @@ msgstr ""
 
 #: templates/notifications/send_notification_form.html:21
 #, python-format
-msgid "And 1 other recipient."
+msgid "And %(counter)s other recipient."
 msgid_plural "And %(counter)s other recipients..."
 msgstr[0] ""
 msgstr[1] ""

--- a/readthedocs/locale/pt_BR/LC_MESSAGES/django.po
+++ b/readthedocs/locale/pt_BR/LC_MESSAGES/django.po
@@ -2342,7 +2342,7 @@ msgstr ""
 
 #: templates/notifications/send_notification_form.html:21
 #, python-format
-msgid "And 1 other recipient."
+msgid "And %(counter)s other recipient."
 msgid_plural "And %(counter)s other recipients..."
 msgstr[0] ""
 msgstr[1] ""

--- a/readthedocs/locale/ru/LC_MESSAGES/django.po
+++ b/readthedocs/locale/ru/LC_MESSAGES/django.po
@@ -26,9 +26,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
-"%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>20) ? 1 : 2);\n"
 
 #: api/utils.py:49
 #, python-format
@@ -493,7 +492,6 @@ msgid_plural "You can adopt %(projects)s projects with your subscription."
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
-msgstr[3] ""
 
 #: gold/templates/gold/projects.html:33 templates/account/email.html:39
 #: templates/projects/domain_list.html:30
@@ -2336,12 +2334,11 @@ msgstr ""
 
 #: templates/notifications/send_notification_form.html:21
 #, python-format
-msgid "And 1 other recipient."
+msgid "And %(counter)s other recipient."
 msgid_plural "And %(counter)s other recipients..."
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
-msgstr[3] ""
 
 #: templates/notifications/send_notification_form.html:32
 msgid "Specify the email content you wish to send:"
@@ -3009,7 +3006,6 @@ msgid_plural "%(builds)s builds"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
-msgstr[3] ""
 
 #: templates/projects/project_delete.html:4
 #: templates/projects/project_delete.html:6

--- a/readthedocs/locale/sk/LC_MESSAGES/django.po
+++ b/readthedocs/locale/sk/LC_MESSAGES/django.po
@@ -2297,7 +2297,7 @@ msgstr ""
 
 #: templates/notifications/send_notification_form.html:21
 #, python-format
-msgid "And 1 other recipient."
+msgid "And %(counter)s other recipient."
 msgid_plural "And %(counter)s other recipients..."
 msgstr[0] ""
 msgstr[1] ""

--- a/readthedocs/locale/uk/LC_MESSAGES/django.po
+++ b/readthedocs/locale/uk/LC_MESSAGES/django.po
@@ -2310,7 +2310,7 @@ msgstr ""
 
 #: templates/notifications/send_notification_form.html:21
 #, python-format
-msgid "And 1 other recipient."
+msgid "And %(counter)s other recipient."
 msgid_plural "And %(counter)s other recipients..."
 msgstr[0] ""
 msgstr[1] ""

--- a/readthedocs/locale/vi_VN/LC_MESSAGES/django.po
+++ b/readthedocs/locale/vi_VN/LC_MESSAGES/django.po
@@ -2298,7 +2298,7 @@ msgstr ""
 
 #: templates/notifications/send_notification_form.html:21
 #, python-format
-msgid "And 1 other recipient."
+msgid "And %(counter)s other recipient."
 msgid_plural "And %(counter)s other recipients..."
 msgstr[0] ""
 

--- a/readthedocs/locale/zh_CN/LC_MESSAGES/django.po
+++ b/readthedocs/locale/zh_CN/LC_MESSAGES/django.po
@@ -2324,7 +2324,7 @@ msgstr ""
 
 #: templates/notifications/send_notification_form.html:21
 #, python-format
-msgid "And 1 other recipient."
+msgid "And %(counter)s other recipient."
 msgid_plural "And %(counter)s other recipients..."
 msgstr[0] ""
 

--- a/readthedocs/locale/zh_TW/LC_MESSAGES/django.po
+++ b/readthedocs/locale/zh_TW/LC_MESSAGES/django.po
@@ -2314,7 +2314,7 @@ msgstr ""
 
 #: templates/notifications/send_notification_form.html:21
 #, python-format
-msgid "And 1 other recipient."
+msgid "And %(counter)s other recipient."
 msgid_plural "And %(counter)s other recipients..."
 msgstr[0] ""
 

--- a/readthedocs/templates/notifications/send_notification_form.html
+++ b/readthedocs/templates/notifications/send_notification_form.html
@@ -19,7 +19,7 @@
       {% if extra_recipients|length > 0 %}
         <li>
           {% blocktrans trimmed count counter=extra_recipients|length %}
-            And 1 other recipient.
+            And {{ counter }} other recipient.
           {% plural %}
             And {{ counter }} other recipients...
           {% endblocktrans %}


### PR DESCRIPTION
Hi there,

Note, first plural form in the Russian isn't only for 1, but also for 21, 31,
etc., so hardcoding "one" (or "1") in the first plural form isn't a good
decision, and it prevents to make correct translation on [transifex.com](https://transifex.com).
Please, see https://docs.readthedocs.io/en/latest/development/i18n.html#plurals
for general instructions.

Also, in Russian there are three forms of plural (I wonder where the four
forms came from?), therefore, the rules were corrected in accordance with
the source: http://docs.translatehouse.org/projects/localization-guide/en/latest/l10n/pluralforms.html

Finally, please update the translation files. I find it rather silly to waste
time translating on [transifex.com](https://transifex.com) the strings that are already gone.