### PR TITLE
Use 2 builders with celery concurrency at 1

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -59,7 +59,7 @@ services:
       - DJANGO_SETTINGS_MODULE=readthedocs.settings.celery_docker
       - CELERY_APP_NAME=readthedocs
 
-  build:
+  build-default: &build
     image: community_server:latest
     volumes:
       - ${PWD}:/usr/src/app/checkouts/readthedocs.org
@@ -67,6 +67,9 @@ services:
     environment:
       - DJANGO_SETTINGS_MODULE=readthedocs.settings.build_docker
       - CELERY_APP_NAME=readthedocs
+
+  build-large:
+    <<: *build
 
   storage:
     # https://github.com/Azure/Azurite

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -10,7 +10,7 @@ class DockerBaseSettings(CommunityDevSettings):
 
     DOCKER_ENABLE = True
     RTD_DOCKER_COMPOSE = True
-    RTD_DOCKER_COMPOSE_VOLUME = 'community_build-user-builds'
+    RTD_DOCKER_COMPOSE_VOLUME = 'community_' + os.environ.get('BUILD_USER_BUILDS_VOLUME')
     RTD_DOCKER_USER = f'{os.geteuid()}:{os.getegid()}'
     DOCKER_LIMITS = {'memory': '1g', 'time': 900}
     USE_SUBDOMAIN = True


### PR DESCRIPTION
This gives us more parity with production where 2 builds can't be ran at the
same time in one builder.

This is useful to avoid `VersionLocked` error when testing locally,
de-duplication of builds (#7123), usage of `build:default` and `build:large` for the router, etc.

Requires https://github.com/readthedocs/common/pull/61/