### PR TITLE
Pin the version of Azurite for docker-compose development

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -69,7 +69,9 @@ services:
       - CELERY_APP_NAME=readthedocs
 
   storage:
-    image: mcr.microsoft.com/azure-storage/azurite:latest
+    # https://github.com/Azure/Azurite
+    # Pin the version of Azurite as there are sometimes backwards incompatible changes
+    image: mcr.microsoft.com/azure-storage/azurite:3.5.0
     volumes:
       - storage_data:/data
     ports:


### PR DESCRIPTION
The goal is to avoid having incompatible versions on different people's development machines. Also, sometimes the storage database is incompatible between versions. If you have an older database from [before Azurite 3.3](https://github.com/Azure/Azurite/releases/tag/v3.3.0-preview), this change will probably be incompatible with your existing data and you'll have to remove it:

```
docker container ls -a | grep -i azurit    # get the container ID
docker container rm <container ID>
docker volume rm community_storage_data
```

The above commands will require you to recreate the static files (`inv docker.up --init`) and your build documentation will no longer be present in local dev and will have to be rebuilt.