### PR TITLE
Include the project slug in the PR context

### DIFF
--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -433,11 +433,13 @@ class GitHubService(Service):
         if state == BUILD_STATUS_SUCCESS:
             target_url = build.version.get_absolute_url()
 
+        context = f'{settings.RTD_BUILD_STATUS_API_NAME}:{project.slug}'
+
         data = {
             'state': github_build_state,
             'target_url': target_url,
             'description': description,
-            'context': settings.RTD_BUILD_STATUS_API_NAME
+            'context': context,
         }
 
         resp = None

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -519,11 +519,13 @@ class GitLabService(Service):
         if state == BUILD_STATUS_SUCCESS:
             target_url = build.version.get_absolute_url()
 
+        context = f'{settings.RTD_BUILD_STATUS_API_NAME}:{project.slug}'
+
         data = {
             'state': gitlab_build_state,
             'target_url': target_url,
             'description': description,
-            'context': settings.RTD_BUILD_STATUS_API_NAME
+            'context': context,
         }
         url = self.adapter.provider_base_url
 


### PR DESCRIPTION
We have cases where the same repo has multiple projects on RTD,
so we can support multiple builds that are happening for the same commit.

This is probably not the best design so we'll want to think more about this,
but I think showing them all for now at least makes sense.