### PR TITLE
Show "Connected Services" form errors to the user

### DIFF
--- a/readthedocs/templates/socialaccount/connections.html
+++ b/readthedocs/templates/socialaccount/connections.html
@@ -18,6 +18,11 @@
         {% endblocktrans %}
       </p>
 
+      {# TODO: style this properly in the new templates #}
+      {% if form.non_field_errors %}
+      {{ form.non_field_errors }}
+      {% endif %}
+
       <div class="module-list-wrapper">
         {% if form.accounts %}
           <ul>


### PR DESCRIPTION
This will inform about,

- account without password
- account without verified email address

We override the `connections.html` file from `django-allauth` and we lost this
chunk of template code in the middle.

Python code:
https://github.com/pennersr/django-allauth/blob/c19a212c6ee786af1bb8bc1b07eb2aa8e2bf531b/allauth/socialaccount/adapter.py#L123-L139
Template code:
https://github.com/pennersr/django-allauth/blob/c19a212c6ee786af1bb8bc1b07eb2aa8e2bf531b/allauth/templates/socialaccount/connections.html#L18-L20

![Screenshot_2020-09-08_15-57-39](https://user-images.githubusercontent.com/244656/92486281-2f845900-f1ec-11ea-86b7-a2cbb5626a53.png)
