### PR TITLE
Pull/Push cached environment using storage

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -8,6 +8,7 @@ from shutil import rmtree
 
 import regex
 from django.conf import settings
+from django.core.files.storage import get_storage_class
 from django.db import models
 from django.db.models import F
 from django.urls import reverse
@@ -450,6 +451,11 @@ class Version(models.Model):
             )
 
         return paths
+
+    def get_storage_environment_cache_path(self):
+        """Return the path of the cached environment tar file."""
+        storage = get_storage_class(settings.RTD_BUILD_ENVIRONMENT_STORAGE)()
+        return storage.join(self.project.slug, f'{self.slug}.tar')
 
     def clean_build_path(self):
         """

--- a/readthedocs/core/utils/general.py
+++ b/readthedocs/core/utils/general.py
@@ -2,6 +2,8 @@
 
 import os
 
+from django.conf import settings
+from django.core.files.storage import get_storage_class
 from django.shortcuts import get_object_or_404
 
 from readthedocs.core.utils import broadcast
@@ -24,3 +26,7 @@ def wipe_version_via_slugs(version_slug, project_slug):
     ]
     for del_dir in del_dirs:
         broadcast(type='build', task=remove_dirs, args=[(del_dir,)])
+
+    # Delete the cache environment from storage
+    storage = get_storage_class(settings.RTD_BUILD_ENVIRONMENT_STORAGE)()
+    storage.delete(version.get_storage_environment_cache_path())

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -129,12 +129,15 @@ class PythonEnvironment:
 
         The decision is made considering if the directories are going to be
         cleaned after the build (``RTD_CLEAN_AFTER_BUILD=True`` or project has
-        the ``CLEAN_AFTER_BUILD`` feature enabled). In this case, there is no
-        need to cache anything.
+        the ``CLEAN_AFTER_BUILD`` feature enabled) and project has not the
+        feature ``CACHED_ENVIRONMENT``. In this case, there is no need to cache
+        anything.
         """
         if (
-            settings.RTD_CLEAN_AFTER_BUILD or
-            self.project.has_feature(Feature.CLEAN_AFTER_BUILD)
+            (
+                settings.RTD_CLEAN_AFTER_BUILD or
+                self.project.has_feature(Feature.CLEAN_AFTER_BUILD)
+            ) and not self.project.has_feature(Feature.CACHED_ENVIRONMENT)
         ):
             return [
                 '--no-cache-dir',

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1515,6 +1515,7 @@ class Feature(models.Model):
     SKIP_SYNC_TAGS = 'skip_sync_tags'
     SKIP_SYNC_BRANCHES = 'skip_sync_branches'
     SKIP_SYNC = 'skip_sync'
+    CACHED_ENVIRONMENT = 'cached_environment'
 
     FEATURES = (
         (USE_SPHINX_LATEST, _('Use latest version of Sphinx')),
@@ -1584,6 +1585,10 @@ class Feature(models.Model):
         (
             SKIP_SYNC,
             _('Skip symlinking and file syncing to webs'),
+        ),
+        (
+            CACHED_ENVIRONMENT,
+            _('Cache the environment (virtualenv, conda, pip cache, repository) in storage'),
         ),
     )
 

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -124,8 +124,8 @@ class CachedEnvironmentMixin:
             with open(tmp_filename, mode='wb') as local_fd:
                     local_fd.write(remote_fd.read())
 
-            tar = tarfile.TarFile(tmp_filename)
-            tar.extractall(self.version.project.doc_path)
+            with tarfile.open(tmp_filename) as tar:
+                tar.extractall(self.version.project.doc_path)
 
             # Cleanup the temporary file
             if os.path.exists(tmp_filename):

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -119,7 +119,7 @@ class CachedEnvironmentMixin:
                     'msg': msg,
                 }
             )
-            tmp_filename = tempfile.mktemp(suffix='.tar')
+            tmp_filename = tempfile.mkstemp(suffix='.tar')
             remote_fd = storage.open(filename, mode='rb')
             with open(tmp_filename, mode='wb') as local_fd:
                     local_fd.write(remote_fd.read())
@@ -140,7 +140,7 @@ class CachedEnvironmentMixin:
             os.path.join(project_path, '.cache'),
         ]
 
-        tmp_filename = tempfile.mktemp(suffix='.tar')
+        tmp_filename = tempfile.mkstemp(suffix='.tar')
         # open just with 'w', to not compress and waste CPU cycles
         with tarfile.open(tmp_filename, 'w') as tar:
             for path in paths:

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -127,6 +127,9 @@ class CachedEnvironmentMixin:
             tar = tarfile.TarFile(tmp_filename)
             tar.extractall(self.version.project.doc_path)
 
+            # Cleanup the temporary file
+            if os.path.exists(tmp_filename):
+                os.remove(tmp_filename)
 
     def push_cached_environment(self):
         if not self.project.has_feature(feature_id=Feature.CACHED_ENVIRONMENT):
@@ -168,6 +171,10 @@ class CachedEnvironmentMixin:
                 self.version.get_storage_environment_cache_path(),
                 fd,
             )
