### PR TITLE
Revert "Add feature flag to just completely skip sync and symlink operations (#6689)"

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -319,24 +319,21 @@ class Version(models.Model):
         """Add permissions to the Version for all owners on save."""
         from readthedocs.projects import tasks
         obj = super().save(*args, **kwargs)
-        if not self.project.has_feature(feature_id='skip_sync'):
-            broadcast(
-                type='app',
-                task=tasks.symlink_project,
-                args=[self.project.pk],
-            )
+        broadcast(
+            type='app',
+            task=tasks.symlink_project,
+            args=[self.project.pk],
+        )
         return obj
 
     def delete(self, *args, **kwargs):  # pylint: disable=arguments-differ
         from readthedocs.projects import tasks
         log.info('Removing files for version %s', self.slug)
-        has_skip_sync = self.project.has_feature(feature_id='skip_sync')
-        if not has_skip_sync:
-            broadcast(
-                type='app',
-                task=tasks.remove_dirs,
-                args=[self.get_artifact_paths()],
-            )
+        broadcast(
+            type='app',
+            task=tasks.remove_dirs,
+            args=[self.get_artifact_paths()],
+        )
 
         # Remove resources if the version is not external
         if self.type != EXTERNAL:
@@ -344,12 +341,11 @@ class Version(models.Model):
 
         project_pk = self.project.pk
         super().delete(*args, **kwargs)
-        if not has_skip_sync:
-            broadcast(
-                type='app',
-                task=tasks.symlink_project,
-                args=[project_pk],
-            )
+        broadcast(
+            type='app',
+            task=tasks.symlink_project,
+            args=[project_pk],
+        )
 
     @property
     def identifier_friendly(self):

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1578,8 +1578,8 @@ class Feature(models.Model):
             _('Skip syncing branches'),
         ),
         (
-            SKIP_SYNC,
-            _('Skip symlinking and file syncing to webs'),
+            SKIP_SYNC_TAGS,
+            _('Skip syncing tags'),
         ),
         (
             CACHED_ENVIRONMENT,

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1514,7 +1514,6 @@ class Feature(models.Model):
     ALL_VERSIONS_IN_HTML_CONTEXT = 'all_versions_in_html_context'
     SKIP_SYNC_TAGS = 'skip_sync_tags'
     SKIP_SYNC_BRANCHES = 'skip_sync_branches'
-    SKIP_SYNC = 'skip_sync'
     CACHED_ENVIRONMENT = 'cached_environment'
 
     FEATURES = (
@@ -1573,10 +1572,6 @@ class Feature(models.Model):
                 'Pass all versions (including private) into the html context '
                 'when building with Sphinx'
             ),
-        ),
-        (
-            SKIP_SYNC_TAGS,
-            _('Skip syncing tags'),
         ),
         (
             SKIP_SYNC_BRANCHES,

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1276,8 +1276,6 @@ def sync_files(
     version = Version.objects.get_object_or_log(pk=version_pk)
     if not version:
         return
-    if version.project.has_feature(Feature.SKIP_SYNC):
-        return
 
     # Sync files to the web servers
     move_files(
@@ -1428,8 +1426,6 @@ def move_files(
 @app.task(queue='web')
 def symlink_project(project_pk):
     project = Project.objects.get(pk=project_pk)
-    if project.has_feature(Feature.SKIP_SYNC):
-        return
     for symlink in [PublicSymlink, PrivateSymlink]:
         sym = symlink(project=project)
         sym.run()
@@ -1446,8 +1442,6 @@ def symlink_domain(project_pk, domain, delete=False):
     :type domain: str
     """
     project = Project.objects.get(pk=project_pk)
-    if project.has_feature(Feature.SKIP_SYNC):
-        return
     for symlink in [PublicSymlink, PrivateSymlink]:
         sym = symlink(project=project)
         if delete:


### PR DESCRIPTION
We don't need this logic anymore,
since the SKIP_TAGS feature flag solves this with less code overhead