### PR TITLE
Migrate sync_versions from an API call to a task

### DIFF
--- a/readthedocs/core/management/commands/pull.py
+++ b/readthedocs/core/management/commands/pull.py
@@ -4,7 +4,7 @@
 
 import logging
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import LabelCommand
 
 from readthedocs.builds.constants import LATEST
 from readthedocs.projects import tasks, utils
@@ -13,12 +13,10 @@ from readthedocs.projects import tasks, utils
 log = logging.getLogger(__name__)
 
 
-class Command(BaseCommand):
+class Command(LabelCommand):
 
     help = __doc__
 
-    def handle(self, *args, **options):
-        if args:
-            for slug in args:
-                version = utils.version_from_slug(slug, LATEST)
-                tasks.sync_repository_task(version.pk)
+    def handle_label(self, label, **options):
+        version = utils.version_from_slug(label, LATEST)
+        tasks.sync_repository_task(version.pk)


### PR DESCRIPTION
This should stop the API from timing out,
since we aren’t running all this logic in process.
This is most important for projects with lots of versions,
because this logic takes a long time to run and times out the web processes.
It also eats up our API processes,
causing other issues with our API because of blocking.

To test this, you can use the `pull` management command on a project you have checked out locally:

```
inv -e docker.manage 'pull time-test’
```