### PR TITLE
Only output debug logging from RTD app

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -603,7 +603,7 @@ class CommunityBaseSettings(Settings):
         },
         'handlers': {
             'console': {
-                'level': 'INFO',
+                'level': 'DEBUG',
                 'class': 'logging.StreamHandler',
                 'formatter': 'default'
             },
@@ -621,7 +621,7 @@ class CommunityBaseSettings(Settings):
             '': {  # root logger
                 'handlers': ['debug', 'console'],
                 # Always send from the root, handlers can filter levels
-                'level': 'DEBUG',
+                'level': 'INFO',
             },
             'readthedocs': {
                 'handlers': ['debug', 'console'],

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -603,7 +603,7 @@ class CommunityBaseSettings(Settings):
         },
         'handlers': {
             'console': {
-                'level': 'DEBUG',
+                'level': 'INFO',
                 'class': 'logging.StreamHandler',
                 'formatter': 'default'
             },

--- a/readthedocs/settings/dev.py
+++ b/readthedocs/settings/dev.py
@@ -57,7 +57,6 @@ class CommunityDevSettings(CommunityBaseSettings):
     @property
     def LOGGING(self):  # noqa - avoid pep8 N802
         logging = super().LOGGING
-        logging['handlers']['console']['level'] = 'DEBUG'
         logging['formatters']['default']['format'] = '[%(asctime)s] ' + self.LOG_FORMAT
         # Allow Sphinx and other tools to create loggers
         logging['disable_existing_loggers'] = False

--- a/readthedocs/settings/dev.py
+++ b/readthedocs/settings/dev.py
@@ -57,6 +57,7 @@ class CommunityDevSettings(CommunityBaseSettings):
     @property
     def LOGGING(self):  # noqa - avoid pep8 N802
         logging = super().LOGGING
+        logging['handlers']['console']['level'] = 'DEBUG'
         logging['formatters']['default']['format'] = '[%(asctime)s] ' + self.LOG_FORMAT
         # Allow Sphinx and other tools to create loggers
         logging['disable_existing_loggers'] = False


### PR DESCRIPTION
In normal settings only log INFO and above,
but in dev we should log DEBUG to console.
This should only output RTD debug messages though,
because others are only logging INFO and above via the logger.