### PR TITLE
Update guide about building consuming too much resources

### DIFF
--- a/docs/guides/build-using-too-many-resources.rst
+++ b/docs/guides/build-using-too-many-resources.rst
@@ -42,17 +42,6 @@ when using multiple channels.
    So, in this case, you could use ``pip`` to install those fewer packages instead of creating a big environment with ``conda``.
 
 
-Use system site-packages for pre-installed libs
------------------------------------------------
-
-There are a few libraries that Read the Docs has already installed (scipy, numpy, matplotlib, pandas, etc)
-in the Docker image used to build your docs. You can check the updated list of pre-installed libraries in the `Docker image repository`_.
-
-To use these pre-installed libraries and avoid consuming time re-downloading/compiling them,
-you can use the :ref:`config-file/v2:python.system_packages` option to have access to them.
-
-.. _Docker image repository: https://github.com/readthedocs/readthedocs-docker-images
-
 Requests more resources
 -----------------------
 

--- a/docs/guides/build-using-too-many-resources.rst
+++ b/docs/guides/build-using-too-many-resources.rst
@@ -41,6 +41,14 @@ when using multiple channels.
    That is, to build the documentation is probably that you need fewer Python packages than to use your library itself.
    So, in this case, you could use ``pip`` to install those fewer packages instead of creating a big environment with ``conda``.
 
+Document Python modules API statically
+--------------------------------------
+
+If you are installing a lot of Python dependencies just to document your Python modules API using ``sphinx.ext.autodoc``,
+you can give a try to `sphinx-autoapi`_ Sphinx's extension instead which should produce the exact same output but running statically.
+This could drastically reduce the memory and bandwidth required to build your docs.
+
+.. _sphinx-autoapi: https://sphinx-autoapi.readthedocs.io/
 
 Requests more resources
 -----------------------


### PR DESCRIPTION
This PR,

- removes the mention about system site-packages because we don't really support them
  - it's impossible to know what versions are installed in the images
  - those packages do not generate any problem related to build resources
  - if we want to go in that direction, we may want to install `torch`, `tensorflow`, etc. See #6742 
- add a new section about `sphinx-autoapi` that we have been recommending it on many different issues already, and it makes sense just to have it documented there as well