### PR TITLE
Make storage classes into module level vars

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -8,7 +8,6 @@ from shutil import rmtree
 
 import regex
 from django.conf import settings
-from django.core.files.storage import get_storage_class
 from django.db import models
 from django.db.models import F
 from django.urls import reverse
@@ -88,6 +87,7 @@ from readthedocs.projects.constants import (
 )
 from readthedocs.projects.models import APIProject, Project
 from readthedocs.projects.version_handling import determine_stable_version
+from readthedocs.storage import build_environment_storage
 
 log = logging.getLogger(__name__)
 
@@ -411,8 +411,7 @@ class Version(TimeStampedModel):
 
     def get_storage_environment_cache_path(self):
         """Return the path of the cached environment tar file."""
-        storage = get_storage_class(settings.RTD_BUILD_ENVIRONMENT_STORAGE)()
-        return storage.join(self.project.slug, f'{self.slug}.tar')
+        return build_environment_storage.join(self.project.slug, f'{self.slug}.tar')
 
     def clean_build_path(self):
         """

--- a/readthedocs/core/utils/general.py
+++ b/readthedocs/core/utils/general.py
@@ -2,13 +2,12 @@
 
 import os
 
-from django.conf import settings
-from django.core.files.storage import get_storage_class
 from django.shortcuts import get_object_or_404
 
 from readthedocs.core.utils import broadcast
 from readthedocs.projects.tasks import remove_dirs
 from readthedocs.builds.models import Version
+from readthedocs.storage import build_environment_storage
 
 
 def wipe_version_via_slugs(version_slug, project_slug):
@@ -28,5 +27,4 @@ def wipe_version_via_slugs(version_slug, project_slug):
         broadcast(type='build', task=remove_dirs, args=[(del_dir,)])
 
     # Delete the cache environment from storage
-    storage = get_storage_class(settings.RTD_BUILD_ENVIRONMENT_STORAGE)()
-    storage.delete(version.get_storage_environment_cache_path())
+    build_environment_storage.delete(version.get_storage_environment_cache_path())

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -11,7 +11,6 @@ from allauth.socialaccount.providers import registry as allauth_registry
 from django.conf import settings
 from django.conf.urls import include
 from django.contrib.auth.models import User
-from django.core.files.storage import get_storage_class
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.db.models import Prefetch
@@ -46,6 +45,7 @@ from readthedocs.projects.validators import (
 )
 from readthedocs.projects.version_handling import determine_stable_version
 from readthedocs.search.parsers import MkDocsParser, SphinxParser
+from readthedocs.storage import build_media_storage
 from readthedocs.vcs_support.backends import backend_cls
 from readthedocs.vcs_support.utils import Lock, NonBlockingLock
 
@@ -844,12 +844,11 @@ class Project(models.Model):
         return self.builds(manager=INTERNAL).filter(success=True).exists()
 
     def has_media(self, type_, version_slug=LATEST, version_type=None):
-        storage = get_storage_class(settings.RTD_BUILD_MEDIA_STORAGE)()
         storage_path = self.get_storage_path(
             type_=type_, version_slug=version_slug,
             version_type=version_type
         )
-        return storage.exists(storage_path)
+        return build_media_storage.exists(storage_path)
 
     def has_pdf(self, version_slug=LATEST, version_type=None):
         return self.has_media(

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -21,7 +21,6 @@ from fnmatch import fnmatch
 import requests
 from celery.exceptions import SoftTimeLimitExceeded
 from django.conf import settings
-from django.core.files.storage import get_storage_class
 from django.db.models import Q
 from django.urls import reverse
 from django.utils import timezone
@@ -73,6 +72,7 @@ from readthedocs.projects.constants import GITHUB_BRAND, GITLAB_BRAND
 from readthedocs.projects.models import APIProject, Feature
 from readthedocs.search.utils import index_new_files, remove_indexed_files
 from readthedocs.sphinx_domains.models import SphinxDomain
+from readthedocs.storage import build_media_storage, build_environment_storage
 from readthedocs.vcs_support import utils as vcs_support_utils
 from readthedocs.worker import app
 
@@ -98,7 +98,6 @@ class CachedEnvironmentMixin:
         if not self.project.has_feature(feature_id=Feature.CACHED_ENVIRONMENT):
             return
 
-        storage = get_storage_class(settings.RTD_BUILD_ENVIRONMENT_STORAGE)()
         filename = self.version.get_storage_environment_cache_path()
 
         msg = 'Checking for cached environment'
@@ -110,7 +109,7 @@ class CachedEnvironmentMixin:
                 'msg': msg,
             }
         )
-        if storage.exists(filename):
+        if build_environment_storage.exists(filename):
             msg = 'Pulling down cached environment from storage'
             log.info(
                 LOG_TEMPLATE,
@@ -120,7 +119,7 @@ class CachedEnvironmentMixin:
                     'msg': msg,
                 }
             )
-            remote_fd = storage.open(filename, mode='rb')
+            remote_fd = build_environment_storage.open(filename, mode='rb')
             with tarfile.open(fileobj=remote_fd) as tar:
                 tar.extractall(self.project.doc_path)
 
@@ -153,7 +152,6 @@ class CachedEnvironmentMixin:
             if os.path.exists(path):
                 tar.add(path, arcname='.cache')
 
-        storage = get_storage_class(settings.RTD_BUILD_ENVIRONMENT_STORAGE)()
         with open(tmp_filename, 'rb') as fd:
             msg = 'Pushing up cached environment to storage'
             log.info(
@@ -164,7 +162,7 @@ class CachedEnvironmentMixin:
                     'msg': msg,
                 }
             )
-            storage.save(
+            build_environment_storage.save(
                 self.version.get_storage_environment_cache_path(),
                 fd,
             )
@@ -1030,7 +1028,6 @@ class UpdateDocsTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
         :param pdf: whether to save PDF output
         :param epub: whether to save ePub output
         """
