### PR TITLE
Upgrade Redis version to match production

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -27,7 +27,7 @@ services:
         GITHUB_TOKEN: ${GITHUB_TOKEN:-}
 
   cache:
-    image: redis:4.0.14
+    image: redis:6.0.5
 
   nginx:
     networks:


### PR DESCRIPTION
This is the current version on AWS for Community.