### PR TITLE
Revert "Use requests.head to query storage.exists"

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -38,8 +38,6 @@ services:
       - ${PWD}/dockerfiles/settings/proxito.py:/usr/src/app/checkouts/readthedocs.org/readthedocs/settings/proxito_docker.py
     environment:
       - DJANGO_SETTINGS_MODULE=readthedocs.settings.proxito_docker
-    extra_hosts:
-      - "community.dev.readthedocs.io:10.10.0.100"
 
   web:
     image: community_server:latest

--- a/readthedocs/storage/azure_storage.py
+++ b/readthedocs/storage/azure_storage.py
@@ -2,9 +2,8 @@
 # Disable: Method 'path' is abstract in class 'Storage' but is not overridden
 
 """Django storage classes to use with Azure Blob storage service."""
-import logging
-import requests
 
+import logging
 from azure.common import AzureMissingResourceHttpError
 from django.conf import settings
 from django.contrib.staticfiles.storage import ManifestFilesMixin
@@ -36,14 +35,9 @@ class AzureBuildMediaStorage(BuildMediaStorageMixin, OverrideHostnameMixin, Azur
         return super().url(name, expire)
 
     def exists(self, name):
-        """
-        Override to use ``requests.head`` instead.
-
-        Azure's API gives us up to 20s timeout on these requests sometimes.
-        """
-        url = self.url(name)
+        """Override to catch timeout exception and return False."""
         try:
-            return requests.head(url, timeout=self.timeout).ok
+            return super().exists(name)
         except Exception:  # pylint: disable=broad-except
             log.exception('Timeout calling Azure .exists. name=%s', name)
             return False


### PR DESCRIPTION
This reverts commit 9c062ecea31196e3715835827c389fa7b22495f7.

It seems that Azure has fixed their problem already and the API is working
better now. Besides, using requests.head here is hitting
buildmedia.readthedocs.org and that's not good.