### PR TITLE
Position the ad at the top of our docs

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,5 +1,4 @@
 /* CSS for sphinx-prompt */
-
 pre.highlight {
   border: 1px solid #e1e4e5;
   overflow-x: auto;
@@ -11,4 +10,9 @@ pre.highlight {
 pre.highlight span[class^="prompt"] {
   font-size: 12px;
   line-height: 1.4;
+}
+
+.rtd-sponsorship {
+  /* 72 is the height of a text-only ad assuming it fits on one line */
+  min-height: 72px;
 }

--- a/docs/_templates/ethicalads.html
+++ b/docs/_templates/ethicalads.html
@@ -1,4 +1,3 @@
 <div class="rtd-sponsorship">
-  <div class="raised" data-ea-publisher="readthedocs" data-ea-type="text"></div>
+  <div class="raised" data-ea-publisher="readthedocs" data-ea-type="text" data-ea-manual="true"></div>
 </div>
-

--- a/docs/_templates/ethicalads.html
+++ b/docs/_templates/ethicalads.html
@@ -1,0 +1,4 @@
+<div class="rtd-sponsorship">
+  <div class="raised" data-ea-publisher="readthedocs" data-ea-type="text"></div>
+</div>
+

--- a/docs/_templates/ethicalads.html
+++ b/docs/_templates/ethicalads.html
@@ -1,3 +1,3 @@
 <div class="rtd-sponsorship">
-  <div class="raised" data-ea-publisher="readthedocs" data-ea-type="text" data-ea-manual="true"></div>
+  <div class="raised" data-ea-publisher="readthedocs" data-ea-type="text"></div>
 </div>

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,8 @@
+{% extends "sphinx_rtd_theme/layout.html" %}
+
+
+{% block document %}
+  {% include "ethicalads.html" %}
+
+  {{ super() }}
+{% endblock document %}

--- a/docs/advertising/ad-customization.rst
+++ b/docs/advertising/ad-customization.rst
@@ -28,7 +28,11 @@ The ad will be inserted into this container wherever this element is in the docu
 
 .. code-block:: html
 
-    <div id="ethical-ad-placement"></div>
+    <div data-ea-publisher="readthedocs"></div>
+
+For additional options, see the `EthicalAds client documentation`_.
+
+.. _EthicalAds client documentation: https://ethical-ad-client.readthedocs.io/
 
 
 In Sphinx
@@ -41,18 +45,23 @@ for inclusion in the `HTML sidebar`_ in your ``conf.py``.
 .. _HTML sidebar: https://www.sphinx-doc.org/page/usage/configuration.html#confval-html_sidebars
 .. _templates_path: https://www.sphinx-doc.org/page/usage/configuration.html#confval-templates_path
 
+
+.. Note: this does not work on the RTD sphinx theme because it doesn't use ``html_sidebars``.
 .. code-block:: python
 
     ## In conf.py
-    html_sidebars = { '**': [
+
+    # This order is defined in the basic theme
+    # but other themes could be different
+    html_sidebars = {'**':[
         'localtoc.html',
         'ethicalads.html',  # Put the ad below the navigation but above previous/next
         'relations.html',
         'sourcelink.html',
         'searchbox.html',
-    ] }
+    ]}
 
 .. code-block:: html
 
     <!-- In _templates/ethicalads.html -->
-    <div id="ethical-ad-placement"></div>
+    <div data-ea-publisher="readthedocs"></div>

--- a/docs/advertising/ad-customization.rst
+++ b/docs/advertising/ad-customization.rst
@@ -28,11 +28,7 @@ The ad will be inserted into this container wherever this element is in the docu
 
 .. code-block:: html
 
-    <div data-ea-publisher="readthedocs"></div>
-
-For additional options, see the `EthicalAds client documentation`_.
-
-.. _EthicalAds client documentation: https://ethical-ad-client.readthedocs.io/
+    <div id="ethical-ad-placement"></div>
 
 
 In Sphinx
@@ -64,4 +60,4 @@ for inclusion in the `HTML sidebar`_ in your ``conf.py``.
 .. code-block:: html
 
     <!-- In _templates/ethicalads.html -->
-    <div data-ea-publisher="readthedocs"></div>
+    <div id="ethical-ad-placement"></div>

--- a/docs/advertising/ad-customization.rst
+++ b/docs/advertising/ad-customization.rst
@@ -28,21 +28,17 @@ The ad will be inserted into this container wherever this element is in the docu
 
 .. code-block:: html
 
-    <div id="ethical-ad-placement"></div>
+    <div data-ea-publisher="readthedocs"></div>
 
+For a complete list of options, see the `ad client documentation <https://ethical-ad-client.readthedocs.io/>`_.
 
-In Sphinx
-~~~~~~~~~
+With Sphinx in the sidebar
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In Sphinx, this is typically done by
 adding a new template (under `templates_path`_)
 for inclusion in the `HTML sidebar`_ in your ``conf.py``.
 
-.. _HTML sidebar: https://www.sphinx-doc.org/page/usage/configuration.html#confval-html_sidebars
-.. _templates_path: https://www.sphinx-doc.org/page/usage/configuration.html#confval-templates_path
-
-
-.. Note: this does not work on the RTD sphinx theme because it doesn't use ``html_sidebars``.
 .. code-block:: python
 
     ## In conf.py
@@ -60,4 +56,37 @@ for inclusion in the `HTML sidebar`_ in your ``conf.py``.
 .. code-block:: html
 
     <!-- In _templates/ethicalads.html -->
-    <div id="ethical-ad-placement"></div>
+    <div data-ea-publisher="readthedocs"></div>
+
+
+.. note::
+
+    The above example does not work in the Read the Docs Sphinx theme which doesn't use ``html_sidebars``.
+    Instead, you can override one of the templates used by the theme to position the ad.
+
+
+With Sphinx in the body
+~~~~~~~~~~~~~~~~~~~~~~~
+
+To put an ad in the body, you will need to override one of the templates (in your `templates_path`_)
+and override a block in that template.
+Due to overriding templates, this will probably need to be customized lightly per theme.
+
+.. code-block:: html
+
+    <!-- In _templates/layout.html -->
+    {% extends "sphinx_rtd_theme/layout.html" %}
+    {% block document %}
+      {% include "ethicalads.html" %}
+
+      {{ super() }}
+    {% endblock document %}
+
+
+    <!-- In _templates/ethicalads.html -->
+    <div data-ea-publisher="readthedocs"></div>
+
+
+
+.. _HTML sidebar: https://www.sphinx-doc.org/page/usage/configuration.html#confval-html_sidebars
+.. _templates_path: https://www.sphinx-doc.org/page/usage/configuration.html#confval-templates_path

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,6 +81,7 @@ gettext_compact = False
 html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']
 html_js_files = ['js/expand_tabs.js']
+html_css_files = ['css/custom.css']
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_logo = 'img/logo.svg'
 html_theme_options = {
@@ -139,7 +140,3 @@ linkcheck_ignore = [
     # This page is under login
     r'https://readthedocs\.org/accounts/gold',
 ]
-
-
-def setup(app):
-    app.add_css_file('css/sphinx_prompt_css.css')


### PR DESCRIPTION
- Always use a text-only ad at the top of our docs
- Allocate space for the ad

## Screenshot

![Screen Shot 2020-10-29 at 7 19 41 PM](https://user-images.githubusercontent.com/185043/97653763-c74d3900-1a1e-11eb-8197-1e4001df8a49.png)
