### PR TITLE
Add a note if build status is not being reported

### DIFF
--- a/docs/guides/autobuild-docs-for-pull-requests.rst
+++ b/docs/guides/autobuild-docs-for-pull-requests.rst
@@ -42,7 +42,8 @@ you might hit one of these issues:
 
 #. **Build status is not being reported on your Pull/Merge Request**.
    You need to make sure that you have granted access to the Read the Docs
-   `OAuth App`_ to your/organizations GitHub account.
+   `OAuth App`_ to your/organizations GitHub account. If you do not see "Read the Docs"
+   among the `OAuth App`_, you might need to disconnect and reconnect to GitHub service.
    Also make sure your webhook is properly setup
    to handle events. You can setup or ``re-sync`` the webhook from your projects admin dashboard.
    Learn more about setting up webhooks from our :doc:`Webhook Documentation </webhooks>`.


### PR DESCRIPTION
In my case webhook worked fine, but RTD could neither update the webhook, nor could provide PR status update.  GitHub service was told to be connected, but there were no OAuth App listed for RTD.  Disconnect/Connect resolved the issue.