### PR TITLE
Add feature flag to just completely skip sync and symlink operations

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1505,6 +1505,7 @@ class Feature(models.Model):
     UPDATE_CONDA_STARTUP = 'update_conda_startup'
     CONDA_APPEND_CORE_REQUIREMENTS = 'conda_append_core_requirements'
     ALL_VERSIONS_IN_HTML_CONTEXT = 'all_versions_in_html_context'
+    SKIP_SYNC = 'skip_sync'
 
     FEATURES = (
         (USE_SPHINX_LATEST, _('Use latest version of Sphinx')),
@@ -1562,6 +1563,9 @@ class Feature(models.Model):
                 'Pass all versions (including private) into the html context '
                 'when building with Sphinx'
             ),
+        ),
+        (
+            SKIP_SYNC, _('Skip symlinking and file syncing to webs'),
         ),
     )
 

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1167,6 +1167,8 @@ def sync_files(
     version = Version.objects.get_object_or_log(pk=version_pk)
     if not version:
         return
+    if version.project.has_feature(Feature.SKIP_SYNC):
+        return
 
     # Sync files to the web servers
     move_files(
@@ -1317,6 +1319,8 @@ def move_files(
 @app.task(queue='web')
 def symlink_project(project_pk):
     project = Project.objects.get(pk=project_pk)
+    if project.has_feature(Feature.SKIP_SYNC):
+        return
     for symlink in [PublicSymlink, PrivateSymlink]:
         sym = symlink(project=project)
         sym.run()
@@ -1333,6 +1337,8 @@ def symlink_domain(project_pk, domain, delete=False):
     :type domain: str
     """
     project = Project.objects.get(pk=project_pk)
+    if project.has_feature(Feature.SKIP_SYNC):
+        return
     for symlink in [PublicSymlink, PrivateSymlink]:
         sym = symlink(project=project)
         if delete:


### PR DESCRIPTION
We can control this on a per-project basis. Once we remove symlinking
and Syncers, this can go away entirely.