### PR TITLE
Upgrade to Ubuntu 20.04 and Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - 3.6
-dist: xenial
+dist: focal
 
 addons:
   hosts:

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ARG GITHUB_TOKEN
 
@@ -9,6 +9,7 @@ ENV LC_ALL en_US.UTF-8
 
 RUN apt-get -y update
 RUN apt-get -y install \
+        cargo \
         curl \
         g++ \
         git-core \

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -50,9 +50,7 @@ elasticsearch==6.8.1  # pyup: <7.0.0
 elasticsearch-dsl==6.4.0  # pyup: <7.0
 django-elasticsearch-dsl==6.4.2  # pyup: <7.0
 selectolax==0.2.7
-
-# Ignoring orjson for now because it makes Travis to fail
-orjson==2.0.7  # pyup: ignore
+orjson==3.3.1
 
 # Utils
 django-gravatar2==1.4.4

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -31,15 +31,12 @@ pyyaml==5.3.1
 Pygments==2.6.1
 
 # Basic tools
-# Redis 3.x has an incompatible change and fails
-# https://stackoverflow.com/questions/53331405/django-compress-error-invalid-input-of-type-cachekey
-# https://github.com/sebleier/django-redis-cache/pull/162
-redis==2.10.6  # pyup: ignore
-# Kombu >4.3 requires redis>=3.2
-kombu==4.3.0  # pyup: ignore
-# Celery 4.2 is incompatible with our code
-# when ALWAYS_EAGER = True
-celery==4.1.1  # pyup: ignore
+redis==3.5.3
+
+# ModuleNotFoundError: No module named 'kombu.five'
+kombu==4.6.11  # pyup: < 5.0
+
+celery==4.4.7
 
 django-allauth==0.42.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 minversion=2.9.0
-envlist = py36,lint,docs
+envlist = py38,lint,docs
 skipsdist = True
 
 [travis]
 python =
-    3.6: py36, codecov
+    3.8: py38, codecov
 
 [testenv]
 description = run test suite for the application with {basepython}


### PR DESCRIPTION
Important changes

- use Python 3.8 to run our application
- use Ubuntu 20.04 LTS for Docker development environment
- use Ubuntu 20.04 LTS for Travis CI
- run tests via tox with Py 3.8
- upgrade `orjson` to be able to build in newer ubuntu
- install `cargo` in Docker image to build `orjson`
- upgrade redis+celery+kombu to avoid issue with `async` as a keyword in Python 3.8

Related https://github.com/readthedocs/readthedocs-docker-images/pull/137