### PR TITLE
Make flyout menu scrollable

### DIFF
--- a/media/css/readthedocs-doc-embed.css
+++ b/media/css/readthedocs-doc-embed.css
@@ -18,6 +18,11 @@
     overscroll-behavior: contain;
 }
 
+.rst-versions.shift-up .rst-current-version {
+    position: sticky;
+    top: 0;
+}
+
 .rst-other-versions {
     text-align: left;
 }

--- a/media/css/readthedocs-doc-embed.css
+++ b/media/css/readthedocs-doc-embed.css
@@ -12,6 +12,12 @@
     height: auto;
 }
 
+.rst-versions.shift-up {
+    max-height: calc(100vh - 50px);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+}
+
 .rst-other-versions {
     text-align: left;
 }


### PR DESCRIPTION
I have a project on RTD which has a lot of branches and tags.

When the RTD theme is used, the "version selection area" in the sidebar is scrollable if the window height is too small to accommodate all those links; see e.g. the page https://nbsphinx.readthedocs.io/en/rtd-theme/ (you probably have to change the height of the browser window to see this).

When a different Sphinx theme is used, the "version selection area" is in a "badge" in the bottom right corner of the page. When this "badge" is opened and the window height is too small, there is no scrolling and the top part of the "version selection" is not visible, see e.g. https://nbsphinx.readthedocs.io/en/alabaster-theme/.

This PR tries to make this scrollable.

I'm not sure whether ` media/css/readthedocs-doc-embed.css` is the right place to put this. `readthedocs/core/static/core/css/badge_only.css` seems to be an alternative location, but I don't know how this is generated.

Maybe there is a much better way to do this. Please let me know any suggestions for improvements.