### PR TITLE
Sphinx: always exclude the build directory

### DIFF
--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -178,3 +178,7 @@ if chinese:
     latex_elements = latex_elements_user or latex_elements_rtd
 elif japanese:
     latex_engine = latex_engine_user or 'platex'
+
+# Make sure our build directory is always excluded
+exclude_patterns = globals().get('exclude_patterns', [])
+exclude_patterns.extend(['_build'])


### PR DESCRIPTION
We use the _build/ directory for all builders.
Some users may not have that directory excluded,
leading to some extra copy operations.

Fixes https://github.com/readthedocs/readthedocs.org/issues/7200