### PR TITLE
Use django storage to build URL returned by El Proxito

### DIFF
--- a/dockerfiles/nginx/proxito.conf
+++ b/dockerfiles/nginx/proxito.conf
@@ -22,9 +22,8 @@ server {
     # Sendfile support to serve the actual files that Proxito has specified
     location /proxito/ {
         internal;
-        # Nginx will strip the `/proxito/` and pass just the `html/$proj/$ver/$filename`
-        # So we need to make sure we pass it to `media/` for the proper URL
-        proxy_pass http://storage:10000/devstoreaccount1/media/;
+        # Nginx will strip the `/proxito/` and pass just the `$storage/$type/$proj/$ver/$filename`
+        proxy_pass http://storage:10000/;
         proxy_set_header Host storage:10000;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/readthedocs/proxito/tests/base.py
+++ b/readthedocs/proxito/tests/base.py
@@ -21,6 +21,7 @@ from readthedocs.projects.models import Project
         'readthedocs.proxito.middleware.ProxitoMiddleware',
     ],
     USE_SUBDOMAIN=True,
+    RTD_BUILD_MEDIA_STORAGE='readthedocs.rtd_tests.storage.BuildMediaFileSystemStorageTest',
 )
 class BaseDocServing(TestCase):
 

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -131,7 +131,7 @@ class TestDocServingBackends(BaseDocServing):
             self.client.get(url, HTTP_HOST=host)
             serve_mock.assert_called_with(
                 mock.ANY,
-                'html/project/latest/awesome.html',
+                '/media/html/project/latest/awesome.html',
                 os.path.join(settings.SITE_ROOT, 'media'),
             )
 
@@ -160,7 +160,9 @@ class TestDocServingBackends(BaseDocServing):
 class TestAdditionalDocViews(BaseDocServing):
     # Test that robots.txt and sitemap.xml work
 
-    def test_default_robots_txt(self):
+    @mock.patch('readthedocs.proxito.views.serve.get_storage_class')
+    def test_default_robots_txt(self, storage_mock):
+        storage_mock()().exists.return_value = False
         self.project.versions.update(active=True, built=True)
         response = self.client.get(
             reverse('robots_txt'),
@@ -172,10 +174,8 @@ class TestAdditionalDocViews(BaseDocServing):
             b'User-agent: *\nAllow: /\nSitemap: https://project.readthedocs.io/sitemap.xml\n'
         )
 
-    @mock.patch('readthedocs.proxito.views.serve.get_storage_class')
-    def test_custom_robots_txt(self, storage_mock):
+    def test_custom_robots_txt(self):
         self.project.versions.update(active=True, built=True)
-        storage_mock()().exists.return_value = True
         response = self.client.get(
             reverse('robots_txt'),
             HTTP_HOST='project.readthedocs.io',
@@ -184,10 +184,8 @@ class TestAdditionalDocViews(BaseDocServing):
             response['x-accel-redirect'], '/proxito/media/html/project/latest/robots.txt',
         )
 
-    @mock.patch('readthedocs.proxito.views.serve.get_storage_class')
-    def test_directory_indexes(self, storage_mock):
+    def test_directory_indexes(self):
         self.project.versions.update(active=True, built=True)
-        storage_mock()().exists.return_value = True
         # Confirm we've serving from storage for the `index-exists/index.html` file
         response = self.client.get(
             reverse('serve_error_404', kwargs={'proxito_path': '/en/latest/index-exists'}),
@@ -217,10 +215,8 @@ class TestAdditionalDocViews(BaseDocServing):
             response['location'], '/en/latest/readme-exists/README.html',
         )
 
-    @mock.patch('readthedocs.proxito.views.serve.get_storage_class')
-    def test_directory_indexes_get_args(self, storage_mock):
+    def test_directory_indexes_get_args(self):
         self.project.versions.update(active=True, built=True)
