### PR TITLE
Add APIv3 version edit URL

### DIFF
--- a/docs/api/v3.rst
+++ b/docs/api/v3.rst
@@ -464,6 +464,7 @@ Version detail
             },
             "urls": {
                 "documentation": "https://pip.pypa.io/en/stable/",
+                "edit": "https://readthedocs.org/dashboard/pip/version/stable/edit/",
                 "vcs": "https://github.com/pypa/pip/tree/19.0.2"
             },
             "_links": {

--- a/docs/api/v3.rst
+++ b/docs/api/v3.rst
@@ -463,8 +463,10 @@ Version detail
                 "epub": "https://pip.readthedocs.io/_/downloads/epub/pip/stable/"
             },
             "urls": {
+                "dashboard": {
+                    "edit": "https://readthedocs.org/dashboard/pip/version/stable/edit/"
+                },
                 "documentation": "https://pip.pypa.io/en/stable/",
-                "edit": "https://readthedocs.org/dashboard/pip/version/stable/edit/",
                 "vcs": "https://github.com/pypa/pip/tree/19.0.2"
             },
             "_links": {

--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -222,13 +222,8 @@ class VersionLinksSerializer(BaseLinksSerializer):
         return self._absolute_url(path)
 
 
-class VersionURLsSerializer(BaseLinksSerializer, serializers.Serializer):
-    documentation = serializers.SerializerMethodField()
+class VersionDashboardURLsSerializer(BaseLinksSerializer, serializers.Serializer):
     edit = serializers.SerializerMethodField()
-    vcs = serializers.URLField(source='vcs_url')
-
-    def get_documentation(self, obj):
-        return obj.project.get_docs_url(version_slug=obj.slug,)
 
     def get_edit(self, obj):
         path = reverse(
@@ -238,6 +233,15 @@ class VersionURLsSerializer(BaseLinksSerializer, serializers.Serializer):
                 'version_slug': obj.slug,
             })
         return self._absolute_url(path)
+
+
+class VersionURLsSerializer(BaseLinksSerializer, serializers.Serializer):
+    documentation = serializers.SerializerMethodField()
+    vcs = serializers.URLField(source='vcs_url')
+    dashboard = VersionDashboardURLsSerializer(source='*')
+
+    def get_documentation(self, obj):
+        return obj.project.get_docs_url(version_slug=obj.slug,)
 
 
 class VersionSerializer(FlexFieldsModelSerializer):

--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -222,12 +222,22 @@ class VersionLinksSerializer(BaseLinksSerializer):
         return self._absolute_url(path)
 
 
-class VersionURLsSerializer(serializers.Serializer):
+class VersionURLsSerializer(BaseLinksSerializer, serializers.Serializer):
     documentation = serializers.SerializerMethodField()
+    edit = serializers.SerializerMethodField()
     vcs = serializers.URLField(source='vcs_url')
 
     def get_documentation(self, obj):
         return obj.project.get_docs_url(version_slug=obj.slug,)
+
+    def get_edit(self, obj):
+        path = reverse(
+            'project_version_detail',
+            kwargs={
+                'project_slug': obj.project.slug,
+                'version_slug': obj.slug,
+            })
+        return self._absolute_url(path)
 
 
 class VersionSerializer(FlexFieldsModelSerializer):

--- a/readthedocs/api/v3/tests/responses/projects-detail.json
+++ b/readthedocs/api/v3/tests/responses/projects-detail.json
@@ -48,8 +48,10 @@
             "slug": "v1.0",
             "type": "tag",
             "urls": {
+                "dashboard": {
+                    "edit": "https://readthedocs.org/dashboard/project/version/v1.0/"
+                },
                 "documentation": "http://project.readthedocs.io/en/v1.0/",
-                "edit": "https://readthedocs.org/dashboard/project/version/v1.0/",
                 "vcs": "https://github.com/rtfd/project/tree/v1.0/"
             },
             "verbose_name": "v1.0"

--- a/readthedocs/api/v3/tests/responses/projects-detail.json
+++ b/readthedocs/api/v3/tests/responses/projects-detail.json
@@ -49,6 +49,7 @@
             "type": "tag",
             "urls": {
                 "documentation": "http://project.readthedocs.io/en/v1.0/",
+                "edit": "https://readthedocs.org/dashboard/project/version/v1.0/",
                 "vcs": "https://github.com/rtfd/project/tree/v1.0/"
             },
             "verbose_name": "v1.0"

--- a/readthedocs/api/v3/tests/responses/projects-versions-builds-list_POST.json
+++ b/readthedocs/api/v3/tests/responses/projects-versions-builds-list_POST.json
@@ -95,8 +95,10 @@
         "slug": "v1.0",
         "type": "tag",
         "urls": {
+            "dashboard": {
+                "edit": "https://readthedocs.org/dashboard/project/version/v1.0/"
+            },
             "documentation": "http://project.readthedocs.io/en/v1.0/",
-            "edit": "https://readthedocs.org/dashboard/project/version/v1.0/",
             "vcs": "https://github.com/rtfd/project/tree/v1.0/"
         },
         "verbose_name": "v1.0"

--- a/readthedocs/api/v3/tests/responses/projects-versions-builds-list_POST.json
+++ b/readthedocs/api/v3/tests/responses/projects-versions-builds-list_POST.json
@@ -96,6 +96,7 @@
         "type": "tag",
         "urls": {
             "documentation": "http://project.readthedocs.io/en/v1.0/",
+            "edit": "https://readthedocs.org/dashboard/project/version/v1.0/",
             "vcs": "https://github.com/rtfd/project/tree/v1.0/"
         },
         "verbose_name": "v1.0"

--- a/readthedocs/api/v3/tests/responses/projects-versions-detail.json
+++ b/readthedocs/api/v3/tests/responses/projects-versions-detail.json
@@ -19,6 +19,7 @@
     "type": "tag",
     "urls": {
         "documentation": "http://project.readthedocs.io/en/v1.0/",
+        "edit": "https://readthedocs.org/dashboard/project/version/v1.0/",
         "vcs": "https://github.com/rtfd/project/tree/v1.0/"
     },
     "verbose_name": "v1.0"

--- a/readthedocs/api/v3/tests/responses/projects-versions-detail.json
+++ b/readthedocs/api/v3/tests/responses/projects-versions-detail.json
@@ -18,8 +18,10 @@
     "slug": "v1.0",
     "type": "tag",
     "urls": {
+        "dashboard": {
+            "edit": "https://readthedocs.org/dashboard/project/version/v1.0/"
+        },
         "documentation": "http://project.readthedocs.io/en/v1.0/",
-        "edit": "https://readthedocs.org/dashboard/project/version/v1.0/",
         "vcs": "https://github.com/rtfd/project/tree/v1.0/"
     },
     "verbose_name": "v1.0"


### PR DESCRIPTION
For use in dashboard client code, having a link to the dashboard for
some resources would be helpful, and would avoid exposing the url
resolver through Django to the JS side.

Requires https://github.com/readthedocs/readthedocs.org/pull/7595