### PR TITLE
Check only override settings

### DIFF
--- a/readthedocs/rtd_tests/tests/test_notifications.py
+++ b/readthedocs/rtd_tests/tests/test_notifications.py
@@ -32,6 +32,7 @@ from readthedocs.projects.notifications import (
         'readthedocs.notifications.backends.SiteBackend',
     ],
     PRODUCTION_DOMAIN='readthedocs.org',
+    SUPPORT_EMAIL='support@readthedocs.org',
 )
 @mock.patch('readthedocs.notifications.notification.render_to_string')
 @mock.patch.object(Notification, 'send')
@@ -69,16 +70,16 @@ class NotificationTests(TestCase):
                 'request': req,
 
                 # readthedocs_processor context
-                'DASHBOARD_ANALYTICS_CODE': None,
-                'DO_NOT_TRACK_ENABLED': False,
-                'GLOBAL_ANALYTICS_CODE': None,
+                'DASHBOARD_ANALYTICS_CODE': mock.ANY,
+                'DO_NOT_TRACK_ENABLED': mock.ANY,
+                'GLOBAL_ANALYTICS_CODE': mock.ANY,
                 'PRODUCTION_DOMAIN': 'readthedocs.org',
-                'PUBLIC_DOMAIN': None,
+                'PUBLIC_DOMAIN': mock.ANY,
                 'SITE_ROOT': mock.ANY,
-                'SUPPORT_EMAIL': None,
+                'SUPPORT_EMAIL': 'support@readthedocs.org',
                 'TEMPLATE_ROOT': mock.ANY,
-                'USE_PROMOS': False,
-                'USE_SUBDOMAIN': False,
+                'USE_PROMOS': mock.ANY,
+                'USE_SUBDOMAIN': mock.ANY,
             },
         )
 


### PR DESCRIPTION
Since we are using this tests in -corporate as well, we need to check only for
settings wee are override in the test to avoid passing in .org and failing in .com