### PR TITLE
Search: Little refactor

### DIFF
--- a/readthedocs/search/api.py
+++ b/readthedocs/search/api.py
@@ -117,21 +117,24 @@ class PageSearchAPIView(generics.ListAPIView):
         # Validate all the required params are there
         self.validate_query_params()
         query = self.request.query_params.get('q', '')
-        kwargs = {'filter_by_user': False, 'filters': {}}
-        kwargs['filters']['project'] = [p.slug for p in self.get_all_projects()]
-        kwargs['filters']['version'] = self._get_version().slug
+        filters = {}
+        filters['project'] = [p.slug for p in self.get_all_projects()]
+        filters['version'] = self._get_version().slug
 
         # Check to avoid searching all projects in case these filters are empty.
-        if not kwargs['filters']['project']:
+        if not filters['project']:
             log.info("Unable to find a project to search")
             return HTMLFile.objects.none()
-        if not kwargs['filters']['version']:
+        if not filters['version']:
             log.info("Unable to find a version to search")
             return HTMLFile.objects.none()
 
-        user = self.request.user
         queryset = PageSearch(
-            query=query, user=user, **kwargs
+            query=query,
+            filters=filters,
+            user=self.request.user,
+            # We use a permission class to control authorization
+            filter_by_user=False,
         )
         return queryset
 

--- a/readthedocs/search/tests/test_faceted_search.py
+++ b/readthedocs/search/tests/test_faceted_search.py
@@ -21,7 +21,7 @@ class TestPageSearch:
         cased_query = getattr(query_text, case)
         query = cased_query()
 
-        page_search = PageSearch(query=query, user='')
+        page_search = PageSearch(query=query)
         results = page_search.execute()
 
         assert len(results) == 1
@@ -37,7 +37,7 @@ class TestPageSearch:
         - Where `Foo` or `Bar` is present
         """
         query = 'Elasticsearch Query'
-        page_search = PageSearch(query=query, user='')
+        page_search = PageSearch(query=query)
         results = page_search.execute()
         assert len(results) == 3
 

--- a/readthedocs/search/tests/test_xss.py
+++ b/readthedocs/search/tests/test_xss.py
@@ -9,7 +9,7 @@ class TestXSS:
 
     def test_facted_page_xss(self, client, project):
         query = 'XSS'
-        page_search = PageSearch(query=query, user='')
+        page_search = PageSearch(query=query)
         results = page_search.execute()
         expected = """
         &lt;h3&gt;<span>XSS</span> exploit&lt;&#x2F;h3&gt;


### PR DESCRIPTION
Looks like user and filter_by_user are still
needed in .com for filtering results in the dashboard (#6341).
But it can be removed from tests.