### PR TITLE
Fix url for downloads and versions if not using subdomains

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -143,6 +143,14 @@ class BaseSphinx(BaseBuilder):
                     self.project.slug, self.version.slug,
                 )
 
+        if settings.USE_SUBDOMAIN:
+            version_urls = [
+                (v.slug, f"/{v.project.language}/{v.slug}/")
+                for v in versions
+            ]
+        else:
+            version_urls = [(v.slug, v.get_absolute_url()) for v in versions]
+
         build_id = self.build_env.build.get('id')
         build_url = None
         if build_id:
@@ -178,7 +186,7 @@ class BaseSphinx(BaseBuilder):
             'conf_py_path': conf_py_path,
             'api_host': settings.PUBLIC_API_URL,
             'commit': commit,
-            'versions': versions,
+            'versions': version_urls,
             'downloads': downloads,
             'subproject_urls': subproject_urls,
             'build_url': build_url,

--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -81,8 +81,8 @@ context = {
     'MEDIA_URL': "{{ settings.MEDIA_URL }}",
     'STATIC_URL': "{{ settings.STATIC_URL }}",
     'PRODUCTION_DOMAIN': "{{ settings.PRODUCTION_DOMAIN }}",
-    'versions': [{% for version in versions %}
-    ("{{ version.slug }}", "/{{ version.project.language }}/{{ version.slug}}/"),{% endfor %}
+    'versions': [{% for slug, url in versions %}
+    ("{{ slug }}", "{{ url }}"),{% endfor %}
     ],
     'downloads': [ {% for key, val in downloads.items %}
     ("{{ key }}", "{{ val }}"),{% endfor %}

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -591,7 +591,11 @@ class Project(models.Model):
         main_project = self.main_language_project or self
         if not settings.USE_SUBDOMAIN:
             # example.com/media/pdf/<project>/<ver>/<filename>
-            storage_path = self.get_storage_path(type_=type_, version_slug=version_slug, include_file=True)  # noqa
+            storage_path = self.get_storage_path(
+                type_=type_,
+                version_slug=version_slug,
+                include_file=True
+            )
             path = f'//{domain}{settings.MEDIA_URL}{storage_path}'
         elif main_project.is_subproject:
             # docs.example.com/_/downloads/<alias>/<lang>/<ver>/pdf/

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -589,7 +589,11 @@ class Project(models.Model):
         # accessed from Web instance
 
         main_project = self.main_language_project or self
-        if main_project.is_subproject:
+        if not settings.USE_SUBDOMAIN:
+            # example.com/media/pdf/<project>/<ver>/<filename>
+            storage_path = self.get_storage_path(type_=type_, version_slug=version_slug, include_file=True)  # noqa
+            path = f'//{domain}{settings.MEDIA_URL}{storage_path}'
+        elif main_project.is_subproject:
             # docs.example.com/_/downloads/<alias>/<lang>/<ver>/pdf/
             path = f'//{domain}/{self.proxied_api_url}downloads/{main_project.alias}/{self.language}/{version_slug}/{type_}/'  # noqa
         else:

--- a/readthedocs/rtd_tests/tests/test_doc_builder.py
+++ b/readthedocs/rtd_tests/tests/test_doc_builder.py
@@ -111,6 +111,7 @@ class SphinxBuilderTest(TestCase):
         self.assertEqual(params['version'], self.version)
         self.assertEqual(params['build_url'], 'https://readthedocs.org/projects/pip/builds/123/')
 
+    @override_settings(USE_SUBDOMAIN=True)
     @patch('readthedocs.doc_builder.backends.sphinx.api')
     @patch('readthedocs.projects.models.api')
     @patch('readthedocs.doc_builder.backends.sphinx.BaseSphinx.docs_dir')
@@ -159,8 +160,8 @@ class SphinxBuilderTest(TestCase):
         base_sphinx.config_file = tempfile.mktemp()
         context = base_sphinx.get_config_params()
         versions = {
-            v.slug
-            for v in context['versions']
+            slug
+            for slug, _ in context['versions']
         }
         self.assertEqual(versions, {'v1', 'v2'})
 


### PR DESCRIPTION
By default the download url returns urls for subdomain configuration,
i.e. a proxied path to the project subdomain. Now, if USE_SUBDOMAIN
is not set, the url is based on the MEDIA_URL of the PRODUCTION_DOMAIN.