### PR TITLE
Import page: fix wizard form

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -85,7 +85,7 @@ class ProjectBasicsForm(ProjectForm):
 
     class Meta:
         model = Project
-        fields = ('name', 'repo', 'repo_type')
+        fields = ('name', 'repo', 'repo_type', 'default_branch')
 
     remote_repository = forms.CharField(
         widget=forms.HiddenInput(),
@@ -166,7 +166,6 @@ class ProjectExtraForm(ProjectForm):
         fields = (
             'description',
             'documentation_type',
-            'default_branch',
             'language',
             'programming_language',
             'tags',

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -245,13 +245,39 @@ class ImportWizardView(
         SessionWizardView,
 ):
 
-    """Project import wizard."""
+    """
+    Project import wizard.
+
+    The get and post methods are overridden in order to save the initial_dict data
+    per session (since it's per class).
+    """
 
     form_list = [
         ('basics', ProjectBasicsForm),
         ('extra', ProjectExtraForm),
     ]
     condition_dict = {'extra': lambda self: self.is_advanced()}
+
+    initial_dict_key = 'initial-data'
+
+    def get(self, *args, **kwargs):
+        # The method from the parent should run first,
+        # as the storage is initialized there.
+        response = super().get(*args, **kwargs)
+        self._set_initial_dict()
+        return response
+
+    def _set_initial_dict(self):
+        """Set or restore the initial_dict from the session."""
+        if self.initial_dict:
+            self.storage.data[self.initial_dict_key] = self.initial_dict
+        else:
+            self.initial_dict = self.storage.data.get(self.initial_dict_key, {})
+
+    def post(self, *args, **kwargs):
+        self._set_initial_dict()
+        # The storage is reset after everything is done.
+        return super().post(*args, **kwargs)
 
     def get_form_kwargs(self, step=None):
         """Get args to pass into form instantiation."""
@@ -417,7 +443,7 @@ class ImportView(PrivateViewMixin, TemplateView):
     def post(self, request, *args, **kwargs):
         initial_data = {}
         initial_data['basics'] = {}
-        for key in ['name', 'repo', 'repo_type', 'remote_repository']:
+        for key in ['name', 'repo', 'repo_type', 'remote_repository', 'default_branch']:
             initial_data['basics'][key] = request.POST.get(key)
         initial_data['extra'] = {}
         for key in ['description', 'project_url']:


### PR DESCRIPTION
The initial data is set at the class level,
this means it doesn't survive for the next form.
I'm using the same method the wizard uses to store information per
session.

This doesn't mean the data is always set as default after saving,
it means the default values are going to be set when the user
is in the advanced form.

So, due to that I have moved the default_branch field to the
basic form, this way the form will always have the default branch.


Close https://github.com/readthedocs/readthedocs.org/issues/7697

:mage_man: 