### PR TITLE
Use timeout on internal API calls

### DIFF
--- a/readthedocs/api/v2/adapters.py
+++ b/readthedocs/api/v2/adapters.py
@@ -1,0 +1,29 @@
+from requests_toolbelt.adapters.host_header_ssl import HostHeaderSSLAdapter
+from requests.adapters import HTTPAdapter
+
+
+class TimeoutAdapter:
+
+    """
+    Adapter to inject ``timeout`` to all the requests.
+
+    Allows us to not wait forever when querying our API internally from the
+    builders and make the build fail faster if it goes wrong.
+
+    https://2.python-requests.org//en/master/user/advanced/#transport-adapters
+    https://2.python-requests.org//en/master/user/advanced/#timeouts
+    """
+
+    def send(self, *args, **kwargs):
+        kwargs.update({
+            'timeout': 5,  # 5 seconds in total (connect + read)
+        })
+        return super().send(*args, **kwargs)
+
+
+class TimeoutHostHeaderSSLAdapter(TimeoutAdapter, HostHeaderSSLAdapter):
+    pass
+
+
+class TimeoutHTTPAdapter(TimeoutAdapter, HTTPAdapter):
+    pass

--- a/readthedocs/api/v2/client.py
+++ b/readthedocs/api/v2/client.py
@@ -5,9 +5,10 @@ import logging
 import requests
 from django.conf import settings
 from requests.packages.urllib3.util.retry import Retry  # noqa
-from requests_toolbelt.adapters import host_header_ssl
 from rest_framework.renderers import JSONRenderer
 from slumber import API, serialize
+
+from .adapters import TimeoutHostHeaderSSLAdapter, TimeoutHTTPAdapter
 
 
 log = logging.getLogger(__name__)
@@ -28,9 +29,9 @@ def setup_api():
     session = requests.Session()
     if settings.SLUMBER_API_HOST.startswith('https'):
         # Only use the HostHeaderSSLAdapter for HTTPS connections
-        adapter_class = host_header_ssl.HostHeaderSSLAdapter
+        adapter_class = TimeoutHostHeaderSSLAdapter
     else:
-        adapter_class = requests.adapters.HTTPAdapter
+        adapter_class = TimeoutHTTPAdapter
 
     # Define a retry mechanism trying to attempt to not fail in the first
     # error. Builders hit this issue frequently because the webs are high loaded


### PR DESCRIPTION
We have experienced some issues for long/infinite waiting time from
builders when hitting the API. Using a timeout is a way to protect
ourselves. We are already using a Retry pattern as well as another way
to protect from a network blip.