### PR TITLE
Define `pre/post_collectstatic` signals and send them

### DIFF
--- a/readthedocs/core/management/commands/collectstatic.py
+++ b/readthedocs/core/management/commands/collectstatic.py
@@ -1,0 +1,17 @@
+"""
+Override to send ``pre_collectstatic`` and ``post_collectstatic`` signal.
+
+``post_collectstatic`` is used to purge the CDN of static files.
+"""
+
+from django.contrib.staticfiles.management.commands import collectstatic
+from readthedocs.core.signals import pre_collectstatic, post_collectstatic
+
+
+class Command(collectstatic.Command):
+
+    def handle(self, **options):
+        pre_collectstatic.send(sender=self.__class__)
+        response = super().handle(**options)
+        post_collectstatic.send(sender=self.__class__)
+        return response

--- a/readthedocs/core/signals.py
+++ b/readthedocs/core/signals.py
@@ -29,6 +29,9 @@ webhook_github = Signal(providing_args=['project', 'data', 'event'])
 webhook_gitlab = Signal(providing_args=['project', 'data', 'event'])
 webhook_bitbucket = Signal(providing_args=['project', 'data', 'event'])
 
+pre_collectstatic = Signal()
+post_collectstatic = Signal()
+
 
 def decide_if_cors(sender, request, **kwargs):  # pylint: disable=unused-argument
     """

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -134,9 +134,14 @@ class CommunityBaseSettings(Settings):
             'django.contrib.contenttypes',
             'django.contrib.sessions',
             'django.contrib.sites',
-            'django.contrib.staticfiles',
             'django.contrib.messages',
             'django.contrib.humanize',
+
+            # readthedocs.core app needs to be before
+            # django.contrib.staticfiles to use our custom collectstatic
+            # command
+            'readthedocs.core',
+            'django.contrib.staticfiles',
 
             # third party apps
             'dj_pagination',
@@ -158,7 +163,6 @@ class CommunityBaseSettings(Settings):
             'readthedocs.projects',
             'readthedocs.organizations',
             'readthedocs.builds',
-            'readthedocs.core',
             'readthedocs.doc_builder',
             'readthedocs.oauth',
             'readthedocs.redirects',


### PR DESCRIPTION
Define these two signals and send them pre_ and post_ collectstatic command is
executed. The `collectstatic` command is overwritten to be able to send these
signals.