### PR TITLE
New docker release (6.0 and testing)

### DIFF
--- a/readthedocs/config/tests/test_config.py
+++ b/readthedocs/config/tests/test_config.py
@@ -974,8 +974,8 @@ class TestBuildConfigV2:
     @pytest.mark.parametrize(
         'image,versions',
         [
-            ('latest', [1, 2.8, 4, 3.8]),
-            ('stable', [1, 2.8, 4, 3.8]),
+            ('latest', [1, 2.8, 4]),
+            ('stable', [1, 2.8, 4]),
         ],
     )
     def test_python_version_invalid(self, image, versions):

--- a/readthedocs/rtd_tests/tests/test_config_integration.py
+++ b/readthedocs/rtd_tests/tests/test_config_integration.py
@@ -146,7 +146,7 @@ class LoadConfigTests(TestCase):
         config = load_yaml_config(self.version)
         self.assertEqual(
             config.get_valid_python_versions(),
-            [2, 2.7, 3, 3.5, 3.6, 3.7, 'pypy3.5'],
+            [2, 2.7, 3, 3.5, 3.6, 3.7, 3.8, 'pypy3.5'],
         )
 
     @mock.patch('readthedocs.doc_builder.config.load_config')

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -424,6 +424,15 @@ class CommunityBaseSettings(Settings):
                 },
             },
         },
+        'readthedocs/build:testing': {
+            'python': {
+                'supported_versions': [2, 2.7, 3, 3.5, 3.6, 3.7, 3.8, 'pypy3.5'],
+                'default_version': {
+                    2: 2.7,
+                    3: 3.7,
+                },
+            },
+        },
     }
 
     # Alias tagged via ``docker tag`` on the build servers

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -415,7 +415,7 @@ class CommunityBaseSettings(Settings):
                 },
             },
         },
-        'readthedocs/build:6.0rc1': {
+        'readthedocs/build:6.0': {
             'python': {
                 'supported_versions': [2, 2.7, 3, 3.5, 3.6, 3.7, 3.8, 'pypy3.5'],
                 'default_version': {
@@ -428,8 +428,8 @@ class CommunityBaseSettings(Settings):
 
     # Alias tagged via ``docker tag`` on the build servers
     DOCKER_IMAGE_SETTINGS.update({
-        'readthedocs/build:stable': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:4.0'),
-        'readthedocs/build:latest': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:5.0'),
+        'readthedocs/build:stable': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:5.0'),
+        'readthedocs/build:latest': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:6.0'),
     })
 
     # All auth

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -424,7 +424,7 @@ class CommunityBaseSettings(Settings):
                 },
             },
         },
-        'readthedocs/build:testing': {
+        'readthedocs/build:7.0': {
             'python': {
                 'supported_versions': [2, 2.7, 3, 3.5, 3.6, 3.7, 3.8, 'pypy3.5'],
                 'default_version': {
@@ -439,6 +439,7 @@ class CommunityBaseSettings(Settings):
     DOCKER_IMAGE_SETTINGS.update({
         'readthedocs/build:stable': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:5.0'),
         'readthedocs/build:latest': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:6.0'),
+        'readthedocs/build:testing': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:7.0'),
     })
 
     # All auth


### PR DESCRIPTION
- Update our Docker settings to support `6.0` and `testing` images in our YAML file.
- Tag 5.0 as stable
- Tag 6.0 as latest

Edit: this PR includes changes from #6653 so be careful when merging.