### PR TITLE
Builds: migrate old builds progressively

### DIFF
--- a/readthedocs/api/v2/utils.py
+++ b/readthedocs/api/v2/utils.py
@@ -209,7 +209,9 @@ def delete_versions_from_db(project, version_data):
             '(Sync Versions) Deleted Versions: project=%s, versions=[%s]',
             project.slug, ' '.join(deleted_versions),
         )
-        to_delete_qs.delete()
+        # Delete one by one to make sure the delete method is called.
+        for version in to_delete_qs.iterator():
+            version.delete()
 
     return deleted_versions
 


### PR DESCRIPTION
With builds/0032 the migration was taking too long.
Migrate old builds before the version is deleted instead.

Ref https://github.com/readthedocs/readthedocs.org/pull/7679/