### PR TITLE
Allow HTTPS without a valid certificate when hitting APIv2

### DIFF
--- a/readthedocs/api/v2/client.py
+++ b/readthedocs/api/v2/client.py
@@ -26,6 +26,7 @@ class DrfJsonSerializer(serialize.JsonSerializer):
 
 def setup_api():
     session = requests.Session()
+    session.verify = False
     if settings.SLUMBER_API_HOST.startswith('https'):
         # Only use the HostHeaderSSLAdapter for HTTPS connections
         adapter_class = TimeoutHostHeaderSSLAdapter


### PR DESCRIPTION
This is required in the transition period while moving from Azure to AWS. It has to be reverted once we are fully deployed on AWS.