### PR TITLE
Allow CORS for Embed API in our PR builds domain

### DIFF
--- a/readthedocs/core/signals.py
+++ b/readthedocs/core/signals.py
@@ -54,6 +54,14 @@ def decide_if_cors(sender, request, **kwargs):  # pylint: disable=unused-argumen
         if domain.exists():
             return True
 
+    if all([
+            request.path_info.startswith('/api/v2/embed/'),
+            request.method in SAFE_METHODS,
+            host == settings.RTD_EXTERNAL_VERSION_DOMAIN,
+    ]):
+        # Allow CORS for embed API in our PR builds
+        return True
+
     valid_url = False
     for url in WHITELIST_URLS:
         if request.path_info.startswith(url):


### PR DESCRIPTION
This PR allows us to use the Embed API in our PR builds.

I'm not sure if this could be a security issue, but I think it's not. It would be good to have some opinions on this. I'm assuming that if you were able to create a PR, you have access to the whole docs repository already.