### PR TITLE
Optimization on `sync_versions` to use ls-remote on Git VCS

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1516,6 +1516,7 @@ class Feature(models.Model):
     CACHED_ENVIRONMENT = 'cached_environment'
     CELERY_ROUTER = 'celery_router'
     LIMIT_CONCURRENT_BUILDS = 'limit_concurrent_builds'
+    VCS_REMOTE_LISTING = 'vcs_remote_listing'
 
     FEATURES = (
         (USE_SPHINX_LATEST, _('Use latest version of Sphinx')),
@@ -1593,6 +1594,10 @@ class Feature(models.Model):
         (
             LIMIT_CONCURRENT_BUILDS,
             _('Limit the amount of concurrent builds'),
+        ),
+        (
+            VCS_REMOTE_LISTING,
+            _('Use remote listing in VCS (e.g. git ls-remote) if supported for sync versions'),
         ),
     )
 

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -381,7 +381,7 @@ class SyncRepositoryTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
                     # all the other cached things (Python packages, Sphinx,
                     # virtualenv, etc)
                     self.pull_cached_environment()
-                    self.sync_repo(environment)
+                    self.update_versions_from_repository(environment)
             return True
         except RepositoryError:
             # Do not log as ERROR handled exceptions
@@ -410,9 +410,9 @@ class SyncRepositoryTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
         # Always return False for any exceptions
         return False
 
-    def sync_repo(self, environment):
+    def update_versions_from_repository(self, environment):
         """
-        Sync a repository doing a full clone (calling super()) or only listing its branches/tags.
+        Update Read the Docs versions from VCS repository.
 
         Depending if the VCS backend supports remote listing, we just list its branches/tags
         remotely or we do a full clone and local listing of branches/tags.
@@ -423,7 +423,7 @@ class SyncRepositoryTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
                 not self.project.has_feature(Feature.VCS_REMOTE_LISTING),
         ]):
             log.info('Syncing repository via full clone. project=%s', self.projec.slug)
-            super().sync_repo(environment)
+            self.sync_repo(environment)
         else:
             log.info('Syncing repository via remote listing. project=%s', self.projec.slug)
             self.sync_versions(version_repo)

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -246,24 +246,33 @@ class SyncRepositoryMixin:
         ``sync_versions`` endpoint.
         """
         version_post_data = {'repo': version_repo.repo_url}
+        tags = None
+        branches = None
+        if version_repo.supports_lsremote and not version_repo.repo_exists():
+            # Do not use ``ls-remote`` if the VCS does not support it or if we
+            # have already cloned the repository locally. The latter happens
+            # when triggering a normal build.
+            branches, tags = version_repo.lsremote
 
         if all([
             version_repo.supports_tags,
             not self.project.has_feature(Feature.SKIP_SYNC_TAGS)
         ]):
+            tags = tags or version_repo.tags
             version_post_data['tags'] = [{
                 'identifier': v.identifier,
                 'verbose_name': v.verbose_name,
-            } for v in version_repo.tags]
+            } for v in tags]
 
         if all([
             version_repo.supports_branches,
             not self.project.has_feature(Feature.SKIP_SYNC_BRANCHES)
         ]):
+            branches = branches or version_repo.branches
             version_post_data['branches'] = [{
                 'identifier': v.identifier,
                 'verbose_name': v.verbose_name,
-            } for v in version_repo.branches]
+            } for v in branches]
 
         self.validate_duplicate_reserved_versions(version_post_data)
 

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -248,7 +248,11 @@ class SyncRepositoryMixin:
         version_post_data = {'repo': version_repo.repo_url}
         tags = None
         branches = None
-        if version_repo.supports_lsremote and not version_repo.repo_exists():
+        if all([
+                version_repo.supports_lsremote,
+                not version_repo.repo_exists(),
+                project.has_feature(Feature.VCS_REMOTE_LISTING),
+        ]):
             # Do not use ``ls-remote`` if the VCS does not support it or if we
             # have already cloned the repository locally. The latter happens
             # when triggering a normal build.

--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -44,6 +44,43 @@ class TestGitBackend(RTDTestCase):
         self.dummy_conf.submodules.include = ALL
         self.dummy_conf.submodules.exclude = []
 
+    def test_git_lsremote(self):
+        repo_path = self.project.repo
+        default_branches = [
+            # comes from ``make_test_git`` function
+            'submodule',
+            'invalidsubmodule',
+        ]
+        branches = [
+            'develop',
+            'master',
+            '2.0.X',
+            'release/2.0.0',
+            'release/foo/bar',
+        ]
+        for branch in branches:
+            create_git_branch(repo_path, branch)
+
+        create_git_tag(repo_path, 'v01')
+        create_git_tag(repo_path, 'v02', annotated=True)
+        create_git_tag(repo_path, 'release-ünîø∂é')
+
+        repo = self.project.vcs_repo()
+        # create the working dir if it not exists. It's required to ``cwd`` to
+        # execute the command
+        repo.check_working_dir()
+        repo_branches, repo_tags = repo.lsremote
+
+        self.assertEqual(
+            set(branches + default_branches),
+            {branch.verbose_name for branch in repo_branches},
+        )
+
+        self.assertEqual(
+            {'v01', 'v02', 'release-ünîø∂é'},
+            {vcs.verbose_name for vcs in repo_tags},
+        )
+
     @patch('readthedocs.projects.models.Project.checkout_path')
     def test_git_branches(self, checkout_path):
         repo_path = self.project.repo

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -8,7 +8,7 @@ import re
 
 import git
 from django.core.exceptions import ValidationError
-from git.exc import BadName, InvalidGitRepositoryError
+from git.exc import BadName, InvalidGitRepositoryError, NoSuchPathError
 
 from readthedocs.builds.constants import EXTERNAL
 from readthedocs.config import ALL
@@ -74,7 +74,7 @@ class Backend(BaseVCS):
     def repo_exists(self):
         try:
             git.Repo(self.working_dir)
-        except InvalidGitRepositoryError:
+        except (InvalidGitRepositoryError, NoSuchPathError):
             return False
         return True
 
@@ -209,6 +209,7 @@ class Backend(BaseVCS):
         """
         cmd = ['git', 'ls-remote', self.repo_url]
 
+        self.check_working_dir()
         code, stdout, stderr = self.run(*cmd)
         if code != 0:
             raise RepositoryError

--- a/readthedocs/vcs_support/base.py
+++ b/readthedocs/vcs_support/base.py
@@ -45,6 +45,9 @@ class BaseVCS:
     supports_branches = False  # Whether this VCS supports branches or not.
     supports_submodules = False
 
+    # Whether this VCS supports listing remotes (branches, tags) without clonning
+    supports_lsremote = False
+
     # =========================================================================
     # General methods
     # =========================================================================


### PR DESCRIPTION
When a webhook is received we synchronize the branches/tags to create new
versions under Read the Docs. For this process we do a full clone of the
repository and iterate over the branches/tags.

As this process of cloning the repository just for updating versions could be
expensive, this commit adds the ability to use `ls-remote` on Git VCS just to
query the repository for its branches/tags without performing a full clone.


Closes #6508