### PR TITLE
Remove task routing for long tasks to build:large

### DIFF
--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -74,15 +74,6 @@ class TaskRouter:
             )
             return self.BUILD_LARGE_QUEUE
 
-        # Build time average is high
-        length_avg = queryset.filter(pk__in=last_builds).aggregate(Avg('length')).get('length__avg')
-        if length_avg and length_avg > self.TIME_AVERAGE:
-            log.info(
-                'Routing task because project has high time average. queue=%s',
-                self.BUILD_LARGE_QUEUE,
-            )
-            return self.BUILD_LARGE_QUEUE
-
         log.info('No routing task because no conditions were met.')
         return
 

--- a/readthedocs/builds/tests/test_celery_task_router.py
+++ b/readthedocs/builds/tests/test_celery_task_router.py
@@ -67,11 +67,3 @@ class TaskRouterTests(TestCase):
         self.assertIsNone(
             self.router.route_for_task(self.task, self.args, {}),
         )
-
-    def test_build_length_high_average(self):
-        high_length = TaskRouter.TIME_AVERAGE + 50
-        self.version.builds.update(length=high_length)
-        self.assertEqual(
-            self.router.route_for_task(self.task, self.args, self.kwargs),
-            TaskRouter.BUILD_LARGE_QUEUE,
-        )


### PR DESCRIPTION
This seems to cause a lot more builds in build:large,
which costs more and often has lower concurrency.
This should hopefully spread our load of long builds,
causing less latency on these tasks.