### PR TITLE
Use the hotfixed version of django-messages-extends

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -91,7 +91,8 @@ nltk==3.4.5
 textblob==0.15.3
 
 django-annoying==0.10.5
-django-messages-extends==0.6.0
+# Messages-extends needs a fix for Django 2.2 which isn't released (0.6.1 isn't out yet)
+git+https://github.com/AliLozano/django-messages-extends.git@b1e4f4c#egg=django-messages-extends==0.6.0
 djangorestframework-jsonp==1.0.2
 django-taggit==1.1.0
 dj-pagination==2.4.0


### PR DESCRIPTION
- This version isn't released yet
- This is needed to delete these permanent messages in Django 2.2