### PR TITLE
Remove 'build environment' from guides

### DIFF
--- a/docs/guides/index.rst
+++ b/docs/guides/index.rst
@@ -28,7 +28,7 @@ whether that is Sphinx or MkDocs.
 Read the Docs how-to guides
 ---------------------------
 
-These guides will help you customize or tune aspects of the Read the Docs build environment.
+These guides will help you customize or tune aspects of the Read the Docs.
 
 .. toctree::
     :maxdepth: 1

--- a/docs/guides/index.rst
+++ b/docs/guides/index.rst
@@ -28,7 +28,7 @@ whether that is Sphinx or MkDocs.
 Read the Docs how-to guides
 ---------------------------
 
-These guides will help you customize or tune aspects of the Read the Docs.
+These guides will help you customize or tune aspects of Read the Docs.
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
There are guides that are about customizing other aspects as well.