### PR TITLE
Truncate the beggining of the commands' output

### DIFF
--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -148,9 +148,9 @@ def archive_builds_task(days=14, limit=200, include_cold=False, delete=False):
         if data:
             for cmd in data:
                 if len(cmd['output']) > MAX_BUILD_COMMAND_SIZE:
-                    cmd['output'] = cmd['output'][:MAX_BUILD_COMMAND_SIZE]
-                    cmd['output'] += "\n\nCommand output too long. Truncated at 1MB."
-                    log.warning('Truncating build command for build %s', build.pk)
+                    cmd['output'] = cmd['output'][-MAX_BUILD_COMMAND_SIZE:]
+                    cmd['output'] = "... (truncated) ...\n\nCommand output too long. Truncated to last 1MB.\n\n" + cmd['output']  # noqa
+                    log.warning('Truncating build command for build. build=%s', build.pk)
             output = BytesIO()
             output.write(json.dumps(data).encode('utf8'))
             output.seek(0)


### PR DESCRIPTION
Instead trunctaing the last part of the command, we truncate the beggining of
it. This allows to understand what's happening if the command fails (e.g. LaTeX
step, https://readthedocs.org/projects/platformio/builds/11763095/) with more context to be able to solve it.

