### PR TITLE
Use watchman when calling `runserver` in local development

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -51,4 +51,15 @@ RUN if [ -n "$GITHUB_TOKEN" ] ; \
         pip3 install --no-cache-dir -e readthedocs-ext ; \
         fi
 
+# Use watchman for Django ``runserver`` command
+# (this is new in Django 2.2 and could help to reduce CPU usage)
+ENV DJANGO_WATCHMAN_TIMEOUT 15
+RUN apt-get install -y libssl-dev autoconf automake libtool
+RUN git clone https://github.com/facebook/watchman.git -b v4.9.0 --depth 1; \
+        cd watchman; \
+        ./autogen.sh; \
+        ./configure; \
+        make; \
+        make install
+
 WORKDIR /usr/src/app/checkouts/readthedocs.org

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -8,6 +8,7 @@ pillow==7.0.0
 
 # local debugging tools
 watchdog==0.9.0
+pywatchman==1.4.1
 datadiff==2.0.0
 ipdb==0.12.2
 pdbpp==0.10.2


### PR DESCRIPTION
watchman is the replacement of pyinotify and it's the recommended way on Linux and MacOS.

https://docs.djangoproject.com/en/2.2/ref/django-admin/#runserver

Django will automatically detect that this is installed and use watchman instead of pyinotify, showing this log in the terminal:

```
django.utils.autoreload:597[20]: INFO Watching for file changes with WatchmanReloader
```

This change could help to reduce the CPU usage when running docker-compose locally.

This is a continuation of the work done in #6812.