### PR TITLE
Upgrade Django to 2.2.16

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -3,7 +3,7 @@
 pip==20.2.2
 virtualenv==20.0.31
 
-django==2.2.15  # pyup: <2.3
+django==2.2.16  # pyup: <2.3
 django-extensions==3.0.5
 django_polymorphic==3.0.0
 django-autoslug==1.9.8


### PR DESCRIPTION
Today was a security release of Django. It does not really affect us because
it's Python 3.7+ and we are in 3.6, but good to upgrade anyways.

https://www.djangoproject.com/weblog/2020/sep/01/security-releases/