### PR TITLE
Builders: little refactor

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -84,7 +84,7 @@ class BaseMkdocs(BaseBuilder):
         if not mkdocs_path:
             mkdocs_path = 'mkdocs.yml'
         return os.path.join(
-            self.cwd,
+            self.project_path,
             mkdocs_path,
         )
 
@@ -197,7 +197,7 @@ class BaseMkdocs(BaseBuilder):
 
         # RTD javascript writing
         rtd_data = self.generate_rtd_data(
-            docs_dir=os.path.relpath(docs_path, self.cwd),
+            docs_dir=os.path.relpath(docs_path, self.project_path),
             mkdocs_config=user_config,
         )
         with open(os.path.join(docs_path, 'readthedocs-data.js'), 'w') as f:
@@ -223,8 +223,8 @@ class BaseMkdocs(BaseBuilder):
         # Write the mkdocs.yml to the build logs
         self.run(
             'cat',
-            os.path.relpath(self.yaml_file, self.cwd),
-            cwd=self.cwd,
+            os.path.relpath(self.yaml_file, self.project_path),
+            cwd=self.project_path,
         )
 
     def generate_rtd_data(self, docs_dir, mkdocs_config):
@@ -282,13 +282,13 @@ class BaseMkdocs(BaseBuilder):
             '--site-dir',
             self.build_dir,
             '--config-file',
-            os.path.relpath(self.yaml_file, self.cwd),
+            os.path.relpath(self.yaml_file, self.project_path),
         ]
         if self.config.mkdocs.fail_on_warning:
             build_command.append('--strict')
         cmd_ret = self.run(
             *build_command,
-            cwd=self.cwd,
+            cwd=self.project_path,
             bin_path=self.python_env.venv_bin(),
         )
         return cmd_ret.successful

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -45,7 +45,7 @@ class BaseSphinx(BaseBuilder):
                 self.config_file = self.project.conf_file(self.version.slug)
             else:
                 self.config_file = os.path.join(
-                    self.cwd,
+                    self.project_path,
                     self.config_file,
                 )
             self.old_artifact_path = os.path.join(
@@ -86,7 +86,7 @@ class BaseSphinx(BaseBuilder):
             os.path.dirname(
                 os.path.relpath(
                     self.config_file,
-                    self.cwd,
+                    self.project_path,
                 ),
             ),
             '',
@@ -224,9 +224,9 @@ class BaseSphinx(BaseBuilder):
             'cat',
             os.path.relpath(
                 self.config_file,
-                self.cwd,
+                self.project_path,
             ),
-            cwd=self.cwd,
+            cwd=self.project_path,
         )
 
     def build(self):
@@ -303,7 +303,7 @@ class BaseSphinx(BaseBuilder):
         cmd_ret = self.run(
             *command,
             bin_path=self.python_env.venv_bin(),
-            cwd=self.cwd,
+            cwd=self.project_path,
             escape_command=False,  # used on DockerBuildCommand
             shell=True,  # used on BuildCommand
             record=False,
@@ -418,7 +418,7 @@ class EpubBuilder(BaseSphinx):
                 '-f',
                 from_file,
                 to_file,
-                cwd=self.cwd,
+                cwd=self.project_path,
             )
 
 
@@ -638,5 +638,5 @@ class PdfBuilder(BaseSphinx):
                 '-f',
                 from_file,
                 to_file,