-        storage_mock()().exists.return_value = True
         # Confirm we've serving from storage for the `index-exists/index.html` file
         response = self.client.get(
             reverse('serve_error_404', kwargs={'proxito_path': '/en/latest/index-exists?foo=bar'}),

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -26,7 +26,7 @@ class TestFullDocServing(BaseDocServing):
         host = 'project.dev.readthedocs.io'
         resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
-            resp['x-accel-redirect'], '/proxito/html/subproject/latest/awesome.html',
+            resp['x-accel-redirect'], '/proxito/media/html/subproject/latest/awesome.html',
         )
 
     def test_subproject_single_version(self):
@@ -36,7 +36,7 @@ class TestFullDocServing(BaseDocServing):
         host = 'project.dev.readthedocs.io'
         resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
-            resp['x-accel-redirect'], '/proxito/html/subproject/latest/awesome.html',
+            resp['x-accel-redirect'], '/proxito/media/html/subproject/latest/awesome.html',
         )
 
     def test_subproject_translation_serving(self):
@@ -44,7 +44,7 @@ class TestFullDocServing(BaseDocServing):
         host = 'project.dev.readthedocs.io'
         resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
-            resp['x-accel-redirect'], '/proxito/html/subproject-translation/latest/awesome.html',
+            resp['x-accel-redirect'], '/proxito/media/html/subproject-translation/latest/awesome.html',
         )
 
     def test_subproject_alias_serving(self):
@@ -52,7 +52,7 @@ class TestFullDocServing(BaseDocServing):
         host = 'project.dev.readthedocs.io'
         resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
-            resp['x-accel-redirect'], '/proxito/html/subproject-alias/latest/awesome.html',
+            resp['x-accel-redirect'], '/proxito/media/html/subproject-alias/latest/awesome.html',
         )
 
     def test_translation_serving(self):
@@ -60,7 +60,7 @@ class TestFullDocServing(BaseDocServing):
         host = 'project.dev.readthedocs.io'
         resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
-            resp['x-accel-redirect'], '/proxito/html/translation/latest/awesome.html',
+            resp['x-accel-redirect'], '/proxito/media/html/translation/latest/awesome.html',
         )
 
     def test_normal_serving(self):
@@ -68,7 +68,7 @@ class TestFullDocServing(BaseDocServing):
         host = 'project.dev.readthedocs.io'
         resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
-            resp['x-accel-redirect'], '/proxito/html/project/latest/awesome.html',
+            resp['x-accel-redirect'], '/proxito/media/html/project/latest/awesome.html',
         )
 
     def test_single_version_serving(self):
@@ -78,7 +78,7 @@ class TestFullDocServing(BaseDocServing):
         host = 'project.dev.readthedocs.io'
         resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
-            resp['x-accel-redirect'], '/proxito/html/project/latest/awesome.html',
+            resp['x-accel-redirect'], '/proxito/media/html/project/latest/awesome.html',
         )
 
     def test_single_version_serving_looks_like_normal(self):
@@ -88,7 +88,7 @@ class TestFullDocServing(BaseDocServing):
         host = 'project.dev.readthedocs.io'
         resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
-            resp['x-accel-redirect'], '/proxito/html/project/latest/en/stable/awesome.html',
+            resp['x-accel-redirect'], '/proxito/media/html/project/latest/en/stable/awesome.html',
         )
 
         # Invalid tests
@@ -140,7 +140,7 @@ class TestDocServingBackends(BaseDocServing):
         resp = self.client.get('/en/latest/awesome.html', HTTP_HOST='project.dev.readthedocs.io')
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(
-            resp['x-accel-redirect'], '/proxito/html/project/latest/awesome.html',
+            resp['x-accel-redirect'], '/proxito/media/html/project/latest/awesome.html',
         )
 
     @override_settings(PYTHON_MEDIA=False)
@@ -149,7 +149,7 @@ class TestDocServingBackends(BaseDocServing):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(
             resp['x-accel-redirect'],
-            '/proxito/html/project/latest/%C3%BA%C3%B1%C3%AD%C4%8D%C3%B3d%C3%A9.html',
+            '/proxito/media/html/project/latest/%C3%BA%C3%B1%C3%AD%C4%8D%C3%B3d%C3%A9.html',
         )
 
 
