### PR TITLE
Log sync_repository_task when we run it

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -359,6 +359,11 @@ class SyncRepositoryTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
                 update_on_success=False,
                 environment=self.get_rtd_env_vars(),
             )
+            log.info(
+                'Running sync_repository_task: project=%s, version=%s',
+                self.project.slug,
+                self.version.slug,
+            )
 
             with environment:
                 before_vcs.send(sender=self.version, environment=environment)

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -360,7 +360,7 @@ class SyncRepositoryTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
                 environment=self.get_rtd_env_vars(),
             )
             log.info(
-                'Running sync_repository_task: project=%s, version=%s',
+                'Running sync_repository_task: project=%s version=%s',
                 self.project.slug,
                 self.version.slug,
             )


### PR DESCRIPTION
This should make it more obvious what our builders are doing