### PR TITLE
Add feature flag letting us ignore `/projects/` on subproject URLs

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1515,6 +1515,7 @@ class Feature(models.Model):
     SKIP_SYNC_TAGS = 'skip_sync_tags'
     SKIP_SYNC_BRANCHES = 'skip_sync_branches'
     CACHED_ENVIRONMENT = 'cached_environment'
+    PROXITO_SUBPROJECT_PATH = 'proxito_subproject_path'
 
     FEATURES = (
         (USE_SPHINX_LATEST, _('Use latest version of Sphinx')),
@@ -1584,6 +1585,10 @@ class Feature(models.Model):
         (
             CACHED_ENVIRONMENT,
             _('Cache the environment (virtualenv, conda, pip cache, repository) in storage'),
+        ),
+        (
+            PROXITO_SUBPROJECT_PATH,
+            _('Remove /projects/ from subproject path'),
         ),
     )
 

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -290,7 +290,8 @@ class TestAdditionalDocViews(BaseDocServing):
         self.project.versions.update(active=True, built=True)
         # Confirm we've serving from storage for the `index-exists/index.html` file
         response = self.client.get(
-            reverse('proxito_404_handler', kwargs={'proxito_path': '/en/latest/index-exists?foo=bar'}),
+            reverse('proxito_404_handler', kwargs={
+                    'proxito_path': '/en/latest/index-exists?foo=bar'}),
             HTTP_HOST='project.readthedocs.io',
         )
         self.assertEqual(
@@ -472,7 +473,7 @@ class TestAdditionalDocViews(BaseDocServing):
         self.subproject.versions.update(active=True, built=True)
         feat = Feature.objects.create(feature_id=Feature.PROXITO_SUBPROJECT_PATH)
         feat.projects.add(self.project)
-        # Confirm we've serving from storage for the `index-exists/index.html` file
+
         response = self.client.get('/subproject/en/latest/t.html',
                                    HTTP_HOST='project.readthedocs.io',
                                    )
@@ -485,7 +486,7 @@ class TestAdditionalDocViews(BaseDocServing):
         self.subproject.versions.update(active=True, built=True)
         feat = Feature.objects.create(feature_id=Feature.PROXITO_SUBPROJECT_PATH)
         feat.projects.add(self.project)
-        # Confirm we've serving from storage for the `index-exists/index.html` file
+
         response = self.client.get('/invalid_subproject/en/latest/t.html',
                                    HTTP_HOST='project.readthedocs.io',
                                    )


### PR DESCRIPTION
This is in production on .com for a customer,
and now this will let us turn it on for users in general.