### PR TITLE
Use total_memory to calculate "time" Docker limit

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-docstring
 
+import logging
 import os
 import subprocess
 import socket
@@ -18,6 +19,7 @@ except ImportError:
 
 
 _ = gettext = lambda s: s
+log = logging.getLogger(__name__)
 
 
 class CommunityBaseSettings(Settings):


### PR DESCRIPTION
4Gb servers:
 - total memory: 3417
 - memory limit: 2700
 - time limit (using memory limit): 700
 - time limit (using total memory): 900 (15 minutes)

8Gb servers:
 - total memory: 7935
 - memory limit: 7200
 - time limit (using memory limit): 1800
 - time limit (using total memory): 2000 (33 minutes)

These numbers are more similar to what we communicate in
https://docs.readthedocs.io/en/stable/builds.html. We are giving an increase of
3 extra minutes in Read the Docs for Business instead of 4 minutes less in Read
the Docs Community.

```
>>> round(3417 - 750, -2)
2700
>>> round(2700 * 0.25, -2)
700.0
>>> round(3417 * 0.25, -2)
900.0
>>> round(7935 - 750, -2)
7200
>>> round(7200 * 0.25, -2)
1800.0
>>> round(7935 * 0.25, -2)
2000.0
```