### PR TITLE
Feature to disable auto-generated index.md/README.rst files

### DIFF
--- a/docs/guides/feature-flags.rst
+++ b/docs/guides/feature-flags.rst
@@ -46,3 +46,11 @@ By default, when Read the Docs runs Sphinx it passes a different output director
 While this is a way to ensure that all the outputs are generated from scratch,
 it may cause your builds to be slow if you have a big set of documentation and builds multiple formats.
 In that case, enabling ``SHARE_SPHINX_DOCTREE`` could help to speed up your builds by sharing the doctree among all the formats.
+
+``DONT_CREATE_INDEX``: :featureflags:`DONT_CREATE_INDEX`
+
+When Read the Docs detects that your project doesn't have an ``index.md`` or ``README.rst``,
+it auto-generate one for you with instructions about how to proceed.
+
+In case you are using a static HTML page as index or an generated index from code,
+this behavior could be a problem. With this feature flag you can disable that.

--- a/readthedocs/doc_builder/base.py
+++ b/readthedocs/doc_builder/base.py
@@ -7,6 +7,8 @@ import os
 import shutil
 from functools import wraps
 
+from readthedocs.projects.models import Feature
+
 
 log = logging.getLogger(__name__)
 
@@ -114,8 +116,9 @@ class BaseBuilder:
             if os.path.exists(readme_filename):
                 return 'README'
 
-            index_file = open(index_filename, 'w+')
-            index_text = """
+            if not self.project.has_feature(Feature.DONT_CREATE_INDEX):
+                index_file = open(index_filename, 'w+')
+                index_text = """
 
 Welcome to Read the Docs
 ------------------------
@@ -131,8 +134,8 @@ Check out our `Getting Started Guide
 familiar with Read the Docs.
                 """
 
-            index_file.write(index_text.format(dir=docs_dir, ext=extension))
-            index_file.close()
+                index_file.write(index_text.format(dir=docs_dir, ext=extension))
+                index_file.close()
         return 'index'
 
     def run(self, *args, **kwargs):

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1553,6 +1553,7 @@ class Feature(models.Model):
     USE_SPHINX_RTD_EXT_LATEST = 'rtd_sphinx_ext_latest'
     DEFAULT_TO_FUZZY_SEARCH = 'default_to_fuzzy_search'
     INDEX_FROM_HTML_FILES = 'index_from_html_files'
+    DONT_CREATE_INDEX = 'dont_create_index'
 
     FEATURES = (
         (USE_SPHINX_LATEST, _('Use latest version of Sphinx')),
@@ -1677,6 +1678,10 @@ class Feature(models.Model):
         (
             INDEX_FROM_HTML_FILES,
             _('Index content directly from html files instead or relying in other sources'),
+        ),
+        (
+            DONT_CREATE_INDEX,
+            _('Do not create index.md or README.rst if the project does not have one.'),
         ),
     )
 


### PR DESCRIPTION
When Read the Docs detects that your project doesn't have an ``index.md`` or
``README.rst``, it auto-generates one for you with instructions about how to
proceed. This behavior may be a problem for some users and they will want to
disable it.

This is happening for example when building with MkDocs and setting

```
theme:
  static_templates:
  - index.html
```

Since there is no `index.md`, Read the Docs will create one from our template
and it will override the `index.html` the user wants to show.

Related to #2483