### PR TITLE
Load YAML files safely

### DIFF
--- a/readthedocs/config/parser.py
+++ b/readthedocs/config/parser.py
@@ -4,8 +4,6 @@
 
 import yaml
 
-from .utils import yaml_load_safely
-
 __all__ = ('parse', 'ParseError')
 
 
@@ -22,7 +20,7 @@ def parse(stream):
     Everything else raises a ``ParseError``.
     """
     try:
-        config = yaml_load_safely(stream)
+        config = yaml.safe_load(stream)
     except yaml.YAMLError as error:
         raise ParseError('YAML: {message}'.format(message=error))
     if not isinstance(config, dict):

--- a/readthedocs/config/parser.py
+++ b/readthedocs/config/parser.py
@@ -4,6 +4,7 @@
 
 import yaml
 
+from .utils import yaml_load_safely
 
 __all__ = ('parse', 'ParseError')
 
@@ -21,7 +22,7 @@ def parse(stream):
     Everything else raises a ``ParseError``.
     """
     try:
-        config = yaml.safe_load(stream)
+        config = yaml_load_safely(stream)
     except yaml.YAMLError as error:
         raise ParseError('YAML: {message}'.format(message=error))
     if not isinstance(config, dict):

--- a/readthedocs/config/tests/test_yaml_loader.py
+++ b/readthedocs/config/tests/test_yaml_loader.py
@@ -16,3 +16,5 @@ def test_yaml_load_safely():
     ''')
     data = yaml_load_safely(content)
     assert data == expected
+    assert type(data['int']) == int
+    assert type(data['float']) == float

--- a/readthedocs/config/tests/test_yaml_loader.py
+++ b/readthedocs/config/tests/test_yaml_loader.py
@@ -1,5 +1,5 @@
 import textwrap
-from readthedocs.config.utils import yaml_load_safely
+from readthedocs.doc_builder.backends.mkdocs import yaml_load_safely
 
 
 def test_yaml_load_safely():

--- a/readthedocs/config/tests/test_yaml_loader.py
+++ b/readthedocs/config/tests/test_yaml_loader.py
@@ -1,0 +1,18 @@
+import textwrap
+from readthedocs.config.utils import yaml_load_safely
+
+
+def test_yaml_load_safely():
+    expected = {
+        'int': 3,
+        'float': 3.0,
+        'unknown': None,
+    }
+
+    content = textwrap.dedent('''
+    int: 3
+    float: !!float 3
+    unknown: !!python/name:unknown_funtion
+    ''')
+    data = yaml_load_safely(content)
+    assert data == expected

--- a/readthedocs/config/utils.py
+++ b/readthedocs/config/utils.py
@@ -29,14 +29,15 @@ def list_to_dict(list_):
     return dict_
 
 
-class SafeLoaderIgnoreUnknown(yaml.SafeLoader):
+class SafeLoaderIgnoreUnknown(yaml.SafeLoader):  # pylint: disable=too-many-ancestors
 
     """
     YAML loader to ignore unknown tags.
 
     Borrowed from https://stackoverflow.com/a/57121993
     """
-    def ignore_unknown(self, node):
+
+    def ignore_unknown(self, node):  # pylint: disable=no-self-use disable=unused-argument
         return None
 
 
@@ -47,7 +48,8 @@ def yaml_load_safely(content):
     """
     Uses ``SafeLoaderIgnoreUnknown`` loader to skip unknown tags.
 
-    When a YAML contains ``!!python/name:int`` it will complete ignore it an return ``None`` for those fields
-    instead of failing. We need this to avoid executing random code, but still support these YAML files.
+    When a YAML contains ``!!python/name:int`` it will complete ignore it an
+    return ``None`` for those fields instead of failing. We need this to avoid
+    executing random code, but still support these YAML files.
     """
     return yaml.load(content, Loader=SafeLoaderIgnoreUnknown)

--- a/readthedocs/config/utils.py
+++ b/readthedocs/config/utils.py
@@ -1,7 +1,5 @@
 """Shared functions for the config module."""
 
-import yaml
-
 
 def to_dict(value):
     """Recursively transform a class from `config.models` to a dict."""

--- a/readthedocs/config/utils.py
+++ b/readthedocs/config/utils.py
@@ -37,7 +37,7 @@ class SafeLoaderIgnoreUnknown(yaml.SafeLoader):  # pylint: disable=too-many-ance
     Borrowed from https://stackoverflow.com/a/57121993
     """
 
-    def ignore_unknown(self, node):  # pylint: disable=no-self-use disable=unused-argument
+    def ignore_unknown(self, node):  # pylint: disable=no-self-use, unused-argument
         return None
 
 

--- a/readthedocs/config/utils.py
+++ b/readthedocs/config/utils.py
@@ -1,5 +1,7 @@
 """Shared functions for the config module."""
 
+import yaml
+
 
 def to_dict(value):
     """Recursively transform a class from `config.models` to a dict."""
@@ -25,3 +27,27 @@ def list_to_dict(list_):
         for i, element in enumerate(list_)
     }
     return dict_
+
+
+class SafeLoaderIgnoreUnknown(yaml.SafeLoader):
+
+    """
+    YAML loader to ignore unknown tags.
+
+    Borrowed from https://stackoverflow.com/a/57121993
+    """
+    def ignore_unknown(self, node):
+        return None
+
+
+SafeLoaderIgnoreUnknown.add_constructor(None, SafeLoaderIgnoreUnknown.ignore_unknown)
+
+
+def yaml_load_safely(content):
+    """
+    Uses ``SafeLoaderIgnoreUnknown`` loader to skip unknown tags.
+
+    When a YAML contains ``!!python/name:int`` it will complete ignore it an return ``None`` for those fields
+    instead of failing. We need this to avoid executing random code, but still support these YAML files.
+    """
+    return yaml.load(content, Loader=SafeLoaderIgnoreUnknown)

--- a/readthedocs/config/utils.py
+++ b/readthedocs/config/utils.py
@@ -27,29 +27,3 @@ def list_to_dict(list_):
         for i, element in enumerate(list_)
     }
     return dict_
-
-
-class SafeLoaderIgnoreUnknown(yaml.SafeLoader):  # pylint: disable=too-many-ancestors
-
-    """
-    YAML loader to ignore unknown tags.
-
-    Borrowed from https://stackoverflow.com/a/57121993
-    """
-
-    def ignore_unknown(self, node):  # pylint: disable=no-self-use, unused-argument
-        return None
-
-
-SafeLoaderIgnoreUnknown.add_constructor(None, SafeLoaderIgnoreUnknown.ignore_unknown)
-
-
-def yaml_load_safely(content):
-    """
-    Uses ``SafeLoaderIgnoreUnknown`` loader to skip unknown tags.
-
-    When a YAML contains ``!!python/name:int`` it will complete ignore it an
-    return ``None`` for those fields instead of failing. We need this to avoid
-    executing random code, but still support these YAML files.
-    """
-    return yaml.load(content, Loader=SafeLoaderIgnoreUnknown)

--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -13,7 +13,6 @@ from django.conf import settings
 from django.template import loader as template_loader
 from readthedocs.projects.constants import MKDOCS_HTML, MKDOCS
 
-from readthedocs.config.utils import yaml_load_safely
 from readthedocs.doc_builder.base import BaseBuilder
 from readthedocs.doc_builder.exceptions import MkDocsYAMLParseError
 from readthedocs.projects.models import Feature
@@ -325,3 +324,29 @@ class MkdocsJSON(BaseMkdocs):
     type = 'mkdocs_json'
     builder = 'json'
     build_dir = '_build/json'
+
+
+class SafeLoaderIgnoreUnknown(yaml.SafeLoader):  # pylint: disable=too-many-ancestors
+
+    """
+    YAML loader to ignore unknown tags.
+
+    Borrowed from https://stackoverflow.com/a/57121993
+    """
+
+    def ignore_unknown(self, node):  # pylint: disable=no-self-use, unused-argument
+        return None
+
+
+SafeLoaderIgnoreUnknown.add_constructor(None, SafeLoaderIgnoreUnknown.ignore_unknown)
+
+
+def yaml_load_safely(content):
+    """
+    Uses ``SafeLoaderIgnoreUnknown`` loader to skip unknown tags.
+
+    When a YAML contains ``!!python/name:int`` it will complete ignore it an
+    return ``None`` for those fields instead of failing. We need this to avoid
+    executing random code, but still support these YAML files.
+    """
+    return yaml.load(content, Loader=SafeLoaderIgnoreUnknown)

--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -13,6 +13,7 @@ from django.conf import settings
 from django.template import loader as template_loader
 from readthedocs.projects.constants import MKDOCS_HTML, MKDOCS
 
+from readthedocs.config.utils import yaml_load_safely
 from readthedocs.doc_builder.base import BaseBuilder
 from readthedocs.doc_builder.exceptions import MkDocsYAMLParseError
 from readthedocs.projects.models import Feature
@@ -75,7 +76,7 @@ class BaseMkdocs(BaseBuilder):
         https://www.mkdocs.org/user-guide/configuration/#use_directory_urls
         """
         with open(self.yaml_file, 'r') as f:
-            config = yaml.safe_load(f)
+            config = yaml_load_safely(f)
             use_directory_urls = config.get('use_directory_urls', True)
             return MKDOCS if use_directory_urls else MKDOCS_HTML
 
@@ -96,7 +97,7 @@ class BaseMkdocs(BaseBuilder):
         :raises: ``MkDocsYAMLParseError`` if failed due to syntax errors.
         """
         try:
-            config = yaml.safe_load(open(self.yaml_file, 'r'))
+            config = yaml_load_safely(open(self.yaml_file, 'r'))
 
             if not config:
                 raise MkDocsYAMLParseError(

--- a/readthedocs/rtd_tests/tests/test_doc_builder.py
+++ b/readthedocs/rtd_tests/tests/test_doc_builder.py
@@ -11,9 +11,8 @@ from django.test.utils import override_settings
 from django_dynamic_fixture import get
 from unittest.mock import patch
 
-from readthedocs.config.utils import yaml_load_safely
 from readthedocs.builds.models import Version
-from readthedocs.doc_builder.backends.mkdocs import MkdocsHTML
+from readthedocs.doc_builder.backends.mkdocs import MkdocsHTML, yaml_load_safely
 from readthedocs.doc_builder.backends.sphinx import BaseSphinx
 from readthedocs.doc_builder.exceptions import MkDocsYAMLParseError
 from readthedocs.doc_builder.python_environments import Virtualenv

--- a/readthedocs/rtd_tests/tests/test_doc_builder.py
+++ b/readthedocs/rtd_tests/tests/test_doc_builder.py
@@ -11,6 +11,7 @@ from django.test.utils import override_settings
 from django_dynamic_fixture import get
 from unittest.mock import patch
 
+from readthedocs.config.utils import yaml_load_safely
 from readthedocs.builds.models import Version
 from readthedocs.doc_builder.backends.mkdocs import MkdocsHTML
 from readthedocs.doc_builder.backends.sphinx import BaseSphinx
@@ -355,7 +356,7 @@ class MkdocsBuilderTest(TestCase):
         # There is a mkdocs.yml file created
         generated_yaml = os.path.join(tmpdir, 'mkdocs.yml')
         self.assertTrue(os.path.exists(generated_yaml))
-        config = yaml.safe_load(open(generated_yaml))
+        config = yaml_load_safely(open(generated_yaml))
         self.assertEqual(
             config['docs_dir'],
             os.path.join(tmpdir, 'docs'),
@@ -412,7 +413,7 @@ class MkdocsBuilderTest(TestCase):
 
         run.assert_called_with('cat', 'mkdocs.yml', cwd=mock.ANY)
 
-        config = yaml.safe_load(open(yaml_file))
+        config = yaml_load_safely(open(yaml_file))
         self.assertEqual(
             config['docs_dir'],
             'docs',
@@ -502,7 +503,7 @@ class MkdocsBuilderTest(TestCase):
 
         run.assert_called_with('cat', 'mkdocs.yml', cwd=mock.ANY)
 
-        config = yaml.safe_load(open(yaml_file))
+        config = yaml_load_safely(open(yaml_file))
         self.assertEqual(
             config['theme_dir'],
             'not-readthedocs',
@@ -606,7 +607,7 @@ class MkdocsBuilderTest(TestCase):
 
         run.assert_called_with('cat', 'mkdocs.yml', cwd=mock.ANY)
 
-        config = yaml.safe_load(open(yaml_file))
+        config = yaml_load_safely(open(yaml_file))
 
         self.assertEqual(
             config['extra_css'],


### PR DESCRIPTION
Use a custom YAML loader to ignore all the unknown tags. This allow us to
support YAML files that have custom tags that are irrelevant for Read the Docs)
but are required for MkDocs to build the documentation properly.

Close: #6889 