### PR TITLE
Proxito: proxy static files

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -17,23 +17,7 @@ from readthedocs.doc_builder.exceptions import MkDocsYAMLParseError
 from readthedocs.projects.constants import MKDOCS, MKDOCS_HTML
 from readthedocs.projects.models import Feature
 
-
 log = logging.getLogger(__name__)
-
-
-def get_absolute_static_url():
-    """
-    Get the fully qualified static URL from settings.
-
-    Mkdocs needs a full domain because it tries to link to local files.
-    """
-    static_url = settings.STATIC_URL
-
-    if not static_url.startswith('http'):
-        domain = settings.PRODUCTION_DOMAIN
-        static_url = 'http://{}{}'.format(domain, static_url)
-
-    return static_url
 
 
 class BaseMkdocs(BaseBuilder):
@@ -152,7 +136,7 @@ class BaseMkdocs(BaseBuilder):
         user_config['docs_dir'] = docs_dir
 
         # Set mkdocs config values
-        static_url = get_absolute_static_url()
+        static_url = self.project.get_static_path()
 
         for config in ('extra_css', 'extra_javascript'):
             user_value = user_config.get(config, [])
@@ -165,7 +149,7 @@ class BaseMkdocs(BaseBuilder):
 
         extra_javascript_list = [
             'readthedocs-data.js',
-            '%score/js/readthedocs-doc-embed.js' % static_url,
+            '%sjavascript/readthedocs-doc-embed.js' % static_url,
             '%sjavascript/readthedocs-analytics.js' % static_url,
         ]
         extra_css_list = [

--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -76,7 +76,7 @@ context = {
     'current_version': "{{ version.verbose_name }}",
     'version_slug': "{{ version.slug }}",
     'MEDIA_URL': "{{ settings.MEDIA_URL }}",
-    'STATIC_URL': "{{ settings.STATIC_URL }}",
+    'STATIC_URL': "{{ project.get_static_path }}",
     'PRODUCTION_DOMAIN': "{{ settings.PRODUCTION_DOMAIN }}",
     'versions': [{% for version in versions %}
     ("{{ version.slug }}", "/{{ version.project.language }}/{{ version.slug}}/"),{% endfor %}

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -573,6 +573,9 @@ class Project(models.Model):
 
         return path
 
+    def get_static_path(self):
+        return self.proxied_api_host + '/static/'
+
     @property
     def proxied_api_host(self):
         """

--- a/readthedocs/proxito/urls.py
+++ b/readthedocs/proxito/urls.py
@@ -45,8 +45,9 @@ from readthedocs.proxito.views.serve import (
     ServePageRedirect,
     ServeRobotsTXT,
     ServeSitemapXML,
+    ServeStaticFiles,
 )
-from readthedocs.proxito.views.utils import proxito_404_page_handler, fast_404
+from readthedocs.proxito.views.utils import fast_404, proxito_404_page_handler
 
 DOC_PATH_PREFIX = getattr(settings, 'DOC_PATH_PREFIX', '')
 
@@ -88,6 +89,18 @@ proxied_urls = [
             DOC_PATH_PREFIX=DOC_PATH_PREFIX,
         ),
         include('readthedocs.api.v2.proxied_urls'),
+    ),
+
+    # Serve static files
+    # /_/static/file.js
+    url(
+        r'^{DOC_PATH_PREFIX}static/'
+        r'(?P<filename>{filename_slug})$'.format(
+            DOC_PATH_PREFIX=DOC_PATH_PREFIX,
+            **pattern_opts,
+        ),
+        ServeStaticFiles.as_view(),
+        name='project_static',
     ),
 ]
 

--- a/readthedocs/rtd_tests/tests/test_doc_builder.py
+++ b/readthedocs/rtd_tests/tests/test_doc_builder.py
@@ -1,19 +1,24 @@
 import os
 import tempfile
 from collections import namedtuple
-
 from unittest import mock
+from unittest.mock import patch
+
 import py
 import pytest
 import yaml
 from django.test import TestCase
 from django.test.utils import override_settings
 from django_dynamic_fixture import get
-from unittest.mock import patch
 
 from readthedocs.builds.models import Version
 from readthedocs.doc_builder.backends.mkdocs import MkdocsHTML, yaml_load_safely
-from readthedocs.doc_builder.backends.sphinx import BaseSphinx, HtmlBuilder, HtmlDirBuilder, SingleHtmlBuilder
+from readthedocs.doc_builder.backends.sphinx import (
+    BaseSphinx,
+    HtmlBuilder,
+    HtmlDirBuilder,
+    SingleHtmlBuilder,
+)
 from readthedocs.doc_builder.config import load_yaml_config
 from readthedocs.doc_builder.exceptions import MkDocsYAMLParseError
 from readthedocs.doc_builder.python_environments import Virtualenv
@@ -420,16 +425,16 @@ class MkdocsBuilderTest(TestCase):
         self.assertEqual(
             config['extra_css'],
             [
-                'http://readthedocs.org/static/css/badge_only.css',
-                'http://readthedocs.org/static/css/readthedocs-doc-embed.css',
+                '/_/static/css/badge_only.css',
+                '/_/static/css/readthedocs-doc-embed.css',
             ],
         )
         self.assertEqual(
             config['extra_javascript'],
             [
                 'readthedocs-data.js',
-                'http://readthedocs.org/static/core/js/readthedocs-doc-embed.js',
-                'http://readthedocs.org/static/javascript/readthedocs-analytics.js',
+                '/_/static/javascript/readthedocs-doc-embed.js',
+                '/_/static/javascript/readthedocs-analytics.js',
             ],
         )
         self.assertIsNone(
@@ -477,16 +482,16 @@ class MkdocsBuilderTest(TestCase):
         self.assertEqual(
             config['extra_css'],
             [
-                'http://readthedocs.org/static/css/badge_only.css',
-                'http://readthedocs.org/static/css/readthedocs-doc-embed.css',
+                '/_/static/css/badge_only.css',
+                '/_/static/css/readthedocs-doc-embed.css',
             ],
         )
         self.assertEqual(
             config['extra_javascript'],
             [
                 'readthedocs-data.js',
-                'http://readthedocs.org/static/core/js/readthedocs-doc-embed.js',
-                'http://readthedocs.org/static/javascript/readthedocs-analytics.js',
+                '/_/static/javascript/readthedocs-doc-embed.js',
+                '/_/static/javascript/readthedocs-analytics.js',
             ],
         )
         self.assertIsNone(
@@ -642,7 +647,7 @@ class MkdocsBuilderTest(TestCase):
                 'google_analytics': ['UA-1234-5', 'mkdocs.org'],
                 'docs_dir': 'docs',
                 'extra_css': [
-                    'http://readthedocs.org/static/css/badge_only.css'
+                    '/_/static/css/badge_only.css'
                 ],
                 'extra_javascript': ['readthedocs-data.js'],
             },
@@ -668,16 +673,16 @@ class MkdocsBuilderTest(TestCase):
         self.assertEqual(
             config['extra_css'],
             [
-                'http://readthedocs.org/static/css/badge_only.css',
-                'http://readthedocs.org/static/css/readthedocs-doc-embed.css',
+                '/_/static/css/badge_only.css',
+                '/_/static/css/readthedocs-doc-embed.css',
             ],
         )
         self.assertEqual(
             config['extra_javascript'],
             [
                 'readthedocs-data.js',
-                'http://readthedocs.org/static/core/js/readthedocs-doc-embed.js',
-                'http://readthedocs.org/static/javascript/readthedocs-analytics.js',
+                '/_/static/javascript/readthedocs-doc-embed.js',
+                '/_/static/javascript/readthedocs-analytics.js',
             ],
         )
 


### PR DESCRIPTION
This can also be done from nginx,
but it will feel weird having that piece of logic outside
the code, so not sure.

A point in favor is that we could start serving static assets
depending on the project, like serve an static file with search
disabled.

Closes https://github.com/readthedocs/readthedocs.org/issues/7273