### PR TITLE
Update ES to 6.8.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
 jobs:
   include:
     - python: 3.6
-      env: TOXENV=py36,codecov TOX_POSARGS='' ES_VERSION=6.5.4 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
+      env: TOXENV=py36,codecov TOX_POSARGS='' ES_VERSION=6.8.12 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
     - python: 3.6
       env: TOXENV=docs
     - python: 3.6


### PR DESCRIPTION
We need this before updating to 7.x. No changes were required, everything just works :)

We need to merge https://github.com/readthedocs/common/pull/72 too.

ref https://github.com/readthedocs/readthedocs.org/issues/5620

We need to update to this version in the admin panel of ES. We don't need to reindex for this operation