### PR TITLE
Sphinx: add --keep-going when fail_on_warning is true

### DIFF
--- a/docs/config-file/v2.rst
+++ b/docs/config-file/v2.rst
@@ -25,7 +25,7 @@ Below is an example YAML file which shows the most common configuration options:
     #  configuration: mkdocs.yml
 
     # Optionally build your docs in additional formats such as PDF
-    formats: 
+    formats:
       - pdf
 
     # Optionally set the version of Python and requirements required to build your docs
@@ -323,7 +323,7 @@ sphinx.fail_on_warning
 ``````````````````````
 
 `Turn warnings into errors <http://www.sphinx-doc.org/en/master/man/sphinx-build.html#id6>`__.
-This means that the build stops at the first warning and exits with exit status 1.
+This means the build fails if there is a warning and exits with exit status 1.
 
 :Type: ``bool``
 :Default: ``false``

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -240,7 +240,7 @@ class BaseSphinx(BaseBuilder):
         if self._force:
             build_command.append('-E')
         if self.config.sphinx.fail_on_warning:
-            build_command.append('-W')
+            build_command.extend(['-W', '--keep-going'])
         doctree_path = f'_build/doctrees-{self.sphinx_builder}'
         if self.project.has_feature(Feature.SHARE_SPHINX_DOCTREE):
             doctree_path = '_build/doctrees'

--- a/readthedocs/rtd_tests/tests/test_config_integration.py
+++ b/readthedocs/rtd_tests/tests/test_config_integration.py
@@ -933,6 +933,7 @@ class TestLoadConfigV2:
 
         args, kwargs = run.call_args
         assert '-W' in args
+        assert '--keep-going' in args
         append_conf.assert_called_once()
         move.assert_called_once()
 


### PR DESCRIPTION
The option was added in sphinx 1.8,
and we only add it if the user sets `fail_on_warning: true`.

https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-keep-going

Closes https://github.com/readthedocs/readthedocs.org/issues/7240