### PR TITLE
Don't do unnecessary queries when listing subprojects

### DIFF
--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -472,8 +472,8 @@ class ProjectRelationshipList(ProjectRelationshipMixin, ListView):
         Get a tuple of subprojects and its absolute URls.
 
         All subprojects share the domain from the parent,
-        so instead of resolving the domain and path of each subproject,
-        we only resolve the path of each one.
+        so instead of resolving the domain and path for each subproject,
+        we resolve only the path of each one.
         """
         subprojects_and_urls = []
 

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -3,7 +3,6 @@
 import csv
 import logging
 from urllib.parse import urlparse
-from readthedocs.core.resolver import resolve, resolve_path
 
 from allauth.socialaccount.models import SocialAccount
 from django.conf import settings
@@ -46,6 +45,7 @@ from readthedocs.core.mixins import (
     LoginRequiredMixin,
     PrivateViewMixin,
 )
+from readthedocs.core.resolver import resolve, resolve_path
 from readthedocs.core.utils import broadcast, trigger_build
 from readthedocs.core.utils.extend import SettingsOverrideObject
 from readthedocs.integrations.models import HttpExchange, Integration

--- a/readthedocs/templates/projects/projectrelationship_list.html
+++ b/readthedocs/templates/projects/projectrelationship_list.html
@@ -48,7 +48,7 @@
       <div class="module-list">
         <div class="module-list-wrapper">
           <ul class="subprojects">
-             {% for subproject, absolute_url in subprojects_and_urls %}
+            {% for subproject, absolute_url in subprojects_and_urls %}
               <li class="module-item subproject">
                 <div class="module-title">
                   <a

--- a/readthedocs/templates/projects/projectrelationship_list.html
+++ b/readthedocs/templates/projects/projectrelationship_list.html
@@ -48,7 +48,7 @@
       <div class="module-list">
         <div class="module-list-wrapper">
           <ul class="subprojects">
-            {% for subproject in object_list %}
+             {% for subproject, absolute_url in subprojects_and_urls %}
               <li class="module-item subproject">
                 <div class="module-title">
                   <a
@@ -58,8 +58,8 @@
                   </a>
                   <span>
                     <a class="module-info subproject-url"
-                      href="{{ subproject.get_absolute_url }}">
-                      {{ subproject.get_absolute_url }}
+                      href="{{ absolute_url }}">
+                      {{ absolute_url }}
                     </a>
                   </span>
                 </div>


### PR DESCRIPTION
This together with:
- https://github.com/readthedocs/readthedocs.org/pull/6867
- https://github.com/readthedocs/readthedocs.org/pull/6865
- https://github.com/readthedocs/readthedocs.org/pull/6864

reduces a lot of queries and without changing the current UI.

This is a benchmark using the django debug toolbar:

Before: 138 queries with 7 subprojects, 17 queries per each additional subproject

With all the changes: 28 queries with 7 subprojects, 1 query per each additional subproject

Fixes https://github.com/readthedocs/readthedocs.org/issues/6455