### PR TITLE
Start storing JSON data for PR builds

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1246,7 +1246,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
            For MkDocs search is indexed from its ``html`` artifacts.
            And in sphinx is run using the rtd-sphinx-extension.
         """
-        return self.is_type_sphinx() and self.version.type != EXTERNAL
+        return self.is_type_sphinx()
 
     def build_docs_localmedia(self):
         """Get local media files with separate build."""


### PR DESCRIPTION
This will let us do a couple things:

* Make the embed API work in PR previews
* Allow us to start indexing search for PRs once we want that feature-set