### PR TITLE
Refactor search view to make use of permission_classes

### DIFF
--- a/readthedocs/api/v2/permissions.py
+++ b/readthedocs/api/v2/permissions.py
@@ -91,7 +91,7 @@ class IsAuthorizedToViewVersion(permissions.BasePermission):
     """
     Checks if the user from the request has permissions to see the version.
 
-    This permission class used in the FooterHTML view.
+    This permission class used in the FooterHTML and PageSearchAPIView views.
 
     .. note::
 

--- a/readthedocs/search/api.py
+++ b/readthedocs/search/api.py
@@ -166,7 +166,7 @@ class PageSearchAPIView(generics.ListAPIView):
         all_projects = []
         for project in list(subprojects) + [main_project]:
             version = (
-                Version.objects
+                Version.internal
                 .public(user=self.request.user, project=project)
                 .filter(slug=main_version.slug)
                 .first()

--- a/readthedocs/search/api.py
+++ b/readthedocs/search/api.py
@@ -153,7 +153,7 @@ class PageSearchAPIView(generics.ListAPIView):
 
     def get_all_projects(self):
         """
-        Return a list containing the project itself and all its subprojects.
+        Return a list containing the project itself and all its subprojects the user has permissions over.
 
         :rtype: list
         """

--- a/readthedocs/search/api.py
+++ b/readthedocs/search/api.py
@@ -124,6 +124,9 @@ class PageSearchAPIView(generics.ListAPIView):
         if not kwargs['filters']['project']:
             log.info("Unable to find a project to search")
             return HTMLFile.objects.none()
+        if not kwargs['filters']['version']:
+            log.info("Unable to find a version to search")
+            return HTMLFile.objects.none()
         user = self.request.user
         queryset = PageSearch(
             query=query, user=user, **kwargs
@@ -157,7 +160,7 @@ class PageSearchAPIView(generics.ListAPIView):
 
     def get_all_projects(self):
         """
-        Return a list containing the project itself and all its subprojects the user has permissions over.
+        Return a list of the project itself and all its subprojects the user has permissions over.
 
         :rtype: list
         """

--- a/readthedocs/search/api.py
+++ b/readthedocs/search/api.py
@@ -120,6 +120,10 @@ class PageSearchAPIView(generics.ListAPIView):
         kwargs = {'filter_by_user': False, 'filters': {}}
         kwargs['filters']['project'] = [p.slug for p in self.get_all_projects()]
         kwargs['filters']['version'] = self._get_version().slug
+        # Check to avoid searching all projects in case project is empty.
+        if not kwargs['filters']['project']:
+            log.info("Unable to find a project to search")
+            return HTMLFile.objects.none()
         user = self.request.user
         queryset = PageSearch(
             query=query, user=user, **kwargs

--- a/readthedocs/search/tests/test_api.py
+++ b/readthedocs/search/tests/test_api.py
@@ -200,11 +200,17 @@ class TestDocumentSearch:
         assert len(resp.data['results']) == 5
 
     def test_doc_search_without_parameters(self, api_client, project):
-        """Hitting Document Search endpoint without query parameters should return error"""
+        """Hitting Document Search endpoint without project and version should return 404."""
         resp = self.get_search(api_client, {})
+        assert resp.status_code == 404
+
+    def test_doc_search_without_query(self, api_client, project):
+        """Hitting Document Search endpoint without a query should return error."""
+        resp = self.get_search(
+            api_client, {'project': project.slug, 'version': project.versions.first().slug})
         assert resp.status_code == 400
         # Check error message is there
-        assert sorted(['q', 'project', 'version']) == sorted(resp.data.keys())
+        assert 'q' in resp.data.keys()
 
     def test_doc_search_subprojects(self, api_client, all_projects):
         """Test Document search return results from subprojects also"""
@@ -256,7 +262,4 @@ class TestDocumentSearch:
             'version': version,
         }
         resp = self.get_search(api_client, search_params)
-        assert resp.status_code == 200
-
-        data = resp.data['results']
-        assert len(data) == 0
+        assert resp.status_code == 404

--- a/readthedocs/search/utils.py
+++ b/readthedocs/search/utils.py
@@ -82,27 +82,6 @@ def remove_indexed_files(model, project_slug, version_slug=None, build_id=None):
         log.exception('Unable to delete a subset of files. Continuing.')
 
 
-# TODO: Rewrite all the views using this in Class Based View,
-# and move this function to a mixin
-def get_project_list_or_404(project_slug, user, version_slug=None):
-    """
-    Return list of project and its subprojects.
-
-    It filters by Version privacy instead of Project privacy,
-    so we can support public versions on private projects.
-    """
-    project_list = []
-    main_project = get_object_or_404(Project, slug=project_slug)
-    subprojects = Project.objects.filter(superprojects__parent_id=main_project.id)
-    for project in list(subprojects) + [main_project]:
-        version = Version.internal.public(user).filter(
-            project__slug=project.slug, slug=version_slug
-        )
-        if version.exists():
-            project_list.append(version.first().project)
-    return project_list
-
-
 def _get_index(indices, index_name):
     """
     Get Index from all the indices.


### PR DESCRIPTION
This is the same as https://github.com/readthedocs/readthedocs.org/pull/6133
but for the search view.

This allows us to override `get_all_projects` in .com
to filter projects using the auth backends.

And make use of the permission class from .com that makes use of the
auth backends.

This doesn't break the current search endpoint in .com
since it filters the versions using `public(user=self.request.user)`

A change is that now when a project or version doesn't exist, a 404 is raised, and we allow search on PR versions.

This is required to proxy search on .com