### PR TITLE
Use requests.head to query storage.exists

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -38,6 +38,8 @@ services:
       - ${PWD}/dockerfiles/settings/proxito.py:/usr/src/app/checkouts/readthedocs.org/readthedocs/settings/proxito_docker.py
     environment:
       - DJANGO_SETTINGS_MODULE=readthedocs.settings.proxito_docker
+    extra_hosts:
+      - "community.dev.readthedocs.io:10.10.0.100"
 
   web:
     image: community_server:latest


### PR DESCRIPTION
We have been having some issues with Azure's API and long timeouts. So, we are
going to try hitting the storage directly with a HEAD request hoping that it
will with better performance.