### PR TITLE
Use "path_with_namespace" for GitLab RemoteRepository full_name Field

### DIFF
--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -180,7 +180,7 @@ class GitLabService(Service):
 
             repo.organization = organization
             repo.name = fields['name']
-            repo.full_name = fields['name_with_namespace']
+            repo.full_name = fields['path_with_namespace']
             repo.description = fields['description']
             repo.ssh_url = fields['ssh_url_to_repo']
             repo.html_url = fields['web_url']
@@ -224,7 +224,7 @@ class GitLabService(Service):
 
         log.info(
             'Not importing %s because mismatched type: visibility=%s',
-            fields['name_with_namespace'],
+            fields['path_with_namespace'],
             fields['visibility'],
         )
 

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -965,7 +965,7 @@ class GitLabOAuthTests(TestCase):
         )
         self.assertIsInstance(repo, RemoteRepository)
         self.assertEqual(repo.name, 'testrepo')
-        self.assertEqual(repo.full_name, 'testorga / testrepo')
+        self.assertEqual(repo.full_name, 'testorga/testrepo')
         self.assertEqual(repo.remote_id, 42)
         self.assertEqual(repo.vcs_provider, GITLAB)
         self.assertEqual(repo.description, 'Test Repo')


### PR DESCRIPTION
For GitLab we use
``repo.full_name = fields['name_with_namespace'] # ("Maksudul Haque / test")``
for ``full_name`` and not
``repo.full_name = fields['path_with_namespace'] # ("saadmk11/test")``
Here ``fields['path_with_namespace']`` is more appropriate for the ``full_name`` field as it looks similar to the other VCS providers (GitHub, BitBucket) ``full_name`` field value.