### PR TITLE
Cloudflare to Cloudflare CNAME Records

### DIFF
--- a/docs/custom_domains.rst
+++ b/docs/custom_domains.rst
@@ -127,21 +127,6 @@ You will need to update your CAA records to allow us to issue the certificate.
 .. _Cloudflare CAA FAQ: https://support.cloudflare.com/hc/en-us/articles/115000310832-Certification-Authority-Authorization-CAA-FAQ
 .. _Amazon CAA guide: https://docs.aws.amazon.com/acm/latest/userguide/setup-caa.html
 
-Notes for Cloudflare DNS users
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Due to a limitation between |org_brand| and Cloudflare,
-a domain cannot be proxied on Cloudflare to another Cloudflare account that also proxies.
-You will see a "CNAME Cross-User Banned" error in your Cloudflare dashboard
-and a ``requested hostname resolves to a Cloudflare zone that is not owned by you`` error in the Read the Docs dashboard.
-In order to do SSL termination, we must proxy this connection.
-If you don't want us to do SSL termination for your domain —
-**which means you are responsible for the SSL certificate** —
-then set your CNAME to ``cloudflare-to-cloudflare.readthedocs.io`` instead of ``readthedocs.io``.
-For more details, see `this previous issue`_.
-
-.. _this previous issue: https://github.com/readthedocs/readthedocs.org/issues/4395
-
 
 Proxy SSL
 ---------


### PR DESCRIPTION
I just set up a CNAME record in Cloudflare pointing to `readthedocs.io` and it got an SSL certificate for the custom domain so this seems to no longer be a problem.