### PR TITLE
Make easy to run search tests in docker compose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ python:
   - 3.6
 dist: xenial
 
+addons:
+  hosts:
+    - search
+
 jobs:
   include:
     - python: 3.6

--- a/docs/development/search.rst
+++ b/docs/development/search.rst
@@ -11,6 +11,7 @@ Local Development Configuration
 
 Installing and running Elasticsearch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 You need to install and run Elasticsearch_ version 6.3 on your local development machine.
 You can get the installation instructions
 `here <https://www.elastic.co/guide/en/elasticsearch/reference/6.3/install-elasticsearch.html>`_.
@@ -19,6 +20,8 @@ Otherwise, you can also start an Elasticsearch Docker container by running the f
     docker run -p 9200:9200 -p 9300:9300 \
            -e "discovery.type=single-node" \
            docker.elastic.co/elasticsearch/elasticsearch:6.3.2
+
+You need to override the ``ES_HOSTS`` and ``ELASTICSEARCH_DSL`` settings to point to ``127.0.0.1:9200``.
 
 Indexing into Elasticsearch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/development/tests.rst
+++ b/docs/development/tests.rst
@@ -35,8 +35,6 @@ you can also set the ``TOX_POSARGS`` environment variable to an empty string::
 .. warning::
 
    Running tests for search needs an Elasticsearch :ref:`instance running locally <development/search:Installing and running Elasticsearch>`.
-   If you are testing inside :ref:`docker compose <development/standards:Working with Docker Compose>`,
-   you'll need to override the ``ES_HOSTS`` and ``ELASTICSEARCH_DSL`` settings to point to ``search:9200`` instead.
 
 To target a specific environment::
 

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -489,10 +489,10 @@ class CommunityBaseSettings(Settings):
     ALLOW_ADMIN = True
 
     # Elasticsearch settings.
-    ES_HOSTS = ['127.0.0.1:9200']
+    ES_HOSTS = ['search:9200']
     ELASTICSEARCH_DSL = {
         'default': {
-            'hosts': '127.0.0.1:9200'
+            'hosts': 'search:9200'
         },
     }
     # Chunk size for elasticsearch reindex celery tasks

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -43,11 +43,6 @@ class DockerBaseSettings(CommunityDevSettings):
 
     # Enable auto syncing elasticsearch documents
     ELASTICSEARCH_DSL_AUTOSYNC = True if 'SEARCH' in os.environ else False
-    ELASTICSEARCH_DSL = {
-        'default': {
-            'hosts': 'search:9200',
-        },
-    }
 
     RTD_CLEAN_AFTER_BUILD = True
 


### PR DESCRIPTION
This works on travis and docker compose without any change on the
settings