### PR TITLE
Add an advertising API timeout

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -560,6 +560,11 @@ class CommunityBaseSettings(Settings):
     # Do Not Track support
     DO_NOT_TRACK_ENABLED = False
 
+    # Advertising configuration defaults
+    ADSERVER_API_BASE = None
+    ADSERVER_API_KEY = None
+    ADSERVER_API_TIMEOUT = 0.35  # seconds
+
     # Misc application settings
     GLOBAL_ANALYTICS_CODE = None
     DASHBOARD_ANALYTICS_CODE = None  # For the dashboard, not docs

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -44,6 +44,8 @@ class DockerBaseSettings(CommunityDevSettings):
     # Create a Token for an admin User and set it here.
     ADSERVER_API_KEY = None
 
+    ADSERVER_API_TIMEOUT = 2  # seconds - Docker for Mac is very slow
+
     # Enable auto syncing elasticsearch documents
     ELASTICSEARCH_DSL_AUTOSYNC = True if 'SEARCH' in os.environ else False
 


### PR DESCRIPTION
This should guard against the adserver responding slowly in production.