### PR TITLE
Route external versions to the queue were default version was built

### DIFF
--- a/readthedocs/builds/tests/test_celery_task_router.py
+++ b/readthedocs/builds/tests/test_celery_task_router.py
@@ -70,21 +70,31 @@ class TaskRouterTests(TestCase):
         )
 
     def test_external_version(self):
-        self.version.type = EXTERNAL
-        self.version.save()
-
-        self.build.builder = 'build-default-a1b2c3'
-        self.build.save()
+        external_version = fixture.get(
+            Version,
+            project=self.project,
+            slug='pull-request',
+            type=EXTERNAL,
+        )
+        default_version = self.project.versions.get(slug=self.project.get_default_version())
+        default_version_build = fixture.get(
+            Build,
+            version=default_version,
+            project=self.project,
+            builder='build-default-a1b2c3',
+        )
+        args = (external_version.pk,)
+        kwargs = {'build_pk': default_version_build.pk}
 
         self.assertEqual(
-            self.router.route_for_task(self.task, self.args, self.kwargs),
+            self.router.route_for_task(self.task, args, kwargs),
             TaskRouter.BUILD_DEFAULT_QUEUE,
         )
 
-        self.build.builder = 'build-large-a1b2c3'
-        self.build.save()
+        default_version_build.builder = 'build-large-a1b2c3'
+        default_version_build.save()
 
         self.assertEqual(
-            self.router.route_for_task(self.task, self.args, self.kwargs),
+            self.router.route_for_task(self.task, args, kwargs),
             TaskRouter.BUILD_LARGE_QUEUE,
         )


### PR DESCRIPTION
When a build for an external version is triggered, we find the the last build
for the default version and use the same queue for this version.

This should make the build to always succeed when it's merged into the default
version since it's using the same build queue.

I thought this was fixed originally in
https://github.com/readthedocs/readthedocs.org/pull/7912/ but that PR was wrong.