### PR TITLE
Use environment variable per run, not per container

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -329,6 +329,7 @@ class DockerBuildCommand(BuildCommand):
             exec_cmd = client.exec_create(
                 container=self.build_env.container_id,
                 cmd=self.get_wrapped_command(),
+                environment=self.environment,
                 stdout=True,
                 stderr=True,
             )
@@ -1051,7 +1052,6 @@ class DockerBuildEnvironment(BuildEnvironment):
                 volumes=self._get_binds(),
                 host_config=self.get_container_host_config(),
                 detach=True,
-                environment=self.environment,
                 user=settings.RTD_DOCKER_USER,
             )
             client.start(container=self.container_id)


### PR DESCRIPTION
Currently we pass the environment vars in the init method
and create the container with that.

This means that we can't modify those after the container creation.
We do allow this in the LocalBuildEnvironment.

This is needed to run git in a container (set envs like `GIT_DIR`).
And to execute the ssh agent inside, (sent envs like `SSH_AUTH_SOCKET`
and `SSH_AGENT_PID`)

This is compatible with current code, so it can be merged just now.