### PR TITLE
Add azurite --loose option

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -76,7 +76,7 @@ services:
       - "10000:10000"
     networks:
       readthedocs:
-    command: ["azurite-blob", "--silent", "--blobPort", "10000", "--blobHost", "0.0.0.0", "--location", "/data"]
+    command: ["azurite-blob", "--silent", "--blobPort", "10000", "--blobHost", "0.0.0.0", "--location", "/data", "--loose"]
 
   azure-cli:
     image: microsoft/azure-cli


### PR DESCRIPTION
I was getting 5xx errors from azurite every other load of a static asset
file. I found this issue and added a fix that was mentioned:
https://github.com/Azure/Azurite/issues/337

I can not reccomend this fix and I did not try to spend any time
understanding Azurite.