### PR TITLE
Make the status name in CI configurable via setting

### DIFF
--- a/readthedocs/builds/constants.py
+++ b/readthedocs/builds/constants.py
@@ -100,8 +100,6 @@ SELECT_BUILD_STATUS = {
     },
 }
 
-RTD_BUILD_STATUS_API_NAME = 'continuous-documentation/read-the-docs'
-
 GITHUB_EXTERNAL_VERSION_NAME = 'Pull Request'
 GITLAB_EXTERNAL_VERSION_NAME = 'Merge Request'
 GENERIC_EXTERNAL_VERSION_NAME = 'External Version'

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -15,7 +15,6 @@ from readthedocs.builds import utils as build_utils
 from readthedocs.builds.constants import (
     BUILD_STATUS_SUCCESS,
     SELECT_BUILD_STATUS,
-    RTD_BUILD_STATUS_API_NAME
 )
 from readthedocs.integrations.models import Integration
 
@@ -438,7 +437,7 @@ class GitHubService(Service):
             'state': github_build_state,
             'target_url': target_url,
             'description': description,
-            'context': RTD_BUILD_STATUS_API_NAME
+            'context': settings.RTD_BUILD_STATUS_API_NAME
         }
 
         resp = None

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -11,7 +11,6 @@ from requests.exceptions import RequestException
 
 from readthedocs.builds.constants import (
     BUILD_STATUS_SUCCESS,
-    RTD_BUILD_STATUS_API_NAME,
     SELECT_BUILD_STATUS,
 )
 from readthedocs.builds import utils as build_utils
@@ -524,7 +523,7 @@ class GitLabService(Service):
             'state': gitlab_build_state,
             'target_url': target_url,
             'description': description,
-            'context': RTD_BUILD_STATUS_API_NAME
+            'context': settings.RTD_BUILD_STATUS_API_NAME
         }
         url = self.adapter.provider_base_url
 

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -99,6 +99,7 @@ class CommunityBaseSettings(Settings):
     RTD_STABLE_VERBOSE_NAME = 'stable'
     RTD_CLEAN_AFTER_BUILD = False
     RTD_MAX_CONCURRENT_BUILDS = 4
+    RTD_BUILD_STATUS_API_NAME = 'docs/readthedocs'
 
     # Database and API hitting settings
     DONT_HIT_API = False


### PR DESCRIPTION
We had the same one on .org/.com and it was overwriting each other.