### PR TITLE
Use `storage.exists` on HEAD method

### DIFF
--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -133,6 +133,17 @@ class ServeDocsBase(ServeRedirectMixin, ServeDocsMixin, View):
             # Signature and Expire time is calculated per file.
             path += 'index.html'
 
+        if request.method == 'HEAD':
+            # When request method is HEAD we can't use ``storage.url`` because
+            # the signature calculated will consider GET as method.
+            # django-storages does not support passing the HTTP method into
+            # ``storage.url`` yet. Because of this, the response won't be
+            # exactly the same between GET and HEAD since we are not passing
+            # the headers returned by the storage itself.
+            if storage.exists(path):
+                return HttpResponse()
+            raise Http404
+
         storage_url = storage.url(path)  # this will remove the trailing slash
         # URL without scheme and domain to perform an NGINX internal redirect
         parsed_url = urlparse(storage_url)._replace(scheme='', netloc='')


### PR DESCRIPTION
When request method is HEAD we can't use ``storage.url`` because the signature calculated will consider GET as method. `django-storages` does not support passing the HTTP method into ``storage.url`` yet. Because of this, the response won't be exactly the same between GET and HEAD since we are not passing the headers returned by the storage itself.

We just use `storage.exists` and return 200 with an empty body or raise 404.