### PR TITLE
Fix flaky test

### DIFF
--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -10,7 +10,6 @@ import sys
 
 from django.conf import settings
 from django.shortcuts import render
-from django.urls.base import set_urlconf
 from django.utils.deprecation import MiddlewareMixin
 
 from readthedocs.projects.models import Domain, Project
@@ -179,7 +178,8 @@ class ProxitoMiddleware(MiddlewareMixin):
         if project.urlconf:
 
             # Stop Django from caching URLs
-            project_timestamp = project.modified_date.strftime("%Y%m%d.%H%M%S")
+            # https://github.com/django/django/blob/stable/2.2.x/django/urls/resolvers.py#L65-L69  # noqa
+            project_timestamp = project.modified_date.strftime("%Y%m%d.%H%M%S%f")
             url_key = f'readthedocs.urls.fake.{project.slug}.{project_timestamp}'
 
             log.info(
@@ -200,10 +200,6 @@ class ProxitoMiddleware(MiddlewareMixin):
         * For custom domains, check the HSTS values on the Domain object.
           The domain object should be saved already in request.domain.
         """
-        # Reset URLconf for this thread
-        # to the original one.
-        set_urlconf(None)
-
         host = request.get_host().lower().split(':')[0]
         public_domain = settings.PUBLIC_DOMAIN.lower().split(':')[0]
 

--- a/readthedocs/proxito/tests/test_middleware.py
+++ b/readthedocs/proxito/tests/test_middleware.py
@@ -1,11 +1,8 @@
 # Copied from test_middleware.py
 
-import sys
-
 import pytest
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.urls.base import get_urlconf, set_urlconf
 from django_dynamic_fixture import get
 
 from readthedocs.builds.models import Version
@@ -152,7 +149,7 @@ class MiddlewareTests(RequestFactoryTestMixin, TestCase):
 
 @pytest.mark.proxito
 @override_settings(PUBLIC_DOMAIN='dev.readthedocs.io')
-class MiddlewareURLConfTests(RequestFactoryTestMixin, TestCase):
+class MiddlewareURLConfTests(TestCase):
 
     def setUp(self):
         self.owner = create_user(username='owner', password='test')
@@ -172,12 +169,6 @@ class MiddlewareURLConfTests(RequestFactoryTestMixin, TestCase):
             active=True,
         )
         self.pip.versions.update(privacy_level=PUBLIC)
-
-        sys.modules['fake_urlconf'] = self.pip.proxito_urlconf
-        set_urlconf('fake_urlconf')
-
-    def tearDown(self):
-        set_urlconf(None)
 
     def test_proxied_api_methods(self):
         # This is mostly a unit test, but useful to make sure the below tests work
@@ -220,7 +211,7 @@ class MiddlewareURLConfTests(RequestFactoryTestMixin, TestCase):
 
 @pytest.mark.proxito
 @override_settings(PUBLIC_DOMAIN='dev.readthedocs.io')
-class MiddlewareURLConfSubprojectTests(RequestFactoryTestMixin, TestCase):
+class MiddlewareURLConfSubprojectTests(TestCase):
 
     def setUp(self):
         self.owner = create_user(username='owner', password='test')
@@ -255,12 +246,6 @@ class MiddlewareURLConfSubprojectTests(RequestFactoryTestMixin, TestCase):
             parent=self.pip,
             child=self.subproject,
         )
-
-        sys.modules['fake_urlconf'] = self.pip.proxito_urlconf
-        set_urlconf('fake_urlconf')
-
-    def tearDown(self):
-        set_urlconf(None)
 
     def test_middleware_urlconf_subproject(self):
         resp = self.client.get('/subpath/subproject/testing/en/foodex.html', HTTP_HOST=self.domain)


### PR DESCRIPTION
Turns out, it was the cache.
If your computer is fast enough,
the same project slug is updated in the same second.

The cache is done at the django level, so not much we can do about it from outside.

With milliseconds hopefully is hard to hit.
Also, set_urlconf to None and to the current urlconf is already done automatically in django 2.2

https://github.com/django/django/blob/stable/2.2.x/django/core/handlers/base.py#L94-L95
https://github.com/django/django/blob/stable/2.2.x/django/core/handlers/base.py#L166