### PR TITLE
Allow receiving `None` for `template_html` when sending emails

### DIFF
--- a/readthedocs/core/tasks.py
+++ b/readthedocs/core/tasks.py
@@ -56,7 +56,8 @@ def send_email_task(
             get_template(template_html).render(context),
             'text/html',
         )
-    except TemplateDoesNotExist:
+    except (TypeError, TemplateDoesNotExist):
+        # TypeError is raised when ``template_html`` is ``None``
         pass
     msg.send()
     log.info('Sent email to recipient: %s', recipient)


### PR DESCRIPTION
We are using this internally and we haven't receiving emails in the
last month or so. I suppose this started happening after the Django
2.2 migration.