-        storage = get_storage_class(settings.RTD_BUILD_MEDIA_STORAGE)()
         log.info(
             LOG_TEMPLATE,
             {
@@ -1086,7 +1083,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
                 },
             )
             try:
-                storage.sync_directory(from_path, to_path)
+                build_media_storage.sync_directory(from_path, to_path)
             except Exception:
                 # Ideally this should just be an IOError
                 # but some storage backends unfortunately throw other errors
@@ -1115,7 +1112,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
                 },
             )
             try:
-                storage.delete_directory(media_path)
+                build_media_storage.delete_directory(media_path)
             except Exception:
                 # Ideally this should just be an IOError
                 # but some storage backends unfortunately throw other errors
@@ -1376,8 +1373,6 @@ def _create_intersphinx_data(version, commit, build):
     if not version.is_sphinx_type:
         return
 
-    storage = get_storage_class(settings.RTD_BUILD_MEDIA_STORAGE)()
-
     html_storage_path = version.project.get_storage_path(
         type_='html', version_slug=version.slug, include_file=False
     )
@@ -1385,17 +1380,17 @@ def _create_intersphinx_data(version, commit, build):
         type_='json', version_slug=version.slug, include_file=False
     )
 
-    object_file = storage.join(html_storage_path, 'objects.inv')
-    if not storage.exists(object_file):
+    object_file = build_media_storage.join(html_storage_path, 'objects.inv')
+    if not build_media_storage.exists(object_file):
         log.debug('No objects.inv, skipping intersphinx indexing.')
         return
 
-    type_file = storage.join(json_storage_path, 'readthedocs-sphinx-domain-names.json')
+    type_file = build_media_storage.join(json_storage_path, 'readthedocs-sphinx-domain-names.json')
     types = {}
     titles = {}
-    if storage.exists(type_file):
+    if build_media_storage.exists(type_file):
         try:
-            data = json.load(storage.open(type_file))
+            data = json.load(build_media_storage.open(type_file))
             types = data['types']
             titles = data['titles']
         except Exception:
@@ -1415,7 +1410,7 @@ def _create_intersphinx_data(version, commit, build):
             log.warning('Sphinx MockApp: %s', msg)
 
     # Re-create all objects from the new build of the version
-    object_file_url = storage.url(object_file)
+    object_file_url = build_media_storage.url(object_file)
     if object_file_url.startswith('/'):
         # Filesystem backed storage simply prepends MEDIA_URL to the path to get the URL
         # This can cause an issue if MEDIA_URL is not fully qualified
