### PR TITLE
cross-linking build limitations for pr builds

### DIFF
--- a/docs/guides/autobuild-docs-for-pull-requests.rst
+++ b/docs/guides/autobuild-docs-for-pull-requests.rst
@@ -51,7 +51,7 @@ Limitations
 -----------
 
 Auto-builds for pull/merge requests have
-:ref:`the same limitations as regular documentation builds <../builds>`.
+:doc:`the same limitations as regular documentation builds </builds>`.
 
 Currently we don't index search for pull request builds.
 Searches will default to the default experience for your tool.

--- a/docs/guides/autobuild-docs-for-pull-requests.rst
+++ b/docs/guides/autobuild-docs-for-pull-requests.rst
@@ -50,6 +50,9 @@ Features
 Limitations
 -----------
 
+Auto-builds for pull/merge requests have
+:ref:`the same limitations as regular documentation builds <../builds>`.
+
 Currently we don't index search for pull request builds.
 Searches will default to the default experience for your tool.
 This is a feature we plan to add,


### PR DESCRIPTION
In https://github.com/readthedocs/readthedocs.org/issues/7240 there was some confusion about what the build limitations were for PR builds. @humitos mentioned that they're the same as for regular builds, so this adds a sentence to cross-link that page.