### PR TITLE
Use path for El Proxito redirects

### DIFF
--- a/readthedocs/proxito/views/mixins.py
+++ b/readthedocs/proxito/views/mixins.py
@@ -128,10 +128,16 @@ class ServeRedirectMixin:
         :returns: the path to redirect the request and its status code
         :rtype: tuple
         """
+
+        # Generate the full path from the filename.
+        path = filename
+        if not filename.startswith('/'):
+            path = '/' + filename
+
         redirect_path, http_status = project.redirects.get_redirect_path_with_status(
             language=lang_slug,
             version_slug=version_slug,
-            path=filename,
+            path=path,
             full_path=full_path,
         )
         return redirect_path, http_status

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -187,7 +187,7 @@ class ServeError404Base(ServeRedirectMixin, View):
             lang_slug,
             version_slug,
             filename,
-            request.path,
+            proxito_path,
         )
         if redirect_path and http_status:
             return self.get_redirect_response(request, redirect_path, http_status)


### PR DESCRIPTION
We were using the filename when the method was expecting the path.

Besides, `request.path` contained `_proxito_404_` which we don't need it, so we use `proxito_path` directly which is the proper full path the user requested.