@@ -1537,15 +1532,13 @@ def _create_imported_files(*, version, commit, build, search_ranking, search_ign
     :returns: paths of changed files
     :rtype: set
     """
-    storage = get_storage_class(settings.RTD_BUILD_MEDIA_STORAGE)()
-
     changed_files = set()
 
     # Re-create all objects from the new build of the version
     storage_path = version.project.get_storage_path(
         type_='html', version_slug=version.slug, include_file=False
     )
-    for root, __, filenames in storage.walk(storage_path):
+    for root, __, filenames in build_media_storage.walk(storage_path):
         for filename in filenames:
             if filename.endswith('.html'):
                 model_class = HTMLFile
@@ -1556,13 +1549,13 @@ def _create_imported_files(*, version, commit, build, search_ranking, search_ign
                 # For projects not behind a CDN, we don't care about non-HTML
                 continue
 
-            full_path = storage.join(root, filename)
+            full_path = build_media_storage.join(root, filename)
 
             # Generate a relative path for storage similar to os.path.relpath
             relpath = full_path.replace(storage_path, '', 1).lstrip('/')
 
             try:
-                md5 = hashlib.md5(storage.open(full_path, 'rb').read()).hexdigest()
+                md5 = hashlib.md5(build_media_storage.open(full_path, 'rb').read()).hexdigest()
             except Exception:
                 log.exception(
                     'Error while generating md5 for %s:%s:%s. Don\'t stop.',
@@ -1808,10 +1801,9 @@ def remove_build_storage_paths(paths):
 
     :param paths: list of paths in build media storage to delete
     """
-    storage = get_storage_class(settings.RTD_BUILD_MEDIA_STORAGE)()
     for storage_path in paths:
         log.info('Removing %s from media storage', storage_path)
-        storage.delete_directory(storage_path)
+        build_media_storage.delete_directory(storage_path)
 
 
 @app.task(queue='web')

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -13,7 +13,6 @@ import requests
 from django.conf import settings
 from django.contrib import messages
 from django.core.cache import cache
-from django.core.files.storage import get_storage_class
 from django.db.models import prefetch_related_objects
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
@@ -37,6 +36,7 @@ from readthedocs.projects.templatetags.projects_tags import sort_version_aware
 from readthedocs.projects.views.mixins import ProjectRelationListMixin
 from readthedocs.proxito.views.mixins import ServeDocsMixin
 from readthedocs.proxito.views.utils import _get_project_data_from_request
+from readthedocs.storage import build_media_storage
 
 from ..constants import PRIVATE
 from .base import ProjectOnboardMixin
@@ -365,7 +365,6 @@ class ProjectDownloadMediaBase(ServeDocsMixin, View):
             uip=get_client_ip(request),
         )
 
-        storage = get_storage_class(settings.RTD_BUILD_MEDIA_STORAGE)()
         storage_path = version.project.get_storage_path(
             type_=type_,
             version_slug=version_slug,
@@ -373,7 +372,7 @@ class ProjectDownloadMediaBase(ServeDocsMixin, View):
         )
 
         # URL without scheme and domain to perform an NGINX internal redirect
