### PR TITLE
Allocate docker limits based on server size.

### DIFF
--- a/readthedocs/doc_builder/constants.py
+++ b/readthedocs/doc_builder/constants.py
@@ -35,7 +35,8 @@ DOCKER_LIMITS = {
 # This assumes 1-builder per server
 try:
     total_memory = int(subprocess.check_output("free -m | awk '/^Mem:/{print $2}'", shell=True))
-except Exception:
+except ValueError:
+    # On systems without a `free` command it will return a string to int and raise a ValueError
     log.exception('Failed to get memory size. Using defaults docker limits')
     total_memory = 0
 

--- a/readthedocs/doc_builder/constants.py
+++ b/readthedocs/doc_builder/constants.py
@@ -60,7 +60,8 @@ elif total_memory > 2000:
         'time': 600,
     })
 
-DOCKER_LIMITS.update(settings.DOCKER_LIMITS)
+if hasattr(settings, 'DOCKER_LIMITS'):
+    DOCKER_LIMITS.update(settings.DOCKER_LIMITS)
 
 
 DOCKER_TIMEOUT_EXIT_CODE = 42

--- a/readthedocs/doc_builder/constants.py
+++ b/readthedocs/doc_builder/constants.py
@@ -4,6 +4,7 @@
 
 import logging
 import re
+import subprocess
 
 from django.conf import settings
 
@@ -25,8 +26,36 @@ if old_config:
     )
     DOCKER_IMAGE_SETTINGS.update(old_config)
 
-DOCKER_LIMITS = {'memory': '200m', 'time': 600}
+DOCKER_LIMITS = {
+    'memory': '200m',
+    'time': 600,
+}
+
+# Set docker limits dynamically based on system memory
+free_memory = int(subprocess.check_output("free -m | awk '/^Mem:/{print $2}'", shell=True))
+if free_memory > 14000:
+    DOCKER_LIMITS.update({
+        'memory': '13g',
+        'time': 2400,
+    })
+elif free_memory > 8000:
+    DOCKER_LIMITS.update({
+        'memory': '7g',
+        'time': 1800,
+    })
+elif free_memory > 4000:
+    DOCKER_LIMITS.update({
+        'memory': '3g',
+        'time': 900,
+    })
+elif free_memory > 2000:
+    DOCKER_LIMITS.update({
+        'memory': '1g',
+        'time': 600,
+    })
+
 DOCKER_LIMITS.update(settings.DOCKER_LIMITS)
+
 
 DOCKER_TIMEOUT_EXIT_CODE = 42
 DOCKER_OOM_EXIT_CODE = 137

--- a/readthedocs/doc_builder/constants.py
+++ b/readthedocs/doc_builder/constants.py
@@ -33,7 +33,12 @@ DOCKER_LIMITS = {
 
 # Set docker limits dynamically based on system memory
 # This assumes 1-builder per server
-total_memory = int(subprocess.check_output("free -m | awk '/^Mem:/{print $2}'", shell=True))
+try:
+    total_memory = int(subprocess.check_output("free -m | awk '/^Mem:/{print $2}'", shell=True))
+except Exception:
+    log.exception('Failed to get memory size. Using defaults docker limits')
+    total_memory = 0
+
 if total_memory > 14000:
     DOCKER_LIMITS.update({
         'memory': '13g',

--- a/readthedocs/doc_builder/constants.py
+++ b/readthedocs/doc_builder/constants.py
@@ -32,23 +32,24 @@ DOCKER_LIMITS = {
 }
 
 # Set docker limits dynamically based on system memory
-free_memory = int(subprocess.check_output("free -m | awk '/^Mem:/{print $2}'", shell=True))
-if free_memory > 14000:
+# This assumes 1-builder per server
+total_memory = int(subprocess.check_output("free -m | awk '/^Mem:/{print $2}'", shell=True))
+if total_memory > 14000:
     DOCKER_LIMITS.update({
         'memory': '13g',
         'time': 2400,
     })
-elif free_memory > 8000:
+elif total_memory > 8000:
     DOCKER_LIMITS.update({
         'memory': '7g',
         'time': 1800,
     })
-elif free_memory > 4000:
+elif total_memory > 4000:
     DOCKER_LIMITS.update({
         'memory': '3g',
         'time': 900,
     })
-elif free_memory > 2000:
+elif total_memory > 2000:
     DOCKER_LIMITS.update({
         'memory': '1g',
         'time': 600,


### PR DESCRIPTION
This assumes 1-builder per server.
It is still able to be overwritten by settings,
so to have this take effect we need to set:

```
DOCKER_LIMITS = None
```