### PR TITLE
Search: don't index inactive versions

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -34,7 +34,6 @@ from readthedocs.builds.constants import (
     BUILD_STATE_CLONING,
     BUILD_STATE_FINISHED,
     BUILD_STATE_INSTALLING,
-    BUILD_STATE_UPLOADING,
     BUILD_STATUS_FAILURE,
     BUILD_STATUS_SUCCESS,
     EXTERNAL,
@@ -86,7 +85,6 @@ from .signals import (
     domain_verify,
     files_changed,
 )
-
 
 log = logging.getLogger(__name__)
 
@@ -1284,8 +1282,12 @@ def fileify(version_pk, commit, build):
     This is so we have an idea of what files we have in the database.
     """
     version = Version.objects.get_object_or_log(pk=version_pk)
-    # Don't index external version builds for now
-    if not version or version.type == EXTERNAL:
+    if (
+        not version
+        or not version.active
+        # Don't index external version for now
+        or version.type == EXTERNAL
+    ):
         return
     project = version.project
 


### PR DESCRIPTION
Kind of related to #7163. We are also building/uploading the html of inactive versions, but kind of edge case and users can still delete the docs (and the index). Anyway, the code to skip the index is easier than the one to skip the build, but we can do it if we want.