### PR TITLE
Do not override the domain of Azure Storage

### DIFF
--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -110,7 +110,6 @@ class DockerBaseSettings(CommunityDevSettings):
     AZURE_ACCOUNT_KEY = 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=='
     AZURE_CONTAINER = 'static'
     AZURE_STATIC_STORAGE_CONTAINER = AZURE_CONTAINER
-    AZURE_MEDIA_STORAGE_HOSTNAME = PRODUCTION_DOMAIN
 
     # We want to replace files for the same version built
     AZURE_OVERWRITE_FILES = True


### PR DESCRIPTION
Now we are not proxying the Storage request via NGINX anymore, all the internal
communication between containers should be done using the containers
host (e.g. `storage:10000`).

This is required for example by the Embed API that hits the storage from the web
container, which does not work anymore hitting `community.dev.readthedocs.io`
since we removed the NGINX proxy rule.