### PR TITLE
Drop mock dependency

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,6 @@ This version has two major changes:
 * It updates our default docker images to stable=5.0 and latest=6.0.
 * It changes our PR builder domain to `readthedocs.build`
 
-* `@gallowayj <https://github.com/gallowayj>`__: Drop mock as a dependency (`#6665 <https://github.com/readthedocs/readthedocs.org/pull/6665>`__)
 * `@humitos <https://github.com/humitos>`__: Use PUBLIC_DOMAIN_USES_HTTPS for resolver tests (`#6673 <https://github.com/readthedocs/readthedocs.org/pull/6673>`__)
 * `@stsewd <https://github.com/stsewd>`__: Always run CoreTagsTests with http (`#6671 <https://github.com/readthedocs/readthedocs.org/pull/6671>`__)
 * `@ericholscher <https://github.com/ericholscher>`__: Remove old docker settings (`#6670 <https://github.com/readthedocs/readthedocs.org/pull/6670>`__)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ This version has two major changes:
 * It updates our default docker images to stable=5.0 and latest=6.0.
 * It changes our PR builder domain to `readthedocs.build`
 
+* `@gallowayj <https://github.com/gallowayj>`__: Drop mock as a dependency (`#6665 <https://github.com/readthedocs/readthedocs.org/pull/6665>`__)
 * `@humitos <https://github.com/humitos>`__: Use PUBLIC_DOMAIN_USES_HTTPS for resolver tests (`#6673 <https://github.com/readthedocs/readthedocs.org/pull/6673>`__)
 * `@stsewd <https://github.com/stsewd>`__: Always run CoreTagsTests with http (`#6671 <https://github.com/readthedocs/readthedocs.org/pull/6671>`__)
 * `@ericholscher <https://github.com/ericholscher>`__: Remove old docker settings (`#6670 <https://github.com/readthedocs/readthedocs.org/pull/6670>`__)

--- a/readthedocs/config/tests/test_config.py
+++ b/readthedocs/config/tests/test_config.py
@@ -4,7 +4,7 @@ import textwrap
 from collections import OrderedDict
 
 import pytest
