### PR TITLE
Bitbucket: mainbranch can be None

### DIFF
--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -155,7 +155,8 @@ class BitbucketService(Service):
 
             repo.html_url = fields['links']['html']['href']
             repo.vcs = fields['scm']
-            repo.default_branch = fields.get('mainbranch', {}).get('name')
+            mainbranch = fields.get('mainbranch') or {}
+            repo.default_branch = mainbranch.get('name')
             repo.account = self.account
 
             avatar_url = fields['links']['avatar']['href'] or ''

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -442,101 +442,6 @@ class GitHubOAuthTests(TestCase):
 class BitbucketOAuthTests(TestCase):
 
     fixtures = ['eric', 'test_data']
-    repo_response_data = {
-        'scm': 'hg',
-        'has_wiki': True,
-        'description': 'Site for tutorial101 files',
-        'links': {
-            'watchers': {
-                'href': 'https://api.bitbucket.org/2.0/repositories/tutorials/tutorials.bitbucket.org/watchers',
-            },
-            'commits': {
-                'href': 'https://api.bitbucket.org/2.0/repositories/tutorials/tutorials.bitbucket.org/commits',
-            },
-            'self': {
-                'href': 'https://api.bitbucket.org/2.0/repositories/tutorials/tutorials.bitbucket.org',
-            },
-            'html': {
-                'href': 'https://bitbucket.org/tutorials/tutorials.bitbucket.org',
-            },
-            'avatar': {
-                'href': 'https://bitbucket-assetroot.s3.amazonaws.com/c/photos/2012/Nov/28/tutorials.bitbucket.org-logo-1456883302-9_avatar.png',
-            },
-            'forks': {
-                'href': 'https://api.bitbucket.org/2.0/repositories/tutorials/tutorials.bitbucket.org/forks',
-            },
-            'clone': [
-                {
-                    'href': 'https://tutorials@bitbucket.org/tutorials/tutorials.bitbucket.org',
-                    'name': 'https',
-                },
-                {
-                    'href': 'ssh://hg@bitbucket.org/tutorials/tutorials.bitbucket.org',
-                    'name': 'ssh',
-                },
-            ],
-            'pullrequests': {
-                'href': 'https://api.bitbucket.org/2.0/repositories/tutorials/tutorials.bitbucket.org/pullrequests',
-            },
-        },
-        'fork_policy': 'allow_forks',
-        'name': 'tutorials.bitbucket.org',
-        'language': 'html/css',
-        'created_on': '2011-12-20T16:35:06.480042+00:00',
-        'full_name': 'tutorials/tutorials.bitbucket.org',
-        'has_issues': True,
-        'owner': {
-            'username': 'tutorials',
-            'display_name': 'tutorials account',
-            'uuid': '{c788b2da-b7a2-404c-9e26-d3f077557007}',
-            'links': {
-                'self': {
-                    'href': 'https://api.bitbucket.org/2.0/users/tutorials',
-                },
-                'html': {
-                    'href': 'https://bitbucket.org/tutorials',
-                },
-                'avatar': {
-                    'href': 'https://bitbucket-assetroot.s3.amazonaws.com/c/photos/2013/Nov/25/tutorials-avatar-1563784409-6_avatar.png',
-                },
-            },
-        },
-        'updated_on': '2014-11-03T02:24:08.409995+00:00',
-        'size': 76182262,
-        'is_private': False,
-        'uuid': '{9970a9b6-2d86-413f-8555-da8e1ac0e542}',
-    }
-
-    team_response_data = {
-        'username': 'teamsinspace',
-        'website': None,
-        'display_name': 'Teams In Space',
-        'uuid': '{61fc5cf6-d054-47d2-b4a9-061ccf858379}',
-        'links': {
-            'self': {
-                'href': 'https://api.bitbucket.org/2.0/teams/teamsinspace',
-            },
-            'repositories': {
-                'href': 'https://api.bitbucket.org/2.0/repositories/teamsinspace',
-            },
-            'html': {'href': 'https://bitbucket.org/teamsinspace'},
-            'followers': {
-                'href': 'https://api.bitbucket.org/2.0/teams/teamsinspace/followers',
-            },
-            'avatar': {
-                'href': 'https://bitbucket-assetroot.s3.amazonaws.com/c/photos/2014/Sep/24/teamsinspace-avatar-3731530358-7_avatar.png',
-            },
-            'members': {
-                'href': 'https://api.bitbucket.org/2.0/teams/teamsinspace/members',
-            },
-            'following': {
-                'href': 'https://api.bitbucket.org/2.0/teams/teamsinspace/following',
-            },
-        },
-        'created_on': '2014-04-08T00:00:14.070969+00:00',
-        'location': None,
-        'type': 'team',
-    }
 
     def setUp(self):
         self.client.login(username='eric', password='test')
@@ -567,9 +472,140 @@ class BitbucketOAuthTests(TestCase):
                 },
                 'url': 'https://readthedocs.io/api/v2/webhook/test/99999999/',
             },]
