### PR TITLE
Fix issue with pip 20.0 breaking on install

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -319,7 +319,7 @@ class Virtualenv(PythonEnvironment):
 
         # Install latest pip first,
         # so it is used when installing the other requirements.
-        cmd = pip_install_cmd + ['pip']
+        cmd = pip_install_cmd + ['pip>=20.0.1']
         self.build_env.run(
             *cmd, bin_path=self.venv_bin(), cwd=self.checkout_path
         )

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -298,6 +298,9 @@ class Virtualenv(PythonEnvironment):
             self.config.python_interpreter,
             '-mvirtualenv',
             site_packages,
+            # This is removed because of the pip breakage,
+            # it was sometimes installing pip 20.0 which broke everything
+            # '--no-download',
             env_path,
             # Don't use virtualenv bin that doesn't exist yet
             bin_path=None,

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -298,7 +298,6 @@ class Virtualenv(PythonEnvironment):
             self.config.python_interpreter,
             '-mvirtualenv',
             site_packages,
-            '--no-download',
             env_path,
             # Don't use virtualenv bin that doesn't exist yet
             bin_path=None,
@@ -319,7 +318,7 @@ class Virtualenv(PythonEnvironment):
 
         # Install latest pip first,
         # so it is used when installing the other requirements.
-        cmd = pip_install_cmd + ['pip>=20.0.1']
+        cmd = pip_install_cmd + ['pip']
         self.build_env.run(
             *cmd, bin_path=self.venv_bin(), cwd=self.checkout_path
         )

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -300,6 +300,7 @@ class Virtualenv(PythonEnvironment):
             site_packages,
             # This is removed because of the pip breakage,
             # it was sometimes installing pip 20.0 which broke everything
+            # https://github.com/readthedocs/readthedocs.org/issues/6585
             # '--no-download',
             env_path,
             # Don't use virtualenv bin that doesn't exist yet


### PR DESCRIPTION
For those finding this on GitHub, this is the step to reproduce thanks to @agjohnson:

```
rm -rf tmp/a
python3.7 -mvirtualenv --system-site-packages --no-download /tmp/a
/tmp/a/bin/python -m pip install --upgrade --cache-dir /tmp/a.cache pip
python3.7 -mvirtualenv --system-site-packages --no-download /tmp/a
/tmp/a/bin/python -m pip install --upgrade --cache-dir /tmp/a.cache pip
```

Example running in our docker container:

```
-> docker run --rm -it readthedocs/build:5.0 /bin/bash
docs@ae7bd8db6007:/$ set -x
docs@ae7bd8db6007:/$
docs@ae7bd8db6007:/$ rm -rf tmp/a
+ rm -rf tmp/a
docs@ae7bd8db6007:/$ python3.7 -mvirtualenv --system-site-packages --no-download /tmp/a
+ python3.7 -mvirtualenv --system-site-packages --no-download /tmp/a
Using base prefix '/home/docs/.pyenv/versions/3.7.3'
New python executable in /tmp/a/bin/python3.7
Also creating executable in /tmp/a/bin/python
Installing setuptools, pip, wheel...
done.
docs@ae7bd8db6007:/$ /tmp/a/bin/python -m pip install --upgrade --cache-dir /tmp/a.cache pip
+ /tmp/a/bin/python -m pip install --upgrade --cache-dir /tmp/a.cache pip
Collecting pip
  Downloading https://files.pythonhosted.org/packages/54/0c/d01aa759fdc501a58f431eb594a17495f15b88da142ce14b5845662c13f3/pip-20.0.2-py2.py3-none-any.whl (1.4MB)
     |████████████████████████████████| 1.4MB 908kB/s
Installing collected packages: pip
  Found existing installation: pip 19.1.1
    Uninstalling pip-19.1.1:
      Successfully uninstalled pip-19.1.1
Successfully installed pip-20.0.2
docs@ae7bd8db6007:/$ python3.7 -mvirtualenv --system-site-packages --no-download /tmp/a
+ python3.7 -mvirtualenv --system-site-packages --no-download /tmp/a
Using base prefix '/home/docs/.pyenv/versions/3.7.3'
New python executable in /tmp/a/bin/python3.7
Not overwriting existing python script /tmp/a/bin/python (you must use /tmp/a/bin/python3.7)
Installing setuptools, pip, wheel...
done.
docs@ae7bd8db6007:/$ /tmp/a/bin/python -m pip install --upgrade --cache-dir /tmp/a.cache pip
+ /tmp/a/bin/python -m pip install --upgrade --cache-dir /tmp/a.cache pip
Traceback (most recent call last):
  File "/home/docs/.pyenv/versions/3.7.3/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/home/docs/.pyenv/versions/3.7.3/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/tmp/a/lib/python3.7/site-packages/pip/__main__.py", line 16, in <module>
    from pip._internal import main as _main  # isort:skip # noqa
  File "/tmp/a/lib/python3.7/site-packages/pip/_internal/__init__.py", line 40, in <module>
    from pip._internal.cli.autocompletion import autocomplete
  File "/tmp/a/lib/python3.7/site-packages/pip/_internal/cli/autocompletion.py", line 8, in <module>
    from pip._internal.cli.main_parser import create_main_parser
  File "/tmp/a/lib/python3.7/site-packages/pip/_internal/cli/main_parser.py", line 12, in <module>
    from pip._internal.commands import (
  File "/tmp/a/lib/python3.7/site-packages/pip/_internal/commands/__init__.py", line 6, in <module>
    from pip._internal.commands.completion import CompletionCommand
  File "/tmp/a/lib/python3.7/site-packages/pip/_internal/commands/completion.py", line 6, in <module>
    from pip._internal.cli.base_command import Command
  File "/tmp/a/lib/python3.7/site-packages/pip/_internal/cli/base_command.py", line 25, in <module>
    from pip._internal.index import PackageFinder
ImportError: cannot import name 'PackageFinder' from 'pip._internal.index' (/tmp/a/lib/python3.7/site-packages/pip/_internal/index/__init__.py)
```