### PR TITLE
Check 404 page once when slug and default_version is the same

### DIFF
--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -261,7 +261,7 @@ class ServeError404Base(ServeRedirectMixin, ServeDocsMixin, View):
         # If that doesn't work, attempt to serve the 404 of the current version (version_slug)
         # Secondly, try to serve the 404 page for the default version
         # (project.get_default_version())
-        for version_slug_404 in [version_slug, final_project.get_default_version()]:
+        for version_slug_404 in set([version_slug, final_project.get_default_version()]):
             for tryfile in ('404.html', '404/index.html'):
                 storage_root_path = final_project.get_storage_path(
                     type_='html',


### PR DESCRIPTION
I found that when the version being accessed is the same as the default version of the project, we are checking twice for the existence of the same files.