### PR TITLE
Grab the correct name of RemoteOrganization to use in the query

### DIFF
--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -205,8 +205,8 @@ class Service:
         ).delete()
 
         # Delete RemoteOrganization where the user doesn't have access anymore
-        organization_names = [o.name for o in remote_organizations if o is not None]
-        self.user.oauth_organizations.exclude(name__in=organization_names).delete()
+        organization_slugs = [o.slug for o in remote_organizations if o is not None]
+        self.user.oauth_organizations.exclude(slug__in=organization_slugs).delete()
 
     def create_repository(self, fields, privacy=None, organization=None):
         """

--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -193,18 +193,18 @@ class Service:
         - updates fields for existing RemoteRepository/Organization
         - deletes old RemoteRepository/Organization that are not present for this user
         """
-        repos = self.sync_repositories()
-        organizations, organization_repos = self.sync_organizations()
+        remote_repositories = self.sync_repositories()
+        remote_organizations, remote_repositories_organizations = self.sync_organizations()
 
         # Delete RemoteRepository where the user doesn't have access anymore
         # (skip RemoteRepository tied to a Project on this user)
-        repository_full_names = self.get_repository_full_names(repos + organization_repos)
+        repository_full_names = [r.full_name for r in remote_repositories + remote_repositories_organizations]
         self.user.oauth_repositories.exclude(
             Q(full_name__in=repository_full_names) | Q(project__isnull=False)
         ).delete()
 
         # Delete RemoteOrganization where the user doesn't have access anymore
-        organization_names = self.get_organization_names(organizations)
+        organization_names = [o.name for o in remote_organizations]
         self.user.oauth_organizations.exclude(name__in=organization_names).delete()
 
     def create_repository(self, fields, privacy=None, organization=None):

--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -198,13 +198,14 @@ class Service:
 
         # Delete RemoteRepository where the user doesn't have access anymore
         # (skip RemoteRepository tied to a Project on this user)
-        repository_full_names = [r.full_name for r in remote_repositories + remote_repositories_organizations]
+        all_remote_repositories = remote_repositories + remote_repositories_organizations
+        repository_full_names = [r.full_name for r in all_remote_repositories if r is not None]
         self.user.oauth_repositories.exclude(
             Q(full_name__in=repository_full_names) | Q(project__isnull=False)
         ).delete()
 
         # Delete RemoteOrganization where the user doesn't have access anymore
-        organization_names = [o.name for o in remote_organizations]
+        organization_names = [o.name for o in remote_organizations if o is not None]
         self.user.oauth_organizations.exclude(name__in=organization_names).delete()
 
     def create_repository(self, fields, privacy=None, organization=None):

--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -88,7 +88,10 @@ class BitbucketService(Service):
                 remote_organizations.append(remote_organization)
 
                 for repo in repos:
-                    remote_repository = self.create_repository(repo, organization=remote_organization)
+                    remote_repository = self.create_repository(
+                        repo,
+                        organization=remote_organization,
+                    )
                     remote_repositories.append(remote_repository)
 
         except ValueError:

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -36,44 +36,42 @@ class GitHubService(Service):
 
     def sync_repositories(self):
         """Sync repositories from GitHub API."""
-        repos = []
+        remote_repositories = []
 
         try:
             repos = self.paginate('https://api.github.com/user/repos?per_page=100')
             for repo in repos:
-                self.create_repository(repo)
+                remote_repository = self.create_repository(repo)
+                remote_repositories.append(remote_repository)
         except (TypeError, ValueError):
             log.warning('Error syncing GitHub repositories')
             raise SyncServiceError(
                 'Could not sync your GitHub repositories, '
                 'try reconnecting your account'
             )
-        return repos
+        return remote_repositories
 
     def sync_organizations(self):
         """Sync organizations from GitHub API."""
-        orgs_details = []
-        repositories = []
+        remote_organizations = []
+        remote_repositories = []
 
         try:
             orgs = self.paginate('https://api.github.com/user/orgs')
             for org in orgs:
-                org_resp = self.get_session().get(org['url'])
-                org_obj = self.create_organization(org_resp.json())
+                org_details = self.get_session().get(org['url']).json()
+                remote_organization = self.create_organization(org_details)
                 # Add repos
                 # TODO ?per_page=100
                 org_repos = self.paginate(
                     '{org_url}/repos'.format(org_url=org['url']),
                 )
 
-                # Add organization details to the result
-                orgs_details.extend(org_resp.json())
-
-                # Add all the repositories for this organization to the result
-                repositories.extend(org_repos)
+                remote_organizations.append(remote_organization)
 
                 for repo in org_repos:
-                    self.create_repository(repo, organization=org_obj)
+                    remote_repository = self.create_repository(repo, organization=remote_organization)
+                    remote_repositories.append(remote_repository)
 
         except (TypeError, ValueError):
             log.warning('Error syncing GitHub organizations')
