### PR TITLE
Allow to use a different url for intersphinx object file download

### DIFF
--- a/docs/development/settings.rst
+++ b/docs/development/settings.rst
@@ -38,6 +38,14 @@ Default: :djangosetting:`PRODUCTION_DOMAIN`
 This is the domain that gets linked to throughout the site when used in production.
 It depends on `USE_SUBDOMAIN`, otherwise it isn't used.
 
+RTD_INTERSPHINX_URL
+-------------------
+
+Default: :djangosetting:`RTD_INTERSPHINX_URL`
+
+This is the domain that is used to fetch the intersphinx inventory file.
+If not set explicitly this is the `PRODUCTION_DOMAIN`.
+
 MULTIPLE_APP_SERVERS
 --------------------
 

--- a/docs/development/settings.rst
+++ b/docs/development/settings.rst
@@ -44,7 +44,7 @@ RTD_INTERSPHINX_URL
 Default: :djangosetting:`RTD_INTERSPHINX_URL`
 
 This is the domain that is used to fetch the intersphinx inventory file.
-If not set explicitly this is the `PRODUCTION_DOMAIN`.
+If not set explicitly this is the ``PRODUCTION_DOMAIN``.
 
 MULTIPLE_APP_SERVERS
 --------------------

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1414,7 +1414,7 @@ def _create_intersphinx_data(version, commit, build):
     if object_file_url.startswith('/'):
         # Filesystem backed storage simply prepends MEDIA_URL to the path to get the URL
         # This can cause an issue if MEDIA_URL is not fully qualified
-        object_file_url = 'http://' + settings.PRODUCTION_DOMAIN + object_file_url
+        object_file_url = settings.RTD_INTERSPHINX_URL + object_file_url
 
     invdata = intersphinx.fetch_inventory(MockApp(), '', object_file_url)
     for key, value in sorted(invdata.items() or {}):

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -50,6 +50,7 @@ class CommunityBaseSettings(Settings):
     PUBLIC_DOMAIN_USES_HTTPS = False
     USE_SUBDOMAIN = False
     PUBLIC_API_URL = 'https://{}'.format(PRODUCTION_DOMAIN)
+    RTD_INTERSPHINX_URL = 'http://{}'.format(PRODUCTION_DOMAIN)
     RTD_EXTERNAL_VERSION_DOMAIN = 'external-builds.readthedocs.io'
 
     # Doc Builder Backends

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -50,7 +50,7 @@ class CommunityBaseSettings(Settings):
     PUBLIC_DOMAIN_USES_HTTPS = False
     USE_SUBDOMAIN = False
     PUBLIC_API_URL = 'https://{}'.format(PRODUCTION_DOMAIN)
-    RTD_INTERSPHINX_URL = 'http://{}'.format(PRODUCTION_DOMAIN)
+    RTD_INTERSPHINX_URL = 'https://{}'.format(PRODUCTION_DOMAIN)
     RTD_EXTERNAL_VERSION_DOMAIN = 'external-builds.readthedocs.io'
 
     # Doc Builder Backends


### PR DESCRIPTION
The current implementation tries to read the file from PRODUCTION_DOMAIN
using HTTP scheme. If PRODUCTION_DOMAIN requires authentication or HTTPS
scheme the request fails.

The new implementation allows to set a different host to be used for
reading the object file in the settings.
Otherwise it uses the old implementation to access PRODUCTION_DOMAIN using
HTTP. Usage in settings:

RTD_INTERSPHINX_URL = 'http://localhost'