### PR TITLE
More fixes for automatic Docker limits

### DIFF
--- a/readthedocs/doc_builder/constants.py
+++ b/readthedocs/doc_builder/constants.py
@@ -50,6 +50,12 @@ elif total_memory > 8000:
         'memory': '7g',
         'time': 1800,
     })
+elif total_memory > 7000:
+    # This is to catch AWS instances that actually only have 7.5G memory
+    DOCKER_LIMITS.update({
+        'memory': '6g',
+        'time': 1800,
+    })
 elif total_memory > 4000:
     DOCKER_LIMITS.update({
         'memory': '3g',

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -23,6 +23,7 @@ from readthedocs.api.v2.client import api
 from readthedocs.builds.constants import LATEST, STABLE, INTERNAL, EXTERNAL
 from readthedocs.core.resolver import resolve, resolve_domain
 from readthedocs.core.utils import broadcast, slugify
+from readthedocs.doc_builder.constants import DOCKER_LIMITS
 from readthedocs.projects import constants
 from readthedocs.projects.exceptions import ProjectConfigurationError
 from readthedocs.projects.managers import HTMLFileManager
@@ -896,7 +897,7 @@ class Project(models.Model):
         if max_lock_age is None:
             max_lock_age = (
                 self.container_time_limit or
-                settings.DOCKER_LIMITS.get('time') or
+                DOCKER_LIMITS.get('time') or
                 settings.REPO_LOCK_SECONDS
             )
 


### PR DESCRIPTION
* Add another level of automatic docker limit configuration for AWS. This is a
  bit of a hack, as the memory limits are different on AWS, but the time should
  still be 3600s by default.
* Fix usage of settings.DOCKER_LIMIT that was missed