@@ -181,7 +181,7 @@ class TestAdditionalDocViews(BaseDocServing):
             HTTP_HOST='project.readthedocs.io',
         )
         self.assertEqual(
-            response['x-accel-redirect'], '/proxito/html/project/latest/robots.txt',
+            response['x-accel-redirect'], '/proxito/media/html/project/latest/robots.txt',
         )
 
     @mock.patch('readthedocs.proxito.views.serve.get_storage_class')

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -95,17 +95,25 @@ class ServeDocsBase(ServeRedirectMixin, ServeDocsMixin, View):
         storage_path = final_project.get_storage_path(
             type_='html', version_slug=version_slug, include_file=False
         )
+
+        storage = get_storage_class(settings.RTD_BUILD_MEDIA_STORAGE)()
+
+        # If ``filename`` is ``''`` it leaves a trailing slash
         path = os.path.join(storage_path, filename)
+
+        url = storage.url(path)  # this will remove the trailing slash
+        # URL without scheme and domain to perform an NGINX internal redirect
+        url = urlparse(url)._replace(scheme='', netloc='').geturl()
 
         # Handle our backend storage not supporting directory indexes,
         # so we need to append index.html when appropriate.
         if path[-1] == '/':
-            path += 'index.html'
+            url += '/index.html'
 
         return self._serve_docs(
             request,
             final_project=final_project,
-            path=path,
+            path=url,
         )
 
     def allowed_user(self, *args, **kwargs):

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -268,10 +268,12 @@ class ServeRobotsTXTBase(ServeDocsMixin, View):
 
         storage = get_storage_class(settings.RTD_BUILD_MEDIA_STORAGE)()
         if storage.exists(path):
+            url = storage.url(path)
+            url = urlparse(url)._replace(scheme='', netloc='').geturl()
             return self._serve_docs(
                 request,
                 final_project=project,
-                path=path,
+                path=url,
             )
 
         sitemap_url = '{scheme}://{domain}/sitemap.xml'.format(

--- a/readthedocs/rtd_tests/storage.py
+++ b/readthedocs/rtd_tests/storage.py
@@ -1,0 +1,6 @@
+from readthedocs.builds.storage import BuildMediaFileSystemStorage
+
+class BuildMediaFileSystemStorageTest(BuildMediaFileSystemStorage):
+
+    def exists(self, *args, **kargs):
+        return True

--- a/readthedocs/settings/test.py
+++ b/readthedocs/settings/test.py
@@ -19,6 +19,8 @@ class CommunityTestSettings(CommunityDevSettings):
     ELASTICSEARCH_DSL_AUTOSYNC = False
     ELASTICSEARCH_DSL_AUTO_REFRESH = True
 
+    RTD_BUILD_MEDIA_STORAGE = 'readthedocs.rtd_tests.storage.BuildMediaFileSystemStorageTest'
+
     @property
     def ES_INDEXES(self):  # noqa - avoid pep8 N802
         es_indexes = super(CommunityTestSettings, self).ES_INDEXES

--- a/readthedocs/settings/test.py
+++ b/readthedocs/settings/test.py
@@ -19,8 +19,6 @@ class CommunityTestSettings(CommunityDevSettings):
     ELASTICSEARCH_DSL_AUTOSYNC = False
     ELASTICSEARCH_DSL_AUTO_REFRESH = True
 
-    RTD_BUILD_MEDIA_STORAGE = 'readthedocs.rtd_tests.storage.BuildMediaFileSystemStorageTest'
-
     @property
     def ES_INDEXES(self):  # noqa - avoid pep8 N802
         es_indexes = super(CommunityTestSettings, self).ES_INDEXES


### PR DESCRIPTION
Isolate fixes from https://github.com/readthedocs/readthedocs.org/pull/6419/commits/6c2b187969bcf7837ed26f5f6511bfd0e7bab106#diff-fd3394188d8793947a3ccbb4924994a1R99 

With this change, we pass the full URL back to NGINX who will proxy it as is to the storage.

This fixes currently 404 in production for test-builds documentation for all versions.