### PR TITLE
Reduce robots.txt cache TTL

### DIFF
--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -343,7 +343,7 @@ class ServeError404(SettingsOverrideObject):
 class ServeRobotsTXTBase(ServeDocsMixin, View):
 
     @method_decorator(map_project_slug)
-    @method_decorator(cache_page(60 * 60 * 12))  # 12 hours
+    @method_decorator(cache_page(60 * 60))  # 1 hour
     def get(self, request, project):
         """
         Serve custom user's defined ``/robots.txt``.


### PR DESCRIPTION
The TTL on the cache_page call of 12 hours exceeds the expiration of the
S3 presign URL expiration TTL. I believe the default here is the
`AWS_QUERYSTRING_EXPIRE` setting, default 3600s:
https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html#settings

Going beyond expiration on the presign URL results in a broken response
to the user, so not something we can safely keep cached.

12 hours is likely far too agressive here anyways. We could likely drop
this to a sub-5m TTL. If this is cached because it's an expensive view,
an hour seems like a good compromise for now.