### PR TITLE
Do not reset the build start time when running build env

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -548,6 +548,7 @@ class BuildEnvironment(BaseEnvironment):
             record=True,
             environment=None,
             update_on_success=True,
+            start_time=None,
     ):
         super().__init__(project, environment)
         self.version = version
@@ -557,7 +558,7 @@ class BuildEnvironment(BaseEnvironment):
         self.update_on_success = update_on_success
 
         self.failure = None
-        self.start_time = datetime.utcnow()
+        self.start_time = start_time or datetime.utcnow()
 
     def __enter__(self):
         return self

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -473,6 +473,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
         if config is not None:
             self.config = config
         self.task = task
+        self.build_start_time = None
         # TODO: remove this
         self.setup_env = None
 
@@ -577,6 +578,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
             update_on_success=False,
             environment=self.get_rtd_env_vars(),
         )
+        self.build_start_time = environment.start_time
 
         # TODO: Remove.
         # There is code that still depends of this attribute
@@ -667,6 +669,9 @@ class UpdateDocsTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
             build=self.build,
             record=record,
             environment=env_vars,
+
+            # Pass ``start_time`` here to not reset the timer
+            start_time=self.build_start_time,
         )
 
         # Environment used for building code, usually with Docker


### PR DESCRIPTION
We are creating one Setup Environment and another Build Environment.
Once each of them is created they define the `start_time` which is UTC
now. Then they use the `start_time` to calculate the `length` of the
build each time the build object is updated via the API.

Since the Build Environment calls again UTC now, we override the old
`start_time` and we loose track of the timing for the Setup
Environment (close repository, among others).

This commit saves the original `start_time` and passes it to the Build
Environment so it continues calculating the difference for the
`length` considering the Setup Environment times as well.

Related to #6793