### PR TITLE
Remove re-authing of users on downloads.

### DIFF
--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -313,6 +313,11 @@ class ProjectDownloadMediaBase(ServeDocsMixin, View):
             if not self.allowed_user(request, final_project, version_slug):
                 return self.get_unauthed_response(request, final_project)
 
+            version = get_object_or_404(
+                final_project.versions,
+                slug=version_slug,
+            )
+
         else:
             # All the arguments come from the URL.
             version = get_object_or_404(

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -313,6 +313,8 @@ class ProjectDownloadMediaBase(ServeDocsMixin, View):
             if not self.allowed_user(request, final_project, version_slug):
                 return self.get_unauthed_response(request, final_project)
 
+            # We don't use ``.public`` in this filter because the access
+            # permission was already granted by ``.allowed_user``
             version = get_object_or_404(
                 final_project.versions,
                 slug=version_slug,

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -313,11 +313,6 @@ class ProjectDownloadMediaBase(ServeDocsMixin, View):
             if not self.allowed_user(request, final_project, version_slug):
                 return self.get_unauthed_response(request, final_project)
 
-            version = get_object_or_404(
-                final_project.versions.public(user=request.user),
-                slug=version_slug,
-            )
-
         else:
             # All the arguments come from the URL.
             version = get_object_or_404(


### PR DESCRIPTION
This was causing an issue on .com.
The `allowed_user` functionality works with logged in docs users,
whereas the `public()` queryset method doesn't.