### PR TITLE
Upgrade celery and its dependencies

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -30,15 +30,9 @@ pyyaml==5.1.2
 Pygments==2.4.2
 
 # Basic tools
-# Redis 3.x has an incompatible change and fails
-# https://stackoverflow.com/questions/53331405/django-compress-error-invalid-input-of-type-cachekey
-# https://github.com/sebleier/django-redis-cache/pull/162
-redis==2.10.6  # pyup: ignore
-# Kombu >4.3 requires redis>=3.2
-kombu==4.3.0  # pyup: ignore
-# Celery 4.2 is incompatible with our code
-# when ALWAYS_EAGER = True
-celery==4.1.1  # pyup: ignore
+redis==3.4.1
+kombu==4.6.8
+celery==4.4.2
 
 django-allauth==0.41.0
 

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -30,7 +30,9 @@ pyyaml==5.1.2
 Pygments==2.4.2
 
 # Basic tools
-redis==3.4.1
+# redis==3.4.1 makes the celery workers to randomly get killed
+redis==3.2.1 # pyup: <3.3
+
 kombu==4.6.8
 celery==4.4.2
 


### PR DESCRIPTION
This is required to gracefully stop celery workers when using scaling groups.