-from mock import DEFAULT, patch
+from unittest.mock import DEFAULT, patch
 from pytest import raises
 
 from readthedocs.config import (

--- a/readthedocs/config/tests/test_validation.py
+++ b/readthedocs/config/tests/test_validation.py
@@ -1,6 +1,6 @@
 import os
 
-from mock import patch
+from unittest.mock import patch
 from pytest import raises
 
 from readthedocs.config.validation import (

--- a/readthedocs/gold/tests/test_forms.py
+++ b/readthedocs/gold/tests/test_forms.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import django_dynamic_fixture as fixture
-import mock
+from unittest import mock
 from django.contrib.auth.models import User
 from django.test import TestCase
 

--- a/readthedocs/gold/tests/test_signals.py
+++ b/readthedocs/gold/tests/test_signals.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import django_dynamic_fixture as fixture
-import mock
+from unittest import mock
 from django.contrib.auth.models import User
 from django.test import TestCase
 

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -3,7 +3,7 @@
 import os
 
 import django_dynamic_fixture as fixture
-import mock
+from unittest import mock
 from django.conf import settings
 from django.http import HttpResponse
 from django.test.utils import override_settings

--- a/readthedocs/rtd_tests/base.py
+++ b/readthedocs/rtd_tests/base.py
@@ -11,7 +11,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.test import RequestFactory, TestCase
-from mock import patch
+from unittest.mock import patch
 
 
 log = logging.getLogger(__name__)

--- a/readthedocs/rtd_tests/mocks/environment.py
+++ b/readthedocs/rtd_tests/mocks/environment.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-import mock
+from unittest import mock
 
 
 class EnvironmentMockGroup:

--- a/readthedocs/rtd_tests/mocks/mock_api.py
+++ b/readthedocs/rtd_tests/mocks/mock_api.py
@@ -2,7 +2,7 @@
 import json
 from contextlib import contextmanager
 
-import mock
+from unittest import mock
 
 
 # Mock tastypi API.

--- a/readthedocs/rtd_tests/mocks/paths.py
+++ b/readthedocs/rtd_tests/mocks/paths.py
@@ -3,7 +3,7 @@
 import os
 import re
 
-import mock
+from unittest import mock
 
 
 def fake_paths(check):

--- a/readthedocs/rtd_tests/tests/projects/test_admin_actions.py
+++ b/readthedocs/rtd_tests/tests/projects/test_admin_actions.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import django_dynamic_fixture as fixture
-import mock
+from unittest import mock
 from django import urls
 from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME
 from django.contrib.auth.models import User

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -2,7 +2,7 @@ import base64
 import datetime
 import json
 
-import mock
+from unittest import mock
 from allauth.socialaccount.models import SocialAccount
 from django.contrib.auth.models import User
 from django.http import QueryDict

--- a/readthedocs/rtd_tests/tests/test_api_permissions.py
+++ b/readthedocs/rtd_tests/tests/test_api_permissions.py
@@ -1,7 +1,7 @@
 from functools import partial
 from unittest import TestCase
 
-from mock import Mock
+from unittest.mock import Mock
 
 from readthedocs.api.v2.permissions import APIRestrictedPermission
 

--- a/readthedocs/rtd_tests/tests/test_automation_rules.py
+++ b/readthedocs/rtd_tests/tests/test_automation_rules.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 from django_dynamic_fixture import get
 

--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -7,7 +7,7 @@ import textwrap
 
 import django_dynamic_fixture as fixture
 from django.contrib.auth.models import User
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from readthedocs.builds.constants import EXTERNAL
 from readthedocs.builds.models import Version

--- a/readthedocs/rtd_tests/tests/test_build_forms.py
+++ b/readthedocs/rtd_tests/tests/test_build_forms.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.urls import reverse

--- a/readthedocs/rtd_tests/tests/test_build_notifications.py
+++ b/readthedocs/rtd_tests/tests/test_build_notifications.py
@@ -6,7 +6,7 @@ import json
 import django_dynamic_fixture as fixture
 from django.core import mail
 from django.test import TestCase
-from mock import patch
+from unittest.mock import patch
 
 from readthedocs.builds.models import Build, Version
 from readthedocs.projects.forms import WebHookForm

--- a/readthedocs/rtd_tests/tests/test_builds.py
+++ b/readthedocs/rtd_tests/tests/test_builds.py
@@ -2,7 +2,7 @@
 import datetime
 import os
 
-import mock
+from unittest import mock
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django_dynamic_fixture import fixture, get

--- a/readthedocs/rtd_tests/tests/test_celery.py
+++ b/readthedocs/rtd_tests/tests/test_celery.py
@@ -7,7 +7,7 @@ from allauth.socialaccount.models import SocialAccount
 from django.contrib.auth.models import User
 from django_dynamic_fixture import get
 from messages_extends.models import Message
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from readthedocs.builds.constants import (
     BUILD_STATE_TRIGGERED,

--- a/readthedocs/rtd_tests/tests/test_config_integration.py
+++ b/readthedocs/rtd_tests/tests/test_config_integration.py
@@ -1,12 +1,12 @@
 import tempfile
 from os import path
 
-import mock
+from unittest import mock
 import pytest
 import yaml
 from django.test import TestCase
 from django_dynamic_fixture import get
-from mock import MagicMock, PropertyMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 from readthedocs.builds.constants import BUILD_STATE_TRIGGERED, EXTERNAL
 from readthedocs.builds.models import Version

--- a/readthedocs/rtd_tests/tests/test_core_tags.py
+++ b/readthedocs/rtd_tests/tests/test_core_tags.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 from django.conf import settings
 from django.test import TestCase

--- a/readthedocs/rtd_tests/tests/test_core_utils.py
+++ b/readthedocs/rtd_tests/tests/test_core_utils.py
@@ -2,11 +2,11 @@
 
 import os
 
-import mock
+from unittest import mock
 from django.http import Http404
 from django.test import TestCase
 from django_dynamic_fixture import get
-from mock import call
+from unittest.mock import call
 
 from readthedocs.builds.constants import LATEST
 from readthedocs.builds.models import Version

--- a/readthedocs/rtd_tests/tests/test_doc_builder.py
+++ b/readthedocs/rtd_tests/tests/test_doc_builder.py
@@ -2,14 +2,14 @@ import os
 import tempfile
 from collections import namedtuple
 
-import mock
+from unittest import mock
 import py
 import pytest
 import yaml
 from django.test import TestCase
 from django.test.utils import override_settings
 from django_dynamic_fixture import get
-from mock import patch
+from unittest.mock import patch
 
 from readthedocs.builds.models import Version
 from readthedocs.doc_builder.backends.mkdocs import MkdocsHTML

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -12,13 +12,13 @@ import re
 import tempfile
 import uuid
 
-import mock
+from unittest import mock
 import pytest
 from django.test import TestCase
 from django_dynamic_fixture import get
 from docker.errors import APIError as DockerAPIError
 from docker.errors import DockerException
-from mock import Mock, PropertyMock, mock_open, patch
+from unittest.mock import Mock, PropertyMock, mock_open, patch
 
 from readthedocs.builds.constants import BUILD_STATE_CLONING
 from readthedocs.builds.models import Version

--- a/readthedocs/rtd_tests/tests/test_doc_serving.py
+++ b/readthedocs/rtd_tests/tests/test_doc_serving.py
@@ -1,14 +1,14 @@
 import os
 
 import django_dynamic_fixture as fixture
-import mock
+from unittest import mock
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.http import Http404, HttpResponse
 from django.test import RequestFactory, TestCase
 from django.test.utils import override_settings
 from django.urls import reverse
-from mock import mock_open, patch
+from unittest.mock import mock_open, patch
 
 from readthedocs.builds.constants import LATEST, EXTERNAL, INTERNAL
 from readthedocs.builds.models import Version

--- a/readthedocs/rtd_tests/tests/test_footer.py
+++ b/readthedocs/rtd_tests/tests/test_footer.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from django.contrib.sessions.backends.base import SessionBase
 from django.test import TestCase
 from django.test.utils import override_settings

--- a/readthedocs/rtd_tests/tests/test_imported_file.py
+++ b/readthedocs/rtd_tests/tests/test_imported_file.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
-import mock
+from unittest import mock
 
 from django.conf import settings
 from django.core.files.storage import get_storage_class

--- a/readthedocs/rtd_tests/tests/test_notifications.py
+++ b/readthedocs/rtd_tests/tests/test_notifications.py
@@ -3,7 +3,7 @@
 
 
 import django_dynamic_fixture as fixture
-import mock
+from unittest import mock
 from django.contrib.auth.models import AnonymousUser, User
 from django.http import HttpRequest
 from django.test import TestCase

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase

--- a/readthedocs/rtd_tests/tests/test_oauth_tasks.py
+++ b/readthedocs/rtd_tests/tests/test_oauth_tasks.py
@@ -7,7 +7,7 @@ from allauth.socialaccount.providers.gitlab.views import GitLabOAuth2Adapter
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django_dynamic_fixture import get
-from mock import patch
+from unittest.mock import patch
 
 from readthedocs.builds.models import Version
 from readthedocs.oauth.services.base import SyncServiceError

--- a/readthedocs/rtd_tests/tests/test_privacy.py
+++ b/readthedocs/rtd_tests/tests/test_privacy.py
@@ -1,6 +1,6 @@
 import logging
 
-import mock
+from unittest import mock
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test.utils import override_settings

--- a/readthedocs/rtd_tests/tests/test_privacy_urls.py
+++ b/readthedocs/rtd_tests/tests/test_privacy_urls.py
@@ -1,6 +1,6 @@
 import re
 
-import mock
+from unittest import mock
 from allauth.socialaccount.models import SocialAccount
 from django.contrib.admindocs.views import extract_views_from_urlpatterns
 from django.test import TestCase

--- a/readthedocs/rtd_tests/tests/test_project.py
+++ b/readthedocs/rtd_tests/tests/test_project.py
@@ -6,7 +6,7 @@ from django.forms.models import model_to_dict
 from django.test import TestCase
 from django.utils import timezone
 from django_dynamic_fixture import get
-from mock import patch
+from unittest.mock import patch
 from rest_framework.reverse import reverse
 
 from readthedocs.builds.constants import (

--- a/readthedocs/rtd_tests/tests/test_project_forms.py
+++ b/readthedocs/rtd_tests/tests/test_project_forms.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test.utils import override_settings

--- a/readthedocs/rtd_tests/tests/test_project_symlinks.py
+++ b/readthedocs/rtd_tests/tests/test_project_symlinks.py
@@ -4,7 +4,7 @@ import os
 import shutil
 import tempfile
 
-import mock
+from unittest import mock
 from django.conf import settings
 from django.test import TestCase, override_settings
 from django.urls import reverse

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.views.generic.base import ContextMixin
 from django_dynamic_fixture import get, new
-from mock import patch
+from unittest.mock import patch
 
 from readthedocs.builds.constants import EXTERNAL, LATEST
 from readthedocs.builds.models import Build, Version

--- a/readthedocs/rtd_tests/tests/test_projects_tasks.py
+++ b/readthedocs/rtd_tests/tests/test_projects_tasks.py
@@ -2,7 +2,7 @@ from __future__ import division, print_function, unicode_literals
 
 from django.test import TestCase
 from django_dynamic_fixture import get
-from mock import patch
+from unittest.mock import patch
 
 from readthedocs.builds.constants import EXTERNAL, BUILD_STATUS_SUCCESS
 from readthedocs.builds.models import Version, Build

--- a/readthedocs/rtd_tests/tests/test_resolver.py
+++ b/readthedocs/rtd_tests/tests/test_resolver.py
@@ -1,5 +1,5 @@
 import django_dynamic_fixture as fixture
-import mock
+from unittest import mock
 from django.test import TestCase, override_settings
 
 from readthedocs.core.resolver import (

--- a/readthedocs/rtd_tests/tests/test_subprojects.py
+++ b/readthedocs/rtd_tests/tests/test_subprojects.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import django_dynamic_fixture as fixture
-import mock
+from unittest import mock
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test.utils import override_settings

--- a/readthedocs/rtd_tests/tests/test_sync_versions.py
+++ b/readthedocs/rtd_tests/tests/test_sync_versions.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import json
-import mock
+from unittest import mock
 
 from django.test import TestCase
 from django.urls import reverse

--- a/readthedocs/rtd_tests/tests/test_views.py
+++ b/readthedocs/rtd_tests/tests/test_views.py
@@ -1,7 +1,7 @@
 import csv
 from urllib.parse import urlsplit
 
-import mock
+from unittest import mock
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.urls import reverse

--- a/readthedocs/rtd_tests/tests/versions/test_admin_actions.py
+++ b/readthedocs/rtd_tests/tests/versions/test_admin_actions.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
 import os
-import mock
+from unittest import mock
 
-from mock import call
+from unittest.mock import call
 import django_dynamic_fixture as fixture
 from django.test import TestCase
 from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME

--- a/readthedocs/search/tests/test_search_tasks.py
+++ b/readthedocs/search/tests/test_search_tasks.py
@@ -1,6 +1,6 @@
 """Tests for search tasks."""
 
-import mock
+from unittest import mock
 import pytest
 
 from django.urls import reverse

--- a/readthedocs/vcs_support/tests.py
+++ b/readthedocs/vcs_support/tests.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import unittest
 
-import mock
+from unittest import mock
 
 from readthedocs.vcs_support import utils
 

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -73,7 +73,6 @@ django-gravatar2==1.4.2
 pytz==2019.3
 Unipath==1.1
 django-kombu==0.9.4
-mock==3.0.5
 stripe==2.38.0
 regex==2019.11.1
 


### PR DESCRIPTION
Dropped mock as a dependency to resolve issue #6665 by changing imports of mock to unittest.mock and removing mock from requirements.txt.  