### PR TITLE
Force to reinstall package

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -92,7 +92,7 @@ textblob==0.15.3
 
 django-annoying==0.10.5
 # Messages-extends needs a fix for Django 2.2 which isn't released (0.6.1 isn't out yet)
-git+https://github.com/AliLozano/django-messages-extends.git@b1e4f4c#egg=django-messages-extends==0.6.0
+git+https://github.com/AliLozano/django-messages-extends.git@b1e4f4c#egg=django-messages-extends==0.6.1-dev
 djangorestframework-jsonp==1.0.2
 django-taggit==1.1.0
 dj-pagination==2.4.0


### PR DESCRIPTION
We already have the 0.6.0 version installed from pypi,
so pip doesn't try to reinstall the package.