### PR TITLE
Define PUBLIC_API_HOST for -ext embed API

### DIFF
--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -18,6 +18,11 @@ class DockerBaseSettings(CommunityDevSettings):
     PUBLIC_DOMAIN = 'community.dev.readthedocs.io'
     PUBLIC_API_URL = 'http://community.dev.readthedocs.io'
     RTD_PROXIED_API_URL = PUBLIC_API_URL
+
+    # Required by /embed/ from -ext
+    # NOTE: this could be replaced by PUBLIC_API_URL
+    PUBLIC_API_HOST = 'http://community.dev.readthedocs.io'
+
     SLUMBER_API_HOST = 'http://web:8000'
 
     MULTIPLE_APP_SERVERS = ['web']


### PR DESCRIPTION
This setting is used at https://github.com/readthedocs/readthedocs-ext/blob/3294b76d97b2c169fb27911b07263bb6fe4b6576/readthedocsext/embed/views.py#L75