### PR TITLE
Fix silly issue with sync_callback

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -2063,11 +2063,9 @@ def clean_project_resources(project, version=None):
 
 
 @app.task(queue='web')
-def sync_callback(_, version_pk, commit, build, *args, **kwargs):
+def sync_callback(version_pk, commit, build, *args, **kwargs):
     """
     Called once the sync_files tasks are done.
-
-    The first argument is the result from previous tasks, which we discard.
     """
     try:
         fileify(version_pk, commit=commit, build=build)


### PR DESCRIPTION
This was used when being chained to pass the prior result,
we don't need it anymore.