### PR TITLE
Log build/sync tasks when triggered

### DIFF
--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -197,6 +197,12 @@ def trigger_build(project, version=None, commit=None, record=True, force=False):
     :returns: Celery AsyncResult promise and Build instance
     :rtype: tuple
     """
+    log.info(
+        'Triggering build. project=%s version=%s commit=%s',
+        project.slug,
+        version.slug if version else None,
+        commit,
+    )
     update_docs_task, build = prepare_build(
         project,
         version,

--- a/readthedocs/core/views/hooks.py
+++ b/readthedocs/core/views/hooks.py
@@ -100,6 +100,11 @@ def sync_versions(project):
             # respect the queue for this project
             options['queue'] = project.build_queue
 
+        log.info(
+            'Triggering sync repository. project=%s version=%s',
+            version.project.slug,
+            version.slug,
+        )
         sync_repository_task.apply_async(
             (version.pk,),
             **options,


### PR DESCRIPTION
Logging these 2 tasks _before executing them_ allows us to know immediately which project could be causing a spike on the celery queues. We can parse the logs and count how many tasks of each per project are waiting to be processed as well.