### PR TITLE
Always run CoreTagsTests with http

### DIFF
--- a/readthedocs/conftest.py
+++ b/readthedocs/conftest.py
@@ -14,8 +14,6 @@ except ImportError:
         ('community', True),
         ('corporate', False),
         ('environment', 'readthedocs'),
-
-        ('url_scheme', 'http'),
     )
 
 
@@ -50,8 +48,3 @@ def settings_modification(settings):
 @pytest.fixture
 def api_client():
     return APIClient()
-
-
-@pytest.fixture(scope="class")
-def url_scheme(request):
-    request.cls.url_scheme = request.config.option.url_scheme

--- a/readthedocs/rtd_tests/tests/test_core_tags.py
+++ b/readthedocs/rtd_tests/tests/test_core_tags.py
@@ -9,14 +9,12 @@ from readthedocs.core.templatetags import core_tags
 from readthedocs.projects.models import Project
 
 
-@pytest.mark.usefixtures("url_scheme")
 @override_settings(USE_SUBDOMAIN=False, PRODUCTION_DOMAIN='readthedocs.org')
 class CoreTagsTests(TestCase):
     fixtures = ['eric', 'test_data']
 
     def setUp(self):
-        url_base = '{scheme}://{domain}/docs/pip{{version}}'.format(
-            scheme=self.url_scheme,
+        url_base = 'http://{domain}/docs/pip{{version}}'.format(
             domain=settings.PRODUCTION_DOMAIN,
         )
 


### PR DESCRIPTION
This is to make some tests pass in .com.

We only uses subdomains on .com,  this setting is always http for .org.