### PR TITLE
Use `conda env update --prune` to re-use the conda environment

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -479,18 +479,37 @@ class Conda(PythonEnvironment):
             self._append_core_requirements()
             self._show_environment_yaml()
 
-        self.build_env.run(
-            'conda',
-            'env',
-            'create',
-            '--quiet',
-            '--name',
-            self.version.slug,
-            '--file',
-            self.config.conda.environment,
-            bin_path=None,  # Don't use conda bin that doesn't exist yet
-            cwd=self.checkout_path,
-        )
+        if self.project.has_feature(Feature.CONDA_UPDATE_ENVIRONMENT):
+            # ``conda env update`` will create the environment or update the
+            # requirements from an environment already created and cached,
+            # prunning the requirements that are not in the environment file
+            # anymore
+            self.build_env.run(
+                'conda',
+                'env',
+                'update',
+                '--quiet',
+                '--name',
+                self.version.slug,
+                '--file',
+                self.config.conda.environment,
+                '--prune',
+                bin_path=None,  # Don't use conda bin that doesn't exist yet
+                cwd=self.checkout_path,
+            )
+        else:
+            self.build_env.run(
+                'conda',
+                'env',
+                'create',
+                '--quiet',
+                '--name',
+                self.version.slug,
+                '--file',
+                self.config.conda.environment,
+                bin_path=None,  # Don't use conda bin that doesn't exist yet
+                cwd=self.checkout_path,
+            )
 
     def _show_environment_yaml(self):
         """Show ``environment.yml`` file in the Build output."""

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1515,6 +1515,7 @@ class Feature(models.Model):
     SKIP_SYNC_TAGS = 'skip_sync_tags'
     SKIP_SYNC_BRANCHES = 'skip_sync_branches'
     CACHED_ENVIRONMENT = 'cached_environment'
+    CONDA_UPDATE_ENVIRONMENT = 'conda_update_environment'
 
     FEATURES = (
         (USE_SPHINX_LATEST, _('Use latest version of Sphinx')),
@@ -1584,6 +1585,10 @@ class Feature(models.Model):
         (
             CACHED_ENVIRONMENT,
             _('Cache the environment (virtualenv, conda, pip cache, repository) in storage'),
+        ),
+        (
+            CONDA_UPDATE_ENVIRONMENT,
+            _('Use `conda env update --prune` instead of `conda env create` to re-use the environment'),
         ),
     )
 


### PR DESCRIPTION
This is similar to what we are doing with pip already: instead of creating the environment from scratch on each build, we can re-use the one that was created before.

The option `--prune` will remove all the packages that were removed from the environment.yml file.

> Under a feature flag so we can start testing it without affecting all the projects

https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#updating-an-environment