### PR TITLE
Add our `readthedocs_processor` data to our notifications

### DIFF
--- a/readthedocs/notifications/notification.py
+++ b/readthedocs/notifications/notification.py
@@ -3,6 +3,7 @@
 """Support for templating of notifications."""
 
 import logging
+from readthedocs.core.context_processors import readthedocs_processor
 
 from django.conf import settings
 from django.db import models
@@ -50,7 +51,7 @@ class Notification:
         return template.render(context=Context(self.get_context_data()))
 
     def get_context_data(self):
-        return {
+        context = {
             self.context_object_name: self.object,
             'request': self.request,
             'production_uri': '{scheme}://{host}'.format(
@@ -58,6 +59,8 @@ class Notification:
                 host=settings.PRODUCTION_DOMAIN,
             ),
         }
+        context.update(readthedocs_processor(self.request))
+        return context
 
     def get_template_names(self, backend_name, source_format=constants.HTML):
         names = []

--- a/readthedocs/rtd_tests/tests/test_notifications.py
+++ b/readthedocs/rtd_tests/tests/test_notifications.py
@@ -67,6 +67,18 @@ class NotificationTests(TestCase):
                 'foo': build,
                 'production_uri': 'https://readthedocs.org',
                 'request': req,
+
+                # readthedocs_processor context
+                'DASHBOARD_ANALYTICS_CODE': None,
+                'DO_NOT_TRACK_ENABLED': False,
+                'GLOBAL_ANALYTICS_CODE': None,
+                'PRODUCTION_DOMAIN': 'readthedocs.org',
+                'PUBLIC_DOMAIN': None,
+                'SITE_ROOT': mock.ANY,
+                'SUPPORT_EMAIL': None,
+                'TEMPLATE_ROOT': mock.ANY,
+                'USE_PROMOS': False,
+                'USE_SUBDOMAIN': False,
             },
         )
 
@@ -220,6 +232,18 @@ class SiteNotificationTests(TestCase):
             'request': None,
             'production_uri': 'https://readthedocs.org',
             'other': {'name': 'other name'},
+
+            # readthedocs_processor context
+            'DASHBOARD_ANALYTICS_CODE': None,
+            'DO_NOT_TRACK_ENABLED': False,
+            'GLOBAL_ANALYTICS_CODE': None,
+            'PRODUCTION_DOMAIN': 'readthedocs.org',
+            'PUBLIC_DOMAIN': None,
+            'SITE_ROOT': mock.ANY,
+            'SUPPORT_EMAIL': None,
+            'TEMPLATE_ROOT': mock.ANY,
+            'USE_PROMOS': False,
+            'USE_SUBDOMAIN': False,
         }
         self.assertEqual(self.n.get_context_data(), context)
 


### PR DESCRIPTION
This fixes an issue where we were sending emails with `Contact us at {{
SUPPORT_EMAIL }}` but the support email variable was not set and the result was
an empty email.

Using our own `readthedocs_processor` here we are passing all the same variables
to the notification that to all the Django templates, avoiding this kind of confusions.