### PR TITLE
Tests: mock update_docs_task to speed up tests

### DIFF
--- a/readthedocs/api/v3/tests/test_builds.py
+++ b/readthedocs/api/v3/tests/test_builds.py
@@ -1,7 +1,11 @@
-from .mixins import APIEndpointMixin
+from unittest import mock
+
 from django.urls import reverse
 
+from .mixins import APIEndpointMixin
 
+
+@mock.patch('readthedocs.projects.tasks.update_docs_task', mock.MagicMock())
 class BuildsEndpointTests(APIEndpointMixin):
 
     def test_projects_builds_list(self):

--- a/readthedocs/api/v3/tests/test_projects.py
+++ b/readthedocs/api/v3/tests/test_projects.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import django_dynamic_fixture as fixture
 from django.urls import reverse
 
@@ -6,6 +8,7 @@ from readthedocs.projects.models import Project
 from .mixins import APIEndpointMixin
 
 
+@mock.patch('readthedocs.projects.tasks.update_docs_task', mock.MagicMock())
 class ProjectsEndpointTests(APIEndpointMixin):
 
     def test_projects_list(self):


### PR DESCRIPTION
Noticed these slow tests today.
Otherwise it will keep retrying till it times out.
Similar to https://github.com/readthedocs/readthedocs.org/pull/7661