### PR TITLE
Hide unbuilt versions in footer flyout

### DIFF
--- a/readthedocs/api/v3/tests/test_versions.py
+++ b/readthedocs/api/v3/tests/test_versions.py
@@ -8,7 +8,7 @@ from readthedocs.builds.models import Version
 from readthedocs.projects.models import Project
 
 
-class VerionsEndpointTests(APIEndpointMixin):
+class VersionsEndpointTests(APIEndpointMixin):
 
     def test_projects_versions_list(self):
         self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')

--- a/readthedocs/builds/querysets.py
+++ b/readthedocs/builds/querysets.py
@@ -24,7 +24,8 @@ class VersionQuerySetBase(models.QuerySet):
             queryset = user_queryset | queryset
         return queryset
 
-    def public(self, user=None, project=None, only_active=True, include_hidden=True):
+    def public(self, user=None, project=None, only_active=True,
+               include_hidden=True, only_built=False):
         queryset = self.filter(privacy_level=constants.PUBLIC)
         if user:
             queryset = self._add_user_repos(queryset, user)
@@ -32,6 +33,8 @@ class VersionQuerySetBase(models.QuerySet):
             queryset = queryset.filter(project=project)
         if only_active:
             queryset = queryset.filter(active=True)
+        if only_built:
+            queryset = queryset.filter(built=True)
         if not include_hidden:
             queryset = queryset.filter(hidden=False)
         return queryset.distinct()

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -881,6 +881,7 @@ class Project(models.Model):
             {
                 'project': self,
                 'only_active': True,
+                'only_built': True,
             },
         )
         versions = (

--- a/readthedocs/rtd_tests/tests/test_footer.py
+++ b/readthedocs/rtd_tests/tests/test_footer.py
@@ -27,7 +27,7 @@ class BaseTestFooterHTML:
             privacy_level=PUBLIC,
             main_language_project=None,
         )
-        self.pip.versions.update(privacy_level=PUBLIC)
+        self.pip.versions.update(privacy_level=PUBLIC, built=True)
 
         self.latest = self.pip.versions.get(slug=LATEST)
         self.url = (
@@ -224,6 +224,62 @@ class BaseTestFooterHTML:
         self.assertIn('/en/latest/', response.data['html'])
         self.assertNotIn('/en/2.0/', response.data['html'])
 
+    def test_built_versions(self):
+        built_version = get(
+            Version,
+            slug='2.0',
+            active=True,
+            built=True,
+            privacy_level=PUBLIC,
+            project=self.pip,
+        )
+
+        # The built versions appears on the footer
+        self.url = (
+            reverse('footer_html') +
+            f'?project={self.pip.slug}&version={self.latest.slug}&page=index&docroot=/'
+        )
+        response = self.render()
+        self.assertIn('/en/latest/', response.data['html'])
+        self.assertIn('/en/2.0/', response.data['html'])
+
+        # We can access the built version, and it appears on the footer
+        self.url = (
+            reverse('footer_html') +
+            f'?project={self.pip.slug}&version={built_version.slug}&page=index&docroot=/'
+        )
+        response = self.render()
+        self.assertIn('/en/latest/', response.data['html'])
+        self.assertIn('/en/2.0/', response.data['html'])
+
+    def test_not_built_versions(self):
+        not_built_version = get(
+            Version,
+            slug='2.0',
+            active=True,
+            built=False,
+            privacy_level=PUBLIC,
+            project=self.pip,
+        )
+
+        # The un-built version doesn't appear on the footer
+        self.url = (
+            reverse('footer_html') +
+            f'?project={self.pip.slug}&version={self.latest.slug}&page=index&docroot=/'
+        )
+        response = self.render()
+        self.assertIn('/en/latest/', response.data['html'])
+        self.assertNotIn('/en/2.0/', response.data['html'])
+
+        # We can access the unbuilt version, but it doesn't appear on the footer
+        self.url = (
+            reverse('footer_html') +
+            f'?project={self.pip.slug}&version={not_built_version.slug}&page=index&docroot=/'
+        )
+        response = self.render()
+        self.assertIn('/en/latest/', response.data['html'])
+        self.assertNotIn('/en/2.0/', response.data['html'])
+
 
 class TestFooterHTML(BaseTestFooterHTML, TestCase):
 
@@ -389,6 +445,7 @@ class TestFooterPerformance(APITestCase):
                 identifier=identifier,
                 type=TAG,
                 active=True,
+                built=True,
             )
 
         with self.assertNumQueries(self.EXPECTED_QUERIES):


### PR DESCRIPTION
Should fix https://github.com/readthedocs/readthedocs.org/issues/6971

This also assumes the latest version has `built=True`, which I'm not sure is the case in production.