### PR TITLE
Revert "Update celery requirements to its latest version"

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -30,9 +30,15 @@ pyyaml==5.1.2
 Pygments==2.4.2
 
 # Basic tools
-redis==3.3.11
-kombu==4.6.7
-celery==4.3.0
+# Redis 3.x has an incompatible change and fails
+# https://stackoverflow.com/questions/53331405/django-compress-error-invalid-input-of-type-cachekey
+# https://github.com/sebleier/django-redis-cache/pull/162
+redis==2.10.6  # pyup: ignore
+# Kombu >4.3 requires redis>=3.2
+kombu==4.3.0  # pyup: ignore
+# Celery 4.2 is incompatible with our code
+# when ALWAYS_EAGER = True
+celery==4.1.1  # pyup: ignore
 
 django-allauth==0.40.0
 


### PR DESCRIPTION
This reverts commit 5939bca415b5fac3ec12ff6fb9557b38b3be84bd.

We noticed a lot of strange issues, including Celery dying without an
error, using the upgraded packages and even 4.4.0. Reverting back to
something that works for now.