### PR TITLE
Privacy levels: Allow to migrate users to public versions

### DIFF
--- a/readthedocs/builds/forms.py
+++ b/readthedocs/builds/forms.py
@@ -20,6 +20,7 @@ from readthedocs.builds.constants import (
 from readthedocs.builds.models import RegexAutomationRule, Version
 from readthedocs.core.mixins import HideProtectedLevelMixin
 from readthedocs.core.utils import trigger_build
+from readthedocs.projects.constants import PUBLIC
 
 
 class VersionForm(HideProtectedLevelMixin, forms.ModelForm):
@@ -82,6 +83,13 @@ class VersionForm(HideProtectedLevelMixin, forms.ModelForm):
 
     def save(self, commit=True):
         obj = super().save(commit=commit)
+
+        # Allow users to make their versions public on save.
+        # TODO: Remove when we dicide to migrate everyone.
+        if not settings.ALLOW_PRIVATE_REPOS and obj.privacy_level != PUBLIC:
+            obj.privacy_level = PUBLIC
+            obj.save()
+
         if obj.active and not obj.built and not obj.uploaded:
             trigger_build(project=obj.project, version=obj)
         return obj


### PR DESCRIPTION
We no longer show the privacy level field,
and we still use the protected/private
field in a couple of places in .org.

If we feel we are ready to migrate those versions, following https://docs.readthedocs.io/en/stable/development/design/privacy-levels.html#upgrade-path-overview

We need to update all protected versions to be public and hidden on .org (the hidden update is already done, so we only need to update them to be public).
And for private versions, we need to make them public and hidden (this isn't done yet).

In .com we need to mark protected versions as private and hidden (the hidden update is already done, so we only need to mark them as private).

We are ready, do we make a data migration (checking the `ALLOW_PRIVATE_REPOS` setting)? or just run a manual update on each site? 