### PR TITLE
Add support for Python 3.9 on "testing" Docker image

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -483,7 +483,7 @@ class CommunityBaseSettings(Settings):
         },
         'readthedocs/build:7.0': {
             'python': {
-                'supported_versions': [2, 2.7, 3, 3.5, 3.6, 3.7, 3.8, 'pypy3.5'],
+                'supported_versions': [2, 2.7, 3, 3.5, 3.6, 3.7, 3.8, 3.9, 'pypy3.5'],
                 'default_version': {
                     2: 2.7,
                     3: 3.7,


### PR DESCRIPTION
Allow users to build with latest release of Python.

Requires: https://github.com/readthedocs/readthedocs-docker-images/pull/159