### PR TITLE
Remove webs from broadcast list

### DIFF
--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -21,7 +21,12 @@ class DockerBaseSettings(CommunityDevSettings):
     SLUMBER_API_HOST = 'http://web:8000'
     RTD_EXTERNAL_VERSION_DOMAIN = 'external-builds.community.dev.readthedocs.io'
 
-    MULTIPLE_APP_SERVERS = ['web']
+    # There is no need to list any web here, because the ``broadcast`` function
+    # on them are just for syncfiles and symlinks
+    MULTIPLE_APP_SERVERS = []
+
+    # We need to list the build here because we still use the ``broadcast``
+    # function for wipping versions
     MULTIPLE_BUILD_SERVERS = ['build']
 
     # Enable auto syncing elasticsearch documents


### PR DESCRIPTION
Use an empty list so webs are not called to execute any of the following tasks:

- syncing files
- remove directories
- update metadata

This is a different approach we could use for #6326 and/or #6535 while we test how it works.