### PR TITLE
PR preview: pass PR and build urls to sphinx context

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from django.conf import settings
 from django.template import loader as template_loader
 from django.template.loader import render_to_string
+from django.urls import reverse
 from requests.exceptions import ConnectionError
 
 from readthedocs.api.v2.client import api
@@ -142,6 +143,19 @@ class BaseSphinx(BaseBuilder):
                     self.project.slug, self.version.slug,
                 )
 
+        build_id = self.build_env.build.get('id')
+        build_url = None
+        if build_id:
+            build_url = reverse(
+                'builds_detail',
+                kwargs={
+                    'project_slug': self.project.slug,
+                    'build_pk': build_id,
+                },
+            )
+            protocol = 'http' if settings.DEBUG else 'https'
+            build_url = f'{protocol}://{settings.PRODUCTION_DOMAIN}{build_url}'
+
         data = {
             'html_theme': 'sphinx_rtd_theme',
             'html_theme_import': 'sphinx_rtd_theme',
@@ -155,6 +169,7 @@ class BaseSphinx(BaseBuilder):
             'versions': versions,
             'downloads': downloads,
             'subproject_urls': subproject_urls,
+            'build_url': build_url,
 
             # GitHub
             'github_user': github_user,

--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -154,6 +154,8 @@ else:
 # Add External version warning banner to the external version documentation
 if '{{ version.type }}' == 'external':
     extensions.insert(1, "readthedocs_ext.external_version_warning")
+    readthedocs_vcs_url = '{{ version.vcs_url }}'
+    readthedocs_build_url = '{{ build_url }}'
 
 project_language = '{{ project.language }}'
 


### PR DESCRIPTION
This is to allow us to link to the PR and to the build
from the docs using our external_version_warning extension.

ref https://github.com/readthedocs/readthedocs-sphinx-ext/pull/95/