### PR TITLE
Search: add cache tags

### DIFF
--- a/readthedocs/api/v2/mixins.py
+++ b/readthedocs/api/v2/mixins.py
@@ -10,12 +10,17 @@ class CachedResponseMixin:
 
     The view inheriting this mixin should implement the
     `self._get_project` and `self._get_version` methods.
+
+    You can add an extra per-project tag by overriding the `project_cache_tag` attribute.
     """
+
+    project_cache_tag = None
 
     def dispatch(self, request, *args, **kwargs):
         response = super().dispatch(request, *args, **kwargs)
         cache_tags = self._get_cache_tags()
-        response['Cache-Tag'] = ','.join(cache_tags)
+        if cache_tags:
+            response['Cache-Tag'] = ','.join(cache_tags)
         return response
 
     def _get_cache_tags(self):
@@ -30,10 +35,13 @@ class CachedResponseMixin:
         try:
             project = self._get_project()
             version = self._get_version()
-            return [
+            tags = [
                 project.slug,
                 f'{project.slug}-{version.slug}',
             ]
+            if self.project_cache_tag:
+                tags.append(f'{project.slug}-{self.project_cache_tag}')
+            return tags
         except Exception as e:
             log.debug('Error while retrieving project and version for this view.')
         return []

--- a/readthedocs/api/v2/mixins.py
+++ b/readthedocs/api/v2/mixins.py
@@ -1,0 +1,39 @@
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class CachedResponseMixin:
+
+    """
+    Add cache tags for project and version to the response of this view.
+
+    The view inheriting this mixin should implement the
+    `self._get_project` and `self._get_version` methods.
+    """
+
+    def dispatch(self, request, *args, **kwargs):
+        response = super().dispatch(request, *args, **kwargs)
+        cache_tags = self._get_cache_tags()
+        response['Cache-Tag'] = ','.join(cache_tags)
+        return response
+
+    def _get_cache_tags(self):
+        """
+        Get cache tags for this view.
+
+        .. warning::
+
+           This method is run at the end of the request,
+           so any exceptions like 404 should be caught.
+        """
+        try:
+            project = self._get_project()
+            version = self._get_version()
+            return [
+                project.slug,
+                f'{project.slug}-{version.slug}',
+            ]
+        except Exception as e:
+            log.debug('Error while retrieving project and version for this view.')
+        return []

--- a/readthedocs/api/v2/views/footer_views.py
+++ b/readthedocs/api/v2/views/footer_views.py
@@ -1,5 +1,6 @@
 """Endpoint to generate footer HTML."""
 
+import logging
 import re
 from functools import lru_cache
 
@@ -11,6 +12,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_jsonp.renderers import JSONPRenderer
 
+from readthedocs.api.v2.mixins import CachedResponseMixin
 from readthedocs.api.v2.permissions import IsAuthorizedToViewVersion
 from readthedocs.builds.constants import LATEST, TAG
 from readthedocs.builds.models import Version
@@ -21,6 +23,8 @@ from readthedocs.projects.version_handling import (
     highest_version,
     parse_version_failsafe,
 )
+
+log = logging.getLogger(__name__)
 
 
 def get_version_compare_data(project, base_version=None):
@@ -79,7 +83,7 @@ def get_version_compare_data(project, base_version=None):
     return ret_val
 
 
-class BaseFooterHTML(APIView):
+class BaseFooterHTML(CachedResponseMixin, APIView):
 
     """
     Render and return footer markup.
@@ -205,6 +209,17 @@ class BaseFooterHTML(APIView):
         }
         return context
 
+    def _get_cache_tags(self):
+        cache_tags = super()._get_cache_tags()
+        try:
+            project = self._get_project()
+            cache_tags.append(
+                f'{project.slug}-rtd-footer',
+            )
+        except Exception as e:
+            log.debug('Error while retrieving project for this view.')
+        return cache_tags
+
     def get(self, request, format=None):
         project = self._get_project()
         version = self._get_version()
@@ -232,14 +247,7 @@ class BaseFooterHTML(APIView):
             'version_supported': version.supported,
         }
 
