### PR TITLE
Respect order when serving 404 (version -> default_version)

### DIFF
--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -261,7 +261,11 @@ class ServeError404Base(ServeRedirectMixin, ServeDocsMixin, View):
         # If that doesn't work, attempt to serve the 404 of the current version (version_slug)
         # Secondly, try to serve the 404 page for the default version
         # (project.get_default_version())
-        for version_slug_404 in set([version_slug, final_project.get_default_version()]):
+        versions = [version_slug]
+        default_version_slug = final_project.get_default_version()
+        if default_version_slug != version_slug:
+            versions.append(default_version_slug)
+        for version_slug_404 in versions:
             for tryfile in ('404.html', '404/index.html'):
                 storage_root_path = final_project.get_storage_path(
                     type_='html',


### PR DESCRIPTION
This is also why tests are failing randomly, a set doesn't keep the
order.