### PR TITLE
Domains: more robust form

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -621,7 +621,7 @@ class DomainBaseForm(forms.ModelForm):
         return self.project
 
     def clean_domain(self):
-        domain = self.cleaned_data['domain']
+        domain = self.cleaned_data['domain'].lower()
         parsed = urlparse(domain)
 
         # Force the scheme to have a valid netloc.

--- a/readthedocs/projects/validators.py
+++ b/readthedocs/projects/validators.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """Validators for projects app."""
 
 import re
@@ -12,39 +10,13 @@ from django.utils.deconstruct import deconstructible
 from django.utils.translation import ugettext_lazy as _
 
 
-domain_regex = (
-    r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}(?<!-)\.?)|'
-    r'localhost|'  # localhost...
-    r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|'  # ...or ipv4
-    r'\[?[A-F0-9]*:[A-F0-9:]+\]?)'  # ...or ipv6
-)
-
-
 @deconstructible
 class DomainNameValidator(RegexValidator):
     message = _('Enter a valid plain or internationalized domain name value')
-    regex = re.compile(domain_regex, re.IGNORECASE)
-
-    def __init__(self, accept_idna=True, **kwargs):
-        message = kwargs.get('message')
-        self.accept_idna = accept_idna
-        super().__init__(**kwargs)
-        if not self.accept_idna and message is None:
-            self.message = _('Enter a valid domain name value')
-
-    def __call__(self, value):
-        try:
-            super().__call__(value)
-        except ValidationError as exc:
-            if not self.accept_idna:
-                raise
-            if not value:
-                raise
-            try:
-                idnavalue = value.encode('idna')
-            except UnicodeError:
-                raise exc
-            super().__call__(idnavalue)
+    # Based on the domain name pattern from https://api.cloudflare.com/#zone-list-zones.
+    regex = re.compile(
+        r'^([a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z0-9-]{2,20}$'
+    )
 
 
 validate_domain_name = DomainNameValidator()

--- a/readthedocs/rtd_tests/tests/test_domains.py
+++ b/readthedocs/rtd_tests/tests/test_domains.py
@@ -106,13 +106,34 @@ class FormTests(TestCase):
         domain = form.save()
         self.assertEqual(domain.domain, 'domain.com')
 
-    def test_invalid_domains(self):
-        invalid = [
-            'python..org',
-            # FIXME: '****.foo.com', current validator says this is valid :shrug:
-            'invalid-.com'
+    def test_valid_domains(self):
+        domains = [
+            'python.org',
+            'a.io',
+            'a.e.i.o.org',
+            'my.domain.com.edu',
+            'my-domain.fav',
         ]
-        for domain in invalid:
+        for domain in domains:
+            form = DomainForm(
+                {'domain': domain},
+                project=self.project,
+            )
+            self.assertTrue(form.is_valid(), domain)
+
+    def test_invalid_domains(self):
+        domains = [
+            'python..org',
+            '****.foo.com',
+            'domain',
+            'domain.com.',
+            'My domain.org',
+            'i.o',
+            '[special].com',
+            'some_thing.org',
+            'invalid-.com',
+        ]
+        for domain in domains:
             form = DomainForm(
                 {'domain': domain},
                 project=self.project,


### PR DESCRIPTION
This form was even accepting spaces...

Based on the regex from https://api.cloudflare.com/
(`pattern: ^([a-zA-Z0-9][\-a-zA-Z0-9]*\.)+[\-a-zA-Z0-9]{2,20}$`)

Closes https://github.com/readthedocs/readthedocs.org/issues/1707