### PR TITLE
Respect `project.build_queue` and `project.skip` when triggering `sync_repository_task`

### DIFF
--- a/readthedocs/api/v2/views/integrations.py
+++ b/readthedocs/api/v2/views/integrations.py
@@ -202,7 +202,7 @@ class WebhookMixin:
             'build_triggered': False,
             'project': project.slug,
             'versions': [version],
-            'versions_synced': True,
+            'versions_synced': version is not None,
         }
 
     def get_external_version_response(self, project):

--- a/readthedocs/core/views/hooks.py
+++ b/readthedocs/core/views/hooks.py
@@ -85,7 +85,16 @@ def sync_versions(project):
         if not version:
             log.info('Unable to sync from %s version', version_identifier)
             return None
-        sync_repository_task.delay(version.pk)
+
+        options = {}
+        if project.build_queue:
+            # respect the queue for this project
+            options['queue'] = project.build_queue
+
+        sync_repository_task.apply_async(
+            (version.pk,),
+            **options,
+        )
         return version.slug
     except Exception:
         log.exception('Unknown sync versions exception')

--- a/readthedocs/core/views/hooks.py
+++ b/readthedocs/core/views/hooks.py
@@ -4,6 +4,7 @@ import logging
 
 from readthedocs.builds.constants import EXTERNAL
 from readthedocs.core.utils import trigger_build
+from readthedocs.projects.models import Project
 from readthedocs.projects.tasks import sync_repository_task
 
 
@@ -75,6 +76,14 @@ def sync_versions(project):
     :returns: The version slug that was used to trigger the clone.
     :rtype: str
     """
+
+    if not Project.objects.is_active(project):
+        log.warning(
+            'Sync not triggered because Project is not active: project=%s',
+            project.slug,
+        )
+        return None
+
     try:
         version_identifier = project.get_default_branch()
         version = (

--- a/readthedocs/core/views/hooks.py
+++ b/readthedocs/core/views/hooks.py
@@ -74,7 +74,7 @@ def sync_versions(project):
     we always pass the default version.
 
     :returns: The version slug that was used to trigger the clone.
-    :rtype: str
+    :rtype: str or ``None`` if failed
     """
 
     if not Project.objects.is_active(project):

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -773,7 +773,10 @@ class IntegrationsTests(TestCase):
     fixtures = ['eric.json', 'test_data.json']
 
     def setUp(self):
