### PR TITLE
Reindex search on the `reindex` queue

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1260,7 +1260,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
 
 
 # Web tasks
-@app.task(queue='web')
+@app.task(queue='reindex')
 def fileify(version_pk, commit, build):
     """
     Create ImportedFile objects for all of a version's files.


### PR DESCRIPTION
This should make our web queue not backup as much.
We should also set `web-extra` to not process this queue,
so we can be sure we're processing tasks off `web` more timely.