### PR TITLE
Allow to add additional binds to Docker build container

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -991,7 +991,7 @@ class DockerBuildEnvironment(BuildEnvironment):
                 },
             }
 
-        binds.update(getattr(settings, 'RTD_DOCKER_ADDITIONAL_BINDS', {}))
+        binds.update(settings.RTD_DOCKER_ADDITIONAL_BINDS)
 
         return binds
 

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -991,6 +991,8 @@ class DockerBuildEnvironment(BuildEnvironment):
                 },
             }
 
+        binds.update(getattr(settings, 'RTD_DOCKER_ADDITIONAL_BINDS', {}))
+
         return binds
 
     def get_container_host_config(self):

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -488,7 +488,7 @@ class CommunityBaseSettings(Settings):
         'readthedocs/build:latest': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:6.0'),
         'readthedocs/build:testing': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:7.0'),
     })
-    # additional binds for the build container
+    # Additional binds for the build container
     RTD_DOCKER_ADDITIONAL_BINDS = {}
 
     def _get_docker_memory_limit(self):

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -488,6 +488,8 @@ class CommunityBaseSettings(Settings):
         'readthedocs/build:latest': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:6.0'),
         'readthedocs/build:testing': DOCKER_IMAGE_SETTINGS.get('readthedocs/build:7.0'),
     })
+    # additional binds for the build container
+    RTD_DOCKER_ADDITIONAL_BINDS = {}
 
     def _get_docker_memory_limit(self):
         try:


### PR DESCRIPTION
Sometimes it might be necessary to add additional binds to the build
container, e.g. to add SSH keys for the docs user to clone private
repositories or for caches. These additional binds can be specified
as field in settings:

DOCKER_ADDITIONAL_BINDS = {
  '/home/docs/.ssh': {
    'bind': '/home/docs/.ssh',
    'mode': 'ro',
  }
}