### PR TITLE
Reduce logging in proxito middleware so it isn't in Sentry

### DIFF
--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -170,7 +170,7 @@ class ProxitoMiddleware(MiddlewareMixin):
         try:
             project = Project.objects.get(slug=request.host_project_slug)
         except Project.DoesNotExist:
-            log.exception('No host_project_slug set on project')
+            log.warning('No host_project_slug set on project')
             return None
 
         # This is hacky because Django wants a module for the URLConf,


### PR DESCRIPTION
This isn't actually useful,
and happens on any 404 page for a non-existing domain.