### PR TITLE
Don't hit the API to inject sphinx context

### DIFF
--- a/readthedocs/rtd_tests/tests/test_doc_builder.py
+++ b/readthedocs/rtd_tests/tests/test_doc_builder.py
@@ -69,59 +69,6 @@ class SphinxBuilderTest(TestCase):
                 expected,
             )
 
-    @patch('readthedocs.doc_builder.backends.sphinx.api')
-    @patch('readthedocs.projects.models.api')
-    @patch('readthedocs.doc_builder.backends.sphinx.BaseSphinx.docs_dir')
-    @patch('readthedocs.builds.models.Version.get_conf_py_path')
-    @patch('readthedocs.projects.models.Project.checkout_path')
-    def test_html_context_only_has_public_versions(
-            self, checkout_path, get_conf_py_path,
-            docs_dir, api_project, api_version,
-    ):
-        tmp_dir = tempfile.mkdtemp()
-        checkout_path.return_value = tmp_dir
-        docs_dir.return_value = tmp_dir
-        get_conf_py_path.side_effect = ProjectConfigurationError
-
-        api_version.version().get.return_value = {'downloads': []}
-        api_project.project().active_versions.get.return_value = {
-            'versions': [
-                {
-                    'slug': 'v1',
-                    'privacy_level': PUBLIC,
-                },
-                {
-                    'slug': 'v2',
-                    'privacy_level': PUBLIC,
-                },
-                {
-                    'slug': 'v3',
-                    'privacy_level': PROTECTED,
-                },
-                {
-                    'slug': 'latest',
-                    'privacy_level': PRIVATE,
-                },
-            ],
-        }
-
-        python_env = Virtualenv(
-            version=self.version,
-            build_env=self.build_env,
-            config=None,
-        )
-        base_sphinx = BaseSphinx(
-            build_env=self.build_env,
-            python_env=python_env,
-        )
-        base_sphinx.config_file = tempfile.mktemp()
-        context = base_sphinx.get_config_params()
-        versions = {
-            v.slug
-            for v in context['versions']
-        }
-        self.assertEqual(versions, {'v1', 'v2'})
-
     @patch('readthedocs.doc_builder.backends.sphinx.BaseSphinx.docs_dir')
     @patch('readthedocs.doc_builder.backends.sphinx.BaseSphinx.create_index')
     @patch('readthedocs.doc_builder.backends.sphinx.BaseSphinx.get_config_params')


### PR DESCRIPTION
This feature flag was used to don't inject private versions,
but we haven't have anyone requesting to enable the feature,
so I'm reusing the flag to skip the API call.

Ref https://github.com/readthedocs/readthedocs.org/issues/6712#issuecomment-592163820
Fixes https://github.com/readthedocs/readthedocs.org/issues/6712