### PR TITLE
Revert usage of watchman

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -51,15 +51,4 @@ RUN if [ -n "$GITHUB_TOKEN" ] ; \
         pip3 install --no-cache-dir -e readthedocs-ext ; \
         fi
 
-# Use watchman for Django ``runserver`` command
-# (this is new in Django 2.2 and could help to reduce CPU usage)
-ENV DJANGO_WATCHMAN_TIMEOUT 15
-RUN apt-get install -y libssl-dev autoconf automake libtool
-RUN git clone https://github.com/facebook/watchman.git -b v4.9.0 --depth 1; \
-        cd watchman; \
-        ./autogen.sh; \
-        ./configure; \
-        make; \
-        make install
-
 WORKDIR /usr/src/app/checkouts/readthedocs.org

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -8,7 +8,6 @@ pillow==7.0.0
 
 # local debugging tools
 watchdog==0.9.0
-pywatchman==1.4.1
 datadiff==2.0.0
 ipdb==0.12.2
 pdbpp==0.10.2


### PR DESCRIPTION
This is only useful if you are running runserver on the host

> If you’re using Linux or MacOS and install both pywatchman and the
> Watchman service, kernel signals will be used to autoreload the server