### PR TITLE
Match Redis version with production

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -26,6 +26,9 @@ services:
       args:
         GITHUB_TOKEN: ${GITHUB_TOKEN:-}
 
+  cache:
+    image: redis:4.0.14
+
   nginx:
     networks:
       readthedocs:


### PR DESCRIPTION
We are currently using v4.0.14 on Azure.