### PR TITLE
Add TOS PDF output

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,6 +62,8 @@ htmlhelp_basename = 'ReadTheDocsdoc'
 latex_documents = [
     ('index', 'ReadTheDocs.tex', u'Read the Docs Documentation',
      u'Eric Holscher, Charlie Leifer, Bobby Grace', 'manual'),
+    ('terms-of-service', 'readthedocs-tos.tex', u'Read the Docs - Terms of Service',
+     u'Read the Docs, Inc', 'manual'),
 ]
 man_pages = [
     ('index', 'read-the-docs', u'Read the Docs Documentation',


### PR DESCRIPTION
Unfortunately, RTD doesn't support this output because it's a secondary
file. You have to generate this file locally, and you have to also
disable `-W` option, as there are warnings that fail the build,
unrelated to this change.