-                cwd=self.cwd,
+                cwd=self.project_path,
             )

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -45,7 +45,7 @@ class BaseSphinx(BaseBuilder):
                 self.config_file = self.project.conf_file(self.version.slug)
             else:
                 self.config_file = os.path.join(
-                    self.project.checkout_path(self.version.slug),
+                    self.cwd,
                     self.config_file,
                 )
             self.old_artifact_path = os.path.join(
@@ -86,7 +86,7 @@ class BaseSphinx(BaseBuilder):
             os.path.dirname(
                 os.path.relpath(
                     self.config_file,
-                    self.project.checkout_path(self.version.slug),
+                    self.cwd,
                 ),
             ),
             '',
@@ -192,7 +192,7 @@ class BaseSphinx(BaseBuilder):
 
         return data
 
-    def append_conf(self, **__):
+    def append_conf(self):
         """
         Find or create a ``conf.py`` and appends default content.
 
@@ -224,9 +224,9 @@ class BaseSphinx(BaseBuilder):
             'cat',
             os.path.relpath(
                 self.config_file,
-                self.project.checkout_path(self.version.slug),
+                self.cwd,
             ),
-            cwd=self.project.checkout_path(self.version.slug),
+            cwd=self.cwd,
         )
 
     def build(self):
@@ -255,8 +255,9 @@ class BaseSphinx(BaseBuilder):
             self.sphinx_build_dir,
         ])
         cmd_ret = self.run(
-            *build_command, cwd=os.path.dirname(self.config_file),
-            bin_path=self.python_env.venv_bin()
+            *build_command,
+            cwd=os.path.dirname(self.config_file),
+            bin_path=self.python_env.venv_bin(),
         )
         return cmd_ret.successful
 
@@ -302,7 +303,7 @@ class BaseSphinx(BaseBuilder):
         cmd_ret = self.run(
             *command,
             bin_path=self.python_env.venv_bin(),
-            cwd=self.project.checkout_path(self.version.slug),
+            cwd=self.cwd,
             escape_command=False,  # used on DockerBuildCommand
             shell=True,  # used on BuildCommand
             record=False,
@@ -397,6 +398,7 @@ class LocalMediaBuilder(BaseSphinx):
 
 
 class EpubBuilder(BaseSphinx):
+
     type = 'sphinx_epub'
     sphinx_builder = 'epub'
     sphinx_build_dir = '_build/epub'
@@ -416,7 +418,7 @@ class EpubBuilder(BaseSphinx):
                 '-f',
                 from_file,
                 to_file,
-                cwd=self.project.checkout_path(self.version.slug),
+                cwd=self.cwd,
             )
 
 
@@ -636,5 +638,5 @@ class PdfBuilder(BaseSphinx):
                 '-f',
                 from_file,
                 to_file,
-                cwd=self.project.checkout_path(self.version.slug),
+                cwd=self.cwd,
             )

--- a/readthedocs/doc_builder/base.py
+++ b/readthedocs/doc_builder/base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """Base classes for Builders."""
 
 import logging
@@ -38,8 +36,7 @@ class BaseBuilder:
     _force = False
 
     ignore_patterns = []
-
-    # old_artifact_path = ..
+    old_artifact_path = None
 
     def __init__(self, build_env, python_env, force=False):
         self.build_env = build_env
@@ -48,6 +45,7 @@ class BaseBuilder:
         self.project = build_env.project
         self.config = python_env.config if python_env else None
         self._force = force
+        self.cwd = self.project.checkout_path(self.version.slug)
         self.target = self.project.artifact_path(
             version=self.version.slug,
             type_=self.type,
@@ -61,6 +59,10 @@ class BaseBuilder:
         """An optional step to force a build even when nothing has changed."""
         log.info('Forcing a build')
         self._force = True
+
+    def append_conf(self):
+        """Set custom configurations for this builder."""
+        pass
 
     def build(self):
         """Do the actual building of the documentation."""
@@ -89,16 +91,12 @@ class BaseBuilder:
 
     def docs_dir(self, docs_dir=None, **__):
         """Handle creating a custom docs_dir if it doesn't exist."""
-        checkout_path = self.project.checkout_path(self.version.slug)
         if not docs_dir:
             for doc_dir_name in ['docs', 'doc', 'Doc', 'book']:
-                possible_path = os.path.join(checkout_path, doc_dir_name)
+                possible_path = os.path.join(self.cwd, doc_dir_name)
                 if os.path.exists(possible_path):
-                    docs_dir = possible_path
-                    break
-        if not docs_dir:
-            docs_dir = checkout_path
-        return docs_dir
+                    return possible_path
+        return docs_dir or self.cwd
 
     def create_index(self, extension='md', **__):
         """Create an index file if it needs it."""

--- a/readthedocs/doc_builder/base.py
+++ b/readthedocs/doc_builder/base.py
@@ -45,7 +45,7 @@ class BaseBuilder:
         self.project = build_env.project
         self.config = python_env.config if python_env else None
         self._force = force
-        self.cwd = self.project.checkout_path(self.version.slug)
+        self.project_path = self.project.checkout_path(self.version.slug)
         self.target = self.project.artifact_path(
             version=self.version.slug,
             type_=self.type,
@@ -91,12 +91,15 @@ class BaseBuilder:
 
     def docs_dir(self, docs_dir=None, **__):
         """Handle creating a custom docs_dir if it doesn't exist."""
-        if not docs_dir:
-            for doc_dir_name in ['docs', 'doc', 'Doc', 'book']:
-                possible_path = os.path.join(self.cwd, doc_dir_name)
-                if os.path.exists(possible_path):
-                    return possible_path
-        return docs_dir or self.cwd
+        if docs_dir:
+            return docs_dir
+
+        for doc_dir_name in ['docs', 'doc', 'Doc', 'book']:
+            possible_path = os.path.join(self.project_path, doc_dir_name)
+            if os.path.exists(possible_path):
+                return possible_path
+
+        return self.project_path
 
     def create_index(self, extension='md', **__):
         """Create an index file if it needs it."""


### PR DESCRIPTION
There are a lot of places where we are using `checkout_path` to refer to the cwd of the project, declare this at the base class instead of duplicating it everywhere.