### PR TITLE
updated bad link to fabfile.py 

### DIFF
--- a/docs/development/i18n.rst
+++ b/docs/development/i18n.rst
@@ -302,7 +302,7 @@ help pages <http://help.transifex.com/features/client/>`_.
 
    For the Read the Docs community site, we use a `fabric script`_ to follow this process:
 
-   .. _fabric script: https://github.com/readthedocs/readthedocs.org/blob/master/fabfile.py
+   .. _fabric script: https://github.com/readthedocs/readthedocs.org/blob/master/tasks.py.
 
    #. Update files and push sources (English) to Transifex:
 


### PR DESCRIPTION
#6525 the link https://github.com/readthedocs/readthedocs.org/blob/master/fabfile.py is updated to https://github.com/readthedocs/readthedocs.org/blob/master/tasks.py.