### PR TITLE
Stop builders gracefully on SIGTERM

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import shutil
+import signal
 import socket
 import tarfile
 import tempfile
@@ -404,7 +405,6 @@ class SyncRepositoryTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
     default_retry_delay=7 * 60,
 )
 def update_docs_task(self, version_pk, *args, **kwargs):
-    import signal
 
     def sigterm_received(*args, **kwargs):
         log.warning('SIGTERM received. Waiting for build to stop gracefully after it finishes.')

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -404,6 +404,15 @@ class SyncRepositoryTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
     default_retry_delay=7 * 60,
 )
 def update_docs_task(self, version_pk, *args, **kwargs):
+    import signal
+
+    def sigterm_received(*args, **kwargs):
+        log.warning('SIGTERM received. Waiting for build to stop gracefully after it finishes.')
+
+    # Do not send the SIGTERM signal to childs (pip is automatically killed when
+    # receives SIGTERM and make the build to fail one command and stop build)
+    signal.signal(signal.SIGTERM, sigterm_received)
+
     try:
         step = UpdateDocsTaskStep(task=self)
         return step.run(version_pk, *args, **kwargs)


### PR DESCRIPTION
When SIGTERM is received by the process that is building a build, we only log a
message instead of passing it to the child processes (`pip` running inside the
Docker container, for example).

Otherwise, the `pip` process also receives the SIGTERM and it kills itself,
producing a `exit_status != 0`, registering this as a BuildCommand and making
the whole build to fail. After that, celery "stops gracefully" with a failed build.

This is useful combined with supervisor to make our builders to stop gracefully
in this scenario:

1. supervisorctl stop build
2. celery receives the SIGTERM and logs the warning message
3. supervisor waits for `stopwaitsecs` before sending SIGKILL