### PR TITLE
New docker image for builders: 8.0

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -447,12 +447,21 @@ class CommunityBaseSettings(Settings):
                 },
             },
         },
+        'readthedocs/build:8.0': {
+            'python': {
+                'supported_versions': [2, 2.7, 3, 3.5, 3.6, 3.7, 3.8, 3.9, 'pypy3.5'],
+                'default_version': {
+                    2: 2.7,
+                    3: 3.7,
+                },
+            },
+        },
     }
     # Alias tagged via ``docker tag`` on the build servers
     DOCKER_IMAGE_SETTINGS.update({
-        'readthedocs/build:stable': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:5.0'),
-        'readthedocs/build:latest': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:6.0'),
-        'readthedocs/build:testing': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:7.0'),
+        'readthedocs/build:stable': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:6.0'),
+        'readthedocs/build:latest': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:7.0'),
+        'readthedocs/build:testing': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:8.0'),
     })
 
     def _get_docker_memory_limit(self):


### PR DESCRIPTION
Enable image 8.0 with Python 3.9 support and Ubuntu 20.04 LTS.

Labelled images now are,

- stable -> 6.0
- latest -> 7.0
- testing -> 8.0

Defaults Python versions are kept the same (2.7 and 3.7).

Requires: https://github.com/readthedocs/readthedocs-docker-images/pull/137