### PR TITLE
Add linkcheck test for the docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ jobs:
     - python: 3.6
       env: TOXENV=docs
     - python: 3.6
+      env: TOXENV=docs-linkcheck
+    - python: 3.6
       env: TOXENV=docs-lint
     - python: 3.6
       env: TOXENV=lint
@@ -18,6 +20,9 @@ jobs:
       env: TOXENV=eslint NODE_VERSION=10.17.0
     - python: 3.6
       env: TOXENV=migrations
+
+  allow_failures:
+    - env: TOXENV=docs-linkcheck
 cache:
   directories:
     - ~/.cache/pip

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -846,7 +846,7 @@ Version 3.2.2
 * `@pyup-bot <https://github.com/pyup-bot>`__: Pin pytest-cov to latest version 2.6.1 (`#5276 <https://github.com/readthedocs/readthedocs.org/pull/5276>`__)
 * `@pyup-bot <https://github.com/pyup-bot>`__: Pin pillow to latest version 5.4.1 (`#5275 <https://github.com/readthedocs/readthedocs.org/pull/5275>`__)
 * `@pyup-bot <https://github.com/pyup-bot>`__: Update elasticsearch to 6.3.1 (`#5274 <https://github.com/readthedocs/readthedocs.org/pull/5274>`__)
-* `@discdiver <https://github.com/discdiver>`__: clarify github integration needs https:// prepended (`#5273 <https://github.com/readthedocs/readthedocs.org/pull/5273>`__)
+* `@discdiver <https://github.com/discdiver>`__: clarify github integration needs ``https://`` prepended (`#5273 <https://github.com/readthedocs/readthedocs.org/pull/5273>`__)
 * `@humitos <https://github.com/humitos>`__: Setup and configure pyup.io (`#5272 <https://github.com/readthedocs/readthedocs.org/pull/5272>`__)
 * `@humitos <https://github.com/humitos>`__: Update all Python dependencies (`#5269 <https://github.com/readthedocs/readthedocs.org/pull/5269>`__)
 * `@davidfischer <https://github.com/davidfischer>`__: Add note about security issue (`#5263 <https://github.com/readthedocs/readthedocs.org/pull/5263>`__)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,6 +110,10 @@ linkcheck_ignore = [
     r'https?://docs\.example\.com',
     r'https://foo\.readthedocs\.io/projects',
     r'https://github\.com.+?#L\d+',
+    r'https://github\.com/readthedocs/readthedocs\.org/issues',
+    r'https://github\.com/readthedocs/readthedocs\.org/pull',
+    r'https://docs\.readthedocs\.io/\?rtd_search',
+    r'https://readthedocs\.org/search',
 ]
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,7 +110,6 @@ linkcheck_ignore = [
     r'https?://docs\.example\.com',
     r'https://foo\.readthedocs\.io/projects',
     r'https://github\.com.+?#L\d+',
-    r'https://$',
 ]
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,13 +104,13 @@ notfound_context = {
 ''',
 }
 linkcheck_ignore = [
-    r'^https?\://127\.0\.0\.1.*',
-    r'^https?\://localhost.*',
-    r'^https?\://yourproject\.readthedocs\.io.*',
-    r'^https?\://docs\.example\.com.*',
-    r'^https?\://foo\.readthedocs\.io/projects.*',
-    r'^https?\://github\.com.+?#L\d+(-L\d+)?',
-    r'^https://$',
+    r'http://127\.0\.0\.1',
+    r'http://localhost',
+    r'https://yourproject\.readthedocs\.io',
+    r'https?://docs\.example\.com',
+    r'https://foo\.readthedocs\.io/projects',
+    r'https://github\.com.+?#L\d+',
+    r'https://$',
 ]
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,6 +103,15 @@ notfound_context = {
 <p>Try using the search box or go to the homepage.</p>
 ''',
 }
+linkcheck_ignore = [
+    r'^https?\://127\.0\.0\.1.*',
+    r'^https?\://localhost.*',
+    r'^https?\://yourproject\.readthedocs\.io.*',
+    r'^https?\://docs\.example\.com.*',
+    r'^https?\://foo\.readthedocs\.io/projects.*',
+    r'^https?\://github\.com.+?#L\d+(-L\d+)?',
+    r'^https://$',
+]
 
 
 def setup(app):

--- a/scripts/travis/run_tests.sh
+++ b/scripts/travis/run_tests.sh
@@ -1,4 +1,4 @@
-if ! [[ "$TOXENV" =~ ^(docs|lint|eslint|migrations) ]];
+if ! [[ "$TOXENV" =~ ^(docs|docs-linkcheck|lint|eslint|migrations) ]];
 then
     args="--including-search"
 fi

--- a/scripts/travis/run_tests.sh
+++ b/scripts/travis/run_tests.sh
@@ -1,4 +1,4 @@
-if ! [[ "$TOXENV" =~ ^(docs|docs-linkcheck|lint|eslint|migrations) ]];
+if ! [[ "$TOXENV" =~ ^(docs|lint|eslint|migrations) ]];
 then
     args="--including-search"
 fi

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion=2.9.0
-envlist = py36,lint,docs,docs-linkcheck
+envlist = py36,lint,docs
 skipsdist = True
 
 [travis]
@@ -28,10 +28,10 @@ commands =
     sphinx-build -W --keep-going -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 [testenv:docs-linkcheck]
-description = build readthedocs documentation
+description = Check for broken links in the docs
 changedir = {toxinidir}/docs
 commands =
-    sphinx-build -W --keep-going -q -b linkcheck -d {envtmpdir}/doctrees . {envtmpdir}/html
+    sphinx-build -W --keep-going -q -b linkcheck -d {envtmpdir}/doctrees . {envtmpdir}/linkcheck
 
 [testenv:migrations]
 description = check for missing migrations

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion=2.9.0
-envlist = py36,lint,docs
+envlist = py36,lint,docs,docs-linkcheck
 skipsdist = True
 
 [travis]
@@ -26,6 +26,12 @@ description = build readthedocs documentation
 changedir = {toxinidir}/docs
 commands =
     sphinx-build -W --keep-going -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+
+[testenv:docs-linkcheck]
+description = build readthedocs documentation
+changedir = {toxinidir}/docs
+commands =
+    sphinx-build -W --keep-going -b linkcheck -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 [testenv:migrations]
 description = check for missing migrations

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ commands =
 description = build readthedocs documentation
 changedir = {toxinidir}/docs
 commands =
-    sphinx-build -W --keep-going -b linkcheck -d {envtmpdir}/doctrees . {envtmpdir}/html
+    sphinx-build -W --keep-going -q -b linkcheck -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 [testenv:migrations]
 description = check for missing migrations


### PR DESCRIPTION
Since it is hard for big documentations to keep all links up with changes in a project, it's a good idea to check the links are working, to prevent broken links as in #6525 and #6541.

Luckily `sphinx` has this feature built in, so I added it to the test suite.

To prevent the test suite from false positive breaking,  i.e. if a website is temporarily down, I made the test [allow_failures](https://docs.travis-ci.com/user/customizing-the-build/#rows-that-are-allowed-to-fail) in the travis build matrix.

I also added some url patterns to be ignored by the test, since they are only an example case, are local development only or test false positive since the ref is generated by javascript. 