### PR TITLE
Speed up the tag index page

### DIFF
--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -55,6 +55,11 @@ class ProjectTagIndex(ListView):
     def get_queryset(self):
         queryset = Project.objects.public(self.request.user)
 
+        # Filters out projects from banned users
+        # This is disabled for performance reasons
+        # https://github.com/readthedocs/readthedocs.org/pull/7671
+        # queryset = queryset.exclude(users__profile__banned=True)
+
         self.tag = get_object_or_404(Tag, slug=self.kwargs.get('tag'))
         queryset = queryset.filter(tags__slug__in=[self.tag.slug])
 

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -54,7 +54,6 @@ class ProjectTagIndex(ListView):
 
     def get_queryset(self):
         queryset = Project.objects.public(self.request.user)
-        queryset = queryset.exclude(users__profile__banned=True)
 
         self.tag = get_object_or_404(Tag, slug=self.kwargs.get('tag'))
         queryset = queryset.filter(tags__slug__in=[self.tag.slug])


### PR DESCRIPTION
Excluding spam projects from the tag index page really slows it down. This involves a project-project self join and then joining against users and the user profile. Each of these tables is a few 100k records. In the worst case, this page can take ~2s to load which can be very bad when the page is crawled repeatedly.

This PR simply removes filtering out spam projects which is the expensive part of this query.

* **PRO:** Speeds the page up drastically without getting rid of it. This page is one of the main ways for projects to get indexed by search engines. It also helps link projects to similar projects. In my tests, this sped things up by over an order of magnitude even in cases where the returned result didn't change from the spam filtering.
* **CON:** Spam projects might show up in the tag index. This probably wouldn't be noticed by users since spam projects don't have real tags that users might browse. However, it might help spam projects to get picked up by search engines although there are other ways search engines can find spam projects. This is mitigated significantly since we now have automated cleanup of spam projects. In total, there are ~2.7k spam projects that aren't autocleaned.