### PR TITLE
CAA records are not only for users of Cloudflare DNS

### DIFF
--- a/docs/custom_domains.rst
+++ b/docs/custom_domains.rst
@@ -63,22 +63,26 @@ You can also host your documentation from your own domain.
          they do not yet allow us to acquire SSL certificates for those domains.
          Follow the new setup to have a SSL certificate.
 
-      .. warning:: Notes for Cloudflare users
+      .. admonition:: Certificate Authority Authorization (CAA)
 
-         - If your domain has configured CAA records, please do not forget to include
-           Cloudflare CAA entries, see their `Certification Authority Authorization (CAA)
-           FAQ <https://support.cloudflare.com/hc/en-us/articles/115000310832-Certification-Authority-Authorization-CAA-FAQ>`__.
+         If your custom domain — either the subdomain you're using or the root domain — has configured CAA records,
+         please do not forget to include Cloudflare CAA entries to allow them to issue an SSL certificate for the domain.
+         See their `CAA FAQ`_ for details.
 
-         - Due to a limitation,
-           a domain cannot be proxied on Cloudflare to another Cloudflare account that also proxies.
-           This results in a "CNAME Cross-User Banned" error.
-           In order to do SSL termination, we must proxy this connection.
-           If you don't want us to do SSL termination for your domain —
-           **which means you are responsible for the SSL certificate** —
-           then set your CNAME to ``cloudflare-to-cloudflare.readthedocs.io`` instead of ``readthedocs.io``.
-           For more details, see `this previous issue`_.
+         .. _CAA FAQ: https://support.cloudflare.com/hc/en-us/articles/115000310832-Certification-Authority-Authorization-CAA-FAQ
 
-           .. _this previous issue: https://github.com/readthedocs/readthedocs.org/issues/4395
+      .. admonition:: Notes for Cloudflare users
+
+         Due to a limitation,
+         a domain cannot be proxied on Cloudflare to another Cloudflare account that also proxies.
+         This results in a "CNAME Cross-User Banned" error.
+         In order to do SSL termination, we must proxy this connection.
+         If you don't want us to do SSL termination for your domain —
+         **which means you are responsible for the SSL certificate** —
+         then set your CNAME to ``cloudflare-to-cloudflare.readthedocs.io`` instead of ``readthedocs.io``.
+         For more details, see `this previous issue`_.
+
+         .. _this previous issue: https://github.com/readthedocs/readthedocs.org/issues/4395
 
    .. tab:: Read the Docs for Business
 

--- a/docs/custom_domains.rst
+++ b/docs/custom_domains.rst
@@ -68,6 +68,7 @@ You can also host your documentation from your own domain.
          If your custom domain — either the subdomain you're using or the root domain — has configured CAA records,
          please do not forget to include Cloudflare CAA entries to allow them to issue a certificate for your custom domain.
          See the `Cloudflare CAA FAQ`_ for details.
+         We need a record that looks like this: ``0 issue "digicert.com"`` in response to ``dig +short CAA <domain>``
 
          .. _Cloudflare CAA FAQ: https://support.cloudflare.com/hc/en-us/articles/115000310832-Certification-Authority-Authorization-CAA-FAQ
 

--- a/docs/custom_domains.rst
+++ b/docs/custom_domains.rst
@@ -66,10 +66,10 @@ You can also host your documentation from your own domain.
       .. admonition:: Certificate Authority Authorization (CAA)
 
          If your custom domain — either the subdomain you're using or the root domain — has configured CAA records,
-         please do not forget to include Cloudflare CAA entries to allow them to issue an SSL certificate for the domain.
-         See their `CAA FAQ`_ for details.
+         please do not forget to include Cloudflare CAA entries to allow them to issue a certificate for your custom domain.
+         See the `Cloudflare CAA FAQ`_ for details.
 
-         .. _CAA FAQ: https://support.cloudflare.com/hc/en-us/articles/115000310832-Certification-Authority-Authorization-CAA-FAQ
+         .. _Cloudflare CAA FAQ: https://support.cloudflare.com/hc/en-us/articles/115000310832-Certification-Authority-Authorization-CAA-FAQ
 
       .. admonition:: Notes for Cloudflare users
 
@@ -103,6 +103,14 @@ You can also host your documentation from your own domain.
 
          Some older setups configured a CNAME record pointing to ``<organization-slug>.users.readthedocs.com``.
          These domains will continue to resolve.
+
+      .. admonition:: Certificate Authority Authorization (CAA)
+
+         If your custom domain — either the subdomain you're using or the root domain — has configured CAA records,
+         please do not forget to include AWS Certificate Manager CAA entries to allow them to issue a certificate for your custom domain.
+         See the `Amazon CAA guide`_ for details.
+
+         .. _Amazon CAA guide: https://docs.aws.amazon.com/acm/latest/userguide/setup-caa.html
 
 Proxy SSL
 ---------


### PR DESCRIPTION
This change moves the CAA record note out of the Cloudflare note. Users of any DNS provider can configure CAA records which prevent us/Cloudflare from issuing SSL certificates.

I also noted that if somebody has a CAA record for the root domain that it also applies to the subdomain.