### PR TITLE
Fix the trailing slash in our repo regexs

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -497,7 +497,6 @@ class Version(models.Model):
         user, repo = get_github_username_repo(repo_url)
         if not user and not repo:
             return ''
-        repo = repo.rstrip('/')
 
         if not filename:
             # If there isn't a filename, we don't need a suffix
@@ -538,7 +537,6 @@ class Version(models.Model):
         user, repo = get_gitlab_username_repo(repo_url)
         if not user and not repo:
             return ''
-        repo = repo.rstrip('/')
 
         if not filename:
             # If there isn't a filename, we don't need a suffix

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -498,6 +498,7 @@ class Version(models.Model):
         if not user and not repo:
             return ''
 
+        repo = repo.rstrip('/')
         if not filename:
             # If there isn't a filename, we don't need a suffix
             source_suffix = ''
@@ -538,6 +539,7 @@ class Version(models.Model):
         if not user and not repo:
             return ''
 
+        repo = repo.rstrip('/')
         if not filename:
             # If there isn't a filename, we don't need a suffix
             source_suffix = ''

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -498,7 +498,6 @@ class Version(models.Model):
         if not user and not repo:
             return ''
 
-        repo = repo.rstrip('/')
         if not filename:
             # If there isn't a filename, we don't need a suffix
             source_suffix = ''
@@ -539,7 +538,6 @@ class Version(models.Model):
         if not user and not repo:
             return ''
 
-        repo = repo.rstrip('/')
         if not filename:
             # If there isn't a filename, we don't need a suffix
             source_suffix = ''
@@ -567,7 +565,6 @@ class Version(models.Model):
         user, repo = get_bitbucket_username_repo(repo_url)
         if not user and not repo:
             return ''
-        repo = repo.rstrip('/')
 
         if not filename:
             # If there isn't a filename, we don't need a suffix
@@ -803,7 +800,6 @@ class Build(models.Model):
                 if not user and not repo:
                     return ''
 
