### PR TITLE
Move docker limits back to setting

### DIFF
--- a/readthedocs/doc_builder/constants.py
+++ b/readthedocs/doc_builder/constants.py
@@ -4,7 +4,6 @@
 
 import logging
 import re
-import subprocess
 
 from django.conf import settings
 
@@ -18,6 +17,7 @@ DOCKER_SOCKET = settings.DOCKER_SOCKET
 DOCKER_VERSION = settings.DOCKER_VERSION
 DOCKER_IMAGE = settings.DOCKER_IMAGE
 DOCKER_IMAGE_SETTINGS = settings.DOCKER_IMAGE_SETTINGS
+DOCKER_LIMITS = settings.DOCKER_LIMITS
 
 old_config = settings.DOCKER_BUILD_IMAGES
 if old_config:
@@ -25,51 +25,6 @@ if old_config:
         'Old config detected, DOCKER_BUILD_IMAGES->DOCKER_IMAGE_SETTINGS',
     )
     DOCKER_IMAGE_SETTINGS.update(old_config)
-
-DOCKER_LIMITS = {
-    'memory': '200m',
-    'time': 600,
-}
-
-# Set docker limits dynamically based on system memory
-# This assumes 1-builder per server
-try:
-    total_memory = int(subprocess.check_output("free -m | awk '/^Mem:/{print $2}'", shell=True))
-except ValueError:
-    # On systems without a `free` command it will return a string to int and raise a ValueError
-    log.exception('Failed to get memory size. Using defaults docker limits')
-    total_memory = 0
-
-if total_memory > 14000:
-    DOCKER_LIMITS.update({
-        'memory': '13g',
-        'time': 2400,
-    })
-elif total_memory > 8000:
-    DOCKER_LIMITS.update({
-        'memory': '7g',
-        'time': 1800,
-    })
-elif total_memory > 7000:
-    # This is to catch AWS instances that actually only have 7.5G memory
-    DOCKER_LIMITS.update({
-        'memory': '6g',
-        'time': 1800,
-    })
-elif total_memory > 4000:
-    DOCKER_LIMITS.update({
-        'memory': '3g',
-        'time': 900,
-    })
-elif total_memory > 2000:
-    DOCKER_LIMITS.update({
-        'memory': '1g',
-        'time': 600,
-    })
-
-if hasattr(settings, 'DOCKER_LIMITS'):
-    DOCKER_LIMITS.update(settings.DOCKER_LIMITS)
-
 
 DOCKER_TIMEOUT_EXIT_CODE = 42
 DOCKER_OOM_EXIT_CODE = 137

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -90,7 +90,6 @@ class CommunityBaseSettings(Settings):
     )
 
     # Read the Docs
-    RTD_IS_PRODUCTION = False
     READ_THE_DOCS_EXTENSIONS = ext
     RTD_LATEST = 'latest'
     RTD_LATEST_VERBOSE_NAME = 'latest'
@@ -482,7 +481,9 @@ class CommunityBaseSettings(Settings):
             'memory': '1g',
             'time': 600,
         }
-        if self.RTD_IS_PRODUCTION:
+
+        # Only run on our servers
+        if self.READ_THE_DOCS_EXTENSIONS:
             memory_limit = self._get_docker_memory_limit()
             if memory_limit:
                 limits = {

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -440,13 +440,16 @@ class CommunityBaseSettings(Settings):
             },
         },
     }
-
     # Alias tagged via ``docker tag`` on the build servers
     DOCKER_IMAGE_SETTINGS.update({
         'readthedocs/build:stable': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:5.0'),
         'readthedocs/build:latest': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:6.0'),
         'readthedocs/build:testing': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:7.0'),
     })
+    DOCKER_LIMITS = {
+        'memory': '1g',
+        'time': 600,
+    }
 
     # All auth
     ACCOUNT_ADAPTER = 'readthedocs.core.adapters.AccountAdapter'

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -2,6 +2,7 @@
 
 import getpass
 import os
+import subprocess
 
 from celery.schedules import crontab
 
@@ -89,6 +90,8 @@ class CommunityBaseSettings(Settings):
     )
 
     # Read the Docs
+    RTD_IS_PRODUCTION = False
+    RTD_SITE = 'community'
     READ_THE_DOCS_EXTENSIONS = ext
     RTD_LATEST = 'latest'
     RTD_LATEST_VERBOSE_NAME = 'latest'
@@ -446,10 +449,62 @@ class CommunityBaseSettings(Settings):
         'readthedocs/build:latest': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:6.0'),
         'readthedocs/build:testing': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:7.0'),
     })
-    DOCKER_LIMITS = {
-        'memory': '1g',
-        'time': 600,
-    }
+
+    def _get_docker_memory_limit(self):
+        try:
+            total_memory = int(subprocess.check_output(
+                "free -m | awk '/^Mem:/{print $2}'",
+                shell=True,
+            ))
+            return round(total_memory - 750, -2)
+        except ValueError:
+            # On systems without a `free` command it will return a string to
+            # int and raise a ValueError
+            log.exception('Failed to get memory size, using defaults Docker limits.')
+
+    def _get_docker_time_limit_coeff(self):
+        """
+        Get Docker time limit as a percentage of memory limit
+
+        Our hard coded time limits were between 0.225 and 0.3 of the memory
+        limit on community, so 0.25 is used. On commercial, we use 2x that by
+        default, 0.5.
+        """
+        coeff = 0.25
+        # This check could be more explicit, and we should probably just have a
+        # base setting with this. Alternatively, we move this method into
+        if self.RTD_SITE == 'commercial':
+            coeff = 0.5
+        return coeff
+
+    @property
+    def DOCKER_LIMITS(self):
+        """
+        Set docker limits dynamically, if in production, based on system memory.
+
+        We do this to avoid having separate build images defined by Salt pillar
+        data. This assumes 1 build process per server, which will be allowed to
+        consume all available memory.
+
+        We substract 750MiB for overhead of processes and base system, and set
+        the build time as proportional to the memory limit.
+        """
+        # Our normal default
+        limits = {
+            'memory': '1g',
+            'time': 600,
+        }
+        if self.RTD_IS_PRODUCTION:
+            memory_limit = self._get_docker_memory_limit()
+            if memory_limit:
+                limits = {
+                    'memory': f'{memory_limit}m',
+                    'time': max(
+                        limits['time'],
+                        round(memory_limit * self._get_docker_time_limit_coeff(), -2),
+                    )
+                }
+        return limits
 
     # All auth
     ACCOUNT_ADAPTER = 'readthedocs.core.adapters.AccountAdapter'


### PR DESCRIPTION
This setting was moved to a constant, which was harder to override and
replicated a lot of the same logic we had for settings. We hit a number
of issues around the DOCKER_LIMITS setting existing, and these constants
not being used, etc.

This hard codes a memory limit, which would be used for dev
environments outside Docker, and perhaps tests. Limits are 1g memory
and 600s build time -- up from 200m memory limit that is too small.

Production guessing of memory/time will be in ops settings now.

Refs #6983