### PR TITLE
Undeprecate APIv2 in docs

### DIFF
--- a/docs/api/v2.rst
+++ b/docs/api/v2.rst
@@ -1,5 +1,5 @@
-API v2 (deprecated)
-===================
+API v2
+======
 
 The Read the Docs API uses :abbr:`REST (Representational State Transfer)`.
 JSON is returned by all API responses including errors
@@ -7,13 +7,15 @@ and HTTP response status codes are to designate success and failure.
 
 .. note::
 
-    A newer and better API v3 is ready to use.
-    Some improvements coming in v3 are:
+    API v2 will be soon completely deprecated. If you are integrating with Read
+    the Docs, you should try to use :doc:`API v3 </api/v3>` instead. API v2 is
+    still used by some application operations still.
 
-    * Simpler URLs which use slugs
+    Some improvements in :doc:`API v3 </api/v3>` are:
+
     * Token based authentication
-    * Import a new project
-    * Activate a version
+    * Easier to use URLs which no longer use numerical ids
+    * More common user actions are exposed through the API
     * Improved error reporting
 
     See its full documentation at :doc:`/api/v3`.

--- a/docs/api/v2.rst
+++ b/docs/api/v2.rst
@@ -5,11 +5,14 @@ The Read the Docs API uses :abbr:`REST (Representational State Transfer)`.
 JSON is returned by all API responses including errors
 and HTTP response status codes are to designate success and failure.
 
-.. note::
+.. warning::
 
-    API v2 will be soon completely deprecated. If you are integrating with Read
-    the Docs, you should try to use :doc:`API v3 </api/v3>` instead. API v2 is
-    still used by some application operations still.
+    API v2 is planned to be deprecated soon, though we have not yet set a time
+    frame for deprecation yet. We will alert users with our plans when we do.
+
+    For now, API v2 is still used by some legacy application operations still,
+    but we highly recommend Read the Docs users use :doc:`API v3 </api/v3>`
+    instead.
 
     Some improvements in :doc:`API v3 </api/v3>` are:
 


### PR DESCRIPTION
APIv2 is still available, we still use it for application operations,
and APIv3 is not quite ready as a replacement for a lot of applications.
I think the docs should reflect that, even if we want new users using
APIv3.