### PR TITLE
Add separate version create view and create view URL

### DIFF
--- a/readthedocs/api/v3/tests/responses/projects-builds-detail.json
+++ b/readthedocs/api/v3/tests/responses/projects-builds-detail.json
@@ -13,7 +13,7 @@
     "urls": {
         "build": "https://readthedocs.org/projects/project/builds/1/",
         "project": "https://readthedocs.org/projects/project/",
-        "version": "https://readthedocs.org/dashboard/project/version/v1.0/"
+        "version": "https://readthedocs.org/dashboard/project/version/v1.0/edit/"
     },
     "project": "project",
     "state": {

--- a/readthedocs/api/v3/tests/responses/projects-detail.json
+++ b/readthedocs/api/v3/tests/responses/projects-detail.json
@@ -29,7 +29,7 @@
                 "urls": {
                     "build": "https://readthedocs.org/projects/project/builds/1/",
                     "project": "https://readthedocs.org/projects/project/",
-                    "version": "https://readthedocs.org/dashboard/project/version/v1.0/"
+                    "version": "https://readthedocs.org/dashboard/project/version/v1.0/edit/"
                 },
                 "project": "project",
                 "state": {

--- a/readthedocs/api/v3/tests/responses/projects-versions-builds-list_POST.json
+++ b/readthedocs/api/v3/tests/responses/projects-versions-builds-list_POST.json
@@ -14,7 +14,7 @@
         "urls": {
             "build": "https://readthedocs.org/projects/project/builds/2/",
             "project": "https://readthedocs.org/projects/project/",
-            "version": "https://readthedocs.org/dashboard/project/version/v1.0/"
+            "version": "https://readthedocs.org/dashboard/project/version/v1.0/edit/"
         },
         "project": "project",
         "state": {

--- a/readthedocs/projects/urls/private.py
+++ b/readthedocs/projects/urls/private.py
@@ -1,5 +1,6 @@
 """Project URLs for authenticated users."""
 
+from django.conf import settings
 from django.conf.urls import url
 from django.contrib.auth.decorators import login_required
 from django.views.generic.base import RedirectView
@@ -83,11 +84,6 @@ urlpatterns = [
         name='project_version_delete_html',
     ),
     url(
-        r'^(?P<project_slug>[-\w]+)/version/create/$',
-        ProjectVersionCreate.as_view(),
-        name='project_version_create',
-    ),
-    url(
         r'^(?P<project_slug>[-\w]+)/version/(?P<version_slug>[^/]+)/edit/$',
         ProjectVersionDetail.as_view(),
         name='project_version_detail',
@@ -151,6 +147,18 @@ urlpatterns = [
         TrafficAnalyticsView.as_view(), name='projects_traffic_analytics',
     ),
 ]
+
+# TODO move this up to the list above when it's not a conditional URL.
+# Currently, this is only used by the new theme, we don't allow for "create" in
+# our current templates.
+if settings.RTD_EXT_THEME_ENABLED:
+    urlpatterns.append(
+        url(
+            r'^(?P<project_slug>[-\w]+)/version/create/$',
+            ProjectVersionCreate.as_view(),
+            name='project_version_create',
+        ),
+    )
 
 domain_urls = [
     url(

--- a/readthedocs/projects/urls/private.py
+++ b/readthedocs/projects/urls/private.py
@@ -41,6 +41,7 @@ from readthedocs.projects.views.private import (
     ProjectUsersCreateList,
     ProjectUsersDelete,
     ProjectVersionDeleteHTML,
+    ProjectVersionCreate,
     ProjectVersionDetail,
     RegexAutomationRuleCreate,
     RegexAutomationRuleUpdate,
@@ -82,7 +83,12 @@ urlpatterns = [
         name='project_version_delete_html',
     ),
     url(
-        r'^(?P<project_slug>[-\w]+)/version/(?P<version_slug>[^/]+)/$',
+        r'^(?P<project_slug>[-\w]+)/version/create/$',
+        ProjectVersionCreate.as_view(),
+        name='project_version_create',
+    ),
+    url(
+        r'^(?P<project_slug>[-\w]+)/version/(?P<version_slug>[^/]+)/edit/$',
         ProjectVersionDetail.as_view(),
         name='project_version_detail',
     ),

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -192,9 +192,7 @@ class ProjectVersionMixin(ProjectAdminMixin, PrivateViewMixin):
         )
 
 
-class ProjectVersionDetail(ProjectVersionMixin, UpdateView):
-
-    template_name = 'projects/project_version_detail.html'
+class ProjectVersionEditMixin(ProjectVersionMixin):
 
     def get_queryset(self):
         return Version.internal.public(
@@ -220,6 +218,16 @@ class ProjectVersionDetail(ProjectVersionMixin, UpdateView):
                 version.built = False
                 version.save()
         return HttpResponseRedirect(self.get_success_url())
+
+
+class ProjectVersionCreate(ProjectVersionEditMixin, CreateView):
+
+    template_name = 'projects/project_version_detail.html'
+
+
+class ProjectVersionDetail(ProjectVersionEditMixin, UpdateView):
+
+    template_name = 'projects/project_version_detail.html'
 
 
 class ProjectVersionDeleteHTML(ProjectVersionMixin, GenericModelView):

--- a/readthedocs/rtd_tests/tests/test_views.py
+++ b/readthedocs/rtd_tests/tests/test_views.py
@@ -99,7 +99,7 @@ class PrivateViewsAreProtectedTests(TestCase):
         self.assertRedirectToLogin(response)
 
     def test_version_detail(self):
-        response = self.client.get('/dashboard/pip/version/0.8.1/')
+        response = self.client.get('/dashboard/pip/version/0.8.1/edit/')
         self.assertRedirectToLogin(response)
 
     def test_project_delete(self):

--- a/readthedocs/templates/projects/project_version_submit.html
+++ b/readthedocs/templates/projects/project_version_submit.html
@@ -2,8 +2,6 @@
 
 <p>
   <input style="display: inline;" type="submit" value="{% trans "Save" %}">
-  {% if version %}
-    {% trans "or" %}
-    <a href="{% url "wipe_version" version.project.slug version.slug %}">{% trans "wipe "%}</a>
-  {% endif %}
+  {% trans "or" %}
+  <a href="{% url "wipe_version" version.project.slug version.slug %}">{% trans "wipe "%}</a>
 </p>

--- a/readthedocs/templates/projects/project_version_submit.html
+++ b/readthedocs/templates/projects/project_version_submit.html
@@ -2,6 +2,8 @@
 
 <p>
   <input style="display: inline;" type="submit" value="{% trans "Save" %}">
-  {% trans "or" %}
-  <a href="{% url "wipe_version" version.project.slug version.slug %}">{% trans "wipe "%}</a>
+  {% if version %}
+    {% trans "or" %}
+    <a href="{% url "wipe_version" version.project.slug version.slug %}">{% trans "wipe "%}</a>
+  {% endif %}
 </p>


### PR DESCRIPTION
This is not currently used outside the new theme, but enables the
solution for #6238 -- latest `master` of the new theme already expects
this code.

For now, the create URL does throw and exception, because we are
rendering template code inside the version form. I'm not going to
address this as the create view is not linked and unused, and we
probably shouldn't be rendering templates inside form instantiation
anyways.

The edit version URL does change with this, to append the `/edit/`
postfix. This was done to match similar URL patterns, and to give a path
for the create view URL that does not match the edit URL pattern.