### PR TITLE
Example about how to kill a running task

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -687,6 +687,12 @@ class Build(models.Model):
         _('Cold Storage'),
         help_text='Build steps stored outside the database.',
     )
+    task_id = models.CharField(
+        _('Celery task id'),
+        max_length=36,
+        null=True,
+        blank=True,
+    )
 
     # Managers
     objects = BuildManager.from_queryset(BuildQuerySet)()

--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -225,7 +225,10 @@ def trigger_build(project, version=None, commit=None, record=True, force=False):
         # Build was skipped
         return (None, None)
 
-    return (update_docs_task.apply_async(), build)
+    task = update_docs_task.apply_async()
+    build.task_id = task.id
+    build.save()
+    return task, build
 
 
 def send_email(

--- a/readthedocs/doc_builder/exceptions.py
+++ b/readthedocs/doc_builder/exceptions.py
@@ -90,3 +90,7 @@ class MkDocsYAMLParseError(BuildEnvironmentError):
         'Please follow the user guide https://www.mkdocs.org/user-guide/configuration/ '
         'to configure the file properly.',
     )
+
+
+class BuildKilled(Exception):
+    pass

--- a/readthedocs/templates/builds/build_detail.html
+++ b/readthedocs/templates/builds/build_detail.html
@@ -30,6 +30,12 @@ $(document).ready(function () {
 {% block content %}
   <div class="build build-detail" id="build-detail">
 
+    <form method="post" action="{% url "builds_detail" build.version.project.slug build.pk %}">
+        {% csrf_token %}
+        <input type="submit" value="{% trans "Cancel build" %}">
+    </form>
+
+
     <!-- Build meta data -->
     <ul class="build-meta">
       <div data-bind="visible: finished()">


### PR DESCRIPTION
:warning: **DO NOT MERGE** :warning: 

This PR is an example of how to cancel an already triggered build.

From what I've seen, it would be good to implement https://github.com/readthedocs/readthedocs.org/issues/3984 before working on a solution to cancel builds. Or, implement _only_ the part needed for now to handle the `BuildKilled` exception.

I think implementing that issue first is better because otherwise, we need to handle the exception `BuildKilled` in many different places inside the code of the task itself:

- environment context manager
- _all the methods_ that are ran inside the task itself

The current implementation "works", but it's not handling the exception in all the places needed. So, depending _when_ you click on "Cancel build" you will get a gracefully killed build (proper set of all the attributes --`success=False`, etc) or a hard killed build.