### PR TITLE
Use Python3.7 on conda base environment when using mamba

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -529,6 +529,7 @@ class Conda(PythonEnvironment):
             '--quiet',
             '--name=base',
             '--channel=conda-forge',
+            'python=3.7',
             'mamba',
             cwd=self.checkout_path,
         )


### PR DESCRIPTION
Mamba 0.1.0 is the latest version that supports Python2 (which is our default in
the conda environment --as we use miniconda2) while the current stable version
is 0.7.6

Using the older version of mamba is causing different resolution issues and
making the build to fail.

Environment still can be created with python2 or python3 versions.

See https://github.com/mamba-org/mamba/issues/640 for more context.