### PR TITLE
External versions: delete after 3 months of being merged/closed

### DIFF
--- a/docs/guides/autobuild-docs-for-pull-requests.rst
+++ b/docs/guides/autobuild-docs-for-pull-requests.rst
@@ -58,7 +58,7 @@ Searches will default to the default experience for your tool.
 This is a feature we plan to add,
 but don't want to overwhelm our search indexes used in production.
 
-The documentation will be keep only for 90 days after the pull/merge request has been closed or merged.
+The built documentation is kept for 90 days after the pull/merge request has been closed or merged.
 
 Troubleshooting
 ---------------

--- a/docs/guides/autobuild-docs-for-pull-requests.rst
+++ b/docs/guides/autobuild-docs-for-pull-requests.rst
@@ -58,6 +58,8 @@ Searches will default to the default experience for your tool.
 This is a feature we plan to add,
 but don't want to overwhelm our search indexes used in production.
 
+The documentation will be keep only for 90 days after the pull/merge request has been closed or merged.
+
 Troubleshooting
 ---------------
 

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -345,9 +345,7 @@ class Version(TimeStampedModel):
     def delete(self, *args, **kwargs):  # pylint: disable=arguments-differ
         from readthedocs.projects import tasks
         log.info('Removing files for version %s', self.slug)
-        # Remove resources if the version is not external
-        if self.type != EXTERNAL:
-            tasks.clean_project_resources(self.project, self)
+        tasks.clean_project_resources(self.project, self)
         super().delete(*args, **kwargs)
 
     @property

--- a/readthedocs/builds/tests/test_tasks.py
+++ b/readthedocs/builds/tests/test_tasks.py
@@ -1,0 +1,70 @@
+from datetime import datetime, timedelta
+
+from django.test import TestCase
+from django_dynamic_fixture import get
+
+from readthedocs.builds.constants import BRANCH, EXTERNAL, TAG
+from readthedocs.builds.models import Version
+from readthedocs.builds.tasks import delete_inactive_external_versions
+from readthedocs.projects.models import Project
+
+
+class TestTasks(TestCase):
+
+    def test_delete_inactive_external_versions(self):
+        project = get(Project)
+        project.versions.all().delete()
+        get(
+            Version,
+            project=project,
+            slug='branch',
+            type=BRANCH,
+            active=False,
+            modified=datetime.now() - timedelta(days=7),
+        )
+        get(
+            Version,
+            project=project,
+            slug='tag',
+            type=TAG,
+            active=True,
+            modified=datetime.now() - timedelta(days=7),
+        )
+        get(
+            Version,
+            project=project,
+            slug='external-active',
+            type=EXTERNAL,
+            active=True,
+            modified=datetime.now() - timedelta(days=7),
+        )
+        get(
+            Version,
+            project=project,
+            slug='external-inactive',
+            type=EXTERNAL,
+            active=False,
+            modified=datetime.now() - timedelta(days=3),
+        )
+        get(
+            Version,
+            project=project,
+            slug='external-inactive-old',
+            type=EXTERNAL,
+            active=False,
+            modified=datetime.now() - timedelta(days=7),
+        )
+
+        self.assertEqual(Version.objects.all().count(), 5)
+        self.assertEqual(Version.external.all().count(), 3)
+
+        # We don't have inactive external versions from 9 days ago.
+        delete_inactive_external_versions(days=9)
+        self.assertEqual(Version.objects.all().count(), 5)
+        self.assertEqual(Version.external.all().count(), 3)
+
+        # We have one inactive external versions from 6 days ago.
+        delete_inactive_external_versions(days=6)
+        self.assertEqual(Version.objects.all().count(), 4)
+        self.assertEqual(Version.external.all().count(), 2)
+        self.assertFalse(Version.objects.filter(slug='external-inactive-old').exists())

