### PR TITLE
Search: exclude some fields from source results

### DIFF
--- a/readthedocs/search/faceted_search.py
+++ b/readthedocs/search/faceted_search.py
@@ -28,6 +28,9 @@ class RTDFacetedSearch(FacetedSearch):
 
     operators = []
 
+    # Sources to be excluded from results.
+    excludes = []
+
     _highlight_options = {
         'encoder': 'html',
         'number_of_fragments': 1,
@@ -201,7 +204,7 @@ class RTDFacetedSearch(FacetedSearch):
         * Adds HTML encoding of results to avoid XSS issues.
         """
         search = search.highlight_options(**self._highlight_options)
-        search = search.source(exclude=['content', 'headers'])
+        search = search.source(excludes=self.excludes)
 
         queries = self._get_queries(
             query=query,
@@ -220,6 +223,7 @@ class ProjectSearchBase(RTDFacetedSearch):
     index = ProjectDocument._index._name
     fields = ('name^10', 'slug^5', 'description')
     operators = ['and', 'or']
+    excludes = ['users', 'language']
 
 
 class PageSearchBase(RTDFacetedSearch):
@@ -248,6 +252,8 @@ class PageSearchBase(RTDFacetedSearch):
     # the score of and should be higher as it satisfies both or and and
     operators = ['and', 'or']
 
+    excludes = ['rank', 'sections', 'domains', 'commit', 'build']
+
     def total_count(self):
         """Returns the total count of results of the current query."""
         s = self.build_search()
@@ -261,6 +267,7 @@ class PageSearchBase(RTDFacetedSearch):
     def query(self, search, query):
         """Manipulates the query to support nested queries and a custom rank for pages."""
         search = search.highlight_options(**self._highlight_options)
+        search = search.source(excludes=self.excludes)
 
         queries = self._get_queries(
             query=query,

--- a/readthedocs/search/serializers.py
+++ b/readthedocs/search/serializers.py
@@ -37,6 +37,7 @@ class ProjectSearchSerializer(serializers.Serializer):
     name = serializers.CharField()
     slug = serializers.CharField()
     link = serializers.CharField(source='url')
+    description = serializers.CharField()
     highlights = ProjectHighlightSerializer(source='meta.highlight', default=dict)
 
 


### PR DESCRIPTION
This should hopefully make search a little faster,
we don't make use of these fields in the serializer.

The big ones are sections and domains,
we will be fetching all of them per each page,
instead of just the ones that matched.

Also fixed a bug, we were omitting the description from the project in
the serializer.

ref #7349 