### PR TITLE
Don't fail a build on api timing out

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -133,7 +133,7 @@ class BaseSphinx(BaseBuilder):
                     ]
                 downloads = api.version(self.version.pk).get()['downloads']
             except Timeout:
-                log.info(
+                log.exception(
                     'Timeout while fetching versions and downloads for Sphinx context. '
                     'project: % version: %',
                     self.project.slug, self.version.slug,

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -135,7 +135,7 @@ class BaseSphinx(BaseBuilder):
             except Timeout:
                 log.exception(
                     'Timeout while fetching versions and downloads for Sphinx context. '
-                    'project: % version: %',
+                    'project: %s version: %s',
                     self.project.slug, self.version.slug,
                 )
 


### PR DESCRIPTION
Injecting versions on the sphinx context isn't that crucial,
since we use the footer_api to get them.

ref https://github.com/readthedocs/readthedocs.org/issues/6712#issuecomment-592154048