### PR TITLE
Fix issue with sphinx domain types with `:` in them:

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1611,7 +1611,7 @@ def _create_intersphinx_data(version, commit, build):
 
     invdata = intersphinx.fetch_inventory(MockApp(), '', object_file_url)
     for key, value in sorted(invdata.items() or {}):
-        domain, _type = key.split(':')
+        domain, _type = key.split(':', 1)
         for name, einfo in sorted(value.items()):
             # project, version, url, display_name
             # ('Sphinx', '1.7.9', 'faq.html#epub-faq', 'Epub info')


### PR DESCRIPTION
This was breaking on keys that look like `'rst:directive:option'`.

Fixes https://sentry.io/organizations/read-the-docs/issues/1146171783/?project=148442&query=is%3Aunresolved