### PR TITLE
[WIP] Docs: fix default value for 'formats' in config file

### DIFF
--- a/docs/config-file/v1.rst
+++ b/docs/config-file/v1.rst
@@ -41,7 +41,7 @@ version
 formats
 ~~~~~~~
 
-* Default: [``htmlzip``, ``pdf``, ``epub``]
+* Default: [``htmlzip``]
 * Options: ``htmlzip``, ``pdf``, ``epub``
 * Type: List
 

--- a/docs/config-file/v2.rst
+++ b/docs/config-file/v2.rst
@@ -69,7 +69,7 @@ Formats of the documentation to be built.
 
 :Type: ``list``
 :Options: ``htmlzip``, ``pdf``, ``epub``
-:Default: ``[]``
+:Default: [``htmlzip``]
 
 Example:
 


### PR DESCRIPTION
In `readthedocs/doc_builder/config.py`, the default seems to be
`['htmlzip']`, with `'epub'` and `'pdf'` appended if they are enabled
in the project dashboard (which they are by default).

I noticed this discrepancy as on some of my projects with no `.readthedocs.yml` file and with the PDF and EPUB options disabled in the dashboard, the HTMLZip downloads would still be generated. Adding a `.readthedocs.yml` with `formats: []` fixes it.

(Note: For additional context, I mentioned this in a support email sent today.)