### PR TITLE
Upgrade Celery and friends to latest versions

### DIFF
--- a/readthedocs/builds/utils.py
+++ b/readthedocs/builds/utils.py
@@ -1,8 +1,8 @@
 """Utilities for the builds app."""
+from time import monotonic
 
 from contextlib import contextmanager
 
-from celery.five import monotonic
 from django.core.cache import cache
 
 from readthedocs.builds.constants import EXTERNAL

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -31,15 +31,9 @@ pyyaml==5.4.1
 Pygments==2.8.0
 
 # Basic tools
-# Redis 3.x has an incompatible change and fails
-# https://stackoverflow.com/questions/53331405/django-compress-error-invalid-input-of-type-cachekey
-# https://github.com/sebleier/django-redis-cache/pull/162
-redis==2.10.6  # pyup: ignore
-# Kombu >4.3 requires redis>=3.2
-kombu==4.3.0  # pyup: ignore
-# Celery 4.2 is incompatible with our code
-# when ALWAYS_EAGER = True
-celery==4.1.1  # pyup: ignore
+redis==3.5.3
+kombu==5.0.2
+celery==5.0.5
 
 # When upgrading to 0.43.0 we should double check the ``base.html`` change
 # described in the changelog. In previous versions, the allauth app included a


### PR DESCRIPTION
We are receiving "Acquire on closed pool" error randomly after running instances
for more than ~1 day and calling `self.app.control.cancel_consumer` from our
task that kills VM instances.

This seems to be a known problem in 3.x Celery verions but some users reported
that it's still present in <4.4.

- https://github.com/celery/celery/issues/4410#issuecomment-505728049
- https://stackoverflow.com/questions/36789805/celery-kombu-fails-after-self-connections-acquire
- https://github.com/celery/celery/issues/1839

Celery released 5.x on September, so I'm upgrading to it directly as a test. If
everything keep working together, we can leave it. Otherwise, we can go back to
latest 4.4.x series: 4.4.7.

Sentry issue on production: https://sentry.io/organizations/read-the-docs/issues/2101960715/?project=148442&query=is%3Aunresolved+builds&statsPeriod=14d

Requires: https://github.com/readthedocs/readthedocs-ops/pull/837
Requires: https://github.com/readthedocs/common/pull/79