### PR TITLE
Proxito: Keep storage class at the class level

### DIFF
--- a/readthedocs/proxito/views/mixins.py
+++ b/readthedocs/proxito/views/mixins.py
@@ -27,6 +27,7 @@ class ServeDocsMixin:
     """Class implementing all the logic to serve a document."""
 
     version_type = INTERNAL
+    storage = get_storage_class(settings.RTD_BUILD_MEDIA_STORAGE)()
 
     def _serve_docs(
             self,
@@ -72,8 +73,7 @@ class ServeDocsMixin:
         """
         log.debug('[Django serve] path=%s, project=%s', path, final_project.slug)
 
-        storage = get_storage_class(settings.RTD_BUILD_MEDIA_STORAGE)()
-        root_path = storage.path('')
+        root_path = self.storage.path('')
         # Serve from Python
         return serve(request, path, root_path)
 

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -5,8 +5,6 @@ import logging
 from urllib.parse import urlparse
 
 from readthedocs.core.resolver import resolve_path
-from django.conf import settings
-from django.core.files.storage import get_storage_class
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import resolve as url_resolve
@@ -320,7 +318,7 @@ class ServeError404Base(ServeRedirectMixin, ServeDocsMixin, View):
                 tryfiles.append('404/index.html')
             for tryfile in tryfiles:
                 storage_filename_path = self.storage.join(storage_root_path, tryfile)
-                if storage.exists(storage_filename_path):
+                if self.storage.exists(storage_filename_path):
                     log.info(
                         'Serving custom 404.html page: [project: %s] [version: %s]',
                         final_project.slug,
@@ -365,7 +363,6 @@ class ServeRobotsTXTBase(ServeDocsMixin, View):
         if no_serve_robots_txt:
             # ... we do return a 404
             raise Http404()
-
 
         storage_path = project.get_storage_path(
             type_='html',


### PR DESCRIPTION
Doing storage.url on a new instance does a lot of overhead tasks.

This fixed the huge overhead issue we were having on our webs. Still need to fix tests to merge it, but it's hotfixed for now to keep the servers happy. 