### PR TITLE
Add support for "packages" install key in v2 config

### DIFF
--- a/docs/config-file/v2.rst
+++ b/docs/config-file/v2.rst
@@ -192,11 +192,11 @@ Example:
    version: 2
 
    python:
-      version: 3.7
-      install:
-         - packages:
-           - mkdocs-material
-           - Pygments
+     version: 3.7
+     install:
+       - packages:
+         - mkdocs-material
+         - Pygments
 
 Packages
 ''''''''

--- a/docs/config-file/v2.rst
+++ b/docs/config-file/v2.rst
@@ -182,7 +182,8 @@ Install packages from a list of requirements.
 This allows you to declare dependencies in the ``.readthedocs.yml`` file instead of creating a separate file.
 
 :Key: `packages`
-:Type: ``string``
+:Type: ``list``
+:Default: ``[]``
 :Required: ``true``
 
 Example:

--- a/docs/config-file/v2.rst
+++ b/docs/config-file/v2.rst
@@ -175,6 +175,29 @@ Example:
   manage the build, this setting will not have any effect. Instead
   add the extra requirements to the ``environment`` file of Conda.
 
+Packages list
+'''''''''''''
+
+Install packages from a list of requirements. This allows you to embed requirements in the
+``.readthedocs.yml`` configuration directly.
+
+:Key: `packages`
+:Type: ``string``
+:Required: ``true``
+
+Example:
+
+.. code-block:: yaml
+
+   version: 2
+
+   python:
+      version: 3.7
+      install:
+         - packages:
+           - mkdocs-material
+           - Pygments
+
 Packages
 ''''''''
 

--- a/docs/config-file/v2.rst
+++ b/docs/config-file/v2.rst
@@ -178,8 +178,8 @@ Example:
 Packages list
 '''''''''''''
 
-Install packages from a list of requirements. This allows you to embed requirements in the
-``.readthedocs.yml`` configuration directly.
+Install packages from a list of requirements.
+This allows you to declare dependencies in the ``.readthedocs.yml`` file instead of creating a separate file.
 
 :Key: `packages`
 :Type: ``string``

--- a/docs/config-file/v2.rst
+++ b/docs/config-file/v2.rst
@@ -175,30 +175,6 @@ Example:
   manage the build, this setting will not have any effect. Instead
   add the extra requirements to the ``environment`` file of Conda.
 
-Packages list
-'''''''''''''
-
-Install packages from a list of requirements.
-This allows you to declare dependencies in the ``.readthedocs.yml`` file instead of creating a separate file.
-
-:Key: `packages`
-:Type: ``list``
-:Default: ``[]``
-:Required: ``true``
-
-Example:
-
-.. code-block:: yaml
-
-   version: 2
-
-   python:
-     version: 3.7
-     install:
-       - packages:
-         - mkdocs-material
-         - Pygments
-
 Packages
 ''''''''
 
@@ -251,6 +227,36 @@ With the previous settings, Read the Docs will execute the next commands:
 
    pip install .[docs]
    python package/setup.py install
+
+Extra dependencies
+''''''''''''''''''
+
+Install packages from a list of requirements.
+This allows you to declare dependencies in the ``.readthedocs.yml`` file instead of creating a separate file.
+
+:Key: `packages`
+:Type: ``list``
+:Default: ``[]``
+:Required: ``true``
+
+Example:
+
+.. code-block:: yaml
+
+   version: 2
+
+   python:
+     version: 3.7
+     install:
+       - packages:
+         - mkdocs-material
+         - Pygments
+
+With the previous settings, Read the Docs will execute the next commands:
+
+.. prompt:: bash $
+
+   pip install mkdocs-material Pygments
 
 python.system_packages
 ``````````````````````

--- a/docs/config-file/v2.rst
+++ b/docs/config-file/v2.rst
@@ -237,7 +237,6 @@ This allows you to declare dependencies in the ``.readthedocs.yml`` file instead
 :Key: `packages`
 :Type: ``list``
 :Default: ``[]``
-:Required: ``true``
 
 Example:
 

--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -843,6 +843,12 @@ class BuildConfigV2(BuildConfigBase):
                     '"{}" key must be a list'.format(packages_key),
                     code=PYTHON_INVALID,
                 )
+            if not packages:
+                self.error(
+                    packages_key,
+                    '"{}" cannot be empty'.format(packages_key),
+                    code=PYTHON_INVALID,
+                )
             python_install['packages'] = packages
         elif 'path' in raw_install:
             path_key = key + '.path'

--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -19,6 +19,7 @@ from .models import (
     Python,
     PythonInstall,
     PythonInstallRequirements,
+    PythonInstallPackages,
     Search,
     Sphinx,
     Submodules,
@@ -833,6 +834,16 @@ class BuildConfigV2(BuildConfigBase):
                     self.base_path,
                 )
                 python_install['requirements'] = requirements
+        elif 'packages' in raw_install:
+            packages_key = key + '.packages'
+            packages = self.pop_config(packages_key)
+            if not isinstance(packages, list):
+                self.error(
+                    packages_key,
+                    '"{}" key must be a list'.format(packages_key),
+                    code=PYTHON_INVALID,
+                )
+            python_install['packages'] = packages
         elif 'path' in raw_install:
             path_key = key + '.path'
             with self.catch_validation_error(path_key):
