### PR TITLE
document installing into a environment with pinned dependencies

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -251,13 +251,14 @@ using a Read the Docs :doc:`config-file/index`.
 .. _pip requirements file: https://pip.pypa.io/en/stable/user_guide.html#requirements-files
 
 
-Can I install into a environment with pinned versions?
-------------------------------------------------------
-To ensure proper installation of the python package, the ``pip`` :ref:`install
+I need to install a package in a environment with pinned versions
+-----------------------------------------------------------------
+
+To ensure proper installation of a python package, the ``pip`` :ref:`install
 method <config-file/v2:python.install>` will automatically upgrade every
 dependency to its most recent version. If instead you'd like to pin your
-dependencies to certain versions, you can add a line to your requirements /
-environment file.
+dependencies outside the package, you can add this line to your requirements or
+environment file (if you are using Conda).
 
 In ``docs/requirements.txt``::
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -256,7 +256,7 @@ I need to install a package in a environment with pinned versions
 
 To ensure proper installation of a python package, the ``pip`` :ref:`install
 method <config-file/v2:python.install>` will automatically upgrade every
-dependency to its most recent version. If instead you'd like to pin your
+dependency to its most recent version in case they aren't pinned by the package definition. If instead you'd like to pin your
 dependencies outside the package, you can add this line to your requirements or
 environment file (if you are using Conda).
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -257,12 +257,12 @@ I need to install a package in a environment with pinned versions
 To ensure proper installation of a python package, the ``pip`` :ref:`install method <config-file/v2:python.install>` will automatically upgrade every dependency to its most recent version in case they aren't pinned by the package definition.
 If instead you'd like to pin your dependencies outside the package, you can add this line to your requirements or environment file (if you are using Conda).
 
-In ``docs/requirements.txt``::
+In your ``requirements.txt`` file::
 
     # path to the directory containing setup.py relative to the project root
     -e .
 
-In ``conda``'s environment files (``docs/environment.yml``), use::
+In your Conda environment file (``environment.yml``)::
 
     # path to the directory containing setup.py relative to the environment file
     -e ..

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -254,11 +254,8 @@ using a Read the Docs :doc:`config-file/index`.
 I need to install a package in a environment with pinned versions
 -----------------------------------------------------------------
 
-To ensure proper installation of a python package, the ``pip`` :ref:`install
-method <config-file/v2:python.install>` will automatically upgrade every
-dependency to its most recent version in case they aren't pinned by the package definition. If instead you'd like to pin your
-dependencies outside the package, you can add this line to your requirements or
-environment file (if you are using Conda).
+To ensure proper installation of a python package, the ``pip`` :ref:`install method <config-file/v2:python.install>` will automatically upgrade every dependency to its most recent version in case they aren't pinned by the package definition.
+If instead you'd like to pin your dependencies outside the package, you can add this line to your requirements or environment file (if you are using Conda).
 
 In ``docs/requirements.txt``::
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -261,12 +261,12 @@ environment file.
 
 In ``docs/requirements.txt``::
 
-    # path to the folder containing setup.py relative to the project root
+    # path to the directory containing setup.py relative to the project root
     -e .
 
 In ``conda``'s environment files (``docs/environment.yml``), use::
 
-    # path to the folder containing setup.py relative to the environment file
+    # path to the directory containing setup.py relative to the environment file
     -e ..
 
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -253,10 +253,11 @@ using a Read the Docs :doc:`config-file/index`.
 
 Can I install into a environment with pinned versions?
 ------------------------------------------------------
-To ensure proper installation of the python package, the ``pip`` `install
-method`_ will automatically upgrade every dependency to its most recent
-version. If instead you'd like to pin your dependencies to certain versions, you
-can add a line to your requirements / environment file.
+To ensure proper installation of the python package, the ``pip`` :ref:`install
+method <config-file/v2:python.install>` will automatically upgrade every
+dependency to its most recent version. If instead you'd like to pin your
+dependencies to certain versions, you can add a line to your requirements /
+environment file.
 
 In ``docs/requirements.txt``::
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -251,6 +251,24 @@ using a Read the Docs :doc:`config-file/index`.
 .. _pip requirements file: https://pip.pypa.io/en/stable/user_guide.html#requirements-files
 
 
+Can I install into a environment with pinned versions?
+------------------------------------------------------
+To ensure proper installation of the python package, the ``pip`` `install
+method`_ will automatically upgrade every dependency to its most recent
+version. If instead you'd like to pin your dependencies to certain versions, you
+can add a line to your requirements / environment file.
+
+In ``docs/requirements.txt``::
+
+    # path to the folder containing setup.py relative to the project root
+    -e .
+
+In ``conda``'s environment files (``docs/environment.yml``), use::
+
+    # path to the folder containing setup.py relative to the environment file
+    -e ..
+
+
 How can I avoid search results having a deprecated version of my docs?
 ----------------------------------------------------------------------
 


### PR DESCRIPTION
As pointed out in #7345, using the `pip` install method will aggressively update packages, even if they were pinned. In some cases, adding the package to `sys.path` is not enough (e.g. when using `setuptools_scm`), so installing is still necessary. This can be done by putting `-e <path>` into the environment (`conda`) / requirements file (at least for `conda` the editable install seems to be necessary).

As suggested in that issue, this adds a faq entry to document that trick.

- closes #7345