### PR TITLE
Show "Uploading" build state when uploading artifacts into storage

### DIFF
--- a/readthedocs/builds/constants.py
+++ b/readthedocs/builds/constants.py
@@ -9,6 +9,7 @@ BUILD_STATE_PULLING_CACHE = 'pulling-cache'
 BUILD_STATE_CLONING = 'cloning'
 BUILD_STATE_INSTALLING = 'installing'
 BUILD_STATE_BUILDING = 'building'
+BUILD_STATE_UPLOADING = 'uploading'
 BUILD_STATE_PUSHING_CACHE = 'pushing-cache'
 BUILD_STATE_FINISHED = 'finished'
 
@@ -18,6 +19,7 @@ BUILD_STATE = (
     (BUILD_STATE_CLONING, _('Cloning')),
     (BUILD_STATE_INSTALLING, _('Installing')),
     (BUILD_STATE_BUILDING, _('Building')),
+    (BUILD_STATE_UPLOADING, _('Uploading')),
     (BUILD_STATE_PUSHING_CACHE, _('Pushing cache')),
     (BUILD_STATE_FINISHED, _('Finished')),
 )

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -35,6 +35,7 @@ from readthedocs.builds.constants import (
     BUILD_STATE_INSTALLING,
     BUILD_STATE_PULLING_CACHE,
     BUILD_STATE_PUSHING_CACHE,
+    BUILD_STATE_UPLOADING,
     BUILD_STATUS_SUCCESS,
     BUILD_STATUS_FAILURE,
     LATEST,
@@ -727,6 +728,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
                         localmedia=bool(outcomes['localmedia']),
                         pdf=bool(outcomes['pdf']),
                         epub=bool(outcomes['epub']),
+                        environment=self.build_env,
                     )
 
                     # Finalize build and update web servers
@@ -965,6 +967,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
             )
             return
 
+        environment.update_build(BUILD_STATE_UPLOADING)
         storage = get_storage_class(settings.RTD_BUILD_MEDIA_STORAGE)()
         log.info(
             LOG_TEMPLATE,


### PR DESCRIPTION
Now, it will show "Uploading" before start performing the upload of build artifacts to the storage.

> NOTE: this PR is branched off of https://github.com/readthedocs/readthedocs.org/pull/6800. So, we will want to merge this one there or change base to master once the other one is merged.

This PR is missing the migration that will just add a new choice in the field.