@@ -82,7 +80,7 @@ class GitHubService(Service):
                 'try reconnecting your account'
             )
 
-        return orgs_details, repositories
+        return remote_organizations, remote_repositories
 
     def create_repository(self, fields, privacy=None, organization=None):
         """
@@ -172,12 +170,6 @@ class GitHubService(Service):
         organization.account = self.account
         organization.save()
         return organization
-
-    def get_repository_full_names(self, repositories):
-        return {repository.get('full_name') for repository in repositories}
-
-    def get_organization_names(self, organizations):
-        return {organization.get('name') for organization in organizations}
 
     def get_next_url_to_paginate(self, response):
         return response.links.get('next', {}).get('url')

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -70,7 +70,10 @@ class GitHubService(Service):
                 remote_organizations.append(remote_organization)
 
                 for repo in org_repos:
-                    remote_repository = self.create_repository(repo, organization=remote_organization)
+                    remote_repository = self.create_repository(
+                        repo,
+                        organization=remote_organization,
+                    )
                     remote_repositories.append(remote_repository)
 
         except (TypeError, ValueError):

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -52,7 +52,7 @@ class GitHubService(Service):
 
     def sync_organizations(self):
         """Sync organizations from GitHub API."""
-        orgs = []
+        orgs_details = []
         repositories = []
 
         try:
@@ -65,6 +65,9 @@ class GitHubService(Service):
                 org_repos = self.paginate(
                     '{org_url}/repos'.format(org_url=org['url']),
                 )
+
+                # Add organization details to the result
+                orgs_details.extend(org_resp.json())
 
                 # Add all the repositories for this organization to the result
                 repositories.extend(org_repos)
@@ -79,7 +82,7 @@ class GitHubService(Service):
                 'try reconnecting your account'
             )
 
-        return orgs, repositories
+        return orgs_details, repositories
 
     def create_repository(self, fields, privacy=None, organization=None):
         """

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -118,7 +118,10 @@ class GitLabService(Service):
                 remote_organizations.append(remote_organization)
 
                 for repo in org_repos:
-                    remote_repository = self.create_repository(repo, organization=remote_organization)
+                    remote_repository = self.create_repository(
+                        repo,
+                        organization=remote_organization,
+                    )
                     remote_repositories.append(remote_repository)
         except (TypeError, ValueError):
             log.warning('Error syncing GitLab organizations')

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -67,7 +67,7 @@ class GitLabService(Service):
         return response.json()
 
     def sync_repositories(self):
-        repos = []
+        remote_repositories = []
         try:
             repos = self.paginate(
                 '{url}/api/v4/projects'.format(url=self.adapter.provider_base_url),
@@ -79,7 +79,8 @@ class GitLabService(Service):
             )
 
             for repo in repos:
-                self.create_repository(repo)
+                remote_repository = self.create_repository(repo)
+                remote_repositories.append(remote_repository)
         except (TypeError, ValueError):
             log.warning('Error syncing GitLab repositories')
             raise SyncServiceError(
@@ -87,11 +88,11 @@ class GitLabService(Service):
                 'try reconnecting your account'
             )
 
-        return repos
+        return remote_repositories
 
     def sync_organizations(self):
-        orgs = []
-        repositories = []
+        remote_organizations = []
+        remote_repositories = []
 
         try:
             orgs = self.paginate(
@@ -102,7 +103,7 @@ class GitLabService(Service):
                 sort='asc',
             )
             for org in orgs:
