### PR TITLE
Add CloudFlare Cache tags support

### DIFF
--- a/readthedocs/projects/signals.py
+++ b/readthedocs/projects/signals.py
@@ -12,7 +12,7 @@ after_build = django.dispatch.Signal(providing_args=['version'])
 project_import = django.dispatch.Signal(providing_args=['project'])
 
 # Used to purge files from the CDN
-files_changed = django.dispatch.Signal(providing_args=['project', 'files'])
+files_changed = django.dispatch.Signal(providing_args=['project', 'version', 'files'])
 
 # Used to force verify a domain (eg. for SSL cert issuance)
 domain_verify = django.dispatch.Signal(providing_args=['domain'])

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1830,6 +1830,7 @@ def _sync_imported_files(version, build, changed_files):
     files_changed.send(
         sender=Project,
         project=version.project,
+        version=version,
         files=changed_files,
     )
 

--- a/readthedocs/proxito/views/mixins.py
+++ b/readthedocs/proxito/views/mixins.py
@@ -126,6 +126,7 @@ class ServeDocsMixin:
         response['X-RTD-Version'] = version_slug
         # Needed to strip any GET args, etc.
         response['X-RTD-Path'] = urlparse(path).path
+        response['Cache-Tags'] = f'{final_project.slug}-{version_slug}'
         if hasattr(request, 'rtdheader'):
             response['X-RTD-Version-Method'] = 'rtdheader'
         if hasattr(request, 'subdomain'):

--- a/readthedocs/proxito/views/mixins.py
+++ b/readthedocs/proxito/views/mixins.py
@@ -126,7 +126,8 @@ class ServeDocsMixin:
         response['X-RTD-Version'] = version_slug
         # Needed to strip any GET args, etc.
         response['X-RTD-Path'] = urlparse(path).path
-        response['Cache-Tags'] = f'{final_project.slug}-{version_slug}'
+        # Include the project & project-version so we can do larger purges if needed
+        response['Cache-Tags'] = f'{final_project.slug}-{version_slug},{final_project.slug}'
         if hasattr(request, 'rtdheader'):
             response['X-RTD-Version-Method'] = 'rtdheader'
         if hasattr(request, 'subdomain'):


### PR DESCRIPTION
This lets us purge the CDN more easily.
This requires a version in the files_changed signal.