### PR TITLE
Install latest mkdocs by default as we do with sphinx

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -374,7 +374,7 @@ class Virtualenv(PythonEnvironment):
                 self.project.get_feature_value(
                     Feature.DEFAULT_TO_MKDOCS_0_17_3,
                     positive='mkdocs==0.17.3',
-                    negative='mkdocs<1.1',
+                    negative='mkdocs',
                 ),
             )
         else:

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -374,7 +374,11 @@ class Virtualenv(PythonEnvironment):
                 self.project.get_feature_value(
                     Feature.DEFAULT_TO_MKDOCS_0_17_3,
                     positive='mkdocs==0.17.3',
-                    negative='mkdocs',
+                    negative=self.project.get_feature_value(
+                        Feature.USE_MKDOCS_LATEST,
+                        positive='mkdocs<1.1',
+                        negative='mkdocs',
+                    ),
                 ),
             )
         else:

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1592,6 +1592,7 @@ class Feature(models.Model):
     USE_SPHINX_LATEST = 'use_sphinx_latest'
     DONT_INSTALL_DOCUTILS = 'dont_install_docutils'
     DEFAULT_TO_MKDOCS_0_17_3 = 'default_to_mkdocs_0_17_3'
+    USE_MKDOCS_LATEST = 'use_mkdocs_latest'
     USE_SPHINX_RTD_EXT_LATEST = 'rtd_sphinx_ext_latest'
     INSTALL_LATEST_SETUPTOOLS = 'install_latest_setuptoold'
 
@@ -1707,6 +1708,7 @@ class Feature(models.Model):
             DEFAULT_TO_MKDOCS_0_17_3,
             _('Install mkdocs 0.17.3 by default'),
         ),
+        (USE_MKDOCS_LATEST, _('Use latest version of MkDocs')),
         (
             USE_SPHINX_RTD_EXT_LATEST,
             _('Use latest version of the Read the Docs Sphinx extension'),


### PR DESCRIPTION
Current version is 1.1, this was pinned as we used to just keep updating them manually and time passed and this wasn't updated. This also matches my lies in https://github.com/readthedocs/readthedocs.org/pull/7859 :D