### PR TITLE
Use x-forwarded-host in local docker environment

### DIFF
--- a/dockerfiles/nginx/web.conf
+++ b/dockerfiles/nginx/web.conf
@@ -17,5 +17,6 @@ server {
 
     location / {
         proxy_pass http://web:8000/;
+        proxy_set_header X-Forwarded-Host $host;
     }
 }

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -21,6 +21,9 @@ class DockerBaseSettings(CommunityDevSettings):
     SLUMBER_API_HOST = 'http://web:8000'
     RTD_EXTERNAL_VERSION_DOMAIN = 'org.dev.readthedocs.build'
 
+    # In the local docker environment, nginx should be trusted to set the host correctly
+    USE_X_FORWARDED_HOST = True
+
     MULTIPLE_APP_SERVERS = ['web']
     MULTIPLE_BUILD_SERVERS = ['build']
 


### PR DESCRIPTION
Without this change anything that called `request.build_absolute_uri` made a URI of the form `http://web:8000/...` instead of `http://community.dev.readthedocs.io/...`.

This prevented the connected accounts (github, bitbucket, gitlab) from working correctly.