### PR TITLE
Respect env variables in all build environments

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -103,10 +103,9 @@ class BuildCommand(BuildCommandResultMixin):
         if cwd is None:
             cwd = os.getcwd()
         self.cwd = cwd
-        self.environment = {}
-        if environment is None:
-            self.environment = os.environ.copy()
-        self.environment.update(environment)
+
+        environment = environment or {}
+        self.environment = environment.copy()
 
         self.combine_output = combine_output
         self.input_data = input_data

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -725,7 +725,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
     def get_env_vars(self):
         """Get bash environment variables used for all builder commands."""
         env = {
-            'READTHEDOCS': True,
+            'READTHEDOCS': 'True',
             'READTHEDOCS_VERSION': self.version.slug,
             'READTHEDOCS_PROJECT': self.project.slug,
             'READTHEDOCS_LANGUAGE': self.project.language,

--- a/readthedocs/vcs_support/base.py
+++ b/readthedocs/vcs_support/base.py
@@ -81,12 +81,7 @@ class BaseVCS:
 
     @property
     def env(self):
-        environment = os.environ.copy()
-
-        # TODO: kind of a hack
-        del environment['PATH']
-
-        return environment
+        return {}
 
     def update(self):
         """


### PR DESCRIPTION
I guess is to get around any security implications.
But modifying the PATH to a local copy of the environments variables of
the host leads to errors.

This was ok when using the local host to run the checkout steps, but now we are running inside the container.

Also, we already set all the `READTHEDOCS` env variables from
 
https://github.com/readthedocs/readthedocs.org/blob/7212d6ff738b24a10fb0f4227d3fbdf69e5cab42/readthedocs/projects/tasks.py#L725-L762

This is needed for #6436