### PR TITLE
Remove DEDUPLICATE_BUILDS feature flag

### DIFF
--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -186,10 +186,6 @@ def prepare_build(
             state=BUILD_STATE_TRIGGERED,
         ).count() > 1
 
-    if not project.has_feature(Feature.DEDUPLICATE_BUILDS):
-        log.debug('Skipping deduplication of builds. Feature not enabled. project=%s', project.slug)
-        skip_build = False
-
     if skip_build:
         # TODO: we could mark the old build as duplicated, however we reset our
         # position in the queue and go back to the end of it --penalization

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1549,7 +1549,6 @@ class Feature(models.Model):
     STORE_PAGEVIEWS = 'store_pageviews'
     SPHINX_PARALLEL = 'sphinx_parallel'
     USE_SPHINX_BUILDERS = 'use_sphinx_builders'
-    DEDUPLICATE_BUILDS = 'deduplicate_builds'
     USE_SPHINX_RTD_EXT_LATEST = 'rtd_sphinx_ext_latest'
     DEFAULT_TO_FUZZY_SEARCH = 'default_to_fuzzy_search'
     INDEX_FROM_HTML_FILES = 'index_from_html_files'
@@ -1661,10 +1660,6 @@ class Feature(models.Model):
         (
             USE_SPHINX_BUILDERS,
             _('Use regular sphinx builders instead of custom RTD builders'),
-        ),
-        (
-            DEDUPLICATE_BUILDS,
-            _('Mark duplicated builds as NOOP to be skipped by builders'),
         ),
         (
             USE_SPHINX_RTD_EXT_LATEST,

--- a/readthedocs/rtd_tests/tests/test_builds.py
+++ b/readthedocs/rtd_tests/tests/test_builds.py
@@ -763,12 +763,6 @@ class DeDuplicateBuildTests(TestCase):
             project=self.project
         )
 
-        get(
-            Feature,
-            feature_id=Feature.DEDUPLICATE_BUILDS,
-            projects=[self.project],
-        )
-
     def test_trigger_duplicated_build_by_commit(self, update_docs_task):
         """
         Trigger a build for the same commit twice.


### PR DESCRIPTION
We have been testing this for some weeks now and we haven't seen any issue with
it. We are ready to remove the feature flag and make this the default behavior.