+
+        # Cleanup the temporary file
+        if os.path.exists(tmp_filename):
+            os.remove(tmp_filename)
 
 
 class SyncRepositoryMixin:

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -122,7 +122,7 @@ class CachedEnvironmentMixin:
             tmp_filename = tempfile.mkstemp(suffix='.tar')
             remote_fd = storage.open(filename, mode='rb')
             with open(tmp_filename, mode='wb') as local_fd:
-                    local_fd.write(remote_fd.read())
+                local_fd.write(remote_fd.read())
 
             with tarfile.open(tmp_filename) as tar:
                 tar.extractall(self.version.project.doc_path)
@@ -158,7 +158,7 @@ class CachedEnvironmentMixin:
 
         storage = get_storage_class(settings.RTD_BUILD_ENVIRONMENT_STORAGE)()
         with open(tmp_filename, 'rb') as fd:
-            msg = 'Pushing up cached environment to storage',
+            msg = 'Pushing up cached environment to storage'
             log.info(
                 LOG_TEMPLATE,
                 {

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -361,6 +361,11 @@ class SyncRepositoryTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
             with environment:
                 before_vcs.send(sender=self.version, environment=environment)
                 with self.project.repo_nonblockinglock(version=self.version):
+                    # When syncing we are only pulling the cached environment
+                    # (without pushing it after it's updated). We only clone the
+                    # repository in this step, and pushing it back will delete
+                    # all the other cached things (Python packages, Sphinx,
+                    # virtualenv, etc)
                     self.pull_cached_environment()
                     self.sync_repo(environment)
             return True

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -119,7 +119,7 @@ class CachedEnvironmentMixin:
                     'msg': msg,
                 }
             )
-            tmp_filename = tempfile.mkstemp(suffix='.tar')
+            _, tmp_filename = tempfile.mkstemp(suffix='.tar')
             remote_fd = storage.open(filename, mode='rb')
             with open(tmp_filename, mode='wb') as local_fd:
                 local_fd.write(remote_fd.read())
@@ -143,7 +143,7 @@ class CachedEnvironmentMixin:
             os.path.join(project_path, '.cache'),
         ]
 
-        tmp_filename = tempfile.mkstemp(suffix='.tar')
+        _, tmp_filename = tempfile.mkstemp(suffix='.tar')
         # open just with 'w', to not compress and waste CPU cycles
         with tarfile.open(tmp_filename, 'w') as tar:
             for path in paths:

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -259,6 +259,7 @@ class CommunityBaseSettings(Settings):
     # Django Storage subclass used to write build artifacts to cloud or local storage
     # https://docs.readthedocs.io/page/development/settings.html#rtd-build-media-storage
     RTD_BUILD_MEDIA_STORAGE = 'readthedocs.builds.storage.BuildMediaFileSystemStorage'
+    RTD_BUILD_ENVIRONMENT_STORAGE = 'readthedocs.builds.storage.BuildMediaFileSystemStorage'
 
     TEMPLATES = [
         {

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -117,6 +117,8 @@ class DockerBaseSettings(CommunityDevSettings):
     RTD_BUILD_MEDIA_STORAGE = 'readthedocs.storage.azure_storage.AzureBuildMediaStorage'
     AZURE_STATIC_STORAGE_HOSTNAME = PRODUCTION_DOMAIN
 
+    RTD_BUILD_ENVIRONMENT_STORAGE = 'readthedocs.storage.azure_storage.AzureBuildEnvironmentStorage'
+
     # Storage for static files (those collected with `collectstatic`)
     STATICFILES_STORAGE = 'readthedocs.storage.azure_storage.AzureStaticStorage'
 

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -117,6 +117,7 @@ class DockerBaseSettings(CommunityDevSettings):
     RTD_BUILD_MEDIA_STORAGE = 'readthedocs.storage.azure_storage.AzureBuildMediaStorage'
     AZURE_STATIC_STORAGE_HOSTNAME = PRODUCTION_DOMAIN
 
+    # Storage backend for build cached environments
     RTD_BUILD_ENVIRONMENT_STORAGE = 'readthedocs.storage.azure_storage.AzureBuildEnvironmentStorage'
 
     # Storage for static files (those collected with `collectstatic`)

--- a/readthedocs/storage/azure_storage.py
+++ b/readthedocs/storage/azure_storage.py
@@ -28,6 +28,11 @@ class AzureBuildStorage(AzureStorage):
     azure_container = getattr(settings, 'AZURE_BUILD_STORAGE_CONTAINER', None) or 'builds'
 
 
+class AzureBuildEnvironmentStorage(BuildMediaStorageMixin, AzureStorage):
+
+    azure_container = getattr(settings, 'AZURE_BUILD_ENVIRONMENT_STORAGE_CONTAINER', None) or 'envs'
+
+
 class AzureStaticStorage(OverrideHostnameMixin, ManifestFilesMixin, AzureStorage):
 
     """


### PR DESCRIPTION
Before starting clonig the repository we check of a cached environment in the storage. If there is one, we pull it and extract it under `project.doc_path` (using the same structure that we have been using) and use those cached files.

Once the build has finished and it was successful, we compress all the environment files (pip cache, checkout, conda and virtualenv environments) and push it to the storage.

The cached is cleaned up when the version is wiped.

This feature is under a Feature flag (`CACHED_ENVIRONMENT`), so we can select specific projects to start testing out this cached environment. It can help on projects with big/huge repositories or that install a lot of dependencies.