### PR TITLE
Use correct Cache-Tag (CDN) and X-RTD-Project header on subprojects

### DIFF
--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -120,7 +120,7 @@ class ProxitoMiddleware(MiddlewareMixin):
     def add_proxito_headers(self, request, response):
         """Add debugging headers to proxito responses."""
 
-        project_slug = getattr(request, 'host_project_slug', '')
+        project_slug = getattr(request, 'path_project_slug', '')
         version_slug = getattr(request, 'path_version_slug', '')
         path = getattr(response, 'proxito_path', '')
 

--- a/readthedocs/proxito/tests/test_headers.py
+++ b/readthedocs/proxito/tests/test_headers.py
@@ -38,6 +38,22 @@ class ProxitoHeaderTests(BaseDocServing):
         self.assertEqual(r['X-RTD-version-Method'], 'path')
         self.assertEqual(r['X-RTD-Path'], '/proxito/media/html/project/latest/index.html')
 
+    def test_subproject_serve_headers(self):
+        r = self.client.get('/projects/subproject/en/latest/', HTTP_HOST='project.dev.readthedocs.io')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r['Cache-Tag'], 'subproject,subproject-latest')
+        self.assertEqual(r['X-RTD-Domain'], 'project.dev.readthedocs.io')
+        self.assertEqual(r['X-RTD-Project'], 'subproject')
+
+        # I think it's not accurate saying that it's `subdomain` the method
+        # that we use to get the project slug here, since it was in fact the
+        # URL's path but we don't have that feature built
+        self.assertEqual(r['X-RTD-Project-Method'], 'subdomain')
+
+        self.assertEqual(r['X-RTD-Version'], 'latest')
+        self.assertEqual(r['X-RTD-version-Method'], 'path')
+        self.assertEqual(r['X-RTD-Path'], '/proxito/media/html/subproject/latest/index.html')
+
     def test_404_headers(self):
         r = self.client.get('/foo/bar.html', HTTP_HOST='project.dev.readthedocs.io')
         self.assertEqual(r.status_code, 404)

--- a/readthedocs/proxito/views/utils.py
+++ b/readthedocs/proxito/views/utils.py
@@ -92,7 +92,8 @@ def _get_project_data_from_request(
     # * Subproject
     # * Translations
 
-    # Set the version slug on the request so we can log it in middleware
+    # Set the project and version slug on the request so we can log it in middleware
+    request.path_project_slug = final_project.slug
     request.path_version_slug = version_slug
 
     return final_project, lang_slug, version_slug, filename


### PR DESCRIPTION
Currently, when accessing a subproject (eg. `edx-guide-for-students` being
subproject of `edx`) we are generating `Cache-Tag: edx,edx-latest`. Then, when
a build for `edx-guide-for-students` on version `latest` succeeds, we are purging
the cache tags `edx-guide-for-students-latest`.

This commit makes the `Cache-Tag` generated for subprojects to use the
subproject's slug instead of the parent's/superproject's slug and matching the
cache tag that we are purging when the build succeeds.

Besides, it fixes the `X-RTD-Project` header as well, since it was using the
same parent's/superproject's slug as value.

Fixes #7590 