-        self.project = get(Project)
+        self.project = get(
+            Project,
+            build_queue=None,
+        )
         self.feature_flag = get(
             Feature,
             projects=[self.project],
@@ -846,6 +849,31 @@ class IntegrationsTests(TestCase):
         self.assertDictEqual(response.data, {'detail': 'This project is currently disabled'})
         self.assertEqual(response.status_code, status.HTTP_406_NOT_ACCEPTABLE)
         self.assertFalse(trigger_build.called)
+
+    @mock.patch('readthedocs.core.views.hooks.sync_repository_task')
+    def test_sync_repository_custom_project_queue(self, sync_repository_task, trigger_build):
+        client = APIClient()
+        self.project.build_queue = 'specific-build-queue'
+        self.project.save()
+
+        headers = {GITHUB_EVENT_HEADER: GITHUB_CREATE}
+        resp = client.post(
+            '/api/v2/webhook/github/{}/'.format(self.project.slug),
+            self.github_payload,
+            format='json',
+            **headers,
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertFalse(resp.data['build_triggered'])
+        self.assertEqual(resp.data['project'], self.project.slug)
+        self.assertEqual(resp.data['versions'], [LATEST])
+        self.assertTrue(resp.data['versions_synced'])
+        trigger_build.assert_not_called()
+        latest_version = self.project.versions.get(slug=LATEST)
+        sync_repository_task.apply_async.assert_called_with(
+            (latest_version.pk,),
+            queue='specific-build-queue',
+        )
 
     def test_github_webhook_for_branches(self, trigger_build):
         """GitHub webhook API."""
@@ -927,7 +955,7 @@ class IntegrationsTests(TestCase):
         self.assertEqual(resp.data['versions'], [LATEST])
         trigger_build.assert_not_called()
         latest_version = self.project.versions.get(slug=LATEST)
-        sync_repository_task.delay.assert_called_with(latest_version.pk)
+        sync_repository_task.apply_async.assert_called_with((latest_version.pk,))
 
     @mock.patch('readthedocs.core.views.hooks.sync_repository_task')
     def test_github_create_event(self, sync_repository_task, trigger_build):
@@ -946,7 +974,7 @@ class IntegrationsTests(TestCase):
         self.assertEqual(resp.data['versions'], [LATEST])
         trigger_build.assert_not_called()
         latest_version = self.project.versions.get(slug=LATEST)
-        sync_repository_task.delay.assert_called_with(latest_version.pk)
+        sync_repository_task.apply_async.assert_called_with((latest_version.pk,))
 
     @mock.patch('readthedocs.core.utils.trigger_build')
     def test_github_pull_request_opened_event(self, trigger_build, core_trigger_build):
@@ -1191,7 +1219,7 @@ class IntegrationsTests(TestCase):
         self.assertEqual(resp.data['versions'], [LATEST])
         trigger_build.assert_not_called()
         latest_version = self.project.versions.get(slug=LATEST)
-        sync_repository_task.delay.assert_called_with(latest_version.pk)
+        sync_repository_task.apply_async.assert_called_with((latest_version.pk,))
 
     def test_github_parse_ref(self, trigger_build):
         wh = GitHubWebhookView()
@@ -1399,7 +1427,7 @@ class IntegrationsTests(TestCase):
         self.assertEqual(resp.data['versions'], [LATEST])
         trigger_build.assert_not_called()
         latest_version = self.project.versions.get(slug=LATEST)
-        sync_repository_task.delay.assert_called_with(latest_version.pk)
+        sync_repository_task.apply_async.assert_called_with((latest_version.pk,))
 
     @mock.patch('readthedocs.core.views.hooks.sync_repository_task')
     def test_gitlab_push_hook_deletion(
@@ -1421,7 +1449,7 @@ class IntegrationsTests(TestCase):
         self.assertEqual(resp.data['versions'], [LATEST])
         trigger_build.assert_not_called()
         latest_version = self.project.versions.get(slug=LATEST)
-        sync_repository_task.delay.assert_called_with(latest_version.pk)
+        sync_repository_task.apply_async.assert_called_with((latest_version.pk,))
 
     @mock.patch('readthedocs.core.views.hooks.sync_repository_task')
     def test_gitlab_tag_push_hook_creation(
@@ -1444,7 +1472,7 @@ class IntegrationsTests(TestCase):
         self.assertEqual(resp.data['versions'], [LATEST])
         trigger_build.assert_not_called()
         latest_version = self.project.versions.get(slug=LATEST)
-        sync_repository_task.delay.assert_called_with(latest_version.pk)
+        sync_repository_task.apply_async.assert_called_with((latest_version.pk,))
 
     @mock.patch('readthedocs.core.views.hooks.sync_repository_task')
     def test_gitlab_tag_push_hook_deletion(
@@ -1467,7 +1495,7 @@ class IntegrationsTests(TestCase):
         self.assertEqual(resp.data['versions'], [LATEST])
         trigger_build.assert_not_called()
         latest_version = self.project.versions.get(slug=LATEST)
-        sync_repository_task.delay.assert_called_with(latest_version.pk)
+        sync_repository_task.apply_async.assert_called_with((latest_version.pk,))
 
     def test_gitlab_invalid_webhook(self, trigger_build):
         """GitLab webhook unhandled event."""
@@ -1919,7 +1947,7 @@ class IntegrationsTests(TestCase):
         self.assertEqual(resp.data['versions'], [LATEST])
         trigger_build.assert_not_called()
         latest_version = self.project.versions.get(slug=LATEST)
-        sync_repository_task.delay.assert_called_with(latest_version.pk)
+        sync_repository_task.apply_async.assert_called_with((latest_version.pk,))
 
     @mock.patch('readthedocs.core.views.hooks.sync_repository_task')
     def test_bitbucket_push_hook_deletion(
@@ -1938,7 +1966,7 @@ class IntegrationsTests(TestCase):
         self.assertEqual(resp.data['versions'], [LATEST])
         trigger_build.assert_not_called()
         latest_version = self.project.versions.get(slug=LATEST)
-        sync_repository_task.delay.assert_called_with(latest_version.pk)
+        sync_repository_task.apply_async.assert_called_with((latest_version.pk,))
 
     def test_bitbucket_invalid_webhook(self, trigger_build):
         """Bitbucket webhook unhandled event."""


### PR DESCRIPTION
When triggering `sync_respository_task` respect the `project.build_queue` and `project.skip` as we do when triggering a build.