### PR TITLE
Add feature flag to just skip the sync version task entirely

### DIFF
--- a/readthedocs/core/views/hooks.py
+++ b/readthedocs/core/views/hooks.py
@@ -4,7 +4,7 @@ import logging
 
 from readthedocs.builds.constants import EXTERNAL
 from readthedocs.core.utils import trigger_build
-from readthedocs.projects.models import Project
+from readthedocs.projects.models import Project, Feature
 from readthedocs.projects.tasks import sync_repository_task
 
 
@@ -93,6 +93,10 @@ def trigger_sync_versions(project):
         )
         if not version:
             log.info('Unable to sync from %s version', version_identifier)
+            return None
+
+        if project.has_feature(Feature.SKIP_SYNC_VERSIONS):
+            log.info('Skipping sync versions for project: project=%s', project.slug)
             return None
 
         options = {}

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1538,6 +1538,7 @@ class Feature(models.Model):
     ALL_VERSIONS_IN_HTML_CONTEXT = 'all_versions_in_html_context'
     SKIP_SYNC_TAGS = 'skip_sync_tags'
     SKIP_SYNC_BRANCHES = 'skip_sync_branches'
+    SKIP_SYNC_VERSIONS = 'skip_sync_versions'
     CACHED_ENVIRONMENT = 'cached_environment'
     LIMIT_CONCURRENT_BUILDS = 'limit_concurrent_builds'
     DISABLE_SERVER_SIDE_SEARCH = 'disable_server_side_search'
@@ -1624,6 +1625,10 @@ class Feature(models.Model):
         (
             SKIP_SYNC_TAGS,
             _('Skip syncing tags'),
+        ),
+        (
+            SKIP_SYNC_VERSIONS,
+            _('Skip sync versions task'),
         ),
         (
             CACHED_ENVIRONMENT,


### PR DESCRIPTION
I'm not set up to test this immediately, so can't verify if this works
or if it solves the problem we're seeing.