### PR TITLE
Search: refactor query objects

### DIFF
--- a/readthedocs/search/documents.py
+++ b/readthedocs/search/documents.py
@@ -52,6 +52,17 @@ class ProjectDocument(RTDDocTypeMixin, Document):
 @page_index.document
 class PageDocument(RTDDocTypeMixin, Document):
 
+    """
+    Document representation of a Page.
+
+    Some text fields use the simple analyzer instead of the default (standard).
+    Simple analyzer will break the text in non-letter characters,
+    so a text like ``python.submodule`` will be broken like [python, submodule]
+    instead of [python.submodule].
+
+    https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-analyzers.html
+    """
+
     # Metadata
     project = fields.KeywordField(attr='project.slug')
     version = fields.KeywordField(attr='version.slug')

--- a/readthedocs/search/faceted_search.py
+++ b/readthedocs/search/faceted_search.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from django.conf import settings
 from elasticsearch import Elasticsearch
@@ -65,35 +66,55 @@ class RTDFacetedSearch(FacetedSearch):
         }
         super().__init__(query=query, filters=valid_filters, **kwargs)
 
-    def _get_text_query(self, *, query, fields, operator):
+    def _get_queries(self, *, query, fields):
+        return self._get_text_queries(
+            query=query,
+            fields=fields,
+        )
+
+    def _get_text_queries(self, *, query, fields):
         """
-        Returns a text query object according to the query.
+        Returns a list of query objects according to the query.
 
         - SimpleQueryString: Provides a syntax to let advanced users manipulate
           the results explicitly.
         - MultiMatch: Allows us to have more control over the results
           (like fuzziness) to provide a better experience for simple queries.
 
+        We need to search for both "and" and "or" operators.
+        The score of "and" should be higher as it satisfies both "or" and "and".
+
         For valid options, see:
 
         - https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html
         - https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html  # noqa
         """
-        if self.use_advanced_query or self._is_advanced_query(query):
-            query_string = SimpleQueryString(
-                query=query,
-                fields=fields,
-                default_operator=operator
-            )
-        else:
-            query_string = MultiMatch(
-                query=query,
-                fields=fields,
-                operator=operator,
-                fuzziness="AUTO:4,6",
-                prefix_length=1,
-            )
-        return query_string
+        queries = []
+        is_advanced_query = self.use_advanced_query or self._is_advanced_query(query)
+        for operator in self.operators:
+            if is_advanced_query:
+                query_string = SimpleQueryString(
+                    query=query,
+                    fields=fields,
+                    default_operator=operator,
+                )
+            else:
+                query_string = self._get_fuzzy_query(
+                    query=query,
+                    fields=fields,
+                    operator=operator,
+                )
+            queries.append(query_string)
+        return queries
+
+    def _get_fuzzy_query(self, *, query, fields, operator):
+        return MultiMatch(
+            query=query,
+            fields=fields,
+            operator=operator,
+            fuzziness="AUTO:4,6",
+            prefix_length=1,
+        )
 
     def _is_advanced_query(self, query):
         """
@@ -126,21 +147,13 @@ class RTDFacetedSearch(FacetedSearch):
         search = search.highlight_options(**self._highlight_options)
         search = search.source(exclude=['content', 'headers'])
 
-        all_queries = []
-
-        # need to search for both 'and' and 'or' operations
-        # the score of and should be higher as it satisfies both or and and
-        for operator in self.operators:
-            query_string = self._get_text_query(
-                query=query,
-                fields=self.fields,
-                operator=operator,
-            )
-            all_queries.append(query_string)
+        queries = self._get_queries(
+            query=query,
+            fields=self.fields,
+        )
 
         # run bool query with should, so it returns result where either of the query matches
-        bool_query = Bool(should=all_queries)
-
+        bool_query = Bool(should=queries)
         search = search.query(bool_query)
         return search
 
@@ -193,57 +206,57 @@ class PageSearchBase(RTDFacetedSearch):
         """Manipulates the query to support nested queries and a custom rank for pages."""
         search = search.highlight_options(**self._highlight_options)
 
-        all_queries = []
+        queries = self._get_queries(
+            query=query,
+            fields=self.fields,
+        )
 
-        # match query for the title (of the page) field.
-        for operator in self.operators:
-            query_string = self._get_text_query(
-                query=query,
-                fields=self.fields,
-                operator=operator,
-            )
-            all_queries.append(query_string)
-
-        # nested query for search in sections
-        sections_nested_query = self.generate_nested_query(
+        sections_nested_query = self._get_nested_query(
             query=query,
             path='sections',
             fields=self._section_fields,
-            inner_hits={
-                'highlight': dict(
-                    self._highlight_options,
-                    fields={
-                        'sections.title': {},
-                        'sections.content': {},
-                    }
-                )
-            }
         )
 
-        # nested query for search in domains
-        domains_nested_query = self.generate_nested_query(
+        domains_nested_query = self._get_nested_query(
             query=query,
             path='domains',
             fields=self._domain_fields,
-            inner_hits={
-                'highlight': dict(
-                    self._highlight_options,
-                    fields={
-                        'domains.name': {},
-                        'domains.docstrings': {},
-                    }
-                )
-            }
         )
 
-        all_queries.extend([sections_nested_query, domains_nested_query])
-
+        queries.extend([sections_nested_query, domains_nested_query])
         final_query = FunctionScore(
-            query=Bool(should=all_queries),
+            query=Bool(should=queries),
             script_score=self._get_script_score(),
         )
         search = search.query(final_query)
         return search
+
+    def _get_nested_query(self, *, query, path, fields):
+        """Generate a nested query with passed parameters."""
+        queries = self._get_queries(
+            query=query,
+            fields=fields,
+        )
+
+        raw_fields = (
+            # Remove boosting from the field
+            re.sub(r'\^.*$', '', field)
+            for field in fields
+        )
+
+        highlight = dict(
+            self._highlight_options,
+            fields={
+                field: {}
+                for field in raw_fields
+            },
+        )
+
+        return Nested(
+            path=path,
+            inner_hits={'highlight': highlight},
+            query=Bool(should=queries),
+        )
 
     def _get_script_score(self):
         """
@@ -304,27 +317,6 @@ class PageSearchBase(RTDFacetedSearch):
                 "params": {"ranking": ranking},
             },
         }
-
-    def generate_nested_query(self, query, path, fields, inner_hits):
-        """Generate a nested query with passed parameters."""
-        queries = []
-
-        for operator in self.operators:
-            query_string = self._get_text_query(
-                query=query,
-                fields=fields,
-                operator=operator,
-            )
-            queries.append(query_string)
-
-        bool_query = Bool(should=queries)
-
-        nested_query = Nested(
-            path=path,
-            inner_hits=inner_hits,
-            query=bool_query
-        )
-        return nested_query
 
 
 class PageSearch(SettingsOverrideObject):

--- a/readthedocs/search/faceted_search.py
+++ b/readthedocs/search/faceted_search.py
@@ -137,7 +137,7 @@ class RTDFacetedSearch(FacetedSearch):
 
         For valid options, see:
 
-        - https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html
+        - https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html  # noqa
         """
         queries = []
         for operator in self.operators:


### PR DESCRIPTION
We were iterating over operators each time and repeating the same fields to get the highlight. I did this mainly to introduce a new improvement for partial results, so ended up splitting this into two PRs so the change is more easy to understand.