### PR TITLE
correct invalid YAML

### DIFF
--- a/docs/config-file/v2.rst
+++ b/docs/config-file/v2.rst
@@ -503,7 +503,7 @@ Note that 0 means *normal rank*, not *no rank*.
         api/v1/*: -5
 
         # Match all files that end with tutorial.html
-        */tutorial.html: 3
+        '*/tutorial.html': 3
 
 .. note::
 


### PR DESCRIPTION
In YAML, scalars cannot start with a `*` as this character is an indicator character ( https://yaml.org/spec/1.2/spec.html#id2772075 , rule [14]) used for denoting aliases ( https://yaml.org/spec/1.2/spec.html#id2786196 ). Therefore this key needs to be quoted.