### PR TITLE
Pass the NO_COLOR env var to builder

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -882,6 +882,9 @@ class UpdateDocsTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
         """Get bash environment variables used for all builder commands."""
         env = self.get_rtd_env_vars()
 
+        # https://no-color.org/
+        env['NO_COLOR'] = '1'
+
         if self.config.conda is not None:
             env.update({
                 'CONDA_ENVS_PATH': os.path.join(self.project.doc_path, 'conda'),

--- a/readthedocs/rtd_tests/tests/test_builds.py
+++ b/readthedocs/rtd_tests/tests/test_builds.py
@@ -349,6 +349,7 @@ class BuildEnvironmentTests(TestCase):
         task.config = mock.Mock(conda=None)
 
         env = {
+            'NO_COLOR': '1',
             'READTHEDOCS': 'True',
             'READTHEDOCS_VERSION': version.slug,
             'READTHEDOCS_PROJECT': project.slug,


### PR DESCRIPTION
We should let tools know that we don't want ANSI escaped colors in
the output.

Closes #6883