### PR TITLE
Avoid failing on empty Webhook URL

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1907,6 +1907,18 @@ def webhook_notification(version, build, hook_url):
     :param build: Build instance that failed
     :param hook_url: Hook URL to send to
     """
+
+    if not hook_url:
+        log.debug(
+            LOG_TEMPLATE,
+            {
+                'project': project.slug,
+                'version': '',
+                'msg': 'Skipping webhook notification. Empty URL.'
+            }
+        )
+        return
+
     project = version.project
 
     data = json.dumps({


### PR DESCRIPTION
Skip webhook URL if it's empty.

Since we send first the webhook notifications, if the user has an
empty webhook configured, none of the email notification were sent.