### PR TITLE
New settings for custom virtualenv pip.conf and pydistutils.cfg

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -332,6 +332,13 @@ class Virtualenv(PythonEnvironment):
             # Don't use the project's root, some config files can interfere
             cwd='$HOME',
         )
+        if getattr(settings, "RTD_PIP_CONF", ""):
+            with open(os.path.join(self.venv_path(), "pip.conf"), "w") as f:
+                f.write(settings.RTD_PIP_CONF)
+
+        if getattr(settings, "RTD_DISTUTILS_CFG", ""):
+            with open(os.path.join(self.checkout_path, ".pydistutils.cfg"), "w") as f:
+                f.write(settings.RTD_DISTUTILS_CFG)
 
     def install_core_requirements(self):
         """Install basic Read the Docs requirements into the virtualenv."""

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -101,6 +101,16 @@ class CommunityBaseSettings(Settings):
     RTD_MAX_CONCURRENT_BUILDS = 4
     RTD_BUILD_STATUS_API_NAME = 'docs/readthedocs'
 
+    # String contents to store in each virtualenv/pip.conf, useful to set a
+    # custom index-url.
+    RTD_PIP_CONF = ""
+    # String contents to store in each current-working-dir (CWD), useful to set
+    # a custom index_url.
+    # This setting is necessary to supplement a custom pip.conf with until
+    # the legacy setup_requires option is removed from Python packages.
+    # https://pip.pypa.io/en/latest/reference/pip_install/#controlling-setup-requires
+    RTD_DISTUTILS_CFG = ""
+
     # Database and API hitting settings
     DONT_HIT_API = False
     DONT_HIT_DB = True


### PR DESCRIPTION
Hi friends!

Am building a proof-of-concept Read the Docs where the PyPi index has to be a local version. This is one of the few adjustments that we needed.

Example config:

```python
# Common setting
RTD_PIP_CONF = (
    "[global]\n"
    "index-url=https://myserver.mydomain.com/pypi/simple"
)

# Needed to support `setup_requires` option used by many packages
RTD_DISTUTILS_CFG = (
    "[easy_install]\n"
    "index_url=https://myserver.mydomain.com/pypi/simple"
)

```

Before reviewing this, a question: Should I write additional documentation for this setting? What sort of exposure is desirable?

---

Edit: Added `RTD_DISTUTILS_CFG`