-                repo = repo.rstrip('/')
                 return GITHUB_PULL_REQUEST_COMMIT_URL.format(
                     user=user,
                     repo=repo,
@@ -815,7 +811,6 @@ class Build(models.Model):
                 if not user and not repo:
                     return ''
 
-                repo = repo.rstrip('/')
                 return GITLAB_MERGE_REQUEST_COMMIT_URL.format(
                     user=user,
                     repo=repo,
@@ -829,7 +824,6 @@ class Build(models.Model):
                 if not user and not repo:
                     return ''
 
-                repo = repo.rstrip('/')
                 return GITHUB_COMMIT_URL.format(
                     user=user,
                     repo=repo,
@@ -840,7 +834,6 @@ class Build(models.Model):
                 if not user and not repo:
                     return ''
 
-                repo = repo.rstrip('/')
                 return GITLAB_COMMIT_URL.format(
                     user=user,
                     repo=repo,
@@ -851,7 +844,6 @@ class Build(models.Model):
                 if not user and not repo:
                     return ''
 
-                repo = repo.rstrip('/')
                 return BITBUCKET_COMMIT_URL.format(
                     user=user,
                     repo=repo,

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -461,9 +461,10 @@ class GitHubService(Service):
             if resp.status_code in [401, 403, 404]:
                 log.info(
                     'GitHub project does not exist or user does not have '
-                    'permissions: project=%s, user=%s',
+                    'permissions: project=%s, user=%s, status=%s',
                     project,
                     self.user,
+                    resp.status_code,
                 )
                 return False
 

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -466,7 +466,7 @@ class GitHubService(Service):
                     project,
                     self.user,
                     resp.status_code,
-                    url=statuses_url
+                    statuses_url,
                 )
                 return False
 

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -445,8 +445,9 @@ class GitHubService(Service):
         resp = None
 
         try:
+            statuses_url = f'https://api.github.com/repos/{owner}/{repo}/statuses/{commit}'
             resp = session.post(
-                f'https://api.github.com/repos/{owner}/{repo}/statuses/{commit}',
+                statuses_url,
                 data=json.dumps(data),
                 headers={'content-type': 'application/json'},
             )
@@ -461,10 +462,11 @@ class GitHubService(Service):
             if resp.status_code in [401, 403, 404]:
                 log.info(
                     'GitHub project does not exist or user does not have '
-                    'permissions: project=%s, user=%s, status=%s',
+                    'permissions: project=%s, user=%s, status=%s, url=%s',
                     project,
                     self.user,
                     resp.status_code,
+                    url=statuses_url
                 )
                 return False
 

--- a/readthedocs/projects/constants.py
+++ b/readthedocs/projects/constants.py
@@ -320,6 +320,7 @@ GITHUB_REGEXS = [
 BITBUCKET_REGEXS = [
     re.compile(r'bitbucket.org/(.+)/(.+)\.git$'),
     re.compile(r'@bitbucket.org/(.+)/(.+)\.git$'),
+    # This must come before the one without a / to make sure we don't capture the /
     re.compile(r'bitbucket.org/(.+)/(.+)/'),
     re.compile(r'bitbucket.org/(.+)/(.+)'),
     re.compile(r'bitbucket.org:(.+)/(.+)\.git$'),
@@ -327,7 +328,7 @@ BITBUCKET_REGEXS = [
 GITLAB_REGEXS = [
     re.compile(r'gitlab.com/(.+)/(.+)(?:\.git){1}$'),
     # This must come before the one without a / to make sure we don't capture the /
-    re.compile(r'gitlab.com/(.+)/(.+)/?'),
+    re.compile(r'gitlab.com/(.+)/(.+)/'),
     re.compile(r'gitlab.com/(.+)/(.+)'),
     re.compile(r'gitlab.com:(.+)/(.+)\.git$'),
 ]

--- a/readthedocs/projects/constants.py
+++ b/readthedocs/projects/constants.py
@@ -320,7 +320,8 @@ GITHUB_REGEXS = [
 BITBUCKET_REGEXS = [
     re.compile(r'bitbucket.org/(.+)/(.+)\.git$'),
     re.compile(r'@bitbucket.org/(.+)/(.+)\.git$'),
-    re.compile(r'bitbucket.org/(.+)/(.+)/?'),
+    re.compile(r'bitbucket.org/(.+)/(.+)/'),
+    re.compile(r'bitbucket.org/(.+)/(.+)'),
     re.compile(r'bitbucket.org:(.+)/(.+)\.git$'),
 ]
 GITLAB_REGEXS = [

--- a/readthedocs/projects/constants.py
+++ b/readthedocs/projects/constants.py
@@ -312,6 +312,8 @@ PROJECT_SLUG_REGEX = r'(?:[-\w]+)'
 
 GITHUB_REGEXS = [
     re.compile(r'github.com/(.+)/(.+)(?:\.git){1}$'),
+    # This must come before the one without a / to make sure we don't capture the /
+    re.compile(r'github.com/(.+)/(.+)/'),
     re.compile(r'github.com/(.+)/(.+)'),
     re.compile(r'github.com:(.+)/(.+)\.git$'),
 ]
@@ -323,6 +325,8 @@ BITBUCKET_REGEXS = [
 ]
 GITLAB_REGEXS = [
     re.compile(r'gitlab.com/(.+)/(.+)(?:\.git){1}$'),
+    # This must come before the one without a / to make sure we don't capture the /
+    re.compile(r'gitlab.com/(.+)/(.+)/?'),
     re.compile(r'gitlab.com/(.+)/(.+)'),
     re.compile(r'gitlab.com:(.+)/(.+)\.git$'),
 ]

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -2179,6 +2179,8 @@ def send_build_status(build_pk, commit, status):
     build = Build.objects.get(pk=build_pk)
     provider_name = build.project.git_provider_name
 
+    log.info('Sending build status. build=%s, project=%s', build.pk, build.project.slug)
+
     if provider_name in [GITHUB_BRAND, GITLAB_BRAND]:
         # get the service class for the project e.g: GitHubService.
         service_class = build.project.git_service_class()

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -201,9 +201,10 @@ class GitHubOAuthTests(TestCase):
         self.assertFalse(success)
         mock_logger.info.assert_called_with(
             'GitHub project does not exist or user does not have '
-            'permissions: project=%s, user=%s',
+            'permissions: project=%s, user=%s, url=%s',
             self.project,
-            self.user
+            self.user,
+            'https://api.github.com/repos/pypa/pip/statuses/297'
         )
 
     @mock.patch('readthedocs.oauth.services.github.log')

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -201,9 +201,10 @@ class GitHubOAuthTests(TestCase):
         self.assertFalse(success)
         mock_logger.info.assert_called_with(
             'GitHub project does not exist or user does not have '
-            'permissions: project=%s, user=%s, url=%s',
+            'permissions: project=%s, user=%s, status=%s, url=%s',
             self.project,
             self.user,
+            404,
             'https://api.github.com/repos/pypa/pip/statuses/297'
         )
 


### PR DESCRIPTION
This was causing an issue with consumers of the GITHUB_REGEX.
We were calling `rstrip` in some client code,
but others were getting the `/`.

This fixes the actual regexs to properly not return the trailing /.