### PR TITLE
Use django autoreload to restart celery workers

### DIFF
--- a/readthedocs/builds/signals.py
+++ b/readthedocs/builds/signals.py
@@ -2,7 +2,28 @@
 
 """Build signals."""
 
-import django.dispatch
+import logging
+import os
+
+from django.conf import settings
+from django.dispatch import receiver, Signal
+from django.utils.autoreload import file_changed
+
+from readthedocs.worker import app
+
+build_complete = Signal(providing_args=['build'])
 
 
-build_complete = django.dispatch.Signal(providing_args=['build'])
+log = logging.getLogger(__file__)
+
+
+if all([
+        # restart workers in local docker compose only
+        settings.RTD_DOCKER_COMPOSE,
+        # restart workers only from web instance
+        os.environ['DJANGO_SETTINGS_MODULE'].endswith('web_docker'),
+]):
+    @receiver(file_changed)
+    def restart_celery_workers(*args, **kwargs):
+        log.info('Restarting celery workers')
+        app.control.broadcast('pool_restart', arguments={'reload': True})

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -97,6 +97,8 @@ class DockerBaseSettings(CommunityDevSettings):
     CELERY_RESULT_SERIALIZER = "json"
     CELERY_ALWAYS_EAGER = False
     CELERY_TASK_IGNORE_RESULT = False
+    # Allow us to reload celery task modules remotely
+    CELERYD_POOL_RESTARTS = True
 
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 


### PR DESCRIPTION
Use Django internals (`file_changed` signal) to detect that a file was changed and Celery `pool_restart` to communicate with workers so they gracefully reload the Python modules for all the tasks they have registered.

This should help with CPU consumption and removes the needing of using `watchmedo` 4 times to inpect the same files (from web, from proxito, from celery and from builder). Now, we just need web and proxito.

Uses https://github.com/readthedocs/common/pull/57