-        url = storage.url(storage_path)
+        url = build_media_storage.url(storage_path)
         url = urlparse(url)._replace(scheme='', netloc='').geturl()
 
         return self._serve_docs(

--- a/readthedocs/proxito/tests/base.py
+++ b/readthedocs/proxito/tests/base.py
@@ -3,17 +3,25 @@
 
 import pytest
 import django_dynamic_fixture as fixture
+from django.conf import settings
 from django.contrib.auth.models import User
+from django.core.files.storage import get_storage_class
 from django.test import TestCase
 
 from readthedocs.projects.constants import PUBLIC
 from readthedocs.projects.models import Project, Domain
+from readthedocs.proxito.views import serve
 
 
 @pytest.mark.proxito
 class BaseDocServing(TestCase):
 
     def setUp(self):
+        # Re-initialize storage
+        # Various tests override either this setting or various aspects of the storage engine
+        # By resetting it every test case, we avoid this caching (which is a huge benefit in prod)
+        serve.build_media_storage = get_storage_class(settings.RTD_BUILD_MEDIA_STORAGE)()
+
         self.eric = fixture.get(User, username='eric')
         self.eric.set_password('eric')
         self.eric.save()

--- a/readthedocs/proxito/views/mixins.py
+++ b/readthedocs/proxito/views/mixins.py
@@ -5,7 +5,6 @@ from urllib.parse import urlparse, urlunparse
 from slugify import slugify as unicode_slugify
 
 from django.conf import settings
-from django.core.files.storage import get_storage_class
 from django.http import (
     HttpResponse,
     HttpResponseRedirect,
@@ -18,6 +17,7 @@ from django.views.static import serve
 from readthedocs.builds.constants import EXTERNAL, INTERNAL
 from readthedocs.core.resolver import resolve
 from readthedocs.redirects.exceptions import InfiniteRedirectException
+from readthedocs.storage import build_media_storage
 
 log = logging.getLogger(__name__)  # noqa
 
@@ -72,8 +72,7 @@ class ServeDocsMixin:
         """
         log.debug('[Django serve] path=%s, project=%s', path, final_project.slug)
 
-        storage = get_storage_class(settings.RTD_BUILD_MEDIA_STORAGE)()
-        root_path = storage.path('')
+        root_path = build_media_storage.path('')
         # Serve from Python
         return serve(request, path, root_path)
 

--- a/readthedocs/search/parsers.py
+++ b/readthedocs/search/parsers.py
@@ -7,9 +7,9 @@ import re
 from urllib.parse import urlparse
 
 import orjson as json
-from django.conf import settings
-from django.core.files.storage import get_storage_class
 from selectolax.parser import HTMLParser
+
+from readthedocs.storage import build_media_storage
 
 log = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ class BaseParser:
     def __init__(self, version):
         self.version = version
         self.project = self.version.project
-        self.storage = get_storage_class(settings.RTD_BUILD_MEDIA_STORAGE)()
+        self.storage = build_media_storage
 
     def _get_page_content(self, page):
         """Gets the page content from storage."""

--- a/readthedocs/storage/__init__.py
+++ b/readthedocs/storage/__init__.py
@@ -1,0 +1,31 @@
+"""
+Provides lazy loaded storage instances for use throughout Read the Docs.
+
+For static files storage, use django.contrib.staticfiles.storage.staticfiles_storage.
+Some storage backends (notably S3) have a slow instantiation time
+so doing those upfront improves performance.
+"""
+from django.conf import settings
+
+from django.core.files.storage import get_storage_class
+from django.utils.functional import LazyObject
+
+
+class ConfiguredBuildMediaStorage(LazyObject):
+    def _setup(self):
+        self._wrapped = get_storage_class(settings.RTD_BUILD_MEDIA_STORAGE)()
+
+
+class ConfiguredBuildEnvironmentStorage(LazyObject):
+    def _setup(self):
+        self._wrapped = get_storage_class(settings.RTD_BUILD_ENVIRONMENT_STORAGE)()
+
+
+class ConfiguredBuildCommandsStorage(LazyObject):
+    def _setup(self):
+        self._wrapped = get_storage_class(settings.RTD_BUILD_COMMANDS_STORAGE)()
+
+
+build_media_storage = ConfiguredBuildMediaStorage()
+build_environment_storage = ConfiguredBuildEnvironmentStorage()
+build_commands_storage = ConfiguredBuildCommandsStorage()

--- a/readthedocs/storage/s3_storage.py
+++ b/readthedocs/storage/s3_storage.py
@@ -22,7 +22,7 @@ class S3BuildMediaStorage(BuildMediaStorageMixin, OverrideHostnameMixin, S3Boto3
 
     """An AWS S3 Storage backend for build artifacts."""
 
-    bucket_name = getattr(settings, 'S3_MEDIA_STORAGE_BUCKET')
+    bucket_name = getattr(settings, 'S3_MEDIA_STORAGE_BUCKET', None)
     override_hostname = getattr(settings, 'S3_MEDIA_STORAGE_OVERRIDE_HOSTNAME', None)
 
     def __init__(self, *args, **kwargs):
@@ -63,7 +63,7 @@ class S3StaticStorage(OverrideHostnameMixin, ManifestFilesMixin, S3Boto3Storage)
     * Uses Django's ManifestFilesMixin to have unique file paths (eg. core.a6f5e2c.css)
     """
 
-    bucket_name = getattr(settings, 'S3_STATIC_STORAGE_BUCKET')
+    bucket_name = getattr(settings, 'S3_STATIC_STORAGE_BUCKET', None)
     override_hostname = getattr(settings, 'S3_STATIC_STORAGE_OVERRIDE_HOSTNAME', None)
 
     def __init__(self, *args, **kwargs):
@@ -82,7 +82,7 @@ class S3StaticStorage(OverrideHostnameMixin, ManifestFilesMixin, S3Boto3Storage)
 
 class S3BuildEnvironmentStorage(BuildMediaStorageMixin, S3Boto3Storage):
 
-    bucket_name = getattr(settings, 'S3_BUILD_ENVIRONMENT_STORAGE_BUCKET')
+    bucket_name = getattr(settings, 'S3_BUILD_ENVIRONMENT_STORAGE_BUCKET', None)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
Some storage backends (notably S3) have extra startup times for the first connection to the backend (~50ms) which means that the storage object has to be reused for the best performance. This reuses them by making our storage instances into lazy loaded module level variables exactly like Django does with `staticfiles_storage`.

This is an alternative to #7905.

## Background

After the Azure -> AWS migration, we noticed that an extremely common piece of code which proxied requests to RTD to the appropriate file in cloud storage was taking much longer than before: ~60ms instead of ~10ms. Because this code is called on every request to docs or a build media file in RTD, it is called high tens to low hundreds of times per second in production and this caused us to need 3-4x the number of instances as normal. We traced it to this startup time in S3 (see [gist](https://gist.github.com/davidfischer/a6739beb9ff00e74e132c65ad502a25e)).

This is the [code for S3 storage](https://github.com/jschneier/django-storages/blob/770332b598712da27ecdba75c9e202ad6a1a8722/storages/backends/s3boto3.py#L336-L352) that results in the extra startup time. This does not occur with Azure storage or filesystem backed storage engines.

Regular Django users who aren't directly using the storages API don't generally see this with S3 because they're typically using `staticfiles_storage` which is lazy loaded once per process. Because RTD uses multiple storage instances which are instantiated frequently, this affects RTD more than a typical Django project.