### PR TITLE
Expose project's environment variables in private versions

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -69,7 +69,7 @@ from readthedocs.doc_builder.loader import get_builder_class
 from readthedocs.doc_builder.python_environments import Conda, Virtualenv
 from readthedocs.oauth.models import RemoteRepository
 from readthedocs.oauth.notifications import GitBuildStatusFailureNotification
-from readthedocs.projects.constants import GITHUB_BRAND, GITLAB_BRAND
+from readthedocs.projects.constants import GITHUB_BRAND, GITLAB_BRAND, PRIVATE
 from readthedocs.projects.models import APIProject, Feature
 from readthedocs.search.utils import index_new_files, remove_indexed_files
 from readthedocs.sphinx_domains.models import SphinxDomain
@@ -955,7 +955,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
         # Update environment from Project's specific environment variables,
         # avoiding to expose environment variables if the version is external
         # for security reasons.
-        if self.version.type != EXTERNAL:
+        if self.version.type != EXTERNAL or self.version.privacy_level == PRIVATE:
             env.update(self.project.environment_variables)
 
         return env


### PR DESCRIPTION
We are not exposing environment variables when building from a Pull
Request (external version) because of security reasons. However, if the version
is private it's safe to use this environment variables at build time, because
the documentation will be available only for authenticated users.