### PR TITLE
Add version_changed signal

### DIFF
--- a/readthedocs/builds/forms.py
+++ b/readthedocs/builds/forms.py
@@ -22,6 +22,7 @@ from readthedocs.builds.models import (
     Version,
     VersionAutomationRule,
 )
+from readthedocs.builds.signals import version_changed
 from readthedocs.core.mixins import HideProtectedLevelMixin
 from readthedocs.core.utils import trigger_build
 
@@ -88,6 +89,8 @@ class VersionForm(HideProtectedLevelMixin, forms.ModelForm):
         obj = super().save(commit=commit)
         if obj.active and not obj.built and not obj.uploaded:
             trigger_build(project=obj.project, version=obj)
+        if self.has_changed():
+            version_changed.send(sender=self.__class__, version=obj)
         return obj
 
 

--- a/readthedocs/builds/signals.py
+++ b/readthedocs/builds/signals.py
@@ -1,8 +1,8 @@
-# -*- coding: utf-8 -*-
-
 """Build signals."""
 
 import django.dispatch
 
 
 build_complete = django.dispatch.Signal(providing_args=['build'])
+# Useful to know when to purge the footer
+version_changed = django.dispatch.Signal(providing_args=['version'])


### PR DESCRIPTION
This is useful to know when to purge the footer.
With ext#404 we now purge the footer from all versions when we purge a version as well.
So this is the only missing place left to purge the footer.