--- a/readthedocs/core/views/hooks.py
+++ b/readthedocs/core/views/hooks.py
@@ -4,9 +4,8 @@ import logging
 
 from readthedocs.builds.constants import EXTERNAL
 from readthedocs.core.utils import trigger_build
-from readthedocs.projects.models import Project, Feature
+from readthedocs.projects.models import Feature, Project
 from readthedocs.projects.tasks import sync_repository_task
-
 
 log = logging.getLogger(__name__)
 
@@ -139,32 +138,36 @@ def get_or_create_external_version(project, identifier, verbose_name):
 
     if created:
         log.info(
-            '(Create External Version) Added Version: [%s] ',
-            external_version.slug
+            'External version created. project=%s version=%s',
+            project.slug, external_version.slug,
         )
     else:
-        # identifier will change if there is a new commit to the Pull/Merge Request
-        if external_version.identifier != identifier:
-            external_version.identifier = identifier
-            external_version.save()
+        # Identifier will change if there is a new commit to the Pull/Merge Request.
+        external_version.identifier = identifier
+        # If the PR was previously closed it was marked as inactive.
+        external_version.active = True
+        external_version.save()
 
-            log.info(
-                '(Update External Version) Updated Version: [%s] ',
-                external_version.slug
-            )
+        log.info(
+            'External version updated: project=%s version=%s',
+            project.slug, external_version.slug,
+        )
     return external_version
 
 
-def delete_external_version(project, identifier, verbose_name):
+def deactivate_external_version(project, identifier, verbose_name):
     """
-    Delete external versions using `identifier` and `verbose_name`.
+    Deactivate external versions using `identifier` and `verbose_name`.
 
     if external version does not exist then returns `None`.
+
+    We mark the version as inactive,
+    so another celery task will remove it after some days.
 
     :param project: Project instance
     :param identifier: Commit Hash
     :param verbose_name: pull/merge request number
-    :returns:  verbose_name (pull/merge request number).
+    :returns: verbose_name (pull/merge request number).
     :rtype: str
     """
     external_version = project.versions(manager=EXTERNAL).filter(
@@ -172,13 +175,12 @@ def delete_external_version(project, identifier, verbose_name):
     ).first()
 
     if external_version:
-        # Delete External Version
-        external_version.delete()
+        external_version.active = False
+        external_version.save()
         log.info(
-            '(Delete External Version) Deleted Version: [%s]',
-            external_version.slug
+            'External version marked as inactive. project=%s version=%s',
+            project.slug, external_version.slug,
         )
-
         return external_version.verbose_name
     return None
 

--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -297,7 +297,7 @@ class Service:
         """
         raise NotImplementedError
 
-    def send_build_status(self, build, commit, state):
+    def send_build_status(self, build, commit, state, link_to_build=False):
         """
         Create commit status for project.
 
@@ -307,6 +307,7 @@ class Service:
         :type commit: str
         :param state: build state failure, pending, or success.
         :type state: str
+        :param link_to_build: If true, link to the build page regardless the state.
         :returns: boolean based on commit status creation was successful or not.
         :rtype: Bool
         """

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -420,7 +420,7 @@ class GitHubService(Service):
         integration.remove_secret()
         return (False, resp)
 
-    def send_build_status(self, build, commit, state):
+    def send_build_status(self, build, commit, state, link_to_build=False):
         """
         Create GitHub commit status for project.
 
@@ -430,6 +430,7 @@ class GitHubService(Service):
         :type state: str
         :param commit: commit sha of the pull request
         :type commit: str
