### PR TITLE
Disable django debug toolbar in El Proxito

### DIFF
--- a/dockerfiles/settings/proxito.py
+++ b/dockerfiles/settings/proxito.py
@@ -4,6 +4,11 @@ from .docker_compose import DockerBaseSettings
 class ProxitoDevSettings(DockerBaseSettings):
     ROOT_URLCONF = 'readthedocs.proxito.urls'
 
+    # El Proxito does not have django-debug-toolbar installed
+    DEBUG_TOOLBAR_CONFIG = {
+        'SHOW_TOOLBAR_CALLBACK': lambda request: False,
+    }
+
     @property
     def MIDDLEWARE(self):  # noqa
         classes = list(super().MIDDLEWARE)


### PR DESCRIPTION
I introduce this on #6488 

When el Proxito renders a 404 it fails trying to show the debug toolbar.