### PR TITLE
Remove old docker settings

### DIFF
--- a/readthedocs/config/tests/test_config.py
+++ b/readthedocs/config/tests/test_config.py
@@ -528,8 +528,8 @@ class TestValidateBuild:
         build = BuildConfigV1(
             {},
             {
-                'build': {'image': 1.0},
-                'python': {'version': '3.3'},
+                'build': {'image': 2.0},
+                'python': {'version': '3.8'},
             },
             source_file=str(tmpdir.join('readthedocs.yml')),
         )
@@ -1000,9 +1000,7 @@ class TestBuildConfigV2:
     @pytest.mark.parametrize(
         'image,default_version',
         [
-            ('1.0', 3.4),
             ('2.0', 3.5),
-            ('3.0', 3.6),
             ('4.0', 3.7),
             ('5.0', 3.7),
             ('latest', 3.7),

--- a/readthedocs/rtd_tests/tests/test_config_integration.py
+++ b/readthedocs/rtd_tests/tests/test_config_integration.py
@@ -117,17 +117,6 @@ class LoadConfigTests(TestCase):
         self.assertEqual(config.python.version, 3)
 
     @mock.patch('readthedocs.doc_builder.config.load_config')
-    def test_python_supported_versions_image_1_0(self, load_config):
-        load_config.side_effect = create_load()
-        self.project.container_image = 'readthedocs/build:1.0'
-        self.project.save()
-        config = load_yaml_config(self.version)
-        self.assertEqual(
-            config.get_valid_python_versions(),
-            [2, 2.7, 3, 3.4],
-        )
-
-    @mock.patch('readthedocs.doc_builder.config.load_config')
     def test_python_supported_versions_image_2_0(self, load_config):
         load_config.side_effect = create_load()
         self.project.container_image = 'readthedocs/build:2.0'

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -370,6 +370,24 @@ class CommunityBaseSettings(Settings):
     DOCKER_DEFAULT_VERSION = 'latest'
     DOCKER_IMAGE = '{}:{}'.format(DOCKER_DEFAULT_IMAGE, DOCKER_DEFAULT_VERSION)
     DOCKER_IMAGE_SETTINGS = {
+        'readthedocs/build:2.0': {
+            'python': {
+                'supported_versions': [2, 2.7, 3, 3.5],
+                'default_version': {
+                    2: 2.7,
+                    3: 3.5,
+                },
+            },
+        },
+        'readthedocs/build:3.0': {
+            'python': {
+                'supported_versions': [2, 2.7, 3, 3.3, 3.4, 3.5, 3.6],
+                'default_version': {
+                    2: 2.7,
+                    3: 3.6,
+                },
+            },
+        },
         'readthedocs/build:4.0': {
             'python': {
                 'supported_versions': [2, 2.7, 3, 3.5, 3.6, 3.7],

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -370,33 +370,6 @@ class CommunityBaseSettings(Settings):
     DOCKER_DEFAULT_VERSION = 'latest'
     DOCKER_IMAGE = '{}:{}'.format(DOCKER_DEFAULT_IMAGE, DOCKER_DEFAULT_VERSION)
     DOCKER_IMAGE_SETTINGS = {
-        'readthedocs/build:1.0': {
-            'python': {
-                'supported_versions': [2, 2.7, 3, 3.4],
-                'default_version': {
-                    2: 2.7,
-                    3: 3.4,
-                },
-            },
-        },
-        'readthedocs/build:2.0': {
-            'python': {
-                'supported_versions': [2, 2.7, 3, 3.5],
-                'default_version': {
-                    2: 2.7,
-                    3: 3.5,
-                },
-            },
-        },
-        'readthedocs/build:3.0': {
-            'python': {
-                'supported_versions': [2, 2.7, 3, 3.3, 3.4, 3.5, 3.6],
-                'default_version': {
-                    2: 2.7,
-                    3: 3.6,
-                },
-            },
-        },
         'readthedocs/build:4.0': {
             'python': {
                 'supported_versions': [2, 2.7, 3, 3.5, 3.6, 3.7],

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -370,21 +370,14 @@ class CommunityBaseSettings(Settings):
     DOCKER_DEFAULT_VERSION = 'latest'
     DOCKER_IMAGE = '{}:{}'.format(DOCKER_DEFAULT_IMAGE, DOCKER_DEFAULT_VERSION)
     DOCKER_IMAGE_SETTINGS = {
+        # A large number of users still have this pinned in their config file.
+        # We must have documented it at some point.
         'readthedocs/build:2.0': {
             'python': {
                 'supported_versions': [2, 2.7, 3, 3.5],
                 'default_version': {
                     2: 2.7,
                     3: 3.5,
-                },
-            },
-        },
-        'readthedocs/build:3.0': {
-            'python': {
-                'supported_versions': [2, 2.7, 3, 3.3, 3.4, 3.5, 3.6],
-                'default_version': {
-                    2: 2.7,
-                    3: 3.6,
                 },
             },
         },


### PR DESCRIPTION
This will stop them from validating in the config,
since we are removing them from the build servers.

We have never supported or documented the support for pinning to a specific version,
so I think this should be safe.