### PR TITLE
Avoid infinite redirect on El Proxito on 404

### DIFF
--- a/readthedocs/proxito/views/mixins.py
+++ b/readthedocs/proxito/views/mixins.py
@@ -156,12 +156,12 @@ class ServeRedirectMixin:
         new_path = request.build_absolute_uri(new_path)
         log.info(
             'Redirecting: from=%s to=%s http_status=%s',
-            request.build_absolute_uri(),
+            request.build_absolute_uri(proxito_path),
             new_path,
             http_status,
         )
 
-        if request.build_absolute_uri() == new_path:
+        if request.build_absolute_uri(proxito_path) == new_path:
             # check that we do have a response and avoid infinite redirect
             log.warning(
                 'Infinite Redirect: FROM URL is the same than TO URL. url=%s',


### PR DESCRIPTION
We need to use `build_absolute_uri` here because we want to compare
the full URL (including domain), but the path has to be replaced with
what's in `proxito_path`.