### PR TITLE
Search: update to ES 7.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,10 @@ jobs:
       - image: 'cimg/python:3.6'
         environment:
           TOX_POSARGS: ''
-      - image: 'docker.elastic.co/elasticsearch/elasticsearch:6.8.12'
+      - image: 'docker.elastic.co/elasticsearch/elasticsearch:7.9.2'
         name: search
+        environment:
+          discovery.type: single-node
     steps:
       - checkout
       - run: git submodule sync

--- a/readthedocs/search/faceted_search.py
+++ b/readthedocs/search/faceted_search.py
@@ -275,7 +275,7 @@ class PageSearchBase(RTDFacetedSearch):
         # we are only interested in the total count
         s = s.extra(size=0)
         s = s.execute()
-        return s.hits.total
+        return s.hits.total['value']
 
     def query(self, search, query):
         """

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -52,9 +52,9 @@ django-allauth==0.42.0  # pyup: ignore
 GitPython==3.1.11
 
 # Search
-elasticsearch==6.8.1  # pyup: <7.0.0
-elasticsearch-dsl==6.4.0  # pyup: <7.0
-django-elasticsearch-dsl==6.4.2  # pyup: <7.0
+elasticsearch==7.9.1  # pyup: <8.0.0
+elasticsearch-dsl==7.3.0  # pyup: <8.0
+django-elasticsearch-dsl==7.1.4  # pyup: <8.0
 selectolax==0.2.9
 
 # NOTE: this dep can be removed in python 3.7 in favor of ``date.fromisoformat``


### PR DESCRIPTION
The only change was:

- https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#hits-total-now-object-search-response

We don't need to re-index, the index is compatible between 6.x and 7.x.

https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html

We need to update common https://github.com/readthedocs/common/pull/74

Closes #5620