### PR TITLE
Docs: Adds Myst to the getting started with sphinx

### DIFF
--- a/docs/intro/getting-started-with-sphinx.rst
+++ b/docs/intro/getting-started-with-sphinx.rst
@@ -104,11 +104,7 @@ Then in your ``conf.py``:
 
    extensions = ['myst-parser']
 
-.. warning:: Markdown doesn't support a lot of the features of Sphinx,
-          like inline markup and directives. However, it works for
-          basic prose content. reStructuredText is the preferred
-          format for technical documentation, please read `this blog post`_
-          for motivation.
+.. warning:: Markdown does works for basic prose content. But reStructuredText is the preferred format for technical documentation, please read `this blog post`_ for motivation.
 
 .. _this blog post: https://www.ericholscher.com/blog/2016/mar/15/dont-use-markdown-for-technical-docs/
 
@@ -120,7 +116,9 @@ Here are some external resources to help you learn more about Sphinx.
 
 * `Sphinx documentation`_
 * :doc:`RestructuredText primer <sphinx:usage/restructuredtext/basics>`
+* `Getting Started with MyST`_
 * `An introduction to Sphinx and Read the Docs for technical writers`_
 
 .. _Sphinx documentation: https://www.sphinx-doc.org/
+.. _Getting Started with MyST: https://myst-parser.readthedocs.io/en/latest/using/intro.html
 .. _An introduction to Sphinx and Read the Docs for technical writers: https://www.ericholscher.com/blog/2016/jul/1/sphinx-and-rtd-for-writers/

--- a/docs/intro/getting-started-with-sphinx.rst
+++ b/docs/intro/getting-started-with-sphinx.rst
@@ -91,7 +91,7 @@ by :doc:`importing your docs </intro/import-guide>`.
 Using Markdown with Sphinx
 --------------------------
 
-You can use Markdown and reStructuredText in the same Sphinx project.
+You can use `Markdown using MyST`_ and reStructuredText in the same Sphinx project.
 We support this natively on Read the Docs, and you can do it locally:
 
 .. prompt:: bash $
@@ -106,6 +106,8 @@ Then in your ``conf.py``:
 
 .. warning:: Markdown does works for basic prose content. But reStructuredText is the preferred format for technical documentation, please read `this blog post`_ for motivation.
 
+.. _Markdown using MyST: https://myst-parser.readthedocs.io/en/latest/using/intro.html
+
 .. _this blog post: https://www.ericholscher.com/blog/2016/mar/15/dont-use-markdown-for-technical-docs/
 
 
@@ -116,9 +118,7 @@ Here are some external resources to help you learn more about Sphinx.
 
 * `Sphinx documentation`_
 * :doc:`RestructuredText primer <sphinx:usage/restructuredtext/basics>`
-* `Getting Started with MyST`_
 * `An introduction to Sphinx and Read the Docs for technical writers`_
 
 .. _Sphinx documentation: https://www.sphinx-doc.org/
-.. _Getting Started with MyST: https://myst-parser.readthedocs.io/en/latest/using/intro.html
 .. _An introduction to Sphinx and Read the Docs for technical writers: https://www.ericholscher.com/blog/2016/jul/1/sphinx-and-rtd-for-writers/

--- a/docs/intro/getting-started-with-sphinx.rst
+++ b/docs/intro/getting-started-with-sphinx.rst
@@ -96,13 +96,13 @@ We support this natively on Read the Docs, and you can do it locally:
 
 .. prompt:: bash $
 
-    pip install recommonmark
+    pip install myst-parser
 
 Then in your ``conf.py``:
 
 .. code-block:: python
 
-   extensions = ['recommonmark']
+   extensions = ['myst-parser']
 
 .. warning:: Markdown doesn't support a lot of the features of Sphinx,
           like inline markup and directives. However, it works for

--- a/docs/intro/getting-started-with-sphinx.rst
+++ b/docs/intro/getting-started-with-sphinx.rst
@@ -104,7 +104,11 @@ Then in your ``conf.py``:
 
    extensions = ['myst-parser']
 
-.. warning:: Markdown does works for basic prose content. But reStructuredText is the preferred format for technical documentation, please read `this blog post`_ for motivation.
+.. warning::
+
+   Markdown does works for basic prose content.
+   But reStructuredText is the preferred format for technical documentation,
+   please read `this blog post`_ for motivation.
 
 .. _Markdown using MyST: https://myst-parser.readthedocs.io/en/latest/using/intro.html
 


### PR DESCRIPTION
Myst is a more maintained and feature complete version of markdown for Sphinx.
Updated `getting-started-with-sphinx.rst` and added Myst instalation
guide under `using-markdown-with-sphinx` section.

Closes https://github.com/readthedocs/readthedocs.org/issues/7937