### PR TITLE
Change the dashboard search to default to searching files

### DIFF
--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -97,6 +97,14 @@ class ProjectDashboard(PrivateViewMixin, ListView):
     model = Project
     template_name = 'projects/project_dashboard.html'
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        # Set the default search to search files instead of projects
+        # when we're hosting private docs
+        if settings.ALLOW_PRIVATE_REPOS:
+            context['type'] = 'file'
+        return context
+
     def validate_primary_email(self, user):
         """
         Sends a persistent error notification.

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -97,6 +97,7 @@ class ProjectDashboard(PrivateViewMixin, ListView):
     model = Project
     template_name = 'projects/project_dashboard.html'
 
+    # pylint: disable=arguments-differ
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         # Set the default search to search files instead of projects

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -100,9 +100,7 @@ class ProjectDashboard(PrivateViewMixin, ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         # Set the default search to search files instead of projects
-        # when we're hosting private docs
-        if settings.ALLOW_PRIVATE_REPOS:
-            context['type'] = 'file'
+        context['type'] = 'file'
         return context
 
     def validate_primary_email(self, user):

--- a/readthedocs/templates/projects/project_dashboard_base.html
+++ b/readthedocs/templates/projects/project_dashboard_base.html
@@ -108,7 +108,7 @@
     <div class="module search search-dashboard">
       <form action="{% url 'search' %}" method="GET">
         <div class="text-input-wrapper search search-dashboard">
-          <input type="text" name="q" class="search" placeholder="{% trans 'Search Read the Docs' %}">
+          <input type="text" name="q" class="search" placeholder="{% trans 'Search all docs' %}">
           {% if type %}
             <input type="hidden" name="type" value="{{ type }}">
           {% endif %}


### PR DESCRIPTION
A project search for the .com use-case only returns projects already in the dashboard,
so it makes little sense there.
This changes it so that the search bar actually searches files first,
which is almost certainly what people want most of the time.

We could also consider changing the default search on the frontpage of the .org to search files,
but I'm not quite sure that is as important. 