### PR TITLE
Register ShutdownBuilder task

### DIFF
--- a/readthedocs/builds/apps.py
+++ b/readthedocs/builds/apps.py
@@ -1,5 +1,9 @@
+import logging
+
 from django.apps import AppConfig
 from django.utils.translation import ugettext_lazy as _
+
+log = logging.getLogger(__name__)
 
 
 class Config(AppConfig):
@@ -11,3 +15,9 @@ class Config(AppConfig):
         from readthedocs.builds.tasks import ArchiveBuilds
         from readthedocs.worker import app
         app.tasks.register(ArchiveBuilds)
+
+        try:
+            from readthedocsext.builds.tasks import ShutdownBuilder
+            app.tasks.register(ShutdownBuilder)
+        except (ModuleNotFoundError, ImportError):
+            log.info('ShutdownBuilder task could not be imported.')


### PR DESCRIPTION
Register the task to shutdown the builders by themselves.

Required by: https://github.com/readthedocs/readthedocs-ext/pull/368