### PR TITLE
Add a reference to the Import guide at the start of Getting started

### DIFF
--- a/docs/intro/getting-started-with-mkdocs.rst
+++ b/docs/intro/getting-started-with-mkdocs.rst
@@ -22,6 +22,8 @@ It has many great features including:
 Quick start
 -----------
 
+.. seealso:: If you already have a Mkdocs project, check out our :doc:`import-guide` guide.
+
 Assuming you have Python already, `install MkDocs`_:
 
 .. prompt:: bash $

--- a/docs/intro/getting-started-with-mkdocs.rst
+++ b/docs/intro/getting-started-with-mkdocs.rst
@@ -22,7 +22,7 @@ It has many great features including:
 Quick start
 -----------
 
-.. seealso:: If you already have a Mkdocs project, check out our :doc:`import-guide` guide.
+.. seealso:: If you already have a Mkdocs project, check out our :doc:`/intro/import-guide` guide.
 
 Assuming you have Python already, `install MkDocs`_:
 

--- a/docs/intro/getting-started-with-sphinx.rst
+++ b/docs/intro/getting-started-with-sphinx.rst
@@ -32,6 +32,8 @@ This screencast will help you get started or you can
 Quick start
 -----------
 
+.. seealso:: If you already have a Sphinx project, check out our :doc:`import-guide` guide.
+
 Assuming you have Python already, :doc:`install Sphinx <sphinx:usage/installation>`:
 
 .. prompt:: bash $

--- a/docs/intro/getting-started-with-sphinx.rst
+++ b/docs/intro/getting-started-with-sphinx.rst
@@ -32,7 +32,7 @@ This screencast will help you get started or you can
 Quick start
 -----------
 
-.. seealso:: If you already have a Sphinx project, check out our :doc:`import-guide` guide.
+.. seealso:: If you already have a Sphinx project, check out our :doc:`/intro/import-guide` guide.
 
 Assuming you have Python already, :doc:`install Sphinx <sphinx:usage/installation>`:
 


### PR DESCRIPTION
This should stop people from overwriting existings docs,
based on user feedback.