### PR TITLE
Delete .cache dir on wipe

### DIFF
--- a/readthedocs/core/utils/general.py
+++ b/readthedocs/core/utils/general.py
@@ -20,6 +20,7 @@ def wipe_version_via_slugs(version_slug, project_slug):
         os.path.join(version.project.doc_path, 'checkouts', version.slug),
         os.path.join(version.project.doc_path, 'envs', version.slug),
         os.path.join(version.project.doc_path, 'conda', version.slug),
+        os.path.join(version.project.doc_path, '.cache', version.slug),
     ]
     for del_dir in del_dirs:
         broadcast(type='build', task=remove_dirs, args=[(del_dir,)])

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1549,7 +1549,7 @@ def clean_build(version_pk):
     # because we are syncing the servers with an async task.
     del_dirs = [
         os.path.join(version.project.doc_path, dir_, version.slug)
-        for dir_ in ('checkouts', 'envs', 'conda')
+        for dir_ in ('checkouts', 'envs', 'conda', '.cache')
     ]
     try:
         with version.project.repo_nonblockinglock(version):


### PR DESCRIPTION
We are not deleting this directory, here is where PIP caches its
packages.

https://github.com/readthedocs/readthedocs.org/blob/c3001be7a3ef41ebc181c194805f86fed6a009c8/readthedocs/projects/models.py#L673-L677

Users can still get the old (buggy) PIP version because of this.

But why wiping worked for a lot of people?

Because after wiping, we recreate the virtual environment and looks like
PIP  doesn't use the packages from the cache.
But in the next build, when reusing the virtual environment, it will use
the packages from the cache.

ref https://github.com/readthedocs/readthedocs.org/issues/6554#issuecomment-577363191