### PR TITLE
Install six as core requirement for builds

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -367,6 +367,7 @@ class Virtualenv(PythonEnvironment):
             'mock==1.0.1',
             'pillow==5.4.1',
             'alabaster>=0.7,<0.8,!=0.7.5',
+            'six',
             'commonmark==0.8.1',
             'recommonmark==0.5.0',
         ]
@@ -623,6 +624,7 @@ class Conda(PythonEnvironment):
         # Install pip-only things.
         pip_requirements = [
             'recommonmark',
+            'six',
         ]
 
         if self.config.doctype == 'mkdocs':

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -1197,6 +1197,7 @@ class TestPythonEnvironment(TestCase):
             'mock',
             'pillow',
             'alabaster',
+            'six',
         ]
         self.base_conda_requirements = [
             'mock',
@@ -1364,6 +1365,7 @@ class TestPythonEnvironment(TestCase):
         conda_requirements = self.base_conda_requirements + conda_sphinx
         pip_requirements = [
             'recommonmark',
+            'six',
             'readthedocs-sphinx-ext',
         ]
 
@@ -1405,6 +1407,7 @@ class TestPythonEnvironment(TestCase):
         conda_requirements = self.base_conda_requirements
         pip_requirements = [
             'recommonmark',
+            'six',
             'mkdocs',
         ]
 


### PR DESCRIPTION
Our config file depends on `six` package to check `string_types`, so we need to
make sure we have it installed as a core requirement.

We were pinning `sphinx<2` which depends on `six`. Now, all the projects using
`USE_LATEST_SPHINX` will install just `sphinx` (currently 3.3.1) which does not
depends on `six` anymore and all they builds will fail.

> `USE_LATEST_SPHINX` is marked for all future projects. So, new projects are hitting this issue currently. I de-activate this feature for new projects while we solve and deploy this.

> We could remove this dependency completely by copying the relevant lines from `six`, but I think it's safer to use `six` while we support Python 2 & 3 together. To remove it, we would need to confirm that we are not requiring six anywhere else as well.

Closes #7705 