### PR TITLE
On Azure .exists blob timeout, log the exception and return False

### DIFF
--- a/readthedocs/storage/azure_storage.py
+++ b/readthedocs/storage/azure_storage.py
@@ -34,7 +34,7 @@ class AzureBuildMediaStorage(BuildMediaStorageMixin, OverrideHostnameMixin, Azur
         """
         return super().url(name, expire)
 
-    def exists(self, name, timeout=None):
+    def exists(self, name):
         """Override to catch timeout exception and return False."""
         try:
             return super().exists(name)

--- a/readthedocs/storage/azure_storage.py
+++ b/readthedocs/storage/azure_storage.py
@@ -14,7 +14,7 @@ from readthedocs.builds.storage import BuildMediaStorageMixin
 from .mixins import OverrideHostnameMixin
 
 
-log = logging.getLogger(__name__)
+log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 class AzureBuildMediaStorage(BuildMediaStorageMixin, OverrideHostnameMixin, AzureStorage):
@@ -38,7 +38,7 @@ class AzureBuildMediaStorage(BuildMediaStorageMixin, OverrideHostnameMixin, Azur
         """Override to catch timeout exception and return False."""
         try:
             return super().exists(name)
-        except:
+        except Exception:  # pylint: disable=broad-except
             log.exception('Timeout calling Azure .exists. name=%s', name)
             return False
 

--- a/readthedocs/storage/azure_storage.py
+++ b/readthedocs/storage/azure_storage.py
@@ -3,6 +3,7 @@
 
 """Django storage classes to use with Azure Blob storage service."""
 
+import logging
 from azure.common import AzureMissingResourceHttpError
 from django.conf import settings
 from django.contrib.staticfiles.storage import ManifestFilesMixin
@@ -11,6 +12,9 @@ from storages.backends.azure_storage import AzureStorage
 from readthedocs.builds.storage import BuildMediaStorageMixin
 
 from .mixins import OverrideHostnameMixin
+
+
+log = logging.getLogger(__name__)
 
 
 class AzureBuildMediaStorage(BuildMediaStorageMixin, OverrideHostnameMixin, AzureStorage):
@@ -29,6 +33,14 @@ class AzureBuildMediaStorage(BuildMediaStorageMixin, OverrideHostnameMixin, Azur
         method to build the signed URL).
         """
         return super().url(name, expire)
+
+    def exists(self, name, timeout=None):
+        """Override to catch timeout exception and return False."""
+        try:
+            return super().exists(name)
+        except:
+            log.exception('Timeout calling Azure .exists. name=%s', name)
+            return False
 
 
 class AzureBuildStorage(AzureStorage):


### PR DESCRIPTION
We have been experimenting some issues with Azure Blob storage. Our current timeout is the django-storages default (20 secs). We want to reduce it to ~2s, but without breaking the code and start returning 500. So, we log the error and return False.