-        response = Response(resp_data)
-        cache_tags = [
-            project.slug,
-            f'{project.slug}-{version.slug}',
-            f'{project.slug}-rtd-footer',
-        ]
-        response['Cache-Tag'] = ','.join(cache_tags)
-        return response
+        return Response(resp_data)
 
 
 class FooterHTML(SettingsOverrideObject):

--- a/readthedocs/api/v2/views/footer_views.py
+++ b/readthedocs/api/v2/views/footer_views.py
@@ -109,6 +109,7 @@ class BaseFooterHTML(CachedResponseMixin, APIView):
     http_method_names = ['get']
     permission_classes = [IsAuthorizedToViewVersion]
     renderer_classes = [JSONRenderer, JSONPRenderer]
+    project_cache_tag = 'rtd-footer'
 
     @lru_cache(maxsize=1)
     def _get_project(self):
@@ -208,17 +209,6 @@ class BaseFooterHTML(CachedResponseMixin, APIView):
             'theme': theme,
         }
         return context
-
-    def _get_cache_tags(self):
-        cache_tags = super()._get_cache_tags()
-        try:
-            project = self._get_project()
-            cache_tags.append(
-                f'{project.slug}-rtd-footer',
-            )
-        except Exception as e:
-            log.debug('Error while retrieving project for this view.')
-        return cache_tags
 
     def get(self, request, format=None):
         project = self._get_project()

--- a/readthedocs/search/api.py
+++ b/readthedocs/search/api.py
@@ -9,6 +9,7 @@ from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.generics import GenericAPIView
 from rest_framework.pagination import PageNumberPagination
 
+from readthedocs.api.v2.mixins import CachedResponseMixin
 from readthedocs.api.v2.permissions import IsAuthorizedToViewVersion
 from readthedocs.builds.models import Version
 from readthedocs.projects.models import Feature, Project
@@ -116,7 +117,7 @@ class SearchPagination(PageNumberPagination):
         return result
 
 
-class PageSearchAPIView(GenericAPIView):
+class PageSearchAPIView(CachedResponseMixin, GenericAPIView):
 
     """
     Main entry point to perform a search using Elasticsearch.

--- a/readthedocs/search/api.py
+++ b/readthedocs/search/api.py
@@ -138,6 +138,7 @@ class PageSearchAPIView(CachedResponseMixin, GenericAPIView):
     permission_classes = [IsAuthorizedToViewVersion]
     pagination_class = SearchPagination
     serializer_class = PageSearchSerializer
+    project_cache_tag = 'rtd-search'
 
     @lru_cache(maxsize=1)
     def _get_project(self):

--- a/readthedocs/search/tests/test_proxied_api.py
+++ b/readthedocs/search/tests/test_proxied_api.py
@@ -11,6 +11,15 @@ class TestProxiedSearchAPI(BaseTestDocumentSearch):
     host = 'docs.readthedocs.io'
 
     def get_search(self, api_client, search_params):
-        # TODO: remove once the api is stable
-        search_params['new-api'] = 'true'
         return api_client.get(self.url, search_params, HTTP_HOST=self.host)
+
+    def test_headers(self, api_client, project):
+        version = project.versions.all().first()
+        search_params = {
+            'project': project.slug,
+            'version': version.slug,
+            'q': 'test',
+        }
+        resp = self.get_search(api_client, search_params)
+        assert resp.status_code == 200
+        assert resp['Cache-Tag'] == f'{project.slug},{project.slug}-{version.slug}'

--- a/readthedocs/search/tests/test_proxied_api.py
+++ b/readthedocs/search/tests/test_proxied_api.py
@@ -22,4 +22,5 @@ class TestProxiedSearchAPI(BaseTestDocumentSearch):
         }
         resp = self.get_search(api_client, search_params)
         assert resp.status_code == 200
-        assert resp['Cache-Tag'] == f'{project.slug},{project.slug}-{version.slug}'
+        cache_tags = f'{project.slug},{project.slug}-{version.slug},{project.slug}-rtd-search'
+        assert resp['Cache-Tag'] == cache_tags


### PR DESCRIPTION
So, there is one catch, search from the main project should be purged when one of the versions from its subprojects change (this can be done by adding one extra query when purging versions).

And... we are also losing some data from search analytics here, so not really sure if we want to cache search after all, or maybe just cache for a shorter time.