### PR TITLE
Remove note about underscore in domain

### DIFF
--- a/docs/custom_domains.rst
+++ b/docs/custom_domains.rst
@@ -13,13 +13,6 @@ If you go to ``<slug>.readthedocs.io``, it should show you the latest version of
 A good example is https://pip.readthedocs.io
 For :doc:`/commercial/index` the subdomain looks like ``<slug>.readthedocs-hosted.com``.
 
-.. note::
-
-   If you have an old project that has an underscore (_) in the name,
-   it will use a subdomain with a hyphen (-).
-   `RFC 1035 <https://tools.ietf.org/html/rfc1035>`_ has more information on valid subdomains.
-
-
 Custom domain support
 ---------------------
 


### PR DESCRIPTION
I think this note distracts more than it helps. There are 7 projects on .org with a `_` in the slug and 4 on .com. Most of these are *our* projects as well. It isn't possible to create a new project with an underscore.