### PR TITLE
Add pytest-custom_exit_code

### DIFF
--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -3,6 +3,7 @@
 
 django-dynamic-fixture==2.0.0
 pytest==5.2.2
+pytest-custom_exit_code==0.3.0
 pytest-django==3.6.0
 pytest-xdist==1.30.0
 pytest-cov==2.8.1

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -3,7 +3,7 @@
 
 django-dynamic-fixture==2.0.0
 pytest==5.2.2
-pytest-custom_exit_code==0.3.0
+pytest-custom-exit-code==0.3.0
 pytest-django==3.6.0
 pytest-xdist==1.30.0
 pytest-cov==2.8.1

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ passenv = CI TRAVIS TRAVIS_*
 deps = -r{toxinidir}/requirements/testing.txt
 changedir = {toxinidir}/readthedocs
 commands =
-    pytest --cov-report= --cov-config {toxinidir}/.coveragerc --cov=. {posargs}
+    pytest --cov-report= --cov-config {toxinidir}/.coveragerc --cov=. --suppress-no-test-exit-code {posargs}
 
 [testenv:docs]
 description = build readthedocs documentation


### PR DESCRIPTION
This is to allow us to ignore the exit code from pytest when
no tests were collected, when using the -k option, for example.