### PR TITLE
Always show the raw compilation for debugging purpose

### DIFF
--- a/readthedocs/templates/builds/build_detail.html
+++ b/readthedocs/templates/builds/build_detail.html
@@ -62,7 +62,7 @@ $(document).ready(function () {
         </li>
       </div>
 
-      <div data-bind="visible: finished()">
+      <div>
         <li>
           <a href="{% url "build-detail" build.pk "txt" %}">
             {% trans "View raw" %}


### PR DESCRIPTION
Let show the compilation log, it's easier to find information inside.