### PR TITLE
Router PRs builds to last queue where a build was executed

### DIFF
--- a/readthedocs/builds/tests/test_celery_task_router.py
+++ b/readthedocs/builds/tests/test_celery_task_router.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.test import TestCase
 from django.test.utils import override_settings
 
+from readthedocs.builds.constants import EXTERNAL
 from readthedocs.builds.models import Build, Version
 from readthedocs.builds.tasks import TaskRouter
 from readthedocs.projects.models import Project
@@ -66,4 +67,24 @@ class TaskRouterTests(TestCase):
     def test_no_build_pk(self):
         self.assertIsNone(
             self.router.route_for_task(self.task, self.args, {}),
+        )
+
+    def test_external_version(self):
+        self.version.type = EXTERNAL
+        self.version.save()
+
+        self.build.builder = 'build-default-a1b2c3'
+        self.build.save()
+
+        self.assertEqual(
+            self.router.route_for_task(self.task, self.args, self.kwargs),
+            TaskRouter.BUILD_DEFAULT_QUEUE,
+        )
+
+        self.build.builder = 'build-large-a1b2c3'
+        self.build.save()
+
+        self.assertEqual(
+            self.router.route_for_task(self.task, self.args, self.kwargs),
+            TaskRouter.BUILD_LARGE_QUEUE,
         )


### PR DESCRIPTION
Currently, every time a PR is triggered to be built we are building it under our
build:large queue. This is because we have no data about this version and we
build them on build:large.

This commit checks where the last build was built when a PR is triggered to be
built and use that queue to build the PR.

Closes https://github.com/readthedocs/readthedocs.org/issues/7815