### PR TITLE
Footer: don't show the version warning for external version

### DIFF
--- a/readthedocs/api/v2/views/footer_views.py
+++ b/readthedocs/api/v2/views/footer_views.py
@@ -16,7 +16,7 @@ from readthedocs.builds.constants import LATEST, TAG
 from readthedocs.builds.models import Version
 from readthedocs.core.utils.extend import SettingsOverrideObject
 from readthedocs.projects.constants import MKDOCS, SPHINX_HTMLDIR
-from readthedocs.projects.models import Project, Feature
+from readthedocs.projects.models import Feature, Project
 from readthedocs.projects.version_handling import (
     highest_version,
     parse_version_failsafe,
@@ -30,7 +30,10 @@ def get_version_compare_data(project, base_version=None):
     :param base_version: We assert whether or not the base_version is also the
                          highest version in the resulting "is_highest" value.
     """
-    if not project.show_version_warning:
+    if (
+        not project.show_version_warning or
+        (base_version and base_version.is_external)
+    ):
         return {'is_highest': False}
 
     versions_qs = (
@@ -214,9 +217,14 @@ class BaseFooterHTML(APIView):
             request,
         )
 
+        show_version_warning = (
+            project.show_version_warning and
+            not version.is_external
+        )
+
         resp_data = {
             'html': html,
-            'show_version_warning': project.show_version_warning,
+            'show_version_warning': show_version_warning,
             'version_active': version.active,
             'version_compare': version_compare_data,
             'version_supported': version.supported,

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -25,8 +25,8 @@ from readthedocs.builds.constants import (
     BUILD_STATE,
     BUILD_STATE_FINISHED,
     BUILD_STATE_TRIGGERED,
-    BUILD_TYPES,
     BUILD_STATUS_CHOICES,
+    BUILD_TYPES,
     EXTERNAL,
     GENERIC_EXTERNAL_VERSION_NAME,
     GITHUB_EXTERNAL_VERSION_NAME,
@@ -179,6 +179,10 @@ class Version(models.Model):
                 pk=self.pk,
             ),
         )
+
+    @property
+    def is_external(self):
+        return self.type == EXTERNAL
 
     @property
     def ref(self):

--- a/readthedocs/rtd_tests/tests/test_footer.py
+++ b/readthedocs/rtd_tests/tests/test_footer.py
@@ -1,4 +1,5 @@
 from unittest import mock
+
 from django.contrib.sessions.backends.base import SessionBase
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -10,7 +11,7 @@ from readthedocs.api.v2.views.footer_views import (
     FooterHTML,
     get_version_compare_data,
 )
-from readthedocs.builds.constants import BRANCH, LATEST, TAG
+from readthedocs.builds.constants import BRANCH, EXTERNAL, LATEST, TAG
 from readthedocs.builds.models import Version
 from readthedocs.core.middleware import ReadTheDocsSessionMiddleware
 from readthedocs.projects.constants import PUBLIC
@@ -70,6 +71,16 @@ class BaseTestFooterHTML:
         self.assertTrue(r.data['version_active'])
         self.assertFalse(r.data['version_compare']['is_highest'])
         self.assertTrue(r.data['version_supported'])
+        self.assertFalse(r.data['show_version_warning'])
+        self.assertEqual(r.context['main_project'], self.pip)
+
+    def test_footer_dont_show_version_warning_for_external_versions(self):
+        self.latest.type = EXTERNAL
+        self.latest.save()
+
+        r = self.render()
+        self.assertEqual(r.status_code, 200)
+        self.assertFalse(r.data['version_compare']['is_highest'])
         self.assertFalse(r.data['show_version_warning'])
         self.assertEqual(r.context['main_project'], self.pip)
 


### PR DESCRIPTION
Fixes https://github.com/readthedocs/readthedocs.org/issues/7218