### PR TITLE
API client: don't retry on POST

### DIFF
--- a/readthedocs/api/v2/adapters.py
+++ b/readthedocs/api/v2/adapters.py
@@ -1,5 +1,5 @@
-from requests_toolbelt.adapters.host_header_ssl import HostHeaderSSLAdapter
 from requests.adapters import HTTPAdapter
+from requests_toolbelt.adapters.host_header_ssl import HostHeaderSSLAdapter
 
 
 class TimeoutAdapter:
@@ -10,8 +10,8 @@ class TimeoutAdapter:
     Allows us to not wait forever when querying our API internally from the
     builders and make the build fail faster if it goes wrong.
 
-    https://2.python-requests.org//en/master/user/advanced/#transport-adapters
-    https://2.python-requests.org//en/master/user/advanced/#timeouts
+    https://2.python-requests.org/page/user/advanced/#transport-adapters
+    https://2.python-requests.org/page/user/advanced/#timeouts
     """
 
     def send(self, *args, **kwargs):

--- a/readthedocs/api/v2/client.py
+++ b/readthedocs/api/v2/client.py
@@ -41,7 +41,7 @@ def setup_api():
         status=3,
         backoff_factor=0.5,  # 0.5, 1, 2 seconds
         method_whitelist=('GET', 'PUT', 'PATCH'),
-        status_forcelist=(408, 413, 429, 500, 502, 503, 504),
+        status_forcelist=(408, 413, 429, 500, 502, 503),
     )
 
     session.mount(

--- a/readthedocs/api/v2/client.py
+++ b/readthedocs/api/v2/client.py
@@ -4,12 +4,11 @@ import logging
 
 import requests
 from django.conf import settings
-from requests.packages.urllib3.util.retry import Retry  # noqa
 from rest_framework.renderers import JSONRenderer
 from slumber import API, serialize
+from urllib3.util.retry import Retry
 
 from .adapters import TimeoutHostHeaderSSLAdapter, TimeoutHTTPAdapter
-
 
 log = logging.getLogger(__name__)
 
@@ -41,7 +40,7 @@ def setup_api():
         connect=3,
         status=3,
         backoff_factor=0.5,  # 0.5, 1, 2 seconds
-        method_whitelist=('GET', 'PUT', 'PATCH', 'POST'),
+        method_whitelist=('GET', 'PUT', 'PATCH'),
         status_forcelist=(408, 413, 429, 500, 502, 503, 504),
     )
 


### PR DESCRIPTION
POST isn't idempotent and can trigger some expensive operations
several times (like sync_versions).