-                org_obj = self.create_organization(org)
+                remote_organization = self.create_organization(org)
                 org_repos = self.paginate(
                     '{url}/api/v4/groups/{id}/projects'.format(
                         url=self.adapter.provider_base_url,
@@ -114,11 +115,11 @@ class GitLabService(Service):
                     sort='asc',
                 )
 
-                # Add organization's repositories to the result
-                repositories.extend(org_repos)
+                remote_organizations.append(remote_organization)
 
                 for repo in org_repos:
-                    self.create_repository(repo, organization=org_obj)
+                    remote_repository = self.create_repository(repo, organization=remote_organization)
+                    remote_repositories.append(remote_repository)
         except (TypeError, ValueError):
             log.warning('Error syncing GitLab organizations')
             raise SyncServiceError(
@@ -126,7 +127,7 @@ class GitLabService(Service):
                 'try reconnecting your account'
             )
 
-        return orgs, repositories
+        return remote_organizations, remote_repositories
 
     def is_owned_by(self, owner_id):
         return self.account.extra_data['id'] == owner_id
@@ -231,12 +232,6 @@ class GitLabService(Service):
         organization.json = json.dumps(fields)
         organization.save()
         return organization
-
-    def get_repository_full_names(self, repositories):
-        return {repository.get('name_with_namespace') for repository in repositories}
-
-    def get_organization_names(self, organizations):
-        return {organization.get('name') for organization in organizations}
 
     def get_webhook_data(self, repo_id, project, integration):
         """

--- a/readthedocs/rtd_tests/tests/test_oauth_sync.py
+++ b/readthedocs/rtd_tests/tests/test_oauth_sync.py
@@ -1,0 +1,224 @@
+from unittest import mock
+
+from allauth.socialaccount.models import SocialAccount, SocialToken
+from allauth.socialaccount.providers.github.views import GitHubOAuth2Adapter
+import django_dynamic_fixture as fixture
+import requests_mock
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from readthedocs.oauth.models import RemoteOrganization, RemoteRepository
+from readthedocs.oauth.services import (
+    GitHubService,
+)
+from readthedocs.projects.models import Project
+
+
+class GitHubOAuthSyncTests(TestCase):
+    payload_user_repos = [{
+        'id': 11111,
+        'node_id': 'a1b2c3',
+        'name': 'repository',
+        'full_name': 'organization/repository',
+        'private': False,
+        'owner': {
+            'login': 'organization',
+            'id': 11111,
+            'node_id': 'a1b2c3',
+            'avatar_url': 'https://avatars3.githubusercontent.com/u/11111?v=4',
+            'gravatar_id': '',
+            'url': 'https://api.github.com/users/organization',
+            'type': 'User',
+            'site_admin': False,
+        },
+        'html_url': 'https://github.com/organization/repository',
+        'description': '',
+        'fork': True,
+        'url': 'https://api.github.com/repos/organization/repository',
+        'created_at': '2019-06-14T14:11:29Z',
+        'updated_at': '2019-06-15T15:05:33Z',
+        'pushed_at': '2019-06-15T15:11:19Z',
+        'git_url': 'git://github.com/organization/repository.git',
+        'ssh_url': 'git@github.com:organization/repository.git',
+        'clone_url': 'https://github.com/organization/repository.git',
+        'svn_url': 'https://github.com/organization/repository',
+        'homepage': None,
+        'language': 'Python',
+        'archived': False,
+        'disabled': False,
+        'open_issues_count': 0,
+        'default_branch': 'master',
+        'permissions': {
+            'admin': False,
+            'push': True,
+            'pull': True,
+        },
+    }]
+
+    def setUp(self):
+        self.user = fixture.get(User)
+        self.socialaccount = fixture.get(
+            SocialAccount,
+            user=self.user,
+            provider=GitHubOAuth2Adapter.provider_id,
+        )
+        self.token = fixture.get(
+            SocialToken,
+            account=self.socialaccount,
+        )
+        self.service = GitHubService.for_user(self.user)[0]
+
+    @requests_mock.Mocker(kw='mock_request')
+    def test_sync_delete_stale(self, mock_request):
+        mock_request.get('https://api.github.com/user/repos', json=self.payload_user_repos)
+        mock_request.get('https://api.github.com/user/orgs', json=[])
+
+        fixture.get(
+            RemoteRepository,
+            account=self.socialaccount,
+            users=[self.user],
+            full_name='organization/repository',
+        )
+        fixture.get(
+            RemoteRepository,
+            account=self.socialaccount,
+            users=[self.user],
+            full_name='organization/old-repository',
+        )
+
+        # RemoteRepository linked to a Project shouldn't be removed
+        project = fixture.get(Project)
+        fixture.get(
+            RemoteRepository,
+            account=self.socialaccount,
+            project=project,
+            users=[self.user],
+            full_name='organization/project-linked-repository',
+        )
+
+        fixture.get(
+            RemoteOrganization,
+            account=self.socialaccount,
+            users=[self.user],
+            name='organization',
+        )
+
+        self.assertEqual(RemoteRepository.objects.count(), 3)
+        self.assertEqual(RemoteOrganization.objects.count(), 1)
+
+        self.service.sync()
+
+        # After calling .sync, old-repository should be deleted,
+        # project-linked-repository should be conserved, and only the one
+        # returned by the API should be present (organization/repository)
+        self.assertEqual(RemoteRepository.objects.count(), 2)
+        self.assertTrue(RemoteRepository.objects.filter(full_name='organization/repository').exists())
+        self.assertTrue(RemoteRepository.objects.filter(full_name='organization/project-linked-repository').exists())
+        self.assertEqual(RemoteOrganization.objects.count(), 0)
+
+    @requests_mock.Mocker(kw='mock_request')
+    def test_sync_repositories(self, mock_request):
+        mock_request.get('https://api.github.com/user/repos', json=self.payload_user_repos)
+
+        self.assertEqual(RemoteRepository.objects.count(), 0)
+        self.assertEqual(RemoteOrganization.objects.count(), 0)
+
+        remote_repositories = self.service.sync_repositories()
+
+        self.assertEqual(RemoteRepository.objects.count(), 1)
+        self.assertEqual(RemoteOrganization.objects.count(), 0)
+        self.assertEqual(len(remote_repositories), 1)
+        remote_repository = remote_repositories[0]
+        self.assertIsInstance(remote_repository, RemoteRepository)
+        self.assertEqual(remote_repository.full_name, 'organization/repository')
+        self.assertEqual(remote_repository.name, 'repository')
+        self.assertFalse(remote_repository.admin)
+        self.assertFalse(remote_repository.private)
+
+    @requests_mock.Mocker(kw='mock_request')
+    def test_sync_organizations(self, mock_request):
+        payload = [{
+            'login': 'readthedocs',
+            'id': 11111,
+            'node_id': 'a1b2c3',
+            'url': 'https://api.github.com/orgs/organization',
+            'avatar_url': 'https://avatars2.githubusercontent.com/u/11111?v=4',
+            'description': ''
+        }]
+        mock_request.get('https://api.github.com/user/orgs', json=payload)
+
+        payload = {
+           'login': 'organization',
+            'id': 11111,
+            'node_id': 'a1b2c3',
+            'url': 'https://api.github.com/orgs/organization',
+            'avatar_url': 'https://avatars2.githubusercontent.com/u/11111?v=4',
+            'description': '',
+            'name': 'Organization',
+            'company': None,
+            'blog': 'http://organization.org',
+            'location': 'Portland, Oregon & Worldwide. ',
+            'email': None,
+            'is_verified': False,
+            'html_url': 'https://github.com/organization',
+            'created_at': '2010-08-16T19:17:46Z',
+            'updated_at': '2020-08-12T14:26:39Z',
+            'type': 'Organization',
+        }
+        mock_request.get('https://api.github.com/orgs/organization', json=payload)
+
+        payload = [{
+            'id': 11111,
+            'node_id': 'a1b2c3',
+            'name': 'repository',
+            'full_name': 'organization/repository',
+            'private': False,
+            'owner': {
+                'login': 'organization',
+                'id': 11111,
+                'node_id': 'a1b2c3',
+                'avatar_url': 'https://avatars3.githubusercontent.com/u/11111?v=4',
+                'gravatar_id': '',
+                'url': 'https://api.github.com/users/organization',
+                'type': 'User',
+                'site_admin': False,
+            },
+            'html_url': 'https://github.com/organization/repository',
+            'description': '',
+            'fork': True,
+            'url': 'https://api.github.com/repos/organization/repository',
+            'created_at': '2019-06-14T14:11:29Z',
+            'updated_at': '2019-06-15T15:05:33Z',
+            'pushed_at': '2019-06-15T15:11:19Z',
+            'git_url': 'git://github.com/organization/repository.git',
+            'ssh_url': 'git@github.com:organization/repository.git',
+            'clone_url': 'https://github.com/organization/repository.git',
+            'svn_url': 'https://github.com/organization/repository',
+            'homepage': None,
+            'language': 'Python',
+            'archived': False,
+            'disabled': False,
+            'open_issues_count': 0,
+            'default_branch': 'master',
+            'permissions': {
+                'admin': False,
+                'push': True,
+                'pull': True,
+            },
+        }]
+        mock_request.get('https://api.github.com/orgs/organization/repos', json=payload)
+
+        self.assertEqual(RemoteRepository.objects.count(), 0)
+        self.assertEqual(RemoteOrganization.objects.count(), 0)
+
+        remote_organizations, remote_repositories = self.service.sync_organizations()
+
+        self.assertEqual(RemoteRepository.objects.count(), 1)
+        self.assertEqual(RemoteOrganization.objects.count(), 1)
+        self.assertEqual(len(remote_organizations), 1)
+        self.assertEqual(len(remote_repositories), 1)
+        remote_organization = remote_organizations[0]
+        self.assertIsInstance(remote_organization, RemoteOrganization)
+        self.assertEqual(remote_organization.name, 'Organization')

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -25,3 +25,5 @@ pytest-mock==3.3.0
 # local debugging tools
 datadiff==2.0.0
 ipdb==0.13.3
+
+requests-mock==1.8.0


### PR DESCRIPTION
~~We were using the naked response from GitHub to exclude `RemoteOrganization`~~
~~objects and delete the ones where the user don't have permissions anymore.~~
~~However, we need the organization details instead that comes with the `name`~~
~~attribute which is the one that we use to create the `RemoteOrganization` object.~~

I refactored this code to always return a list of `RemoteRepository` and `RemoteOrganization` from the `sync_repositories` and `sync_organizations` methods on each service to avoid using the wrong field name, as we were doing.

Closes #7381 