### PR TITLE
Don't do extra query if the project is a translation

### DIFF
--- a/readthedocs/core/resolver.py
+++ b/readthedocs/core/resolver.py
@@ -218,8 +218,10 @@ class ResolverBase:
         # Track what projects have already been traversed to avoid infinite
         # recursion. We can't determine a root project well here, so you get
         # what you get if you have configured your project in a strange manner
-        projects = projects or set()
-        projects.add(project)
+        if projects is None:
+            projects = {project}
+        else:
+            projects.add(project)
 
         next_project = None
         if project.main_language_project:

--- a/readthedocs/core/resolver.py
+++ b/readthedocs/core/resolver.py
@@ -218,17 +218,17 @@ class ResolverBase:
         # Track what projects have already been traversed to avoid infinite
         # recursion. We can't determine a root project well here, so you get
         # what you get if you have configured your project in a strange manner
-        if projects is None:
-            projects = [project]
-        else:
-            projects.append(project)
+        projects = projects or set()
+        projects.add(project)
 
         next_project = None
-        relation = project.get_parent_relationship()
         if project.main_language_project:
             next_project = project.main_language_project
-        elif relation:
-            next_project = relation.parent
+        else:
+            relation = project.get_parent_relationship()
+            if relation:
+                next_project = relation.parent
+
         if next_project and next_project not in projects:
             return self._get_canonical_project(next_project, projects)
         return project


### PR DESCRIPTION
We only check for superprojects if the project isn't a translation.
This reduces a query

Ref https://github.com/readthedocs/readthedocs.org/issues/6455