### PR TITLE
Truncate output at the start for large commands

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -242,9 +242,11 @@ class BuildCommand(BuildCommandResultMixin):
                 self.build_env.build.get('id'),
                 self.get_command(),
             )
-            sanitized = sanitized[:allowed_length]
-            sanitized += '\n\n\nOutput is too big. Chunked at {} bytes'.format(
-                allowed_length,
+            truncated_output = sanitized[-allowed_length:]
+            sanitized = (
+                '.. (truncated) ...\n'
+                f'Output is too big. Truncated at {allowed_length} bytes.\n\n\n'
+                f'{truncated_output}'
             )
 
         return sanitized


### PR DESCRIPTION
The other PR was when archiving the builds, not the ones we show to the user

Ref https://github.com/readthedocs/readthedocs.org/pull/7449