### PR TITLE
Fix a case where "tags" is interpreted as a project slug

### DIFF
--- a/readthedocs/projects/urls/public.py
+++ b/readthedocs/projects/urls/public.py
@@ -17,6 +17,11 @@ urlpatterns = [
         name='projects_dashboard_redirect',
     ),
     url(
+        r'^tags/(?P<tag>[-\w]+)/$',
+        ProjectTagIndex.as_view(),
+        name='projects_tag_detail',
+    ),
+    url(
         r'^(?P<invalid_project_slug>{project_slug}_{project_slug})/'.format(**pattern_opts),
         public.project_redirect,
         name='project_redirect',
@@ -81,10 +86,5 @@ urlpatterns = [
         r'^(?P<project_slug>{project_slug})/versions/$'.format(**pattern_opts),
         public.project_versions,
         name='project_version_list',
-    ),
-    url(
-        r'^tags/(?P<tag>[-\w]+)/$',
-        ProjectTagIndex.as_view(),
-        name='projects_tag_detail',
     ),
 ]


### PR DESCRIPTION
- Assumption: There should not be a project named "tags"
- Longer term this opens up a discussion about banned project names

## Issue

Currently https://readthedocs.org/projects/tags/search/ gives a 404. It should return a list of projects for this tag. It does this because the [URL route here](https://github.com/readthedocs/readthedocs.org/blob/8726eec2d8b5e3d2ecc157d07ee203f95429cfdb/readthedocs/projects/urls/public.py#L62) is looked at first.