### PR TITLE
Fix the caching of featured projects

### DIFF
--- a/readthedocs/rtd_tests/tests/test_views.py
+++ b/readthedocs/rtd_tests/tests/test_views.py
@@ -362,34 +362,17 @@ class TestSearchAnalyticsView(TestCase):
             self.assertEqual(body[-1][1], 'hello world')
 
 
-class TestHomepage(TestCase):
-
-    def setUp(self):
-        self.eric = User(username='eric')
-        self.eric.set_password('test')
-        self.eric.save()
+class TestHomepageCache(TestCase):
 
     def tearDown(self):
         cache.clear()
 
-    def test_homepage_queries_logged_out(self):
+    def test_homepage_queries(self):
         with self.assertNumQueries(1):
             r = self.client.get('/')
             self.assertEqual(r.status_code, 200)
 
         # Cache
         with self.assertNumQueries(0):
-            r = self.client.get('/')
-            self.assertEqual(r.status_code, 200)
-
-    def test_homepage_queries_logged_in(self):
-        self.client.login(username='eric', password='test')
-
-        with self.assertNumQueries(9):
-            r = self.client.get('/')
-            self.assertEqual(r.status_code, 200)
-
-        # Cache
-        with self.assertNumQueries(8):
             r = self.client.get('/')
             self.assertEqual(r.status_code, 200)

--- a/readthedocs/rtd_tests/tests/test_views.py
+++ b/readthedocs/rtd_tests/tests/test_views.py
@@ -364,6 +364,9 @@ class TestSearchAnalyticsView(TestCase):
 
 class TestHomepageCache(TestCase):
 
+    def setUp(self):
+        cache.clear()
+
     def tearDown(self):
         cache.clear()
 

--- a/readthedocs/templates/homepage.html
+++ b/readthedocs/templates/homepage.html
@@ -114,9 +114,9 @@
     {% include "core/widesearchbar.html" %}
   </section>
 
-  {% if featured_list %}
   {% get_current_language as language %}
   {% cache 600 homepage_featured_list language %}
+  {% if featured_list %}
     <!-- BEGIN projects list -->
     <section>
       <h3>{% trans "Featured Projects" %}</h3>
@@ -129,8 +129,8 @@
       </div>
     </section>
     <!-- END projects list -->
-  {% endcache %}
   {% endif %}
+  {% endcache %}
 
   <!-- Funding and Contributing -->
   <section>


### PR DESCRIPTION
Currently the `if` block actually evaluates the queryset,
causing it never to actually cache the query that we want it to cache.