### PR TITLE
Fix five ImportError

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -41,6 +41,10 @@ kombu==4.3.0  # pyup: ignore
 # when ALWAYS_EAGER = True
 celery==4.1.1  # pyup: ignore
 
+# There are ImportErrors in Celery tasks because of an unbounded transient dependency on Vine, which breaks at vine>=5.
+# https://stackoverflow.com/a/63774459
+vine==1.3.0
+
 django-allauth==0.42.0
 
 GitPython==3.1.8


### PR DESCRIPTION
Example:

```
celery_1       | Traceback (most recent call last):
celery_1       |   File "/usr/lib/python3.7/runpy.py", line 183, in _run_module_as_main
celery_1       |     mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
celery_1       |   File "/usr/lib/python3.7/runpy.py", line 142, in _get_module_details
celery_1       |     return _get_module_details(pkg_main_name, error)
celery_1       |   File "/usr/lib/python3.7/runpy.py", line 109, in _get_module_details
celery_1       |     __import__(pkg_name)
celery_1       |   File "/usr/share/readthedocs/git/venv/lib/python3.7/site-packages/celery/__init__.py", line 153, in <module>
celery_1       |     from . import local  # noqa
celery_1       |   File "/usr/share/readthedocs/git/venv/lib/python3.7/site-packages/celery/local.py", line 17, in <module>
celery_1       |     from .five import PY3, bytes_if_py2, items, string, string_t
```