### PR TITLE
Lower rank for custom install docs.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,3 +15,6 @@ search:
 
     # Internal documentation
     development/design/*: -5
+
+    # Useful content, but not something we want most users finding
+    custom_installs/*: -6


### PR DESCRIPTION
We don’t want users finding these generally.