### PR TITLE
Don't pass build to environment when doing a sync

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -481,7 +481,7 @@ class BaseEnvironment:
                 log.warning(
                     LOG_TEMPLATE,
                     {
-                        'project': self.project.slug,
+                        'project': self.project.slug if self.project else '',
                         'version': 'latest',
                         'msg': msg,
                     }
@@ -570,8 +570,8 @@ class BuildEnvironment(BaseEnvironment):
         log.info(
             LOG_TEMPLATE,
             {
-                'project': self.project.slug,
-                'version': self.version.slug,
+                'project': self.project.slug if self.project else '',
+                'version': self.version.slug if self.version else '',
                 'msg': 'Build finished',
             }
         )
@@ -614,9 +614,9 @@ class BuildEnvironment(BaseEnvironment):
                 extra={
                     'stack': True,
                     'tags': {
-                        'build': self.build.get('id'),
-                        'project': self.project.slug,
-                        'version': self.version.slug,
+                        'build': self.build.get('id') if self.build else '',
+                        'project': self.project.slug if self.project else '',
+                        'version': self.version.slug if self.version else '',
                     },
                 },
             )

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -243,7 +243,6 @@ class SyncRepositoryTaskStep(SyncRepositoryMixin):
             environment = LocalBuildEnvironment(
                 project=self.project,
                 version=self.version,
-                build=self.build,
                 record=False,
                 update_on_success=False,
             )


### PR DESCRIPTION
We don't record this step, so we don't have a `build`

Also, added protection against None. We default project, version and build to None,
but in some parts we assume there aren't None.