### PR TITLE
GitHub Action to find Python syntax errors and undefined names

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,13 @@
+name: lint_python
+on: [push, pull_request]
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+      - run: pip install codespell flake8  # pytest
+      # - run: codespell --quiet-level=2  # --ignore-words-list="" --skip=""
+      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+      # - run: pip install -r requirements.txt || true
+      # - run: pytest

--- a/readthedocs/search/tests/test_views.py
+++ b/readthedocs/search/tests/test_views.py
@@ -347,7 +347,7 @@ class TestPageSearch(object):
         assert len(version_facets) == 4
 
         project_versions = [v.slug for v in versions] + [LATEST]
-        assert sorted(project_versions) == sorted(resulted_version_facets)
+        assert sorted(project_versions) == sorted(version_facets_str)
 
     def test_file_search_subprojects(self, client, all_projects, es_index):
         """


### PR DESCRIPTION
GitHub Action to find Python syntax errors and undefined names.
```
./readthedocs/search/tests/test_views.py:350:51: F821 undefined name 'resulted_version_facets'
        assert sorted(project_versions) == sorted(resulted_version_facets)
                                                  ^
1     F821 undefined name 'resulted_version_facets'
1
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.

@dojutsu-user