### PR TITLE
Enable content security policy in report-only mode

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -77,6 +77,18 @@ class CommunityBaseSettings(Settings):
     SECURE_CONTENT_TYPE_NOSNIFF = True
     X_FRAME_OPTIONS = 'DENY'
 
+    # Content Security Policy
+    # https://django-csp.readthedocs.io/
+    CSP_BLOCK_ALL_MIXED_CONTENT = True
+    CSP_DEFAULT_SRC = None  # This could be improved
+    CSP_FRAME_ANCESTORS = ("'none'",)
+    CSP_OBJECT_SRC = ("'none'",)
+    CSP_REPORT_URI = None
+    CSP_REPORT_ONLY = True  # Set to false to enable CSP in blocking mode
+    CSP_EXCLUDE_URL_PREFIXES = (
+        "/admin/",
+    )
+
     # Read the Docs
     READ_THE_DOCS_EXTENSIONS = ext
     RTD_LATEST = 'latest'
@@ -180,6 +192,7 @@ class CommunityBaseSettings(Settings):
         'readthedocs.core.middleware.SubdomainMiddleware',
         'readthedocs.core.middleware.SingleVersionMiddleware',
         'corsheaders.middleware.CorsMiddleware',
+        'csp.middleware.CSPMiddleware',
     )
 
     AUTHENTICATION_BACKENDS = (

--- a/readthedocs/settings/proxito.py
+++ b/readthedocs/settings/proxito.py
@@ -29,7 +29,15 @@ class ProxitoDevSettings(base.CommunityBaseSettings):
             'readthedocs.core.middleware.SubdomainMiddleware'
         )
         classes[index] = 'readthedocs.proxito.middleware.ProxitoMiddleware'
-        classes.remove('readthedocs.core.middleware.SingleVersionMiddleware')
+
+        middleware_to_remove = (
+            'readthedocs.core.middleware.SingleVersionMiddleware',
+            'csp.middleware.CSPMiddleware',
+        )
+        for mw in middleware_to_remove:
+            if mw in classes:
+                classes.remove(mw)
+
         return classes
 
 

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -113,3 +113,6 @@ azure-storage-common==1.4.2
 
 # Required only in development and linting
 django-debug-toolbar==2.0
+
+# For enabling content-security-policy
+django-csp==3.6


### PR DESCRIPTION
[Content security policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) is a security measure that sites can opt into by sending a configurable HTTP header. When a site is really locked down, this can prevent most XSS attacks by restricting inline JS completely or restricting the origins where scripts may be loaded from or send data to.

Getting there will be hard and this is just a very first step in that process. This change:

- Enables CSP in report-only mode. It will not actually block anything. Violations will be noted to the browser console. In prod, violations can be reported to Sentry if `CSP_REPORT_URI` is configured (the reporting is done by the browser, not some task in our code).
- If CSP were not in report-only mode, the current settings would prevent
  * framing the site (already prevented with x-frame-options)
  * embedding any applets, objects, or embeds
  * blocking any mixed content (loading styles over HTTP while the main site is HTTPS)
- This applies only to the core site, not to any documentation sites.

This change can create a feedback loop where we can slowly add policies, fix any issues we see from those policies reported to Sentry from production, and then ensure there's no fallout from those policies. When we are happy with our settings, we can switch from report-only to actually enforce the policy.

Ref  #2793