### PR TITLE
docs: fix simple typo, tanslations -> translations

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -67,7 +67,7 @@ def pull(ctx):
 def docs(ctx, regenerate_config=False, push=False):
     """Pull and push translations to Transifex for our docs"""
     with ctx.cd(os.path.join(ROOT_PATH, 'docs')):
-        # Update our tanslations
+        # Update our translations
         ctx.run('tx pull -a')
         # Update resources
         if regenerate_config:


### PR DESCRIPTION
There is a small typo in tasks.py.

Should read `translations` rather than `tanslations`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md