### PR TITLE
Don't allow empty tags

### DIFF
--- a/readthedocs/projects/tag_utils.py
+++ b/readthedocs/projects/tag_utils.py
@@ -26,7 +26,7 @@ def rtd_parse_tags(tag_string):
         tag_string = tag_string.lower().replace('_', '-')
 
     tags = (slugify(tag) for tag in _parse_tags(tag_string))
-    return sorted([tag for tag in tags if tag])
+    return sorted(tag for tag in tags if tag)
 
 
 def remove_unused_tags():

--- a/readthedocs/projects/tag_utils.py
+++ b/readthedocs/projects/tag_utils.py
@@ -25,7 +25,7 @@ def rtd_parse_tags(tag_string):
     if tag_string:
         tag_string = tag_string.lower().replace('_', '-')
 
-    tags = [slugify(tag) for tag in _parse_tags(tag_string)]
+    tags = (slugify(tag) for tag in _parse_tags(tag_string))
     return sorted([tag for tag in tags if tag])
 
 

--- a/readthedocs/projects/tag_utils.py
+++ b/readthedocs/projects/tag_utils.py
@@ -16,6 +16,7 @@ def rtd_parse_tags(tag_string):
     - Lowercases all tags
     - Converts underscores to hyphens
     - Slugifies tags
+    - Removes empty tags
 
     :see: https://django-taggit.readthedocs.io/page/custom_tagging.html
     :param tag_string: a delimited string of tags
@@ -24,7 +25,8 @@ def rtd_parse_tags(tag_string):
     if tag_string:
         tag_string = tag_string.lower().replace('_', '-')
 
-    return sorted([slugify(tag) for tag in _parse_tags(tag_string)])
+    tags = [slugify(tag) for tag in _parse_tags(tag_string)]
+    return sorted([tag for tag in tags if tag])
 
 
 def remove_unused_tags():


### PR DESCRIPTION
It is possible to get an empty tag by putting the following into the tag string `a,!`. Mostly spam projects have done this. This change will ensure empty tags aren't saved.

Current functionality:

```
>>> from readthedocs.projects.tag_utils import rtd_parse_tags
>>> rtd_parse_tags('a,!')
['', 'a']  # After this change the result will be ['a']
```