### PR TITLE
Skip .cache directory for cached builds if it does not exist

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -157,7 +157,8 @@ class CachedEnvironmentMixin:
 
             # Special handling for .cache directory because it's per-project
             path = os.path.join(project_path, '.cache')
-            tar.add(path, arcname='.cache')
+            if os.path.exists(path):
+                tar.add(path, arcname='.cache')
 
         storage = get_storage_class(settings.RTD_BUILD_ENVIRONMENT_STORAGE)()
         with open(tmp_filename, 'rb') as fd:


### PR DESCRIPTION
Small fix to avoid adding the `.cache` directory if it does not exists. This is the case of project using `conda` to build their docs.