### PR TITLE
Add more exceptions as WARNING log level

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -26,6 +26,10 @@ from readthedocs.builds.models import BuildCommandResultMixin
 from readthedocs.core.utils import slugify
 from readthedocs.projects.constants import LOG_TEMPLATE
 from readthedocs.projects.models import Feature
+from readthedocs.projects.exceptions import (
+    RepositoryError,
+    ProjectConfigurationError,
+)
 
 from .constants import (
     DOCKER_HOSTNAME_MAX_LEN,
@@ -528,15 +532,18 @@ class BuildEnvironment(BaseEnvironment):
                               successful
     """
 
-    # Exceptions considered ERROR from a Build perspective but as a WARNING for
-    # the application itself. These exception are logged as warning and not sent
-    # to Sentry.
+    # These exceptions are considered ERROR from a Build perspective (the build
+    # failed and can continue) but as a WARNING for the application itself (RTD
+    # code didn't failed). These exception are logged as ``WARNING`` and they
+    # are not sent to Sentry.
     WARNING_EXCEPTIONS = (
         VersionLockedError,
         ProjectBuildsSkippedError,
         YAMLParseError,
         BuildTimeoutError,
         MkDocsYAMLParseError,
+        RepositoryError,
+        ProjectConfigurationError,
     )
 
     def __init__(

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -307,7 +307,10 @@ class SyncRepositoryMixin:
         return env
 
 
-@app.task(max_retries=5, default_retry_delay=7 * 60)
+@app.task(
+    max_retries=5,
+    default_retry_delay=7 * 60,
+)
 def sync_repository_task(version_pk):
     """Celery task to trigger VCS version sync."""
     try:
@@ -394,25 +397,10 @@ class SyncRepositoryTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
         return False
 
 
-# Exceptions under ``throws`` argument are considered ERROR from a Build
-# perspective (the build failed and can continue) but as a WARNING for the
-# application itself (RTD code didn't failed). These exception are logged as
-# ``INFO`` and they are not sent to Sentry.
 @app.task(
     bind=True,
     max_retries=5,
     default_retry_delay=7 * 60,
-    throws=(
-        VersionLockedError,
-        ProjectBuildsSkippedError,
-        YAMLParseError,
-        BuildTimeoutError,
-        BuildEnvironmentWarning,
-        RepositoryError,
-        ProjectConfigurationError,
-        ProjectBuildsSkippedError,
-        MkDocsYAMLParseError,
-    ),
 )
 def update_docs_task(self, version_pk, *args, **kwargs):
     try:


### PR DESCRIPTION
`RepositoryError` and `ProjectConfigurationError` are user errors that
we should not log as ERROR, but as WARNING instead.

Also, the `throws` list is removed here since all these exceptions
happen inside the Build Environment who already manage them in the
`__exit__` method and so, they are never seen by the task.