### PR TITLE
Proxito middleware: reset to original urlconf after request

### DIFF
--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -10,6 +10,7 @@ import sys
 
 from django.conf import settings
 from django.shortcuts import render
+from django.urls.base import set_urlconf
 from django.utils.deprecation import MiddlewareMixin
 
 from readthedocs.projects.models import Domain, Project
@@ -199,6 +200,10 @@ class ProxitoMiddleware(MiddlewareMixin):
         * For custom domains, check the HSTS values on the Domain object.
           The domain object should be saved already in request.domain.
         """
+        # Reset URLconf for this thread
+        # to the original one.
+        set_urlconf(None)
+
         host = request.get_host().lower().split(':')[0]
         public_domain = settings.PUBLIC_DOMAIN.lower().split(':')[0]
 

--- a/readthedocs/proxito/tests/test_middleware.py
+++ b/readthedocs/proxito/tests/test_middleware.py
@@ -3,11 +3,13 @@
 import sys
 
 import pytest
-from django.urls.base import set_urlconf, get_urlconf
 from django.test import TestCase
 from django.test.utils import override_settings
+from django.urls.base import get_urlconf, set_urlconf
 from django_dynamic_fixture import get
 
+from readthedocs.builds.models import Version
+from readthedocs.projects.constants import PUBLIC
 from readthedocs.projects.models import Domain, Project, ProjectRelationship
 from readthedocs.proxito.middleware import ProxitoMiddleware
 from readthedocs.rtd_tests.base import RequestFactoryTestMixin
@@ -159,9 +161,17 @@ class MiddlewareURLConfTests(RequestFactoryTestMixin, TestCase):
             Project,
             slug='pip',
             users=[self.owner],
-            privacy_level='public',
+            privacy_level=PUBLIC,
             urlconf='subpath/to/$version/$language/$filename'  # Flipped
         )
+        self.testing_version = get(
+            Version,
+            slug='testing',
+            project=self.pip,
+            built=True,
+            active=True,
+        )
+        self.pip.versions.update(privacy_level=PUBLIC)
 
         sys.modules['fake_urlconf'] = self.pip.proxito_urlconf
         set_urlconf('fake_urlconf')
@@ -220,17 +230,26 @@ class MiddlewareURLConfSubprojectTests(RequestFactoryTestMixin, TestCase):
             name='pip',
             slug='pip',
             users=[self.owner],
-            privacy_level='public',
+            privacy_level=PUBLIC,
             urlconf='subpath/$subproject/$version/$language/$filename'  # Flipped
         )
+        self.testing_version = get(
+            Version,
+            slug='testing',
+            project=self.pip,
+            built=True,
+            active=True,
+        )
+        self.pip.versions.update(privacy_level=PUBLIC)
         self.subproject = get(
             Project,
             name='subproject',
             slug='subproject',
             users=[self.owner],
-            privacy_level='public',
+            privacy_level=PUBLIC,
             main_language_project=None,
         )
+        self.subproject.versions.update(privacy_level=PUBLIC)
         self.relationship = get(
             ProjectRelationship,
             parent=self.pip,

--- a/readthedocs/proxito/tests/test_middleware.py
+++ b/readthedocs/proxito/tests/test_middleware.py
@@ -163,12 +163,11 @@ class MiddlewareURLConfTests(RequestFactoryTestMixin, TestCase):
             urlconf='subpath/to/$version/$language/$filename'  # Flipped
         )
 
-        self.old_urlconf = get_urlconf()
         sys.modules['fake_urlconf'] = self.pip.proxito_urlconf
         set_urlconf('fake_urlconf')
 
     def tearDown(self):
-        set_urlconf(self.old_urlconf)
+        set_urlconf(None)
 
     def test_proxied_api_methods(self):
         # This is mostly a unit test, but useful to make sure the below tests work
@@ -238,9 +237,11 @@ class MiddlewareURLConfSubprojectTests(RequestFactoryTestMixin, TestCase):
             child=self.subproject,
         )
 
-        self.old_urlconf = get_urlconf()
         sys.modules['fake_urlconf'] = self.pip.proxito_urlconf
         set_urlconf('fake_urlconf')
+
+    def tearDown(self):
+        set_urlconf(None)
 
     def test_middleware_urlconf_subproject(self):
         resp = self.client.get('/subpath/subproject/testing/en/foodex.html', HTTP_HOST=self.domain)

--- a/readthedocs/proxito/tests/test_middleware.py
+++ b/readthedocs/proxito/tests/test_middleware.py
@@ -233,13 +233,6 @@ class MiddlewareURLConfSubprojectTests(RequestFactoryTestMixin, TestCase):
             privacy_level=PUBLIC,
             urlconf='subpath/$subproject/$version/$language/$filename'  # Flipped
         )
-        self.testing_version = get(
-            Version,
-            slug='testing',
-            project=self.pip,
-            built=True,
-            active=True,
-        )
         self.pip.versions.update(privacy_level=PUBLIC)
         self.subproject = get(
             Project,
@@ -248,6 +241,13 @@ class MiddlewareURLConfSubprojectTests(RequestFactoryTestMixin, TestCase):
             users=[self.owner],
             privacy_level=PUBLIC,
             main_language_project=None,
+        )
+        self.testing_version = get(
+            Version,
+            slug='testing',
+            project=self.subproject,
+            built=True,
+            active=True,
         )
         self.subproject.versions.update(privacy_level=PUBLIC)
         self.relationship = get(

--- a/readthedocs/proxito/tests/test_middleware.py
+++ b/readthedocs/proxito/tests/test_middleware.py
@@ -242,8 +242,6 @@ class MiddlewareURLConfSubprojectTests(RequestFactoryTestMixin, TestCase):
         sys.modules['fake_urlconf'] = self.pip.proxito_urlconf
         set_urlconf('fake_urlconf')
 
-    # TODO: Figure out why this is failing in travis
-    @pytest.mark.xfail(strict=True)
     def test_middleware_urlconf_subproject(self):
         resp = self.client.get('/subpath/subproject/testing/en/foodex.html', HTTP_HOST=self.domain)
         self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
This also fixes a flaky test.
We hit this before proxito too
https://github.com/readthedocs/readthedocs.org/blob/8ebded69160f495c56e2966da90bad3be2dc9f5f/readthedocs/core/middleware.py#L132-L136