### PR TITLE
Search: use with_positions_offsets term vector for some fields

### DIFF
--- a/readthedocs/search/documents.py
+++ b/readthedocs/search/documents.py
@@ -59,8 +59,11 @@ class PageDocument(RTDDocTypeMixin, Document):
     Simple analyzer will break the text in non-letter characters,
     so a text like ``python.submodule`` will be broken like [python, submodule]
     instead of [python.submodule].
+    See more at https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-analyzers.html  # noqa
 
-    https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-analyzers.html
+    Some text fields use the ``with_positions_offsets`` term vector,
+    this is to have faster highlighting on big documents.
+    See more at https://www.elastic.co/guide/en/elasticsearch/reference/7.9/term-vector.html
     """
 
     # Metadata
@@ -77,7 +80,7 @@ class PageDocument(RTDDocTypeMixin, Document):
         properties={
             'id': fields.KeywordField(),
             'title': fields.TextField(),
-            'content': fields.TextField(),
+            'content': fields.TextField(term_vector='with_positions_offsets'),
         }
     )
     domains = fields.NestedField(
@@ -89,7 +92,7 @@ class PageDocument(RTDDocTypeMixin, Document):
 
             # For showing in the search result
             'type_display': fields.TextField(),
-            'docstrings': fields.TextField(),
+            'docstrings': fields.TextField(term_vector='with_positions_offsets'),
 
             # Simple analyzer breaks on `.`,
             # otherwise search results are too strict for this use case


### PR DESCRIPTION
Big documents will take some time (and memory) to find and highlight results.
Using a term vector will reduce this computation,
but it will increase the size of the index.
We have a lot of free space, so we are fine.

This was working before for big documents because there wasn't a limit
by default https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#_limiting_the_length_of_an_analyzed_text_during_highlighting

I added this only to fields that can be big, the other text fields don't think will get much from this change, but let me know if you want me to put this on all text fields.