### PR TITLE
Remove domain verify signal and task

### DIFF
--- a/readthedocs/projects/signals.py
+++ b/readthedocs/projects/signals.py
@@ -13,6 +13,3 @@ project_import = django.dispatch.Signal(providing_args=['project'])
 
 # Used to purge files from the CDN
 files_changed = django.dispatch.Signal(providing_args=['project', 'version', 'files'])
-
-# Used to force verify a domain (eg. for SSL cert issuance)
-domain_verify = django.dispatch.Signal(providing_args=['domain'])

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -84,7 +84,6 @@ from .signals import (
     after_vcs,
     before_build,
     before_vcs,
-    domain_verify,
     files_changed,
 )
 
@@ -1874,20 +1873,6 @@ def finish_inactive_builds():
     log.info(
         'Builds marked as "Terminated due inactivity": %s',
         builds_finished,
-    )
-
-
-@app.task(queue='web')
-def retry_domain_verification(domain_pk):
-    """
-    Trigger domain verification on a domain.
-
-    :param domain_pk: a `Domain` pk to verify
-    """
-    domain = Domain.objects.get(pk=domain_pk)
-    domain_verify.send(
-        sender=domain.__class__,
-        domain=domain,
     )
 
 

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -82,7 +82,6 @@ from readthedocs.projects.views.mixins import (
 )
 from readthedocs.search.models import SearchQuery
 
-from ..tasks import retry_domain_verification
 
 log = logging.getLogger(__name__)
 
@@ -712,11 +711,11 @@ class DomainList(DomainMixin, ListViewWithForm):
         ctx = super().get_context_data(**kwargs)
 
         # Get the default docs domain
-        ctx['default_domain'] = settings.PUBLIC_DOMAIN if settings.USE_SUBDOMAIN else settings.PRODUCTION_DOMAIN  # noqa
-
-        # Retry validation on all domains if applicable
-        for domain in ctx['domain_list']:
-            retry_domain_verification.delay(domain_pk=domain.pk)
+        ctx['default_domain'] = (
+            settings.PUBLIC_DOMAIN
+            if settings.USE_SUBDOMAIN
+            else settings.PRODUCTION_DOMAIN
+        )
 
         return ctx
 


### PR DESCRIPTION
This happens in a periodic task every five minutes now.
There are other PRs to delete more code in -corp and -ext.