### PR TITLE
Update Transifex Integration details in Internationalization page.

### DIFF
--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -300,18 +300,20 @@ help pages <http://help.transifex.com/features/client/>`_.
 
 .. note::
 
-   For the Read the Docs community site, we use a `fabric script`_ to follow this process:
+   For the Read the Docs community site, we use `Invoke`_
+   with a `tasks.py file`_ to follow this process:
 
-   .. _fabric script: https://github.com/readthedocs/readthedocs.org/blob/master/fabfile.py
+   .. _Invoke: https://www.pyinvoke.org/
+   .. _tasks.py file: https://github.com/readthedocs/readthedocs.org/blob/master/tasks.py
 
    #. Update files and push sources (English) to Transifex:
 
       .. prompt:: bash $
 
-         fab i18n_push_source
+         invoke l10n.push
 
-   #. Pull changes (new translations) from Transifex:
+   #. Pull the updated translations from Transifex:
 
       .. prompt:: bash $
 
-         fab i18n_pull
+         invoke l10n.pull


### PR DESCRIPTION
This commit changes the bad link to fabfile.py to tasks.py file in Internationalization page.

Fixes #6525.