### PR TITLE
Store pageviews via signals, not tasks

### DIFF
--- a/readthedocs/analytics/apps.py
+++ b/readthedocs/analytics/apps.py
@@ -11,3 +11,6 @@ class AnalyticsAppConfig(AppConfig):
 
     name = 'readthedocs.analytics'
     verbose_name = 'Analytics'
+
+    def ready(self):
+        from . import signals  # noqa

--- a/readthedocs/analytics/signals.py
+++ b/readthedocs/analytics/signals.py
@@ -1,0 +1,32 @@
+"""Django signals for the analytics app."""
+from django.db.models import F
+from django.dispatch import receiver
+from django.utils import timezone
+
+from readthedocs.api.v2.signals import footer_response
+from readthedocs.projects.models import Feature
+
+from .models import PageView
+
+
+@receiver(footer_response)
+def increase_page_view_count(sender, **kwargs):
+    """Increase the page view count for the given project."""
+    del sender  # unused
+    context = kwargs['context']
+
+    project = context['project']
+    version = context['version']
+    # footer_response sends an empty path for the index
+    path = context['path'] or '/'
+
+    if project.has_feature(Feature.STORE_PAGEVIEWS):
+        page_view, _ = PageView.objects.get_or_create(
+            project=project,
+            version=version,
+            path=path,
+            date=timezone.now().date(),
+        )
+        PageView.objects.filter(pk=page_view.pk).update(
+            view_count=F('view_count') + 1
+        )

--- a/readthedocs/analytics/tasks.py
+++ b/readthedocs/analytics/tasks.py
@@ -3,13 +3,10 @@
 """Tasks for Read the Docs' analytics."""
 
 from django.conf import settings
-from django.db.models import F
 from django.utils import timezone
 
 import readthedocs
 from readthedocs.worker import app
-from readthedocs.builds.models import Version
-from readthedocs.projects.models import Project
 
 from .models import PageView
 from .utils import send_to_analytics
@@ -75,22 +72,6 @@ def analytics_event(
     data.update(DEFAULT_PARAMETERS)
     data.update(kwargs)
     send_to_analytics(data)
-
-
-@app.task(queue='web')
-def increase_page_view_count(project_slug, version_slug, path):
-    """Increase the page view count for the given project."""
-    project = Project.objects.get(slug=project_slug)
-
-    page_view, _ = PageView.objects.get_or_create(
-        project=project,
-        version=Version.objects.get(project=project, slug=version_slug),
-        path=path,
-        date=timezone.now().date(),
-    )
-    PageView.objects.filter(pk=page_view.pk).update(
-        view_count=F('view_count') + 1
-    )
 
 
 @app.task(queue='web')

--- a/readthedocs/api/v2/views/footer_views.py
+++ b/readthedocs/api/v2/views/footer_views.py
@@ -21,7 +21,6 @@ from readthedocs.projects.version_handling import (
     highest_version,
     parse_version_failsafe,
 )
-from readthedocs.analytics.tasks import increase_page_view_count
 
 
 def get_version_compare_data(project, base_version=None):
@@ -222,15 +221,6 @@ class BaseFooterHTML(APIView):
             'version_compare': version_compare_data,
             'version_supported': version.supported,
         }
-
-        # increase the page view count for the given page
-        page_slug = request.GET.get('page', '')
-        if page_slug and project.has_feature(Feature.STORE_PAGEVIEWS):
-            increase_page_view_count.delay(
-                project_slug=context['project'].slug,
-                version_slug=context['version'].slug,
-                path=page_slug
-            )
 
         # Allow folks to hook onto the footer response for various information
         # collection, or to modify the resp_data.

--- a/readthedocs/rtd_tests/tests/test_footer.py
+++ b/readthedocs/rtd_tests/tests/test_footer.py
@@ -434,37 +434,31 @@ class TestFooterPerformance(APITestCase):
 
     def test_version_queries(self):
         # The number of Versions shouldn't impact the number of queries
-        with mock.patch('readthedocs.api.v2.views.footer_views.increase_page_view_count') as mocked:
-            mocked.side_effect = None
+        with self.assertNumQueries(self.EXPECTED_QUERIES):
+            response = self.render()
+            self.assertContains(response, '0.8.1')
 
-            with self.assertNumQueries(self.EXPECTED_QUERIES):
-                response = self.render()
-                self.assertContains(response, '0.8.1')
+        for patch in range(3):
+            identifier = '0.99.{}'.format(patch)
+            self.pip.versions.create(
+                verbose_name=identifier,
+                identifier=identifier,
+                type=TAG,
+                active=True,
+                built=True
+            )
 
-            for patch in range(3):
-                identifier = '0.99.{}'.format(patch)
-                self.pip.versions.create(
-                    verbose_name=identifier,
-                    identifier=identifier,
-                    type=TAG,
-                    active=True,
-                    built=True
-                )
-
-            with self.assertNumQueries(self.EXPECTED_QUERIES):
-                response = self.render()
-                self.assertContains(response, '0.99.0')
+        with self.assertNumQueries(self.EXPECTED_QUERIES):
+            response = self.render()
+            self.assertContains(response, '0.99.0')
 
     def test_domain_queries(self):
         # Setting up a custom domain shouldn't impact the number of queries
-        with mock.patch('readthedocs.api.v2.views.footer_views.increase_page_view_count') as mocked:
-            mocked.side_effect = None
+        self.pip.domains.create(
+            domain='http://docs.foobar.com',
+            canonical=True,
+        )
 
-            self.pip.domains.create(
-                domain='http://docs.foobar.com',
-                canonical=True,
-            )
-
-            with self.assertNumQueries(self.EXPECTED_QUERIES):
-                response = self.render()
-                self.assertContains(response, 'docs.foobar.com')
+        with self.assertNumQueries(self.EXPECTED_QUERIES):
+            response = self.render()
+            self.assertContains(response, 'docs.foobar.com')


### PR DESCRIPTION
Sending a task per pageview quickly overwhelmed our tasks queues. Instead, this uses a signal we are already sending. Currently, this will result in no more queries than normal unless the project has the Feature flag `STORE_PAGEVIEWS`. However, if the project has that set, there will be 2 additional queries.