-    }
+        }
+        self.repo_response_data = {
+            'scm': 'hg',
+            'has_wiki': True,
+            'description': 'Site for tutorial101 files',
+            'links': {
+                'watchers': {
+                    'href': 'https://api.bitbucket.org/2.0/repositories/tutorials/tutorials.bitbucket.org/watchers',
+                },
+                'commits': {
+                    'href': 'https://api.bitbucket.org/2.0/repositories/tutorials/tutorials.bitbucket.org/commits',
+                },
+                'self': {
+                    'href': 'https://api.bitbucket.org/2.0/repositories/tutorials/tutorials.bitbucket.org',
+                },
+                'html': {
+                    'href': 'https://bitbucket.org/tutorials/tutorials.bitbucket.org',
+                },
+                'avatar': {
+                    'href': 'https://bitbucket-assetroot.s3.amazonaws.com/c/photos/2012/Nov/28/tutorials.bitbucket.org-logo-1456883302-9_avatar.png',
+                },
+                'forks': {
+                    'href': 'https://api.bitbucket.org/2.0/repositories/tutorials/tutorials.bitbucket.org/forks',
+                },
+                'clone': [
+                    {
+                        'href': 'https://tutorials@bitbucket.org/tutorials/tutorials.bitbucket.org',
+                        'name': 'https',
+                    },
+                    {
+                        'href': 'ssh://hg@bitbucket.org/tutorials/tutorials.bitbucket.org',
+                        'name': 'ssh',
+                    },
+                ],
+                'pullrequests': {
+                    'href': 'https://api.bitbucket.org/2.0/repositories/tutorials/tutorials.bitbucket.org/pullrequests',
+                },
+            },
+            'fork_policy': 'allow_forks',
+            'name': 'tutorials.bitbucket.org',
+            'language': 'html/css',
+            'created_on': '2011-12-20T16:35:06.480042+00:00',
+            'full_name': 'tutorials/tutorials.bitbucket.org',
+            'has_issues': True,
+            'owner': {
+                'username': 'tutorials',
+                'display_name': 'tutorials account',
+                'uuid': '{c788b2da-b7a2-404c-9e26-d3f077557007}',
+                'links': {
+                    'self': {
+                        'href': 'https://api.bitbucket.org/2.0/users/tutorials',
+                    },
+                    'html': {
+                        'href': 'https://bitbucket.org/tutorials',
+                    },
+                    'avatar': {
+                        'href': 'https://bitbucket-assetroot.s3.amazonaws.com/c/photos/2013/Nov/25/tutorials-avatar-1563784409-6_avatar.png',
+                    },
+                },
+            },
+            'updated_on': '2014-11-03T02:24:08.409995+00:00',
+            'size': 76182262,
+            'is_private': False,
+            'uuid': '{9970a9b6-2d86-413f-8555-da8e1ac0e542}',
+            'mainbranch': {
+                'type': 'branch',
+                'name': 'main',
+            },
+        }
+
+        self.team_response_data = {
+            'username': 'teamsinspace',
+            'website': None,
+            'display_name': 'Teams In Space',
+            'uuid': '{61fc5cf6-d054-47d2-b4a9-061ccf858379}',
+            'links': {
+                'self': {
+                    'href': 'https://api.bitbucket.org/2.0/teams/teamsinspace',
+                },
+                'repositories': {
+                    'href': 'https://api.bitbucket.org/2.0/repositories/teamsinspace',
+                },
+                'html': {'href': 'https://bitbucket.org/teamsinspace'},
+                'followers': {
+                    'href': 'https://api.bitbucket.org/2.0/teams/teamsinspace/followers',
+                },
+                'avatar': {
+                    'href': 'https://bitbucket-assetroot.s3.amazonaws.com/c/photos/2014/Sep/24/teamsinspace-avatar-3731530358-7_avatar.png',
+                },
+                'members': {
+                    'href': 'https://api.bitbucket.org/2.0/teams/teamsinspace/members',
+                },
+                'following': {
+                    'href': 'https://api.bitbucket.org/2.0/teams/teamsinspace/following',
+                },
+            },
+            'created_on': '2014-04-08T00:00:14.070969+00:00',
+            'location': None,
+            'type': 'team',
+        }
 
     def test_make_project_pass(self):
+        repo = self.service.create_repository(
+            self.repo_response_data, organization=self.org,
+            privacy=self.privacy,
+        )
+        self.assertIsInstance(repo, RemoteRepository)
+        self.assertEqual(repo.name, 'tutorials.bitbucket.org')
+        self.assertEqual(repo.full_name, 'tutorials/tutorials.bitbucket.org')
+        self.assertEqual(repo.description, 'Site for tutorial101 files')
+        self.assertEqual(repo.default_branch, 'main')
+        self.assertEqual(
+            repo.avatar_url, (
+                'https://bitbucket-assetroot.s3.amazonaws.com/c/photos/2012/Nov/28/'
+                'tutorials.bitbucket.org-logo-1456883302-9_avatar.png'
+            ),
+        )
+        self.assertIn(self.user, repo.users.all())
+        self.assertEqual(repo.organization, self.org)
+        self.assertEqual(
+            repo.clone_url,
+            'https://bitbucket.org/tutorials/tutorials.bitbucket.org',
+        )
+        self.assertEqual(
+            repo.ssh_url,
+            'ssh://hg@bitbucket.org/tutorials/tutorials.bitbucket.org',
+        )
+        self.assertEqual(
+            repo.html_url,
+            'https://bitbucket.org/tutorials/tutorials.bitbucket.org',
+        )
+
+    def test_make_project_mainbranch_none(self):
+        self.repo_response_data['mainbranch'] = None
         repo = self.service.create_repository(
             self.repo_response_data, organization=self.org,
             privacy=self.privacy,
@@ -598,6 +634,7 @@ class BitbucketOAuthTests(TestCase):
             repo.html_url,
             'https://bitbucket.org/tutorials/tutorials.bitbucket.org',
         )
+        self.assertEqual(repo.default_branch, None)
 
     def test_make_project_fail(self):
         data = self.repo_response_data.copy()


### PR DESCRIPTION
For some reason the API sometimes doesn't have a mainbranch,
and it doesn't have an empty dict but None as value...