### PR TITLE
Show debug toolbar when running docker compose

### DIFF
--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -58,6 +58,10 @@ class DockerBaseSettings(CommunityDevSettings):
             }
         }
 
+    DEBUG_TOOLBAR_CONFIG = {
+        'SHOW_TOOLBAR_CALLBACK': lambda request: True,
+    }
+
     ACCOUNT_EMAIL_VERIFICATION = "none"
     SESSION_COOKIE_DOMAIN = None
     CACHES = {


### PR DESCRIPTION
We can't depend on DEBUG + INTERNAL_IPS (default check) because the IP of the docker container is dynamic.