### PR TITLE
Add remoterepo query param

### DIFF
--- a/readthedocs/api/v2/views/model_views.py
+++ b/readthedocs/api/v2/views/model_views.py
@@ -380,6 +380,9 @@ class RemoteRepositoryViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         query = self.model.objects.api(self.request.user)
+        full_name = self.request.query_params.get('full_name', None)
+        if full_name is not None:
+            query = query.filter(full_name__icontains=full_name)
         org = self.request.query_params.get('org', None)
         if org is not None:
             query = query.filter(organization__pk=org)

--- a/readthedocs/api/v2/views/model_views.py
+++ b/readthedocs/api/v2/views/model_views.py
@@ -380,7 +380,7 @@ class RemoteRepositoryViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         query = self.model.objects.api(self.request.user)
-        full_name = self.request.query_params.get('full_name', None)
+        full_name = self.request.query_params.get('full_name')
         if full_name is not None:
             query = query.filter(full_name__icontains=full_name)
         org = self.request.query_params.get('org', None)


### PR DESCRIPTION
This is used by new theme to perform search as you type directly against
the api response. API v2 is used here as we don't have this modeled at
all in APIv3 yet.