### PR TITLE
Add Management Command to Dump Project and RemoteRepository Relationship in JSON format

### DIFF
--- a/readthedocs/projects/management/commands/dump_project_remote_repo_relation.py
+++ b/readthedocs/projects/management/commands/dump_project_remote_repo_relation.py
@@ -1,0 +1,45 @@
+import json
+
+from django.core.management.base import BaseCommand
+
+from readthedocs.projects.models import Project
+
+
+class Command(BaseCommand):
+    help = "Dump Project and RemoteRepository Relationship in JSON format"
+
+    def handle(self, *args, **options):
+        data = []
+
+        queryset = Project.objects.filter(
+            remote_repository__isnull=False,
+        ).values_list('id', 'remote_repository__json').distinct()
+
+        for project_id, remote_repository__json in queryset:
+            try:
+                json_data = json.loads(remote_repository__json)
+                # GitHub and GitLab uses `id` and Bitbucket uses `uuid`
+                # for the repository id
+                remote_id = json_data.get('id') or json_data.get('uuid')
+
+                if remote_id:
+                    data.append({
+                        'remote_id': remote_id,
+                        'project_id': project_id
+                    })
+                else:
+                    self.stdout.write(
+                        self.style.ERROR(
+                            f'Project {project_id} does not have a remote_repository remote_id'
+                        )
+                    )
+            except json.decoder.JSONDecodeError:
+                self.stdout.write(
+                    self.style.ERROR(
+                        f'Project {project_id} does not have a valid remote_repository__json'
+                    )
+                )
+
+        # Dump the data to a json file
+        with open('project-remote-repo-dump.json', 'w') as f:
+            f.write(json.dumps(data))

--- a/readthedocs/projects/management/commands/dump_project_remote_repo_relation.py
+++ b/readthedocs/projects/management/commands/dump_project_remote_repo_relation.py
@@ -24,12 +24,13 @@ class Command(BaseCommand):
             username=Subquery(users.values("username")[:1])
         ).values_list(
             'id',
+            'slug',
             'remote_repository__json',
             'remote_repository__html_url',
             'username'
         ).distinct()
 
-        for project_id, remote_repo_json, url, username in queryset.iterator():
+        for project_id, slug, remote_repo_json, url, username in queryset.iterator():
             try:
                 json_data = json.loads(remote_repo_json)
                 # GitHub and GitLab uses `id` and Bitbucket uses `uuid`
@@ -39,6 +40,7 @@ class Command(BaseCommand):
                 if remote_id:
                     data.append({
                         'project_id': project_id,
+                        'slug': slug,
                         'remote_id': remote_id,
                         'html_url': url,
                         'username': username,
@@ -46,13 +48,13 @@ class Command(BaseCommand):
                 else:
                     self.stdout.write(
                         self.style.ERROR(
-                            f'Project {project_id} does not have a remote_repository remote_id'
+                            f'Project {slug} does not have a remote_repository remote_id'
                         )
                     )
             except json.decoder.JSONDecodeError:
                 self.stdout.write(
                     self.style.ERROR(
-                        f'Project {project_id} does not have a valid remote_repository__json'
+                        f'Project {slug} does not have a valid remote_repository__json'
                     )
                 )
 

--- a/readthedocs/projects/management/commands/dump_project_remote_repo_relation.py
+++ b/readthedocs/projects/management/commands/dump_project_remote_repo_relation.py
@@ -1,6 +1,9 @@
 import json
 
+from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
+from django.db.models import OuterRef, Subquery
+from django.utils import timezone
 
 from readthedocs.projects.models import Project
 
@@ -11,21 +14,34 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         data = []
 
+        users = User.objects.filter(
+            oauth_repositories__project=OuterRef("pk")
+        )
+
         queryset = Project.objects.filter(
             remote_repository__isnull=False,
-        ).values_list('id', 'remote_repository__json').distinct()
+        ).annotate(
+            username=Subquery(users.values("username")[:1])
+        ).values_list(
+            'id',
+            'remote_repository__json',
+            'remote_repository__html_url',
+            'username'
+        ).distinct()
 
-        for project_id, remote_repository__json in queryset:
+        for project_id, remote_repo_json, url, username in queryset.iterator():
             try:
-                json_data = json.loads(remote_repository__json)
+                json_data = json.loads(remote_repo_json)
                 # GitHub and GitLab uses `id` and Bitbucket uses `uuid`
                 # for the repository id
                 remote_id = json_data.get('id') or json_data.get('uuid')
 
                 if remote_id:
                     data.append({
+                        'project_id': project_id,
                         'remote_id': remote_id,
-                        'project_id': project_id
+                        'html_url': url,
+                        'username': username,
                     })
                 else:
                     self.stdout.write(
@@ -41,5 +57,5 @@ class Command(BaseCommand):
                 )
 
         # Dump the data to a json file
-        with open('project-remote-repo-dump.json', 'w') as f:
+        with open(f'project-remote-repo-dump-{timezone.now():%Y-%m-%d-%H:%M}.json', 'w') as f:
             f.write(json.dumps(data))


### PR DESCRIPTION
This is one of two PR's for dumping/loading Project and RemoteRepository Relationship data.

This PR adds a management command to dump the project -> RemoteRepository relationship data in a json file. So, that It can be loaded by another command to update the relationship for the new tables.

ref: https://github.com/readthedocs/readthedocs.org/issues/7806