@@ -1112,6 +1123,8 @@ class BuildConfigV2(BuildConfigBase):
         for install in python['install']:
             if 'requirements' in install:
                 python_install.append(PythonInstallRequirements(**install),)
+            elif 'packages' in install:
+                python_install.append(PythonInstallPackages(**install),)
             elif 'path' in install:
                 python_install.append(PythonInstall(**install),)
         return Python(

--- a/readthedocs/config/models.py
+++ b/readthedocs/config/models.py
@@ -41,6 +41,11 @@ class PythonInstallRequirements(Base):
     __slots__ = ('requirements',)
 
 
+class PythonInstallPackages(Base):
+
+    __slots__ = ('packages',)
+
+
 class PythonInstall(Base):
 
     __slots__ = (

--- a/readthedocs/config/tests/test_config.py
+++ b/readthedocs/config/tests/test_config.py
@@ -1105,7 +1105,7 @@ class TestBuildConfigV2:
         assert isinstance(install[0], PythonInstallRequirements)
         assert install[0].requirements == 'requirements.txt'
 
-    def test_python_install_requires_check_valid(self, tmpdir):
+    def test_python_install_packages_check_valid(self, tmpdir):
         build = self.get_build_config(
             {
                 'python': {

--- a/readthedocs/config/tests/test_config.py
+++ b/readthedocs/config/tests/test_config.py
@@ -1125,6 +1125,38 @@ class TestBuildConfigV2:
         assert isinstance(install[0], PythonInstallPackages)
         assert install[0].packages == ['package_a', 'package_b >=3.0.0,<4.0.0']
 
+    def test_python_install_packages_must_be_list(self, tmpdir):
+        build = self.get_build_config(
+            {
+                'python': {
+                    'install': [{
+                        'packages': {},
+                    }],
+                },
+            },
+            source_file=str(tmpdir.join('readthedocs.yml')),
+        )
+        with raises(InvalidConfig) as excinfo:
+            build.validate()
+        assert excinfo.value.key == 'python.install.0.packages'
+        assert '"python.install.0.packages" key must be a list' in str(excinfo.value)
+
+    def test_python_install_packages_must_not_be_empty(self, tmpdir):
+        build = self.get_build_config(
+            {
+                'python': {
+                    'install': [{
+                        'packages': [],
+                    }],
+                },
+            },
+            source_file=str(tmpdir.join('readthedocs.yml')),
+        )
+        with raises(InvalidConfig) as excinfo:
+            build.validate()
+        assert excinfo.value.key == 'python.install.0.packages'
+        assert '"python.install.0.packages" cannot be empty' in str(excinfo.value)
+
     def test_python_install_requirements_does_not_allow_null(self, tmpdir):
         build = self.get_build_config(
             {

--- a/readthedocs/config/tests/test_config.py
+++ b/readthedocs/config/tests/test_config.py
@@ -33,6 +33,7 @@ from readthedocs.config.models import (
     Conda,
     PythonInstall,
     PythonInstallRequirements,
+    PythonInstallPackages,
 )
 from readthedocs.config.validation import (
     INVALID_BOOL,
@@ -1103,6 +1104,26 @@ class TestBuildConfigV2:
         assert len(install) == 1
         assert isinstance(install[0], PythonInstallRequirements)
         assert install[0].requirements == 'requirements.txt'
+
+    def test_python_install_requires_check_valid(self, tmpdir):
+        build = self.get_build_config(
+            {
+                'python': {
+                    'install': [{
+                        'packages': [
+                            'package_a',
+                            'package_b >=3.0.0,<4.0.0',
+                        ],
+                    }],
+                },
+            },
+            source_file=str(tmpdir.join('readthedocs.yml')),
+        )
+        build.validate()
+        install = build.python.install
+        assert len(install) == 1
+        assert isinstance(install[0], PythonInstallPackages)
+        assert install[0].packages == ['package_a', 'package_b >=3.0.0,<4.0.0']
 
     def test_python_install_requirements_does_not_allow_null(self, tmpdir):
         build = self.get_build_config(

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -438,7 +438,7 @@ class Virtualenv(PythonEnvironment):
 
     def install_packages_list(self, install):
         """
-        Install requirements from a string specification using pip.
+        Install requirements from a list of strings using pip.
 
         :param install: A instal object from the config module.
         :type install: readthedocs.config.modules.PythonInstallPackages

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -456,7 +456,7 @@ class Virtualenv(PythonEnvironment):
             '--exists-action=w',
             *self._pip_cache_cmd_argument(),
         ]
-        args += install.requirements
+        args += install.packages
         self.build_env.run(
             *args,
             cwd=self.checkout_path,


### PR DESCRIPTION
This adds support for a `packages` install option in the v2 config file. Example:

```yml
version: 3.7
install:
  - packages:
    - mkdocs-material
    - Pygments
```

The motivation for this change is that you don't have to have a `requirements.txt` in your project when you only need those requirements for the Read the Docs build environment.

__Testing__

* [x] Add unit test
* [ ] Actually test the package installation (`install_packages_list()`)