### PR TITLE
RTDFacetedSearch: pass filters in one way only

### DIFF
--- a/readthedocs/search/api.py
+++ b/readthedocs/search/api.py
@@ -120,13 +120,15 @@ class PageSearchAPIView(generics.ListAPIView):
         kwargs = {'filter_by_user': False, 'filters': {}}
         kwargs['filters']['project'] = [p.slug for p in self.get_all_projects()]
         kwargs['filters']['version'] = self._get_version().slug
-        # Check to avoid searching all projects in case project is empty.
+
+        # Check to avoid searching all projects in case these filters are empty.
         if not kwargs['filters']['project']:
             log.info("Unable to find a project to search")
             return HTMLFile.objects.none()
         if not kwargs['filters']['version']:
             log.info("Unable to find a version to search")
             return HTMLFile.objects.none()
+
         user = self.request.user
         queryset = PageSearch(
             query=query, user=user, **kwargs

--- a/readthedocs/search/faceted_search.py
+++ b/readthedocs/search/faceted_search.py
@@ -39,7 +39,14 @@ class RTDFacetedSearch(FacetedSearch):
         self.using = Elasticsearch(**settings.ELASTICSEARCH_DSL['default'])
 
         filters = filters or {}
-        super().__init__(query, filters, **kwargs)
+
+        # We may recieve invalid filters
+        valid_filters = {
+            k: v
+            for k, v in filters.items()
+            if k in self.facets
+        }
+        super().__init__(query=query, filters=valid_filters, **kwargs)
 
     def query(self, search, query):
         """

--- a/readthedocs/search/views.py
+++ b/readthedocs/search/views.py
@@ -8,13 +8,12 @@ from django.shortcuts import get_object_or_404, render
 
 from readthedocs.builds.constants import LATEST
 from readthedocs.projects.models import Project
+from readthedocs.search import utils
 from readthedocs.search.faceted_search import (
     ALL_FACETS,
     PageSearch,
     ProjectSearch,
 )
-from readthedocs.search import utils
-
 
 log = logging.getLogger(__name__)
 LOG_TEMPLATE = '(Elastic Search) [%(user)s:%(type)s] [%(project)s:%(version)s:%(language)s] %(msg)s'
@@ -71,15 +70,15 @@ def elastic_search(request, project_slug=None):
     facets = {}
 
     if user_input.query:
-        kwargs = {}
+        filters = {}
 
         for avail_facet in ALL_FACETS:
             value = getattr(user_input, avail_facet, None)
             if value:
-                kwargs[avail_facet] = value
+                filters[avail_facet] = value
 
         search = search_facets[user_input.type](
-            query=user_input.query, user=request.user, **kwargs
+            query=user_input.query, filters=filters, user=request.user,
         )
         results = search[:50].execute()
         facets = results.facets


### PR DESCRIPTION
Currently, we can pass filters as keywords (if they match a valid
filter) or in the `filters` keyword.

The original model FacetedSearch allows to pass filter only using the
filfilters keyword.

All places were refactored so we always pass the filters in the filters
arg.