### PR TITLE
Remove SPHINX_PARALLEL feature flag and make it the default

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -273,9 +273,7 @@ class BaseSphinx(BaseBuilder):
         )
 
     def sphinx_parallel_arg(self):
-        if self.project.has_feature(Feature.SPHINX_PARALLEL):
-            return ['-j', 'auto']
-        return []
+        return ['-j', 'auto']
 
     def venv_sphinx_supports_latexmk(self):
         """

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1547,7 +1547,6 @@ class Feature(models.Model):
     LIST_PACKAGES_INSTALLED_ENV = 'list_packages_installed_env'
     VCS_REMOTE_LISTING = 'vcs_remote_listing'
     STORE_PAGEVIEWS = 'store_pageviews'
-    SPHINX_PARALLEL = 'sphinx_parallel'
     USE_SPHINX_BUILDERS = 'use_sphinx_builders'
     DEDUPLICATE_BUILDS = 'deduplicate_builds'
     USE_SPHINX_RTD_EXT_LATEST = 'rtd_sphinx_ext_latest'
@@ -1653,10 +1652,6 @@ class Feature(models.Model):
         (
             STORE_PAGEVIEWS,
             _('Store pageviews for this project'),
-        ),
-        (
-            SPHINX_PARALLEL,
-            _('Use "-j auto" when calling sphinx-build'),
         ),
         (
             USE_SPHINX_BUILDERS,


### PR DESCRIPTION
We have been testing `SPHINX_PARALLEL` feature flag for some weeks now and we saw
some improvement on build times.

However, all the projects need to

* install `readthedocs-sphinx-ext>=2.1.0` (can be forced with
`USE_SPHINX_RTD_EXT_LATEST` flag for now)
* do not install any extension that does not support parallel reading
* build on `build:large` queue in community (`build:default` has only one CPU)

As we are using `-j auto`, enabling it when it's not available won't be an issue
and builds should keep working properly.