+        :param link_to_build: If true, link to the build page regardless the state.
         :returns: boolean based on commit status creation was successful or not.
         :rtype: Bool
         """
@@ -443,7 +444,7 @@ class GitHubService(Service):
 
         target_url = build.get_full_url()
 
-        if state == BUILD_STATUS_SUCCESS:
+        if not link_to_build and state == BUILD_STATUS_SUCCESS:
             target_url = build.version.get_absolute_url()
 
         context = f'{settings.RTD_BUILD_STATUS_API_NAME}:{project.slug}'

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -508,7 +508,7 @@ class GitLabService(Service):
         integration.remove_secret()
         return (False, resp)
 
-    def send_build_status(self, build, commit, state):
+    def send_build_status(self, build, commit, state, link_to_build=False):
         """
         Create GitLab commit status for project.
 
@@ -518,6 +518,7 @@ class GitLabService(Service):
         :type state: str
         :param commit: commit sha of the pull request
         :type commit: str
+        :param link_to_build: If true, link to the build page regardless the state.
         :returns: boolean based on commit status creation was successful or not.
         :rtype: Bool
         """
@@ -536,7 +537,7 @@ class GitLabService(Service):
 
         target_url = build.get_full_url()
 
-        if state == BUILD_STATUS_SUCCESS:
+        if not link_to_build and state == BUILD_STATUS_SUCCESS:
             target_url = build.version.get_absolute_url()
 
         context = f'{settings.RTD_BUILD_STATUS_API_NAME}:{project.slug}'

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1892,7 +1892,7 @@ def retry_domain_verification(domain_pk):
 
 
 @app.task(queue='web')
-def send_build_status(build_pk, commit, status):
+def send_build_status(build_pk, commit, status, link_to_build=False):
     """
     Send Build Status to Git Status API for project external versions.
 
@@ -1932,7 +1932,12 @@ def send_build_status(build_pk, commit, status):
 
         if service is not None:
             # Send status report using the API.
-            success = service.send_build_status(build, commit, status)
+            success = service.send_build_status(
+                build=build,
+                commit=commit,
+                state=status,
+                link_to_build=link_to_build,
+            )
 
         if success:
             log.info(

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -1,8 +1,8 @@
 import base64
 import datetime
 import json
-
 from unittest import mock
+
 from allauth.socialaccount.models import SocialAccount
 from django.contrib.auth.models import User
 from django.http import QueryDict
@@ -16,13 +16,13 @@ from readthedocs.api.v2.views.integrations import (
     GITHUB_CREATE,
     GITHUB_DELETE,
     GITHUB_EVENT_HEADER,
-    GITHUB_PUSH,
-    GITHUB_SIGNATURE_HEADER,
     GITHUB_PULL_REQUEST,
+    GITHUB_PULL_REQUEST_CLOSED,
     GITHUB_PULL_REQUEST_OPENED,
     GITHUB_PULL_REQUEST_REOPENED,
-    GITHUB_PULL_REQUEST_CLOSED,
     GITHUB_PULL_REQUEST_SYNC,
+    GITHUB_PUSH,
+    GITHUB_SIGNATURE_HEADER,
     GITLAB_MERGE_REQUEST,
     GITLAB_MERGE_REQUEST_CLOSE,
     GITLAB_MERGE_REQUEST_MERGE,
@@ -37,7 +37,7 @@ from readthedocs.api.v2.views.integrations import (
     GitLabWebhookView,
 )
 from readthedocs.api.v2.views.task_views import get_status_data
-from readthedocs.builds.constants import LATEST, EXTERNAL
+from readthedocs.builds.constants import EXTERNAL, LATEST
 from readthedocs.builds.models import Build, BuildCommandResult, Version
 from readthedocs.integrations.models import Integration
 from readthedocs.oauth.models import RemoteOrganization, RemoteRepository
@@ -47,7 +47,6 @@ from readthedocs.projects.models import (
     Feature,
     Project,
 )
-
 
 super_auth = base64.b64encode(b'super:test').decode('utf-8')
 eric_auth = base64.b64encode(b'eric:test').decode('utf-8')
@@ -1154,12 +1153,12 @@ class IntegrationsTests(TestCase):
         )
         external_version = self.project.versions(
             manager=EXTERNAL
-        ).filter(verbose_name=pull_request_number)
+        ).get(verbose_name=pull_request_number)
 
