### PR TITLE
Move changes_files to before search indexing

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1539,6 +1539,15 @@ def _create_imported_files(version, commit, build):
                 build=build,
             )
 
+    # This signal is used for clearing the CDN,
+    # so send it as soon as we have the list of changed files
+    files_changed.send(
+        sender=Project,
+        project=version.project,
+        version=version,
+        files=changed_files,
+    )
+
     return changed_files
 
 
@@ -1579,14 +1588,6 @@ def _sync_imported_files(version, build, changed_files):
         .filter(project=version.project, version=version)
         .exclude(build=build)
         .delete()
-    )
-
-    # Send signal with changed files
-    files_changed.send(
-        sender=Project,
-        project=version.project,
-        version=version,
-        files=changed_files,
     )
 
 


### PR DESCRIPTION
This signal is used to clear the CDN,
so we want it to happen as soon a possible.