### PR TITLE
Pull only latest image for development

### DIFF
--- a/docs/development/standards.rst
+++ b/docs/development/standards.rst
@@ -105,7 +105,7 @@ After cloning ``readthedocs.org`` repository, you need to
 
    .. prompt:: bash
 
-      inv docker.pull
+      inv docker.pull --only-latest
 
 #. start all the containers:
 
@@ -172,6 +172,7 @@ save some work while typing docker compose commands. This section explains these
 ``inv docker.pull``
     Downloads and tags all the Docker images required for builders.
 
+    * ``--only-latest`` does not pull ``stable`` and ``testing`` images.
 
 Adding a new Python dependency
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
There is no need to pull all the images when developing locally. So, we recommend to just use `--only-latest` on the guide.