### PR TITLE
Use gitpython to get current commit

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -13,9 +13,9 @@ from django.conf import settings
 from django.template import loader as template_loader
 
 from readthedocs.doc_builder.base import BaseBuilder
+from readthedocs.doc_builder.environments import LocalBuildEnvironment
 from readthedocs.doc_builder.exceptions import MkDocsYAMLParseError
 from readthedocs.projects.models import Feature
-
 
 log = logging.getLogger(__name__)
 
@@ -225,6 +225,11 @@ class BaseMkdocs(BaseBuilder):
             # http://www.mkdocs.org/user-guide/configuration/#google_analytics
             analytics_code = mkdocs_config['google_analytics'][0]
 
+        repo = self.project.vcs_repo(
+            version=self.version.slug,
+            environment=self.build_env,
+        )
+
         # Will be available in the JavaScript as READTHEDOCS_DATA.
         readthedocs_data = {
             'project': self.version.project.slug,
@@ -239,7 +244,7 @@ class BaseMkdocs(BaseBuilder):
             'api_host': settings.PUBLIC_API_URL,
             'proxied_api_host': settings.RTD_PROXIED_API_URL,
             'ad_free': not self.project.show_advertising,
-            'commit': self.version.project.vcs_repo(self.version.slug).commit,
+            'commit': repo.commit,
             'global_analytics_code': settings.GLOBAL_ANALYTICS_CODE,
             'user_analytics_code': analytics_code,
         }

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -18,6 +18,7 @@ from django.template.loader import render_to_string
 
 from readthedocs.api.v2.client import api
 from readthedocs.builds import utils as version_utils
+from readthedocs.doc_builder.environments import LocalBuildEnvironment
 from readthedocs.projects.constants import PUBLIC
 from readthedocs.projects.exceptions import ProjectConfigurationError
 from readthedocs.projects.models import Feature
@@ -28,7 +29,6 @@ from ..constants import PDF_RE
 from ..environments import BuildCommand, DockerBuildCommand
 from ..exceptions import BuildEnvironmentError
 from ..signals import finalize_sphinx_context_data
-
 
 log = logging.getLogger(__name__)
 
@@ -131,6 +131,10 @@ class BaseSphinx(BaseBuilder):
                 ]
             downloads = api.version(self.version.pk).get()['downloads']
 
+        repo = self.project.vcs_repo(
+            version=self.version.slug,
+            environment=self.build_env,
+        )
         data = {
             'html_theme': 'sphinx_rtd_theme',
             'html_theme_import': 'sphinx_rtd_theme',
@@ -141,7 +145,7 @@ class BaseSphinx(BaseBuilder):
             'conf_py_path': conf_py_path,
             'api_host': settings.PUBLIC_API_URL,
             'proxied_api_host': settings.RTD_PROXIED_API_URL,
-            'commit': self.project.vcs_repo(self.version.slug).commit,
+            'commit': repo.commit,
             'versions': versions,
             'downloads': downloads,
 

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -717,7 +717,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin):
             # Re raise the exception to stop the build at this point
             raise
 
-        commit = self.commit or self.project.vcs_repo(self.version.slug).commit
+        commit = self.commit or self.get_vcs_repo(environment).commit
         if commit:
             self.build['commit'] = commit
 

--- a/readthedocs/rtd_tests/tests/test_doc_builder.py
+++ b/readthedocs/rtd_tests/tests/test_doc_builder.py
@@ -14,6 +14,7 @@ from mock import patch
 from readthedocs.builds.models import Version
 from readthedocs.doc_builder.backends.mkdocs import MkdocsHTML
 from readthedocs.doc_builder.backends.sphinx import BaseSphinx
+from readthedocs.doc_builder.environments import LocalBuildEnvironment
 from readthedocs.doc_builder.exceptions import MkDocsYAMLParseError
 from readthedocs.doc_builder.python_environments import Virtualenv
 from readthedocs.projects.constants import PRIVATE, PROTECTED, PUBLIC
@@ -29,9 +30,10 @@ class SphinxBuilderTest(TestCase):
         self.project = Project.objects.get(slug='pip')
         self.version = self.project.versions.first()
 
-        self.build_env = namedtuple('project', 'version')
-        self.build_env.project = self.project
-        self.build_env.version = self.version
+        self.build_env = LocalBuildEnvironment(
+            project=self.project,
+            version=self.version,
+        )
 
         BaseSphinx.type = 'base'
         BaseSphinx.sphinx_build_dir = tempfile.mkdtemp()
@@ -224,9 +226,10 @@ class MkdocsBuilderTest(TestCase):
         self.project = get(Project, documentation_type='mkdocs', name='mkdocs')
         self.version = get(Version, project=self.project)
 
-        self.build_env = namedtuple('project', 'version')
-        self.build_env.project = self.project
-        self.build_env.version = self.version
+        self.build_env = LocalBuildEnvironment(
+            project=self.project,
+            version=self.version,
+        )
 
     @patch('readthedocs.projects.models.Project.checkout_path')
     def test_get_theme_name(self, checkout_path):

--- a/readthedocs/vcs_support/backends/bzr.py
+++ b/readthedocs/vcs_support/backends/bzr.py
@@ -80,7 +80,7 @@ class Backend(BaseVCS):
 
     @property
     def commit(self):
-        _, stdout = self.run('bzr', 'revno')[:2]
+        _, stdout = self.run('bzr', 'revno', record=False)[:2]
         return stdout.strip()
 
     def checkout(self, identifier=None):

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -237,8 +237,8 @@ class Backend(BaseVCS):
     @property
     def commit(self):
         if self.repo_exists():
-            _, stdout, _ = self.run('git', 'rev-parse', 'HEAD')
-            return stdout.strip()
+            repo = git.Repo(self.working_dir)
+            return str(repo.head.commit)
         return None
 
     @property

--- a/readthedocs/vcs_support/backends/hg.py
+++ b/readthedocs/vcs_support/backends/hg.py
@@ -105,7 +105,7 @@ class Backend(BaseVCS):
 
     @property
     def commit(self):
-        _, stdout = self.run('hg', 'identify', '--id')[:2]
+        _, stdout = self.run('hg', 'identify', '--id', record=False)[:2]
         return stdout.strip()
 
     def checkout(self, identifier=None):

--- a/readthedocs/vcs_support/backends/svn.py
+++ b/readthedocs/vcs_support/backends/svn.py
@@ -101,7 +101,7 @@ class Backend(BaseVCS):
 
     @property
     def commit(self):
-        _, stdout = self.run('svnversion')[:2]
+        _, stdout = self.run('svnversion', record=False)[:2]
         return stdout.strip()
 
     def checkout(self, identifier=None):


### PR DESCRIPTION
This is so we can use the current build environment (without showing this command to the user),
instead of relying on the default created by vcs.base.

ref #6546