### PR TITLE
Save builder when the build is concurrency limited

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -613,6 +613,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
                         'error': BuildMaxConcurrencyError.message.format(
                             limit=max_concurrent_builds,
                         ),
+                        'builder': socket.gethostname(),
                     })
                     self.task.retry(
                         exc=BuildMaxConcurrencyError,


### PR DESCRIPTION
This helps us to know in which queue the build is limited and have better metrics.