### PR TITLE
Fix proxito redirects breaking without a /

### DIFF
--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -183,15 +183,16 @@ class ServeError404Base(ServeRedirectMixin, View):
 
         # Always add a `/` to the filename to match our old logic:
         # https://github.com/readthedocs/readthedocs.org/blob/4b09c7a0ab45cd894c3373f7f07bad7161e4b223/readthedocs/redirects/utils.py#L60
+        redirect_file = filename
         if lang_slug and version_slug:
-            filename = '/' + filename
+            redirect_filename = '/' + filename
 
         # Check and perform redirects on 404 handler
         redirect_path, http_status = self.get_redirect(
             project=final_project,
             lang_slug=lang_slug,
             version_slug=version_slug,
-            filename=filename,
+            filename=redirect_filename,
             full_path=proxito_path,
         )
         if redirect_path and http_status:

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -181,13 +181,17 @@ class ServeError404Base(ServeRedirectMixin, View):
             filename=kwargs.get('filename', ''),
         )
 
+        # Always add a `/` to the filename to match our old logic:
+        # https://github.com/readthedocs/readthedocs.org/blob/4b09c7a0ab45cd894c3373f7f07bad7161e4b223/readthedocs/redirects/utils.py#L60
+        filename = '/' + filename
+
         # Check and perform redirects on 404 handler
         redirect_path, http_status = self.get_redirect(
-            final_project,
-            lang_slug,
-            version_slug,
-            filename,
-            proxito_path,
+            project=final_project,
+            lang_slug=lang_slug,
+            version_slug=version_slug,
+            filename=filename,
+            full_path=proxito_path,
         )
         if redirect_path and http_status:
             return self.get_redirect_response(request, redirect_path, http_status)

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -183,7 +183,7 @@ class ServeError404Base(ServeRedirectMixin, View):
 
         # Always add a `/` to the filename to match our old logic:
         # https://github.com/readthedocs/readthedocs.org/blob/4b09c7a0ab45cd894c3373f7f07bad7161e4b223/readthedocs/redirects/utils.py#L60
-        redirect_file = filename
+        redirect_filename = filename
         if lang_slug and version_slug:
             redirect_filename = '/' + filename
 

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -183,7 +183,8 @@ class ServeError404Base(ServeRedirectMixin, View):
 
         # Always add a `/` to the filename to match our old logic:
         # https://github.com/readthedocs/readthedocs.org/blob/4b09c7a0ab45cd894c3373f7f07bad7161e4b223/readthedocs/redirects/utils.py#L60
-        filename = '/' + filename
+        if lang_slug and version_slug:
+            filename = '/' + filename
 
         # Check and perform redirects on 404 handler
         redirect_path, http_status = self.get_redirect(


### PR DESCRIPTION
This is an artifact of our old redirects code:

```
(Pdb) l
 59         match = re.match(
 60             r'^/(?P<language>%s)/(?P<version_slug>[^/]+)(?P<path>/.*)$' % LANGUAGES_REGEX,
 61             path,
 62         )
 63         import pdb; pdb.set_trace()
 64  ->     if match:
 65             language = match.groupdict()['language']
 66             version_slug = match.groupdict()['version_slug']
 67             path = match.groupdict()['path']
 68             return language, version_slug, path
 69         return None, None, path
(Pdb) match.groups()
('en', 'latest', '/foo.html')
(Pdb)
```

In particular, the regex was capturing the language as `everything up to /`, which then left the `/` always in the filename. 