### PR TITLE
New block on footer template to override from corporate

### DIFF
--- a/readthedocs/api/v2/templates/restapi/footer.html
+++ b/readthedocs/api/v2/templates/restapi/footer.html
@@ -126,7 +126,8 @@
       </dl>
       {% endblock %}
 
-
+      {% block auth %}
+      {% endblock %}
 
       <hr/>
       {% block footer %}


### PR DESCRIPTION
We are extending this block from corporate code to show an extra section in the flyout menu.