### PR TITLE
Canonical/HTTPS redirect fix

### DIFF
--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -56,7 +56,10 @@ def map_host_to_project_slug(request):  # pylint: disable=too-many-return-statem
             project_slug = host_parts[0]
             request.subdomain = True
             log.debug('Proxito Public Domain: host=%s', host)
-            if Domain.objects.filter(project__slug=project_slug).filter(canonical=True).exists():
+            if Domain.objects.filter(project__slug=project_slug).filter(
+                canonical=True,
+                https=True,
+            ).exists():
                 log.debug('Proxito Public Domain -> Canonical Domain Redirect: host=%s', host)
                 request.canonicalize = 'canonical-cname'
             return project_slug

--- a/readthedocs/proxito/tests/test_middleware.py
+++ b/readthedocs/proxito/tests/test_middleware.py
@@ -50,7 +50,7 @@ class MiddlewareTests(RequestFactoryTestMixin, TestCase):
             self.assertEqual(request.canonicalize, 'https')
 
     def test_canonical_cname_redirect(self):
-        """Requests to the public domain URL should redirect to the custom domain only if the domain is canonical."""
+        """Requests to the public domain URL should redirect to the custom domain if the domain is canonical/https."""
         cname = 'docs.random.com'
         domain = get(Domain, project=self.pip, domain=cname, canonical=False, https=False)
 
@@ -59,8 +59,9 @@ class MiddlewareTests(RequestFactoryTestMixin, TestCase):
         self.assertIsNone(res)
         self.assertFalse(hasattr(request, 'canonicalize'))
 
-        # Make the domain canonical and make sure we redirect
+        # Make the domain canonical/https and make sure we redirect
         domain.canonical = True
+        domain.https = True
         domain.save()
         for url in (self.url, '/subdir/'):
             request = self.request(url, HTTP_HOST='pip.dev.readthedocs.io')


### PR DESCRIPTION
- Only canonicalize domain when HTTPS and canonical
- On RTD for Business there was an infinite redirect issue here as the resolver won't use a custom domain without HTTPS.