### PR TITLE
Upgrade django-storages to support URLs with more http methods

### DIFF
--- a/readthedocs/builds/storage.py
+++ b/readthedocs/builds/storage.py
@@ -186,3 +186,16 @@ class BuildMediaFileSystemStorage(BuildMediaStorageMixin, FileSystemStorage):
         if not self.exists(path):
             return [], []
         return super().listdir(path)
+
+    def url(self, name, *args, **kwargs):  # noqa
+        """
+        Override to accept extra arguments and ignore them all.
+
+        This method helps us to bring compatibility between Azure Blob Storage
+        (which does not use the HTTP method) and Amazon S3 (who requires HTTP
+        method to build the signed URL).
+
+        ``FileSystemStorage`` does not support any other argument than ``name``.
+        https://docs.djangoproject.com/en/2.2/ref/files/storage/#django.core.files.storage.Storage.url
+        """
+        return super().url(name)

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -133,18 +133,7 @@ class ServeDocsBase(ServeRedirectMixin, ServeDocsMixin, View):
             # Signature and Expire time is calculated per file.
             path += 'index.html'
 
-        if request.method == 'HEAD':
-            # When request method is HEAD we can't use ``storage.url`` because
-            # the signature calculated will consider GET as method.
-            # django-storages does not support passing the HTTP method into
-            # ``storage.url`` yet. Because of this, the response won't be
-            # exactly the same between GET and HEAD since we are not passing
-            # the headers returned by the storage itself.
-            if storage.exists(path):
-                return HttpResponse()
-            raise Http404
-
-        storage_url = storage.url(path)  # this will remove the trailing slash
+        storage_url = storage.url(path, http_method=request.method)  # this will remove the trailing slash
         # URL without scheme and domain to perform an NGINX internal redirect
         parsed_url = urlparse(storage_url)._replace(scheme='', netloc='')
         final_url = parsed_url.geturl()

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -133,7 +133,9 @@ class ServeDocsBase(ServeRedirectMixin, ServeDocsMixin, View):
             # Signature and Expire time is calculated per file.
             path += 'index.html'
 
-        storage_url = storage.url(path, http_method=request.method)  # this will remove the trailing slash
+        # NOTE: calling ``.url`` will remove the trailing slash
+        storage_url = storage.url(path, http_method=request.method)
+
         # URL without scheme and domain to perform an NGINX internal redirect
         parsed_url = urlparse(storage_url)._replace(scheme='', netloc='')
         final_url = parsed_url.geturl()

--- a/readthedocs/storage/azure_storage.py
+++ b/readthedocs/storage/azure_storage.py
@@ -21,6 +21,17 @@ class AzureBuildMediaStorage(BuildMediaStorageMixin, OverrideHostnameMixin, Azur
     override_hostname = getattr(settings, 'AZURE_MEDIA_STORAGE_HOSTNAME', None)
 
 
+    def url(self, name, expire=None, http_method=None):
+        """
+        Override to accept ``http_method`` and ignore it.
+
+        This method helps us to bring compatibility between Azure Blob Storage
+        (which does not use the HTTP method) and Amazon S3 (who requires HTTP
+        method to build the signed URL).
+        """
+        return super().url(name, expire)
+
+
 class AzureBuildStorage(AzureStorage):
 
     """An Azure Storage backend for build cold storage."""

--- a/readthedocs/storage/azure_storage.py
+++ b/readthedocs/storage/azure_storage.py
@@ -20,8 +20,7 @@ class AzureBuildMediaStorage(BuildMediaStorageMixin, OverrideHostnameMixin, Azur
     azure_container = getattr(settings, 'AZURE_MEDIA_STORAGE_CONTAINER', None) or 'media'
     override_hostname = getattr(settings, 'AZURE_MEDIA_STORAGE_HOSTNAME', None)
 
-
-    def url(self, name, expire=None, http_method=None):
+    def url(self, name, expire=None, http_method=None):  # noqa
         """
         Override to accept ``http_method`` and ignore it.
 

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -106,9 +106,10 @@ django-cors-middleware==1.4.0
 user-agents==2.0
 
 # Utilities used to upload build media to cloud storage
-django-storages[azure]==1.7.2
-azure-storage-blob==1.5.0
-azure-storage-common==1.4.2
+# django-storages is pinned to this particular commit because it
+# supports generating URLs with other method than GET when using
+# private buckets
+git+https://github.com/jschneier/django-storages@d0f027c98a877f75615cfc42b4d51c038fa41bf6#egg=django-storages[azure]==1.9.1
 
 # Required only in development and linting
 django-debug-toolbar==2.0


### PR DESCRIPTION
This PR upgrades django-storages to a not yet released version to support HEAD method when generating storage URLs that are private (include signed tokens).

I checked the changelog and there is nothing breaking as far as I can tell. All the tests that I did locally using Azurite worked properly.

Note that I'm removing `azure-storage-blob` and `azure-storage-common` from our pinned versions because those are correctly specified on django-storage dependencies as `azure-storage-blob >=1.3.1,<12.0.0`.

I'm interesting on merging this sooner than later, so we can have a week or similar of testing locally before deploying it. Best way to test this is to pull down the PR, re-generate the docker image completely (without cache: `inv docker.build`) and do some storage related operations (build, serve docs, wipe, collectstatic, etc)