### PR TITLE
Mkdocs: default to "docs" for docs_dir

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -115,6 +115,7 @@ class BaseMkdocs(BaseBuilder):
             )
             return {
                 'site_name': self.version.project.name,
+                'docs_dir': self.docs_dir(),
             }
         except yaml.YAMLError as exc:
             note = ''
@@ -139,13 +140,11 @@ class BaseMkdocs(BaseBuilder):
         user_config = self.load_yaml_config()
 
         # Handle custom docs dirs
-        user_docs_dir = user_config.get('docs_dir')
-        if not isinstance(user_docs_dir, (type(None), str)):
+        docs_dir = user_config.get('docs_dir', 'docs')
+        if not isinstance(docs_dir, (type(None), str)):
             raise MkDocsYAMLParseError(
                 MkDocsYAMLParseError.INVALID_DOCS_DIR_CONFIG,
             )
-
-        docs_dir = self.docs_dir(docs_dir=user_docs_dir)
 
         self.create_index(extension='md')
         user_config['docs_dir'] = docs_dir

--- a/readthedocs/rtd_tests/tests/test_doc_builder.py
+++ b/readthedocs/rtd_tests/tests/test_doc_builder.py
@@ -350,7 +350,10 @@ class MkdocsBuilderTest(TestCase):
         self.assertEqual(builder.get_theme_name({}), 'readthedocs')
         with patch('readthedocs.doc_builder.backends.mkdocs.yaml') as mock_yaml:
             with patch('readthedocs.doc_builder.backends.mkdocs.MkdocsHTML.load_yaml_config') as mock_load_yaml_config:
-                mock_load_yaml_config.return_value = {'site_name': self.project.name}
+                mock_load_yaml_config.return_value = {
+                    'site_name': self.project.name,
+                    'docs_dir': tmpdir,
+                }
                 builder.append_conf()
 
             mock_yaml.safe_dump.assert_called_once_with(
@@ -374,6 +377,7 @@ class MkdocsBuilderTest(TestCase):
                 mock_load_yaml_config.return_value = {
                     'site_name': self.project.name,
                     'theme': 'customtheme',
+                    'docs_dir': tmpdir,
                 }
                 builder.append_conf()
 


### PR DESCRIPTION
This value has been the default since the start of the project
https://github.com/mkdocs/mkdocs/blob/0.13.0/mkdocs/config/defaults.py#L44

We should respect that default value,
(we should actually don't edit it at all https://github.com/readthedocs/readthedocs.org/issues/2483).

So, instead of trying to guess the docs dir always,
only try to guess it if the user doesn't have mkdocs.yaml file.

This should avoid any backwards incompatibility and avoid weird bugs to
new users till we completely remove all magic.

Closes https://github.com/readthedocs/readthedocs.org/issues/7539