### PR TITLE
Canonicalize domains and redirect in proxito

### DIFF
--- a/dockerfiles/nginx/proxito.conf
+++ b/dockerfiles/nginx/proxito.conf
@@ -58,6 +58,8 @@ server {
         add_header X-RTD-Domain $rtd_domain always;
         set $rtd_method $upstream_http_x_rtd_version_method;
         add_header X-RTD-Version-Method $rtd_method always;
+        set $rtd_redirect $upstream_http_x_rtd_redirect;
+        add_header X-RTD-Redirect $rtd_redirect always;
     }
 
     # Serve 404 pages here

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -95,10 +95,8 @@ def map_host_to_project_slug(request):  # pylint: disable=too-many-return-statem
             log.debug('Proxito CNAME HTTPS Redirect: host=%s', host)
             request.canonicalize = 'https'
 
-        if not domain.canonical:
-            # This should redirect to the canonical CNAME
-            log.debug('Proxito CNAME Non-Canonical Redirect: host=%s', host)
-            request.canonicalize = 'noncanonical-cname'
+        # NOTE: consider redirecting non-canonical custom domains to the canonical one
+        # Whether that is another custom domain or the public domain
 
         return project_slug
 

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -87,7 +87,9 @@ def map_host_to_project_slug(request):  # pylint: disable=too-many-return-statem
         if domain.https and not request.is_secure():
             # Redirect HTTP -> HTTPS (302) for this custom domain
             log.debug('Proxito CNAME HTTPS Redirect: host=%s', host)
-            return redirect('https://{}{}'.format(host, request.get_full_path()))
+            resp = redirect('https://{}{}'.format(host, request.get_full_path()))
+            resp['X-RTD-Redirect'] = 'https'
+            return resp
 
         return project_slug
 

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -87,7 +87,7 @@ def map_host_to_project_slug(request):  # pylint: disable=too-many-return-statem
         if domain.https and not request.is_secure():
             # Redirect HTTP -> HTTPS (302) for this custom domain
             log.debug('Proxito CNAME HTTPS Redirect: host=%s', host)
-            return redirect('https://%s%s' % (host, request.get_full_path()))
+            return redirect('https://{}{}'.format(host, request.get_full_path()))
 
         return project_slug
 

--- a/readthedocs/proxito/tests/base.py
+++ b/readthedocs/proxito/tests/base.py
@@ -5,10 +5,9 @@ import pytest
 import django_dynamic_fixture as fixture
 from django.contrib.auth.models import User
 from django.test import TestCase
-from django.test.utils import override_settings
 
 from readthedocs.projects.constants import PUBLIC
-from readthedocs.projects.models import Project
+from readthedocs.projects.models import Project, Domain
 
 
 @pytest.mark.proxito
@@ -66,3 +65,7 @@ class BaseDocServing(TestCase):
         )
         self.subproject_alias.versions.update(privacy_level=PUBLIC)
         self.project.add_subproject(self.subproject_alias, alias='this-is-an-alias')
+
+        # These can be set to canonical as needed in specific tests
+        self.domain = fixture.get(Domain, project=self.project, domain='docs1.example.com', https=True)
+        self.domain2 = fixture.get(Domain, project=self.project, domain='docs2.example.com', https=True)

--- a/readthedocs/proxito/tests/test_middleware.py
+++ b/readthedocs/proxito/tests/test_middleware.py
@@ -51,6 +51,10 @@ class MiddlewareTests(RequestFactoryTestMixin, TestCase):
                 res['Location'],
                 f'https://{domain}{url}',
             )
+            self.assertEqual(
+                res['X-RTD-Redirect'],
+                'https',
+            )
 
     def test_proper_cname_uppercase(self):
         get(Domain, project=self.pip, domain='docs.random.com')

--- a/readthedocs/proxito/tests/test_middleware.py
+++ b/readthedocs/proxito/tests/test_middleware.py
@@ -38,6 +38,20 @@ class MiddlewareTests(RequestFactoryTestMixin, TestCase):
         self.assertEqual(request.cname, True)
         self.assertEqual(request.host_project_slug, 'pip')
 
