### PR TITLE
Don't track 404 pageviews

### DIFF
--- a/readthedocs/analytics/signals.py
+++ b/readthedocs/analytics/signals.py
@@ -19,8 +19,9 @@ def increase_page_view_count(sender, **kwargs):
     version = context['version']
     # footer_response sends an empty path for the index
     path = context['path'] or '/'
+    page_slug = context['page_slug']
 
-    if project.has_feature(Feature.STORE_PAGEVIEWS):
+    if page_slug != "404" and project.has_feature(Feature.STORE_PAGEVIEWS):
         page_view, _ = PageView.objects.get_or_create(
             project=project,
             version=version,

--- a/readthedocs/api/v2/views/footer_views.py
+++ b/readthedocs/api/v2/views/footer_views.py
@@ -157,6 +157,7 @@ class BaseFooterHTML(APIView):
             'project': project,
             'version': version,
             'path': path,
+            'page_slug': page_slug,
             'downloads': version.get_downloads(pretty=True),
             'current_version': version.verbose_name,
             'versions': self._get_active_versions_sorted(),


### PR DESCRIPTION
There's no real point to tracking the vast amount of security bots and crawlers that hit our site.