### PR TITLE
Add a middleware for referrer policy

### DIFF
--- a/dockerfiles/nginx/proxito.conf
+++ b/dockerfiles/nginx/proxito.conf
@@ -64,6 +64,8 @@ server {
         add_header X-RTD-Redirect $rtd_redirect always;
         set $cache_tag $upstream_http_cache_tag;
         add_header Cache-Tag $cache_tag always;
+        set $referrer_policy $upstream_http_referrer_policy;
+        add_header Referrer-Policy $referrer_policy always;
     }
 
     # Serve 404 pages here

--- a/readthedocs/core/middleware.py
+++ b/readthedocs/core/middleware.py
@@ -188,7 +188,7 @@ class ReferrerPolicyMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
 
-        if not hasattr(settings, 'SECURE_REFERRER_POLICY'):
+        if not settings.SECURE_REFERRER_POLICY:
             log.warning("SECURE_REFERRER_POLICY not set - not setting the referrer policy")
             raise MiddlewareNotUsed()
         if settings.SECURE_REFERRER_POLICY not in self.VALID_REFERRER_POLICIES:

--- a/readthedocs/core/middleware.py
+++ b/readthedocs/core/middleware.py
@@ -6,6 +6,7 @@ from django.contrib.sessions.backends.base import SessionBase
 from django.contrib.sessions.backends.base import UpdateError
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.exceptions import SuspiciousOperation
+from django.core.exceptions import ImproperlyConfigured, MiddlewareNotUsed
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.http import Http404, HttpResponseBadRequest
 from django.urls.base import set_urlconf
@@ -155,4 +156,47 @@ class ReadTheDocsSessionMiddleware(SessionMiddleware):
                                 httponly=settings.SESSION_COOKIE_HTTPONLY or None,
                                 samesite=settings.SESSION_COOKIE_SAMESITE,
                             )
+        return response
+
+
+class ReferrerPolicyMiddleware:
+
+    """
+    A middleware implementing the Referrer-Policy header.
+
+    The value of the header will be read from the SECURE_REFERRER_POLICY setting.
+
+    IMPORTANT:
+        In Django 3.x, this feature is built-in to the SecurityMiddleware.
+        After upgrading to Django3, this middleware should be removed.
+        https://docs.djangoproject.com/en/3.1/ref/middleware/#referrer-policy
+
+    Based heavily on: https://github.com/ubernostrum/django-referrer-policy
+    """
+
+    VALID_REFERRER_POLICIES = [
+        'no-referrer',
+        'no-referrer-when-downgrade',
+        'origin',
+        'origin-when-cross-origin',
+        'same-origin',
+        'strict-origin',
+        'strict-origin-when-cross-origin',
+        'unsafe-url',
+    ]
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+        if not hasattr(settings, 'SECURE_REFERRER_POLICY'):
+            log.warning("SECURE_REFERRER_POLICY not set - not setting the referrer policy")
+            raise MiddlewareNotUsed()
+        if settings.SECURE_REFERRER_POLICY not in self.VALID_REFERRER_POLICIES:
+            raise ImproperlyConfigured(
+                "settings.SECURE_REFERRER_POLICY has an illegal value."
+            )
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        response['Referrer-Policy'] = settings.SECURE_REFERRER_POLICY
         return response

--- a/readthedocs/core/middleware.py
+++ b/readthedocs/core/middleware.py
@@ -166,7 +166,7 @@ class ReferrerPolicyMiddleware:
 
     The value of the header will be read from the SECURE_REFERRER_POLICY setting.
 
-    IMPORTANT:
+    Important:
         In Django 3.x, this feature is built-in to the SecurityMiddleware.
         After upgrading to Django3, this middleware should be removed.
         https://docs.djangoproject.com/en/3.1/ref/middleware/#referrer-policy

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -76,6 +76,7 @@ class CommunityBaseSettings(Settings):
     # https://docs.djangoproject.com/en/1.11/ref/middleware/#django.middleware.security.SecurityMiddleware
     SECURE_BROWSER_XSS_FILTER = True
     SECURE_CONTENT_TYPE_NOSNIFF = True
+    SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
     X_FRAME_OPTIONS = 'DENY'
 
     # Content Security Policy
@@ -193,6 +194,7 @@ class CommunityBaseSettings(Settings):
         'dj_pagination.middleware.PaginationMiddleware',
         'corsheaders.middleware.CorsMiddleware',
         'csp.middleware.CSPMiddleware',
+        'readthedocs.core.middleware.ReferrerPolicyMiddleware',
     )
 
     AUTHENTICATION_BACKENDS = (

--- a/readthedocs/settings/proxito/base.py
+++ b/readthedocs/settings/proxito/base.py
@@ -11,6 +11,7 @@ class CommunityProxitoSettingsMixin:
 
     ROOT_URLCONF = 'readthedocs.proxito.urls'
     USE_SUBDOMAIN = True
+    SECURE_REFERRER_POLICY = "no-referrer-when-downgrade"
 
     @property
     def DATABASES(self):


### PR DESCRIPTION
This sets a [referrer policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy) with the value of `strict-origin-when-cross-origin` for the RTD dashboard. Proxito (which serves documentation sites) will use `no-referrer-when-downgrade` so that API calls from docs sites to readthedocs.org will report the referrer.

Setting the setting `SECURE_REFERRER_POLICY=None` will turn off the middleware.

I didn't use the existing [django-referrer-policy](https://github.com/ubernostrum/django-referrer-policy) module because this new middleware is setup so that it can just be removed when we upgrade to Django 3. Referrer policy is a built-in feature of Django's SecurityMiddleware (which we use) in Django 3. The django-referrer-policy uses a different setting name than what Django uses in Django3.