### PR TITLE
Mark a build as DUPLICATED (same version) only it's close in time

### DIFF
--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -184,6 +184,7 @@ def prepare_build(
             project=project,
             version=version,
             state=BUILD_STATE_TRIGGERED,
+            date__gte=timezone.now() - datetime.timedelta(minutes=5),
         ).count() > 1
 
     if not project.has_feature(Feature.DEDUPLICATE_BUILDS):

--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -1,5 +1,6 @@
 """Common utilty functions."""
 
+import datetime
 import errno
 import logging
 import os
@@ -7,6 +8,7 @@ import re
 
 from celery import chord, group
 from django.conf import settings
+from django.utils import timezone
 from django.utils.functional import keep_lazy
 from django.utils.safestring import SafeText, mark_safe
 from django.utils.text import slugify as slugify_base
@@ -184,6 +186,12 @@ def prepare_build(
             project=project,
             version=version,
             state=BUILD_STATE_TRIGGERED,
+            # By filtering for builds triggered in the previous 5 minutes we
+            # avoid false positives for builds that failed for any reason and
+            # didn't update their state, ending up on blocked builds for that
+            # version (all the builds are marked as DUPLICATED in that case).
+            # Adding this date condition, we reduce the risk of hitting this
+            # problem to 5 minutes only.
             date__gte=timezone.now() - datetime.timedelta(minutes=5),
         ).count() > 1
 


### PR DESCRIPTION
Instead of checking for "any other build for this verion in TRIGGRERED state" we
also add the filter for builds triggered in the previous 5 minutes. This allows
us to avoid false positives for builds that failed for any reason and didn't
update their state, ending up on blocked builds for that version (all the builds
were marked as DUPLICATED in that case).

Adding this date condition, we reduce the risk of hitting this problem to 5
minutes only.

If the build takes more than 5 minutes to complete, users could end up with
builds building exacly the same version (and commit); but this is how it works
right now without this DEDUPLICATE_BUILDS feature. So, I think it's still an
improvement to avoid builds triggered in flood.