### PR TITLE
Return max_concurrent_builds in ProjectAdminSerializer

### DIFF
--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -71,6 +71,7 @@ class ProjectAdminSerializer(ProjectSerializer):
             'has_valid_webhook',
             'show_advertising',
             'environment_variables',
+            'max_concurrent_builds',
         )
 
 

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -501,11 +501,18 @@ class UpdateDocsTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
 
             if self.project.has_feature(Feature.LIMIT_CONCURRENT_BUILDS):
                 response = api_v2.build.running.get(project__slug=self.project.slug)
+                builds_running = response.get('count', 0)
                 max_concurrent_builds = (
                     self.project.max_concurrent_builds or
                     settings.RTD_MAX_CONCURRENT_BUILDS
                 )
-                if response.get('count', 0) >= max_concurrent_builds:
+                log.info(
+                    'Concurrent builds: max=%s running=%s project=%s',
+                    max_concurrent_builds,
+                    builds_running,
+                    self.project.slug,
+                )
+                if builds_running >= max_concurrent_builds:
                     log.warning(
                         'Delaying tasks due to concurrency limit. project=%s version=%s',
                         self.project.slug,

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -2288,6 +2288,7 @@ class APIVersionTests(TestCase):
                 'id': 6,
                 'install_project': False,
                 'language': 'en',
+                'max_concurrent_builds': None,
                 'name': 'Pip',
                 'programming_language': 'words',
                 'python_interpreter': 'python3',


### PR DESCRIPTION
Use this value to know max concurrent builds per-project. There was a bug that
we weren't sending this value in the serializer and it was always None.

Besides, it adds some useful logging to know what's happening.