### PR TITLE
Allow user to set `build.image: testing` in the config file

### DIFF
--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -268,9 +268,9 @@ class BuildConfigBase:
 
         The user can use any of this values in the YAML file. These values are
         the keys of ``DOCKER_IMAGE_SETTINGS`` Django setting (without the
-        ``readthedocs/build`` part) plus ``stable`` and ``latest``.
+        ``readthedocs/build`` part) plus ``stable``, ``latest`` and ``testing``.
         """
-        images = {'stable', 'latest'}
+        images = {'stable', 'latest', 'testing'}
         for k in settings.DOCKER_IMAGE_SETTINGS:
             _, version = k.split(':')
             if re.fullmatch(r'^[\d\.]+$', version):

--- a/readthedocs/config/tests/test_config.py
+++ b/readthedocs/config/tests/test_config.py
@@ -880,7 +880,7 @@ class TestBuildConfigV2:
             build.validate()
         assert excinfo.value.key == 'conda.environment'
 
-    @pytest.mark.parametrize('value', ['stable', 'latest'])
+    @pytest.mark.parametrize('value', ['stable', 'latest', 'testing'])
     def test_build_image_check_valid(self, value):
         build = self.get_build_config({'build': {'image': value}})
         build.validate()


### PR DESCRIPTION
We have a new `testing` image now that we can recommend to users when they need something extra that it's now in our current image, but will be available in the following image.

This allow us to not have to do work manually (like modifying `container_image` in the db), clearly communicate to the user that they are using something that it's not released yet and also allow them to opt-in/out when they want.