### PR TITLE
Default python version per Docker image

### DIFF
--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -295,7 +295,7 @@ class BuildConfigBase:
             )
         return settings.DOCKER_IMAGE_SETTINGS[build_image]['python']['supported_versions']
 
-    def get_default_python_version_for_image(self, build_image, python):
+    def get_default_python_version_for_image(self, build_image, python_version):
         """
         Return the default Python version for Docker image and Py2 or Py3.
 
@@ -303,9 +303,9 @@ class BuildConfigBase:
             (``readthedocs/build:4.0``, not just ``4.0``)
         :type build_image: str
 
-        :param python: major Python version (``2`` or ``3``) to get its default
-            full version
-        :type python: int
+        :param python_version: major Python version (``2`` or ``3``) to get its
+            default full version
+        :type python_version: int
 
         :returns: default version for the ``DOCKER_DEFAULT_VERSION`` if not
                   ``build_image`` found.
@@ -315,7 +315,7 @@ class BuildConfigBase:
                 settings.DOCKER_DEFAULT_IMAGE,
                 self.default_build_image,
             )
-        return settings.DOCKER_IMAGE_SETTINGS[build_image]['python']['default_version'][python]
+        return settings.DOCKER_IMAGE_SETTINGS[build_image]['python']['default_version'][python_version]
 
     def as_dict(self):
         config = {}

--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -255,11 +255,10 @@ class BuildConfigBase:
     def python_full_version(self):
         ver = self.python.version
         if ver in [2, 3]:
-            # Get the highest version of the major series version if user only
-            # gave us a version of '2', or '3'
-            ver = max(
-                v for v in self.get_valid_python_versions()
-                if not isinstance(v, str) and v < ver + 1
+            # use default Python version if user only set '2', or '3'
+            return self.get_default_python_version_for_image(
+                self.build.image,
+                ver,
             )
         return ver
 
@@ -295,6 +294,28 @@ class BuildConfigBase:
                 self.default_build_image,
             )
         return settings.DOCKER_IMAGE_SETTINGS[build_image]['python']['supported_versions']
+
+    def get_default_python_version_for_image(self, build_image, python):
+        """
+        Return the default Python version for Docker image and Py2 or Py3.
+
+        :param build_image: the Docker image complete name, already validated
+            (``readthedocs/build:4.0``, not just ``4.0``)
+        :type build_image: str
+
+        :param python: major Python version (``2`` or ``3``) to get its default
+            full version
+        :type python: int
+
+        :returns: default version for the ``DOCKER_DEFAULT_VERSION`` if not
+                  ``build_image`` found.
+        """
+        if build_image not in settings.DOCKER_IMAGE_SETTINGS:
+            build_image = '{}:{}'.format(
+                settings.DOCKER_DEFAULT_IMAGE,
+                self.default_build_image,
+            )
+        return settings.DOCKER_IMAGE_SETTINGS[build_image]['python']['default_version'][python]
 
     def as_dict(self):
         config = {}

--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -30,11 +30,10 @@ from .validation import (
     validate_bool,
     validate_choice,
     validate_dict,
-    validate_path,
     validate_list,
+    validate_path,
     validate_string,
 )
-
 
 __all__ = (
     'ALL',
@@ -83,7 +82,7 @@ class ConfigFileNotFound(ConfigError):
 
     def __init__(self, directory):
         super().__init__(
-            f"Configuration file not found in: {directory}",
+            f'Configuration file not found in: {directory}',
             CONFIG_FILE_REQUIRED,
         )
 
@@ -315,7 +314,11 @@ class BuildConfigBase:
                 settings.DOCKER_DEFAULT_IMAGE,
                 self.default_build_image,
             )
-        return settings.DOCKER_IMAGE_SETTINGS[build_image]['python']['default_version'][python_version]
+        return (
+            # For linting
+            settings.DOCKER_IMAGE_SETTINGS[build_image]['python']
+            ['default_version'][python_version]
+        )
 
     def as_dict(self):
         config = {}
@@ -426,7 +429,9 @@ class BuildConfigV1(BuildConfigBase):
                 )
         # Update docker default settings from image name
         if build['image'] in settings.DOCKER_IMAGE_SETTINGS:
-            self.env_config.update(settings.DOCKER_IMAGE_SETTINGS[build['image']])
+            self.env_config.update(
+                settings.DOCKER_IMAGE_SETTINGS[build['image']]
+            )
 
         # Allow to override specific project
         config_image = self.defaults.get('build_image')

--- a/readthedocs/config/tests/test_config.py
+++ b/readthedocs/config/tests/test_config.py
@@ -997,6 +997,28 @@ class TestBuildConfigV2:
         build.validate()
         assert build.python.version == 3
 
+    @pytest.mark.parametrize(
+        'image,default_version',
+        [
+            ('1.0', 3.4),
+            ('2.0', 3.5),
+            ('3.0', 3.6),
+            ('4.0', 3.7),
+            ('5.0', 3.7),
+            ('latest', 3.7),
+            ('stable', 3.7),
+        ],
+    )
+    def test_python_version_default_from_image(self, image, default_version):
+        build = self.get_build_config({
+            'build': {
+                'image': image,
+            },
+        })
+        build.validate()
+        assert build.python.version == int(default_version)  # 2 or 3
+        assert build.python_full_version == default_version
+
     @pytest.mark.parametrize('value', [2, 3])
     def test_python_version_overrides_default(self, value):
         build = self.get_build_config(

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -371,31 +371,55 @@ class CommunityBaseSettings(Settings):
         'readthedocs/build:1.0': {
             'python': {
                 'supported_versions': [2, 2.7, 3, 3.4],
+                'default_version': {
+                    2: 2.7,
+                    3: 3.4,
+                },
             },
         },
         'readthedocs/build:2.0': {
             'python': {
                 'supported_versions': [2, 2.7, 3, 3.5],
+                'default_version': {
+                    2: 2.7,
+                    3: 3.5,
+                },
             },
         },
         'readthedocs/build:3.0': {
             'python': {
                 'supported_versions': [2, 2.7, 3, 3.3, 3.4, 3.5, 3.6],
+                'default_version': {
+                    2: 2.7,
+                    3: 3.6,
+                },
             },
         },
         'readthedocs/build:4.0': {
             'python': {
                 'supported_versions': [2, 2.7, 3, 3.5, 3.6, 3.7],
+                'default_version': {
+                    2: 2.7,
+                    3: 3.7,
+                },
             },
         },
         'readthedocs/build:5.0': {
             'python': {
                 'supported_versions': [2, 2.7, 3, 3.5, 3.6, 3.7, 'pypy3.5'],
+                'default_version': {
+                    2: 2.7,
+                    3: 3.7,
+                },
             },
         },
         'readthedocs/build:6.0rc1': {
             'python': {
                 'supported_versions': [2, 2.7, 3, 3.5, 3.6, 3.7, 3.8, 'pypy3.5'],
+                'default_version': {
+                    2: 2.7,
+                    3: 3.7,
+                },
             },
         },
     }

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -369,22 +369,34 @@ class CommunityBaseSettings(Settings):
     DOCKER_IMAGE = '{}:{}'.format(DOCKER_DEFAULT_IMAGE, DOCKER_DEFAULT_VERSION)
     DOCKER_IMAGE_SETTINGS = {
         'readthedocs/build:1.0': {
-            'python': {'supported_versions': [2, 2.7, 3, 3.4]},
+            'python': {
+                'supported_versions': [2, 2.7, 3, 3.4],
+            },
         },
         'readthedocs/build:2.0': {
-            'python': {'supported_versions': [2, 2.7, 3, 3.5]},
+            'python': {
+                'supported_versions': [2, 2.7, 3, 3.5],
+            },
         },
         'readthedocs/build:3.0': {
-            'python': {'supported_versions': [2, 2.7, 3, 3.3, 3.4, 3.5, 3.6]},
+            'python': {
+                'supported_versions': [2, 2.7, 3, 3.3, 3.4, 3.5, 3.6],
+            },
         },
         'readthedocs/build:4.0': {
-            'python': {'supported_versions': [2, 2.7, 3, 3.5, 3.6, 3.7]},
+            'python': {
+                'supported_versions': [2, 2.7, 3, 3.5, 3.6, 3.7],
+            },
         },
         'readthedocs/build:5.0': {
-            'python': {'supported_versions': [2, 2.7, 3, 3.5, 3.6, 3.7, 'pypy3.5']},
+            'python': {
+                'supported_versions': [2, 2.7, 3, 3.5, 3.6, 3.7, 'pypy3.5'],
+            },
         },
         'readthedocs/build:6.0rc1': {
-            'python': {'supported_versions': [2, 2.7, 3, 3.5, 3.6, 3.7, 3.8, 'pypy3.5']},
+            'python': {
+                'supported_versions': [2, 2.7, 3, 3.5, 3.6, 3.7, 3.8, 'pypy3.5'],
+            },
         },
     }
 


### PR DESCRIPTION
Instead of always picking the latest minor version when the user just put '2' or '3' in their YAML file, we use a default Python version per Docker image.

This allows us to upgrade our Docker images (`latest` or `stable`) introducing new versions of Python (like `3.8`) without forcing users without specifying a Python version to use the new Python version.

We can easily change the `default_version` in our `latest` or `stable` image when we the new Python version gets more stable and we know we won't affect too many users with the change.

> We can release a `6.0` (plus `testing`) Docker image from current `master` after this gets merged and deployed. We need to create another PR to add this value into the Docker setting, though. See #6654 

Related #6324 