### PR TITLE
Modifications required to implement GitHub SSO in commercial

### DIFF
--- a/readthedocs/core/permissions.py
+++ b/readthedocs/core/permissions.py
@@ -8,14 +8,38 @@ from readthedocs.core.utils.extend import SettingsOverrideObject
 class AdminPermissionBase:
 
     @classmethod
-    def is_admin(cls, user, project):
+    def admins(cls, obj):
+        from readthedocs.projects.models import Project
+        from readthedocs.organizations.models import Organization
+
+        if isinstance(obj, Project):
+            return project.users.all()
+
+        if isinstance(obj, Organization):
+            return obj.owners.all()
+
+    @classmethod
+    def members(cls, obj):
+        from readthedocs.projects.models import Project
+        from readthedocs.organizations.models import Organization
+
+        if isinstance(obj, Project):
+            return project.users.all()
+
+        if isinstance(obj, Organization):
+            return User.objects.filter(
+                Q(teams__organization=obj) | Q(owner_organizations=obj),
+            ).distinct()
+
+    @classmethod
+    def is_admin(cls, user, obj):
         # This explicitly uses "user in project.users.all" so that
         # users on projects can be cached using prefetch_related or prefetch_related_objects
-        return user in project.users.all() or user.is_superuser
+        return user in cls.admins(obj) or user.is_superuser
 
     @classmethod
     def is_member(cls, user, obj):
-        return user in obj.users.all() or user.is_superuser
+        return user in cls.members(obj) or user.is_superuser
 
 
 class AdminPermission(SettingsOverrideObject):

--- a/readthedocs/core/permissions.py
+++ b/readthedocs/core/permissions.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 """Objects for User permission checks."""
+from django.contrib.auth.models import User
+from django.db.models import Q
 
 from readthedocs.core.utils.extend import SettingsOverrideObject
 
@@ -13,7 +15,7 @@ class AdminPermissionBase:
         from readthedocs.organizations.models import Organization
 
         if isinstance(obj, Project):
-            return project.users.all()
+            return obj.users.all()
 
         if isinstance(obj, Organization):
             return obj.owners.all()
@@ -24,7 +26,7 @@ class AdminPermissionBase:
         from readthedocs.organizations.models import Organization
 
         if isinstance(obj, Project):
-            return project.users.all()
+            return obj.users.all()
 
         if isinstance(obj, Organization):
             return User.objects.filter(

--- a/readthedocs/organizations/models.py
+++ b/readthedocs/organizations/models.py
@@ -3,7 +3,6 @@
 from autoslug import AutoSlugField
 from django.contrib.auth.models import User
 from django.db import models
-from django.db.models import Q
 from django.urls import reverse
 from django.utils.crypto import salted_hmac
 from django.utils.translation import ugettext_lazy as _

--- a/readthedocs/organizations/models.py
+++ b/readthedocs/organizations/models.py
@@ -1,7 +1,6 @@
 """Organizations models."""
 
 from autoslug import AutoSlugField
-from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import models
 from django.db.models import Q

--- a/readthedocs/organizations/models.py
+++ b/readthedocs/organizations/models.py
@@ -9,6 +9,7 @@ from django.utils.crypto import salted_hmac
 from django.utils.translation import ugettext_lazy as _
 
 from readthedocs.core.utils import slugify
+from readthedocs.core.permissions import AdminPermission
 
 from . import constants
 from .managers import TeamManager, TeamMemberManager
@@ -90,6 +91,14 @@ class Organization(models.Model):
 
     def get_absolute_url(self):
         return reverse('organization_detail', args=(self.slug,))
+
+    @property
+    def users(self):
+        return AdminPermission.members(self)
+
+    @property
+    def members(self):
+        return AdminPermission.members(self)
 
     def save(self, *args, **kwargs):  # pylint: disable=arguments-differ
         if not self.slug:

--- a/readthedocs/organizations/models.py
+++ b/readthedocs/organizations/models.py
@@ -97,11 +97,13 @@ class Organization(models.Model):
         sso_users = User.objects.none()
         # TODO: find another way to check if we are under corporate site
         if settings.ALLOW_PRIVATE_REPOS:
-            from readthedocsinc.acl.sso.models import SSOIntegration
+            from readthedocsinc.acl.sso.models import SSOIntegration  # noqa
             if SSOIntegration.objects.filter(organization=self).exists():
                 # TODO: use RemoteRepository.remote_id instead of full_name
                 full_names = self.projects.values('remote_repository__full_name')
-                sso_users = User.objects.filter(oauth_repositories__full_name__in=full_names).distinct()
+                sso_users = User.objects.filter(
+                    oauth_repositories__full_name__in=full_names,
+                ).distinct()
 
         return (
             # Members


### PR DESCRIPTION
Changes on this PR:

- user is part of an organization if there is at least one `Project` imported under that `Organization` that it's linked to a `RemoteRepository` the user owns and the organization has `SSOIntegration` enabled

- `Organization.members` and `Organization.users` methods were moved to `AdminPermission.members`

   > Note that `.members` and `.users` return exactly the same users

- delete `RemoteRepository` instances when syncing GitHub (only those instances that are not tied to a `Project`) (Fixes, partially, #2412)