### PR TITLE
allow "x-" options in readthedocs.yml configuration

### DIFF
--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -1085,10 +1085,13 @@ class BuildConfigV2(BuildConfigBase):
         }
 
         Will return `['key', 'name']`.
+
+        Ignores keys that start with ``x-``.
         """
-        if isinstance(value, dict) and value:
-            key_name = next(iter(value))
-            return [key_name] + self._get_extra_key(value[key_name])
+        if isinstance(value, dict):
+            key_name = next((k for k in value if not k.startswith('x-')), None)
+            if key_name is not None:
+                return [key_name] + self._get_extra_key(value[key_name])
         return []
 
     @property

--- a/readthedocs/config/tests/test_config.py
+++ b/readthedocs/config/tests/test_config.py
@@ -1966,6 +1966,7 @@ class TestBuildConfigV2:
             ({'one': {'two': 3}}, ['one', 'two']),
             (OrderedDict([('one', 1), ('two', 2)]), ['one']),
             (OrderedDict([('one', {'two': 2}), ('three', 3)]), ['one', 'two']),
+            ({'one': 1, 'x-two': 2}, ['one']),
         ],
     )
     def test_get_extra_key(self, value, expected):


### PR DESCRIPTION
This Pull Request will allow that options starting with `x-` can be added to the `.readthedocs.yml` configuration. This is useful for custom workflows where it makes sense to embed additional options in the Read the Docs configuration. The `x-` convention is also used by Docker-Compose, for example.

My personal use case for this is to embed the configuration for [`readthedocs-custom-steps`](https://pypi.org/project/readthedocs-custom-steps/) in the configuration directly, instead of a having to use a separate `.readthedocs-custom-steps.yml` file.
