### PR TITLE
Use `admin` user for SLUMBER API on local environment

### DIFF
--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -20,6 +20,8 @@ class DockerBaseSettings(CommunityDevSettings):
     PUBLIC_API_URL = f'http://{PRODUCTION_DOMAIN}'
 
     SLUMBER_API_HOST = 'http://web:8000'
+    SLUMBER_USERNAME = 'admin'
+    SLUMBER_PASSWORD = 'admin'
 
     RTD_EXTERNAL_VERSION_DOMAIN = 'org.dev.readthedocs.build'
 


### PR DESCRIPTION
By default on local docker environment we were usign `test` user for SLUMBER
API. However, this user is not created at `--init` and it has to be created
manually.

To avoid this extra step, we are defining `admin` user for SLUMBER which is
created automatically on init.