### PR TITLE
Search: filter only active and built versions from subprojects

### DIFF
--- a/readthedocs/search/api.py
+++ b/readthedocs/search/api.py
@@ -259,7 +259,12 @@ class PageSearchAPIView(GenericAPIView):
         """Get a version from the subproject."""
         return (
             Version.internal
-            .public(user=self.request.user, project=subproject, include_hidden=False)
+            .public(
+                user=self.request.user,
+                project=subproject,
+                include_hidden=False,
+                only_built=True,
+            )
             .filter(slug=version_slug)
             .first()
         )

--- a/readthedocs/search/tests/conftest.py
+++ b/readthedocs/search/tests/conftest.py
@@ -35,7 +35,11 @@ def all_projects(es_index, mock_processed_json, db, settings):
             main_language_project=None,
             privacy_level=PUBLIC,
         )
-        project.versions.update(privacy_level=PUBLIC)
+        project.versions.update(
+            privacy_level=PUBLIC,
+            built=True,
+            active=True,
+        )
 
         for file_basename in PROJECT_DATA_FILES[project.slug]:
             # file_basename in config are without extension so add html extension


### PR DESCRIPTION
This wasn't causing any problems in production because we already filter by active versions only, but better be safe.