+    def test_proper_cname_https_upgrade(self):
+        domain = 'docs.random.com'
+        get(Domain, project=self.pip, domain=domain, https=True)
+
+        for url in (self.url, '/subdir/'):
+            request = self.request(url, HTTP_HOST=domain)
+            res = self.run_middleware(request)
+            self.assertIsNotNone(res)
+            self.assertEqual(res.status_code, 302)
+            self.assertEqual(
+                res['Location'],
+                f'https://{domain}{url}',
+            )
+
     def test_proper_cname_uppercase(self):
         get(Domain, project=self.pip, domain='docs.random.com')
         request = self.request(self.url, HTTP_HOST='docs.RANDOM.COM')

--- a/readthedocs/proxito/tests/test_middleware.py
+++ b/readthedocs/proxito/tests/test_middleware.py
@@ -69,6 +69,8 @@ class MiddlewareTests(RequestFactoryTestMixin, TestCase):
             self.assertTrue(hasattr(request, 'canonicalize'))
             self.assertEqual(request.canonicalize, 'canonical-cname')
 
+    # We are not canonicalizing custom domains -> public domain for now
+    @pytest.mark.xfail(strict=True)
     def test_canonical_cname_redirect_public_domain(self):
         """Requests to a custom domain should redirect to the public domain or canonical domain if not canonical."""
         cname = 'docs.random.com'

--- a/readthedocs/proxito/tests/test_redirects.py
+++ b/readthedocs/proxito/tests/test_redirects.py
@@ -1,6 +1,6 @@
 # Copied from .org test_redirects
 
-
+import pytest
 from django.test import override_settings
 
 from .base import BaseDocServing
@@ -66,14 +66,15 @@ class RedirectTests(BaseDocServing):
         self.assertEqual(r['X-RTD-Redirect'], 'canonical-cname')
 
         # We should redirect before 404ing
-        r = self.client.get('/en/latest/404after302', HTTP_HOST=self.domain2.domain)
+        r = self.client.get('/en/latest/404after302', HTTP_HOST='project.dev.readthedocs.io')
         self.assertEqual(r.status_code, 302)
         self.assertEqual(
             r['Location'], f'https://{self.domain.domain}/en/latest/404after302',
         )
-        # Ensure this redirects a noncanonical CNAME to the canonical one
-        self.assertEqual(r['X-RTD-Redirect'], 'noncanonical-cname')
+        self.assertEqual(r['X-RTD-Redirect'], 'canonical-cname')
 
+    # We are not canonicalizing custom domains -> public domain for now
+    @pytest.mark.xfail(strict=True)
     def test_canonicalize_cname_to_public_domain_redirect(self):
         """Redirect to the public domain if the CNAME is not canonical."""
         r = self.client.get('/', HTTP_HOST=self.domain.domain)

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -76,6 +76,10 @@ class ServeDocsBase(ServeRedirectMixin, ServeDocsMixin, View):
             final_project.slug, subproject_slug, lang_slug, version_slug, filename
         )
 
+        # Handle requests that need canonicalizing (eg. HTTP -> HTTPS, redirect to canonical domain)
+        if hasattr(request, 'canonicalize'):
+            return self.canonical_redirect(request, final_project, version_slug, filename)
+
         # Handle a / redirect when we aren't a single version
         if all([
                 lang_slug is None,


### PR DESCRIPTION
- Do HTTP -> HTTPS redirects if `domain.https`
- Redirect public domain to canonical CNAME if `domain.canonical`
- ~~Redirect CNAME -> public domain (or another canonical domain) if the requested custom domain is not canonical~~
- Set additional data on the `X-RTD-Redirect` header whether the redirect is to canonicalize, a system redirect, or a user redirect

If this is merged, #6882 can be closed as it won't be needed. This is an alternative that uses the same code from the resolver to perform the redirect to the appropriate domain.

Fixes: https://github.com/readthedocs/readthedocs.org/issues/4641

## Concerns

I don't think the HTTP -> HTTPS redirect is a concern. Users who set `domain.https` will be happy with the change and users who didn't won't see a change.

~~The canonicalizing domain change is a little more worrying. Users who don't have `domain.canonical` set might be surprised their domain is now redirecting to `slug.readthedocs.io/...` (or the equivalent on readthedocs.com). Maybe we need a big note in the changelog about setting `domain.canonical`?~~