### PR TITLE
Log Stripe errors when trying to delete customer/subscription

### DIFF
--- a/readthedocs/payments/utils.py
+++ b/readthedocs/payments/utils.py
@@ -7,11 +7,15 @@ These are mostly one-off functions. Define the bulk of Stripe operations on
 :py:class:`readthedocs.payments.forms.StripeResourceMixin`.
 """
 
+import logging
+
 import stripe
+
 from django.conf import settings
 
 
 stripe.api_key = settings.STRIPE_SECRET
+log = logging.getLogger(__name__)
 
 
 def delete_customer(customer_id):

--- a/readthedocs/payments/utils.py
+++ b/readthedocs/payments/utils.py
@@ -20,7 +20,10 @@ def delete_customer(customer_id):
         customer = stripe.Customer.retrieve(customer_id)
         return customer.delete()
     except stripe.error.InvalidRequestError:
-        pass
+        log.exception(
+            'Customer not deleted. Customer not found on Stripe. customer=%s',
+            customer_id,
+        )
 
 
 def cancel_subscription(customer_id, subscription_id):
@@ -31,4 +34,9 @@ def cancel_subscription(customer_id, subscription_id):
             subscription = customer.subscriptions.retrieve(subscription_id)
             return subscription.delete()
     except stripe.error.StripeError:
-        pass
+        log.exception(
+            'Subscription not cancelled. Customer/Subscription not found on Stripe. '
+            'customer=%s subscription=%s',
+            customer_id,
+            subscription_id,
+        )


### PR DESCRIPTION
Call `log.exception` instead of just `pass` to log these errors and know what's
happening in production.