### PR TITLE
Update Single Sign On documentation with latest features/changes

### DIFF
--- a/docs/commercial/single-sign-on.rst
+++ b/docs/commercial/single-sign-on.rst
@@ -12,11 +12,11 @@ Single Sign-On is supported on |com_brand| for Pro and Enterprise plans.
 Currently, we support two different types of Single Sign-On:
 
 * Authentication *and* authorization are managed by the Identity Provider (e.g. GitHub, Bitbucket or GitLab)
-* Authentication is managed by the Identity Provider (e.g. a ``@company.com`` verified email address)
+* Authentication (*only*) is managed by the Identity Provider (e.g. an active GSuite/Google ``@company.com`` with a verified email address)
 
 .. note::
 
-   SSO is currently in **Beta** and only GitHub and Company Email are supported for now.
+   SSO is currently in **Beta** and only GitHub, Bitbucket, GitLab and Google are supported for now.
    If you would like to apply for the Beta, please `contact us <mailto:support@readthedocs.com>`_.
 
 .. contents::
@@ -66,11 +66,45 @@ Adding users as owners of your organization will give them permissions to import
 Note that to be able to import a project, that user must have **admin** permissions in the VCS repository associated.
 
 
-SSO with your company email address
------------------------------------
+Revoke access to a project
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Using your company's email address (e.g. ``employee@company.com``) allows you to
-"grant **read** access to all the projects under your organization to users with a ``@company.com`` verified email address".
+If a user should not have access anymore to a project for any reason,
+a VCS repository's admin (e.g. user with Admin role on GitHub for that specific repository)
+can revoke access to the VCS repository and this will be automatically reflected in Read the Docs.
+
+The same process is followed in case you need to remove **admin** access,
+but still want that user to have access to read the documentation.
+Instead of revoking access completely, just need lower down permissions to **read** only.
+
+
+SSO with GSuite (Google email account)
+--------------------------------------
+
+Using your company's Google email address (e.g. ``employee@company.com``) allows you to
+manage authentication for your organization's members.
+As this Identity Provider does not provide authorization over each repositories/projects per user,
+permissions are managed by the :ref:`internal Read the Docs's Teams <commercial/organizations:Team Types>` authorization system.
+
+By default, users that Sign Up with a Google account do not have any permissions over any project.
+However, you can define which Teams users matching your company's domain email address will auto-join when they Sign Up.
+Read the following sections to learn how to grant read and admin access.
+
+
+Grant access to read a project
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can add a user under a "Read Only Team" to grant **read** permissions to all the projects under that Team.
+This can be done under "your organization detail's page" > :guilabel:`Teams` > :guilabel:`Read Only` > :guilabel:`Invite Member`.
+
+To avoid this repetitive task for each employee of your company,
+the owner of the Read the Docs organization can mark one or many Teams for users matching the company's domain email
+to join these Teams automaically when they Sign Up.
+
+For example, you can create a "General Documentaion (Read Only)" team
+with the projects that all employees of your company should have access to
+and mark it as :guilabel:`Auto join users with an organization's email address to this team`.
+Then all users that Sign Up with their ``employee@company.com`` email will automatically join this Team and have **read** access to those projects.
 
 
 Grant access to administer a project
@@ -88,3 +122,17 @@ they will be granted access to import a project.
 
 Note that to be able to import a project, that user must have **admin** permissions in the GitHub, Bitbucket or GitLab repository associated,
 and their social account connected with Read the Docs.
+
+
+Revoke user's access to a project
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To revoke access to a project for a particular user, you should remove that user from the Team that contains that Project.
+This can be done under "your organization detail's page" > :guilabel:`Teams` > :guilabel:`Read Only` and click :guilabel:`Remove` next to the user you want to revoke access.
+
+
+Revoke user's access to all the projects
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By disabling the GSuite/Google account with email ``employee@company.com``,
+you revoke access to all the projects that user had access and disable login on Read the Docs completely for that user.


### PR DESCRIPTION
- Mention that we support GitLab and Bitbucket as well
- Remove "SSO with your company email address" and mention Google SSO instead
- Owners can mark a Team to auto-join
- Add "GSuite" word so it appears in results
- Add section to revoke user's access to project
- Revoke access to all the projects / Disable GSuite account
