### PR TITLE
Fix tests ahead of django-dynamic-fixture update

### DIFF
--- a/readthedocs/proxito/tests/base.py
+++ b/readthedocs/proxito/tests/base.py
@@ -21,7 +21,6 @@ class BaseDocServing(TestCase):
             Project,
             slug='project',
             privacy_level=PUBLIC,
-            version_privacy_level=PUBLIC,
             users=[self.eric],
             main_language_project=None,
         )

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -354,7 +354,9 @@ class APIBuildTests(TestCase):
         client = APIClient()
         api_user = get(User, is_staff=False, password='test')
         client.force_authenticate(user=api_user)
-        build = get(Build, project_id=1, version_id=1, state='cloning')
+        project = Project.objects.get(pk=1)
+        version = project.versions.first()
+        build = get(Build, project=project, version=version, state='cloning')
         resp = client.put(
             '/api/v2/build/{}/'.format(build.pk),
             {
@@ -373,7 +375,9 @@ class APIBuildTests(TestCase):
         Super users should be able to read/write the `builder` property, but we
         don't expose this to end users via the API
         """
-        build = get(Build, project_id=1, version_id=1, builder='foo')
+        project = Project.objects.get(pk=1)
+        version = project.versions.first()
+        build = get(Build, project=project, version=version, builder='foo')
         client = APIClient()
 
         api_user = get(User, is_staff=False, password='test')
@@ -423,7 +427,9 @@ class APIBuildTests(TestCase):
         self.assertEqual(build['commands'][0]['description'], 'foo')
 
     def test_get_raw_log_success(self):
-        build = get(Build, project_id=1, version_id=1, builder='foo')
+        project = Project.objects.get(pk=1)
+        version = project.versions.first()
+        build = get(Build, project=project, version=version, builder='foo')
         get(
             BuildCommandResult,
             build=build,
@@ -462,8 +468,10 @@ class APIBuildTests(TestCase):
         )
 
     def test_get_raw_log_building(self):
+        project = Project.objects.get(pk=1)
+        version = project.versions.first()
         build = get(
-            Build, project_id=1, version_id=1,
+            Build, project=project, version=version,
             builder='foo', success=False,
             exit_code=1, state='building',
         )
@@ -506,8 +514,10 @@ class APIBuildTests(TestCase):
         )
 
     def test_get_raw_log_failure(self):
+        project = Project.objects.get(pk=1)
+        version = project.versions.first()
         build = get(
-            Build, project_id=1, version_id=1,
+            Build, project=project, version=version,
             builder='foo', success=False, exit_code=1,
         )
         get(
@@ -562,8 +572,12 @@ class APIBuildTests(TestCase):
         Should return the list of builds according to the
         commit query params
         """
-        get(Build, project_id=1, version_id=1, builder='foo', commit='test')
-        get(Build, project_id=2, version_id=1, builder='foo', commit='other')
+        project1 = Project.objects.get(pk=1)
+        project2 = Project.objects.get(pk=2)
+        version1 = project1.versions.first()
+        version2 = project2.versions.first()
+        get(Build, project=project1, version=version1, builder='foo', commit='test')
+        get(Build, project=project2, version=version2, builder='foo', commit='other')
         client = APIClient()
         api_user = get(User, is_staff=False, password='test')
         client.force_authenticate(user=api_user)
@@ -635,7 +649,7 @@ class APITests(TestCase):
 
     def test_remote_repository_pagination(self):
         account = get(SocialAccount, provider='github')
-        user = get(User, socialaccount_set=[account])
+        user = get(User)
         for _ in range(20):
             get(RemoteRepository, users=[user], account=account)
 
@@ -649,7 +663,7 @@ class APITests(TestCase):
 
     def test_remote_organization_pagination(self):
         account = get(SocialAccount, provider='github')
-        user = get(User, socialaccount_set=[account])
+        user = get(User)
         for _ in range(30):
             get(RemoteOrganization, users=[user], account=account)
 
@@ -719,9 +733,9 @@ class APIImportTests(TestCase):
         account_a = get(SocialAccount, provider='github')
         account_b = get(SocialAccount, provider='github')
         account_c = get(SocialAccount, provider='github')
-        user_a = get(User, password='test', socialaccount_set=[account_a])
-        user_b = get(User, password='test', socialaccount_set=[account_b])
-        user_c = get(User, password='test', socialaccount_set=[account_c])
+        user_a = get(User, password='test')
+        user_b = get(User, password='test')
+        user_c = get(User, password='test')
         org_a = get(RemoteOrganization, users=[user_a], account=account_a)
         repo_a = get(
             RemoteRepository,

--- a/readthedocs/rtd_tests/tests/test_core_utils.py
+++ b/readthedocs/rtd_tests/tests/test_core_utils.py
@@ -174,7 +174,6 @@ class CoreUtilTests(TestCase):
             'commit': None
         }
         options = {
-            'queue': mock.ANY,
             'time_limit': 3,
             'soft_time_limit': 3,
             'priority': CELERY_HIGH,
@@ -241,7 +240,6 @@ class CoreUtilTests(TestCase):
             'commit': None
         }
         options = {
-            'queue': mock.ANY,
             'time_limit': mock.ANY,
             'soft_time_limit': mock.ANY,
             'priority': CELERY_LOW,
@@ -265,7 +263,6 @@ class CoreUtilTests(TestCase):
             'commit': None
         }
         options = {
-            'queue': mock.ANY,
             'time_limit': mock.ANY,
             'soft_time_limit': mock.ANY,
             'priority': CELERY_MEDIUM,

--- a/readthedocs/rtd_tests/tests/test_privacy_urls.py
+++ b/readthedocs/rtd_tests/tests/test_privacy_urls.py
@@ -150,7 +150,7 @@ class ProjectMixin(URLAccessMixin):
 
     def setUp(self):
         super().setUp()
-        self.build = get(Build, project=self.pip)
+        self.build = get(Build, project=self.pip, version=self.pip.versions.first())
         self.tag = get(Tag, slug='coolness')
         self.subproject = get(
             Project, slug='sub', language='ja',
@@ -352,7 +352,7 @@ class APIMixin(URLAccessMixin):
 
     def setUp(self):
         super().setUp()
-        self.build = get(Build, project=self.pip)
+        self.build = get(Build, project=self.pip, version=self.pip.versions.first())
         self.build_command_result = get(BuildCommandResult, build=self.build)
         self.domain = get(Domain, domain='docs.foobar.com', project=self.pip)
         self.social_account = get(SocialAccount)

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,7 +1,7 @@
 -r pip.txt
 -r local-docs-build.txt
 
-django-dynamic-fixture==2.0.0
+django-dynamic-fixture==3.1.0
 pytest==5.2.2
 pytest-custom-exit-code==0.3.0
 pytest-django==3.6.0


### PR DESCRIPTION
Closes https://github.com/readthedocs/readthedocs.org/issues/6886

Latest pyup dependency update - https://github.com/readthedocs/readthedocs.org/pull/7012

There were a couple of tests failing locally that looked unrelated to the django-dynamic-fixure upgrade:
- ~~test_privacy_urls.py~~ (fixed)
- ~~test_core_utils.py~~ (fixed)