### PR TITLE
Return 400 when importing an already existing project

### DIFF
--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -11,6 +11,7 @@ from rest_flex_fields.serializers import FlexFieldsSerializerMixin
 from rest_framework import serializers
 
 from readthedocs.builds.models import Build, Version
+from readthedocs.core.utils import slugify
 from readthedocs.projects.constants import (
     LANGUAGES,
     PROGRAMMING_LANGUAGES,
@@ -419,6 +420,14 @@ class ProjectCreateSerializer(FlexFieldsModelSerializer):
             'repository',
             'homepage',
         )
+
+    def validate_name(self, value):
+        potential_slug = slugify(value)
+        if Project.objects.filter(slug=potential_slug).exists():
+            raise serializers.ValidationError(
+                _('Project with slug "{0}" already exists.').format(potential_slug),
+            )
+        return value
 
 
 class ProjectUpdateSerializer(FlexFieldsModelSerializer):


### PR DESCRIPTION
Given the name of the project, calculate its potential slug and check there is
no project matching that slug already at serializer validation.

Closes #6947 