### PR TITLE
Reserve 1Gb for Application Memory

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -495,7 +495,7 @@ class CommunityBaseSettings(Settings):
                 "free -m | awk '/^Mem:/{print $2}'",
                 shell=True,
             ))
-            return total_memory, round(total_memory - 750, -2)
+            return total_memory, round(total_memory - 1000, -2)
         except ValueError:
             # On systems without a `free` command it will return a string to
             # int and raise a ValueError


### PR DESCRIPTION
We have noticed some strange behavior when trying to `create_container` and
`remove_container` using the Docker API. For some reason we started getting
ReadTimeout and I'm supposing that our Docker daemon has been restarted (because
of OOM) or in a dumb state.

This commit increases from 750 to 1000 Mb of RAM memory reserved for our
application and OS processes.

The user will get 7000Mb instead of 7200Mb in build-large instances and
in build-default instances they will get 2400 intead of 2700Mb.

Reference: https://github.com/readthedocs/readthedocs.org/issues/7583#issuecomment-718702683