### PR TITLE
Use `permissions` (project and group) for `RemoteRepository.admin` on GitLab

### DIFF
--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -137,7 +137,8 @@ class GitLabService(Service):
         return remote_organizations, remote_repositories
 
     def create_repository(self, fields, privacy=None, organization=None):
-        """Update or create a repository from GitLab API response.
+        """
+        Update or create a repository from GitLab API response.
 
         ``admin`` field is computed using the ``permissions`` fields from the
         repository response. The permission from GitLab is given by an integer:

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -951,12 +951,10 @@ class GitLabOAuthTests(TestCase):
         return data
 
     def test_make_project_pass(self):
-        with mock.patch('readthedocs.oauth.services.gitlab.GitLabService.is_owned_by') as m:  # yapf: disable
-            m.return_value = True
-            repo = self.service.create_repository(
-                self.repo_response_data, organization=self.org,
-                privacy=self.privacy,
-            )
+        repo = self.service.create_repository(
+            self.repo_response_data, organization=self.org,
+            privacy=self.privacy,
+        )
         self.assertIsInstance(repo, RemoteRepository)
         self.assertEqual(repo.name, 'testrepo')
         self.assertEqual(repo.full_name, 'testorga / testrepo')
@@ -1009,9 +1007,7 @@ class GitLabOAuthTests(TestCase):
         """
         data = self.repo_response_data.copy()
         data['visibility'] = 'public'
-        with mock.patch('readthedocs.oauth.services.gitlab.GitLabService.is_owned_by') as m:  # yapf: disable
-            m.return_value = True
-            repo = self.service.create_repository(data, organization=self.org)
+        repo = self.service.create_repository(data, organization=self.org)
         self.assertIsNotNone(repo)
 
     @mock.patch('readthedocs.oauth.services.gitlab.log')


### PR DESCRIPTION
When syncing `RemoteRepository` in GitLab we were only checking if the user was
the owner of the project, but we weren't checking for permissions given by
belonging to a group.

This commit makes usage of 40 (maintainer) and 50 (owner) permission levels to
check these permissions granted by being part of a group.


Closes #7475 