### PR TITLE
[WIP] Add support for "requires" key in Python install config and allow extra keys beginning with "x-"

### DIFF
--- a/docs/config-file/v2.rst
+++ b/docs/config-file/v2.rst
@@ -175,6 +175,27 @@ Example:
   manage the build, this setting will not have any effect. Instead
   add the extra requirements to the ``environment`` file of Conda.
 
+Requirements List
+'''''''''''''''''
+
+Install packages from a list of requirements as a string (similar to how they would be
+listed on the command-line when invoking ``pip install``).
+
+:Key: `requires`
+:Type: ``string``
+:Required: ``true``
+
+Example:
+
+.. code-block:: yaml
+
+   version: 2
+
+   python:
+      version: 3.7
+      install:
+         - requires: mkdocs-material Pygments
+
 Packages
 ''''''''
 

--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -20,6 +20,7 @@ from .models import (
     Python,
     PythonInstall,
     PythonInstallRequirements,
+    PythonInstallRequirementsList,
     Search,
     Sphinx,
     Submodules,

--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -5,6 +5,7 @@
 import copy
 import os
 import re
+import shlex
 from contextlib import contextmanager
 
 from django.conf import settings
@@ -833,6 +834,9 @@ class BuildConfigV2(BuildConfigBase):
                     self.base_path,
                 )
                 python_install['requirements'] = requirements
+        elif 'requires' in raw_install:
+            requires_key = key + 'requires'
+            python_install['requires'] = shlex.split(self.pop_config(requires_key))
         elif 'path' in raw_install:
             path_key = key + '.path'
             with self.catch_validation_error(path_key):
@@ -1113,6 +1117,8 @@ class BuildConfigV2(BuildConfigBase):
         for install in python['install']:
             if 'requirements' in install:
                 python_install.append(PythonInstallRequirements(**install),)
+            elif 'requires' in install:
+                python_install.append(PythonInstallRequirementsList(install['requires']))
             elif 'path' in install:
                 python_install.append(PythonInstall(**install),)
         return Python(

--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -1119,7 +1119,7 @@ class BuildConfigV2(BuildConfigBase):
             if 'requirements' in install:
                 python_install.append(PythonInstallRequirements(**install),)
             elif 'requires' in install:
-                python_install.append(PythonInstallRequirementsList(install['requires']))
+                python_install.append(PythonInstallRequirementsList(install['requires']),)
             elif 'path' in install:
                 python_install.append(PythonInstall(**install),)
         return Python(

--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -1086,9 +1086,10 @@ class BuildConfigV2(BuildConfigBase):
 
         Will return `['key', 'name']`.
         """
-        if isinstance(value, dict) and value:
-            key_name = next(iter(value))
-            return [key_name] + self._get_extra_key(value[key_name])
+        if isinstance(value, dict):
+            key_name = next((k for k in value if not k.startswith('x-')), None)
+            if key_name is not None:
+                return [key_name] + self._get_extra_key(value[key_name])
         return []
 
     @property

--- a/readthedocs/config/models.py
+++ b/readthedocs/config/models.py
@@ -41,6 +41,11 @@ class PythonInstallRequirements(Base):
     __slots__ = ('requirements',)
 
 
+class PythonInstallRequirementsList(Base):
+
+    __slots__ = ('requirements',)
+
+
 class PythonInstall(Base):
 
     __slots__ = (

--- a/readthedocs/config/tests/test_config.py
+++ b/readthedocs/config/tests/test_config.py
@@ -33,6 +33,7 @@ from readthedocs.config.models import (
     Conda,
     PythonInstall,
     PythonInstallRequirements,
+    PythonInstallRequirementsList,
 )
 from readthedocs.config.validation import (
     INVALID_BOOL,
@@ -1103,6 +1104,23 @@ class TestBuildConfigV2:
         assert len(install) == 1
         assert isinstance(install[0], PythonInstallRequirements)
         assert install[0].requirements == 'requirements.txt'
+
+    def test_python_install_requires_check_valid(self, tmpdir):
+        build = self.get_build_config(
+            {
+                'python': {
+                    'install': [{
+                        'requires': 'package_a "package_b >=3.0.0,<4.0.0"',
+                    }],
+                },
+            },
+            source_file=str(tmpdir.join('readthedocs.yml')),
+        )
+        build.validate()
+        install = build.python.install
+        assert len(install) == 1
+        assert isinstance(install[0], PythonInstallRequirementsList)
+        assert install[0].requirements == ['package_a', 'package_b >=3.0.0,<4.0.0']
 
     def test_python_install_requirements_does_not_allow_null(self, tmpdir):
         build = self.get_build_config(

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -14,7 +14,11 @@ from django.conf import settings
 
 from readthedocs.builds.constants import EXTERNAL
 from readthedocs.config import PIP, SETUPTOOLS, ParseError, parse as parse_yaml
-from readthedocs.config.models import PythonInstall, PythonInstallRequirements
+from readthedocs.config.models import (
+    PythonInstall,
+    PythonInstallRequirements,
+    PythonInstallRequirementsList,
+)
 from readthedocs.doc_builder.config import load_yaml_config
 from readthedocs.doc_builder.constants import DOCKER_IMAGE
 from readthedocs.doc_builder.environments import DockerBuildEnvironment
@@ -77,8 +81,8 @@ class PythonEnvironment:
         for install in self.config.python.install:
             if isinstance(install, PythonInstallRequirements):
                 self.install_requirements_file(install)
-            if isinstance(install, PythonInstallRequirementsString):
-                self.install_requirements_string(install)
+            if isinstance(install, PythonInstallRequirementsList):
+                self.install_requirements_list(install)
             if isinstance(install, PythonInstall):
                 self.install_package(install)
 
@@ -432,12 +436,12 @@ class Virtualenv(PythonEnvironment):
                 bin_path=self.venv_bin(),
             )
 
-    def install_requirements_string(self, install):
+    def install_requirements_list(self, install):
         """
         Install requirements from a string specification using pip.
 
         :param install: A instal object from the config module.
-        :type install: readthedocs.config.modules.PythonInstallRequirementsString
+        :type install: readthedocs.config.modules.PythonInstallRequirementsList
         """
 
         args = [

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -77,6 +77,8 @@ class PythonEnvironment:
         for install in self.config.python.install:
             if isinstance(install, PythonInstallRequirements):
                 self.install_requirements_file(install)
+            if isinstance(install, PythonInstallRequirementsString):
+                self.install_requirements_string(install)
             if isinstance(install, PythonInstall):
                 self.install_package(install)
 
@@ -429,6 +431,33 @@ class Virtualenv(PythonEnvironment):
                 cwd=self.checkout_path,
                 bin_path=self.venv_bin(),
             )
+
+    def install_requirements_string(self, install):
+        """
+        Install requirements from a string specification using pip.
+
+        :param install: A instal object from the config module.
+        :type install: readthedocs.config.modules.PythonInstallRequirementsString
+        """
+
+        args = [
+            self.venv_bin(filename='python'),
+            '-m',
+            'pip',
+            'install',
+        ]
+        if self.project.has_feature(Feature.PIP_ALWAYS_UPGRADE):
+            args += ['--upgrade']
+        args += [
+            '--exists-action=w',
+            *self._pip_cache_cmd_argument(),
+        ]
+        args += install.requirements
+        self.build_env.run(
+            *args,
+            cwd=self.checkout_path,
+            bin_path=self.venv_bin(),
+        )
 
     def list_packages_installed(self):
         """List packages installed in pip."""


### PR DESCRIPTION
* Adds support for a "requires" install step in the Python install config. This allows you to specify requirements directly in the readthedocs config.
* Allow extra keys in the v2 configuration file if the key name starts with `x-`.

My motivation for this change is to reduce the number of files needed if 

a) the requirements are needed only for readthedocs, and thus it makes sense to put them in the configuration directly, and
b) add the ability to enrich the readthedocs config with non-standard data for custom workflows

