### PR TITLE
Redirect HTTP -> HTTPS for custom domains

### DIFF
--- a/dockerfiles/nginx/proxito.conf
+++ b/dockerfiles/nginx/proxito.conf
@@ -58,6 +58,8 @@ server {
         add_header X-RTD-Domain $rtd_domain always;
         set $rtd_method $upstream_http_x_rtd_version_method;
         add_header X-RTD-Version-Method $rtd_method always;
+        set $rtd_redirect $upstream_http_x_rtd_redirect;
+        add_header X-RTD-Redirect $rtd_redirect always;
     }
 
     # Serve 404 pages here

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -87,7 +87,9 @@ def map_host_to_project_slug(request):  # pylint: disable=too-many-return-statem
         if domain.https and not request.is_secure():
             # Redirect HTTP -> HTTPS (302) for this custom domain
             log.debug('Proxito CNAME HTTPS Redirect: host=%s', host)
-            return redirect('https://{}{}'.format(host, request.get_full_path()))
+            resp = redirect('https://{}{}'.format(host, request.get_full_path()))
+            resp['X-RTD-Redirect'] = 'https'
+            return resp
 
         return project_slug
 

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -87,7 +87,7 @@ def map_host_to_project_slug(request):  # pylint: disable=too-many-return-statem
         if domain.https and not request.is_secure():
             # Redirect HTTP -> HTTPS (302) for this custom domain
             log.debug('Proxito CNAME HTTPS Redirect: host=%s', host)
-            return redirect('https://%s%s' % (host, request.get_full_path()))
+            return redirect('https://{}{}'.format(host, request.get_full_path()))
 
         return project_slug
 

--- a/readthedocs/proxito/tests/test_middleware.py
+++ b/readthedocs/proxito/tests/test_middleware.py
@@ -51,6 +51,10 @@ class MiddlewareTests(RequestFactoryTestMixin, TestCase):
                 res['Location'],
                 f'https://{domain}{url}',
             )
+            self.assertEqual(
+                res['X-RTD-Redirect'],
+                'https',
+            )
 
     def test_proper_cname_uppercase(self):
         get(Domain, project=self.pip, domain='docs.random.com')

--- a/readthedocs/proxito/tests/test_middleware.py
+++ b/readthedocs/proxito/tests/test_middleware.py
@@ -38,6 +38,20 @@ class MiddlewareTests(RequestFactoryTestMixin, TestCase):
         self.assertEqual(request.cname, True)
         self.assertEqual(request.host_project_slug, 'pip')
 
+    def test_proper_cname_https_upgrade(self):
+        domain = 'docs.random.com'
+        get(Domain, project=self.pip, domain=domain, https=True)
+
+        for url in (self.url, '/subdir/'):
+            request = self.request(url, HTTP_HOST=domain)
+            res = self.run_middleware(request)
+            self.assertIsNotNone(res)
+            self.assertEqual(res.status_code, 302)
+            self.assertEqual(
+                res['Location'],
+                f'https://{domain}{url}',
+            )
+
     def test_proper_cname_uppercase(self):
         get(Domain, project=self.pip, domain='docs.random.com')
         request = self.request(self.url, HTTP_HOST='docs.RANDOM.COM')


### PR DESCRIPTION
- Only redirect if the appropriate flag is set on the Domain (default is not to redirect)
- Use a 302 redirect for now. Ideally this is a 301 redirect, but redirecting other people's domains with a 301 is always a bit risky. If things go smoothly, it's an easy change to switch from a 301 to a 302.

Fixes #4641