### PR TITLE
Footer: add cache tags

### DIFF
--- a/readthedocs/api/v2/views/footer_views.py
+++ b/readthedocs/api/v2/views/footer_views.py
@@ -232,7 +232,9 @@ class BaseFooterHTML(APIView):
             'version_supported': version.supported,
         }
 
-        return Response(resp_data)
+        response = Response(resp_data)
+        response['Cache-Tag'] = f'{project.slug},{project.slug}-rtd-footer'
+        return response
 
 
 class FooterHTML(SettingsOverrideObject):

--- a/readthedocs/api/v2/views/footer_views.py
+++ b/readthedocs/api/v2/views/footer_views.py
@@ -233,7 +233,12 @@ class BaseFooterHTML(APIView):
         }
 
         response = Response(resp_data)
-        response['Cache-Tag'] = f'{project.slug},{project.slug}-rtd-footer'
+        cache_tags = [
+            project.slug,
+            f'{project.slug}-{version.slug}',
+            f'{project.slug}-rtd-footer',
+        ]
+        response['Cache-Tag'] = ','.join(cache_tags)
         return response
 
 

--- a/readthedocs/proxito/tests/test_headers.py
+++ b/readthedocs/proxito/tests/test_headers.py
@@ -1,9 +1,11 @@
+import django_dynamic_fixture as fixture
 import pytest
 from django.test import override_settings
+from django.urls import reverse
 
-import django_dynamic_fixture as fixture
-
+from readthedocs.builds.constants import LATEST
 from readthedocs.projects.models import Domain
+
 from .base import BaseDocServing
 
 
@@ -81,3 +83,13 @@ class ProxitoHeaderTests(BaseDocServing):
         self.assertEqual(r['X-RTD-Version'], 'latest')
         self.assertEqual(r['X-RTD-version-Method'], 'path')
         self.assertEqual(r['X-RTD-Path'], '/proxito/media/html/project/latest/index.html')
+
+    def test_footer_headers(self):
+        version = self.project.versions.get(slug=LATEST)
+        url = (
+            reverse('footer_html') +
+            f'?project={self.project.slug}&version={version.slug}'
+        )
+        r = self.client.get(url, HTTP_HOST='project.dev.readthedocs.io')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r['Cache-Tag'], 'project,project-rtd-footer')

--- a/readthedocs/proxito/tests/test_headers.py
+++ b/readthedocs/proxito/tests/test_headers.py
@@ -92,4 +92,4 @@ class ProxitoHeaderTests(BaseDocServing):
         )
         r = self.client.get(url, HTTP_HOST='project.dev.readthedocs.io')
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r['Cache-Tag'], 'project,project-rtd-footer')
+        self.assertEqual(r['Cache-Tag'], 'project,project-latest,project-rtd-footer')


### PR DESCRIPTION
I wasn't able to add the cache tag in the proxito middleware,
since it makes use of ``path_project_slug``,
that is is sets only on the serve views.

I added the project and version tag as well,
so it gets cleared when the project/version is purged.