### PR TITLE
Catch `requests.exceptions.ReadTimeout` when removing container

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -16,7 +16,7 @@ from docker import APIClient
 from docker.errors import APIError as DockerAPIError
 from docker.errors import DockerException
 from docker.errors import NotFound as DockerNotFoundError
-from requests.exceptions import ConnectionError
+from requests.exceptions import ConnectionError, ReadTimeout
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 from slumber.exceptions import HttpClientError
 
@@ -906,7 +906,7 @@ class DockerBuildEnvironment(BuildEnvironment):
                 )
             # Catch direct failures from Docker API or with an HTTP request.
             # These errors should not surface to the user.
-            except (DockerAPIError, ConnectionError):
+            except (DockerAPIError, ConnectionError, ReadTimeout):
                 log.exception(
                     LOG_TEMPLATE,
                     {


### PR DESCRIPTION
We are already catching other similar exceptions here, log them and continuing
with the build. However, there is now another similar exception
`requests.exceptions.ReadTimeout` that's causing some builds to fail.

This commit catchs this exceptions and makes the build to behave in the same way
as we are doing with similar exceptions.

Related https://github.com/readthedocs/readthedocs.org/issues/7583#issuecomment-718246665