### PR TITLE
Re-sync GitHub (RemoteRepository and RemoteOrganization) on webhook

### DIFF
--- a/readthedocs/api/v2/views/integrations.py
+++ b/readthedocs/api/v2/views/integrations.py
@@ -6,6 +6,9 @@ import json
 import logging
 import re
 
+from allauth.socialaccount.providers.github.provider import GitHubProvider
+from allauth.socialaccount.models import SocialAccount
+
 from django.shortcuts import get_object_or_404
 from rest_framework import permissions, status
 from rest_framework.exceptions import NotFound, ParseError
@@ -27,6 +30,7 @@ from readthedocs.core.views.hooks import (
     build_external_version,
 )
 from readthedocs.integrations.models import HttpExchange, Integration
+from readthedocs.oauth.services.github import GitHubService
 from readthedocs.projects.models import Project, Feature
 
 
@@ -34,6 +38,7 @@ log = logging.getLogger(__name__)
 
 GITHUB_EVENT_HEADER = 'HTTP_X_GITHUB_EVENT'
 GITHUB_SIGNATURE_HEADER = 'HTTP_X_HUB_SIGNATURE'
+GITHUB_MEMBER = 'member'
 GITHUB_PUSH = 'push'
 GITHUB_PULL_REQUEST = 'pull_request'
 GITHUB_PULL_REQUEST_OPENED = 'opened'
@@ -458,6 +463,16 @@ class GitHubWebhookView(WebhookMixin, APIView):
                 return self.get_response_push(self.project, branches)
             except KeyError:
                 raise ParseError('Parameter "ref" is required')
+
+        # Re-sync repositories for the user if any permission has changed
+        if event == GITHUB_MEMBER:
+            uid = self.data.get('member').get('id')
+            socialaccount = SocialAccount.objects.get(
+                provider=GitHubProvider.id,
+                uid=uid,
+            )
+            service = GitHubService(user=socialaccount.user, account=socialaccount)
+            service.sync()
 
         return None
 

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -197,7 +197,7 @@ class GitHubService(Service):
                 'secret': integration.secret,
                 'content_type': 'json',
             },
-            'events': ['push', 'pull_request', 'create', 'delete'],
+            'events': ['push', 'pull_request', 'create', 'delete', 'member'],
         })
 
     def get_provider_data(self, project, integration):


### PR DESCRIPTION
Add `member` event when creating the Read the Docs' webhook on each repository
imported under Read the Docs.

This webhook will communicate back to us when a collaborator was
added/removed/changed from that repository in particular. This allow us to
trigger the re-sync method for the GitHub service on that user and
create/delete/change `RemoteRepository` objects for that user.

Examples,

* user is removed from having access to a repository -> remove RemoteRepository
* user is added access to a repository -> create RemoteRepository
* user is removed admin access but keep read access -> `.admin=False`

Related to #7185 

Documentation reference: https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#member