### PR TITLE
Perform redirects at db level

### DIFF
--- a/readthedocs/redirects/querysets.py
+++ b/readthedocs/redirects/querysets.py
@@ -1,6 +1,8 @@
 """Queryset for the redirects app."""
 
 from django.db import models
+from django.db.models import Value, CharField, IntegerField, Q, F, ExpressionWrapper
+from django.db.models.functions import Substr, Length
 
 from readthedocs.core.utils.extend import SettingsOverrideObject
 
@@ -25,7 +27,79 @@ class RedirectQuerySetBase(models.QuerySet):
         return queryset
 
     def get_redirect_path_with_status(self, path, full_path=None, language=None, version_slug=None):
-        for redirect in self.select_related('project'):
+        # add extra fields with the ``path`` and ``full_path`` to perform a
+        # filter at db level instead with Python
+        queryset = self.annotate(
+            path=Value(
+                path,
+                output_field=CharField(),
+            ),
+            full_path=Value(
+                full_path,
+                output_field=CharField(),
+            ),
+
+            from_url_length=ExpressionWrapper(
+                Length('from_url'),
+                output_field=IntegerField(),
+            ),
+
+            # 1-indexed
+            from_url_without_rest=Substr(
+                'from_url',
+                1,
+                F('from_url_length') - 5,  # Strip "$rest"
+                output_field=CharField(),
+            ),
+
+            # 1-indexed
+            full_path_without_rest=Substr(
+                'full_path',
+                1,
+                F('from_url_length') - 5,  # Strip "$rest"
+                output_field=CharField(),
+            ),
+        )
+        prefix = Q(
+            redirect_type='prefix',
+            path__startswith=F('from_url'),
+        )
+        page = Q(
+            redirect_type='page',
+            path__iexact=F('from_url'),
+        )
+        exact = (
+            Q(
+                redirect_type='exact',
+                from_url__endswith='$rest',
+                # This works around a bug in Django doing a substr and an endswith,
+                # so instead we do 2 substrs and an exact
+                # https://code.djangoproject.com/ticket/29155
+                full_path_without_rest=F('from_url_without_rest'),
+            ) | Q(
+                redirect_type='exact',
+                full_path__iexact=F('from_url'),
+            )
+        )
+        sphinx_html = (
+            Q(
+                redirect_type='sphinx_html',
+                path__endswith='/',
+            ) | Q(
+                redirect_type='sphinx_html',
+                path__endswith='/index.html',
+            )
+        )
+        sphinx_htmldir = Q(
+            redirect_type='sphinx_htmldir',
+            path__endswith='.html',
+        )
+
+        # There should be one and only one redirect returned by this query. I
+        # can't think in a case where there can be more at this point. I'm
+        # leaving the loop just in case for now
+        queryset = queryset.filter(prefix | page | exact | sphinx_html | sphinx_htmldir)
+        for redirect in queryset.select_related('project'):
             new_path = redirect.get_redirect_path(
                 path=path,
                 language=language,


### PR DESCRIPTION
This is another attempt to perform redirects at DB level and be able to put them at Proxito level, allowing to redirect to be executed not only on 404s.

It continues the work we did at #6398 but that we reverted at #6430 because we found an issue with Exact Redirects with `from_url` smaller than 5 chars long. This PR workarounds that case, giving us the opportunity to keep exploring this idea of performing redirects at DB level.