### PR TITLE
Rename docker settings to fix local environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ env.bak/
 venv.bak/
 
 dev.db-journal
-/readthedocs/settings/build.py
-/readthedocs/settings/celery.py
-/readthedocs/settings/web.py
+/readthedocs/settings/build_docker.py
+/readthedocs/settings/celery_docker.py
+/readthedocs/settings/proxito_docker.py
+/readthedocs/settings/web_docker.py

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -35,17 +35,17 @@ services:
     image: community_server:latest
     volumes:
       - ${PWD}:/usr/src/app/checkouts/readthedocs.org
-      - ${PWD}/dockerfiles/settings/proxito.py:/usr/src/app/checkouts/readthedocs.org/readthedocs/settings/proxito.py
+      - ${PWD}/dockerfiles/settings/proxito.py:/usr/src/app/checkouts/readthedocs.org/readthedocs/settings/proxito_docker.py
     environment:
-      - DJANGO_SETTINGS_MODULE=readthedocs.settings.proxito
+      - DJANGO_SETTINGS_MODULE=readthedocs.settings.proxito_docker
 
   web:
     image: community_server:latest
     volumes:
       - ${PWD}:/usr/src/app/checkouts/readthedocs.org
-      - ${PWD}/dockerfiles/settings/web.py:/usr/src/app/checkouts/readthedocs.org/readthedocs/settings/web.py
+      - ${PWD}/dockerfiles/settings/web.py:/usr/src/app/checkouts/readthedocs.org/readthedocs/settings/web_docker.py
     environment:
-      - DJANGO_SETTINGS_MODULE=readthedocs.settings.web
+      - DJANGO_SETTINGS_MODULE=readthedocs.settings.web_docker
       - HOSTIP=${HOSTIP:-}
     extra_hosts:
       - "community.dev.readthedocs.io:10.10.0.100"
@@ -54,18 +54,18 @@ services:
     image: community_server:latest
     volumes:
       - ${PWD}:/usr/src/app/checkouts/readthedocs.org
-      - ${PWD}/dockerfiles/settings/celery.py:/usr/src/app/checkouts/readthedocs.org/readthedocs/settings/celery.py
+      - ${PWD}/dockerfiles/settings/celery.py:/usr/src/app/checkouts/readthedocs.org/readthedocs/settings/celery_docker.py
     environment:
-      - DJANGO_SETTINGS_MODULE=readthedocs.settings.celery
+      - DJANGO_SETTINGS_MODULE=readthedocs.settings.celery_docker
       - CELERY_APP_NAME=readthedocs
 
   build:
     image: community_server:latest
     volumes:
       - ${PWD}:/usr/src/app/checkouts/readthedocs.org
-      - ${PWD}/dockerfiles/settings/build.py:/usr/src/app/checkouts/readthedocs.org/readthedocs/settings/build.py
+      - ${PWD}/dockerfiles/settings/build.py:/usr/src/app/checkouts/readthedocs.org/readthedocs/settings/build_docker.py
     environment:
-      - DJANGO_SETTINGS_MODULE=readthedocs.settings.build
+      - DJANGO_SETTINGS_MODULE=readthedocs.settings.build_docker
       - CELERY_APP_NAME=readthedocs
 
   storage:


### PR DESCRIPTION
Use a different names for Docker Compose settings after https://github.com/readthedocs/readthedocs.org/pull/6623 that creates a new directory called `proxito/` under settings.