-        # external version should be deleted
-        self.assertFalse(external_version.exists())
+        # External version should be inactive.
+        self.assertFalse(external_version.active)
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        self.assertTrue(resp.data['version_deleted'])
+        self.assertTrue(resp.data['version_deactivated'])
         self.assertEqual(resp.data['project'], self.project.slug)
         self.assertEqual(resp.data['versions'], [version.verbose_name])
         core_trigger_build.assert_not_called()
@@ -1864,12 +1863,12 @@ class IntegrationsTests(TestCase):
         )
         external_version = self.project.versions(
             manager=EXTERNAL
-        ).filter(verbose_name=merge_request_number)
+        ).get(verbose_name=merge_request_number)
 
-        # external version should be deleted
-        self.assertFalse(external_version.exists())
+        # External version should be inactive.
+        self.assertFalse(external_version.active)
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        self.assertTrue(resp.data['version_deleted'])
+        self.assertTrue(resp.data['version_deactivated'])
         self.assertEqual(resp.data['project'], self.project.slug)
         self.assertEqual(resp.data['versions'], [version.verbose_name])
         core_trigger_build.assert_not_called()
@@ -1908,12 +1907,12 @@ class IntegrationsTests(TestCase):
         )
         external_version = self.project.versions(
             manager=EXTERNAL
-        ).filter(verbose_name=merge_request_number)
+        ).get(verbose_name=merge_request_number)
 
         # external version should be deleted
-        self.assertFalse(external_version.exists())
+        self.assertFalse(external_version.active)
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        self.assertTrue(resp.data['version_deleted'])
+        self.assertTrue(resp.data['version_deactivated'])
         self.assertEqual(resp.data['project'], self.project.slug)
         self.assertEqual(resp.data['versions'], [version.verbose_name])
         core_trigger_build.assert_not_called()

--- a/readthedocs/rtd_tests/tests/test_celery.py
+++ b/readthedocs/rtd_tests/tests/test_celery.py
@@ -357,7 +357,10 @@ class TestCeleryBuilding(TestCase):
         )
 
         send_build_status.assert_called_once_with(
-            external_build, external_build.commit, BUILD_STATUS_SUCCESS
+            build=external_build,
+            commit=external_build.commit,
+            state=BUILD_STATUS_SUCCESS,
+            link_to_build=False,
         )
         self.assertEqual(Message.objects.filter(user=self.eric).count(), 0)
 
@@ -414,7 +417,10 @@ class TestCeleryBuilding(TestCase):
         )
 
         send_build_status.assert_called_once_with(
-            external_build, external_build.commit, BUILD_STATUS_SUCCESS
+            build=external_build,
+            commit=external_build.commit,
+            state=BUILD_STATUS_SUCCESS,
+            link_to_build=False,
         )
         self.assertEqual(Message.objects.filter(user=self.eric).count(), 0)
 

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -405,6 +405,11 @@ class CommunityBaseSettings(Settings):
                 'days': 1,
             },
         },
+        'every-day-delete-inactive-external-versions': {
+            'task': 'readthedocs.builds.tasks.delete_inactive_external_versions',
+            'schedule': crontab(minute=0, hour=1),
+            'options': {'queue': 'web'},
+        },
     }
 
     MULTIPLE_APP_SERVERS = [CELERY_DEFAULT_QUEUE]


### PR DESCRIPTION
Currently, we are deleting external versions
when they are closed, but their docs remain in storage.
With this change we mark them as inactive instead.
Later a task will delete all external versions that are inactive
and their last activity was from 3 months ago.
The task is run once every day (not sure if this should run more frequently).

Before being deleted the status is updated to link to the build page
instead (the build will be deleted currently, but I'm changing that in
another PR).

Ref https://github.com/readthedocs/readthedocs.org/issues/7674