### PR TITLE
Upgrade `postgres-client` to v12 in Docker image

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -20,13 +20,22 @@ RUN apt-get -y install \
         build-essential \
         python3-pip \
         python3-dev \
-        postgresql-client \
         libmysqlclient-dev \
         libfreetype6 \
         libjpeg-dev \
         sqlite \
         netcat \
         telnet
+
+# https://www.postgresql.org/download/linux/ubuntu/
+# Use PostgreSQL client 12 from official PostgreSQL Ubuntu's repository to avoid this WARNING
+# WARNING: psql major version 10, server major version 12.
+# Some psql features might not work.
+# TODO: remove this when upgrading to Ubuntu 20.04 LTS
+RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+RUN curl -s https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+RUN apt-get -y update
+RUN apt-get -y install postgresql-client-12
 
 # Uncomment en_US.UTF-8 locale and generate it
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \


### PR DESCRIPTION
This is required to have a fully compatible client with the new features from
v12, which is the one that we are using on our docker setup, but also in
production.

As a example, the following command fails with the old client:

```
psql (10.15 (Ubuntu 10.15-0ubuntu0.18.04.1), server 12.5 (Debian 12.5-1.pgdg100+1))
WARNING: psql major version 10, server major version 12.
         Some psql features might not work.
Type "help" for help.

docs_db=# \d oauth_remoterepository
ERROR:  column c.relhasoids does not exist
LINE 1: ...riggers, c.relrowsecurity, c.relforcerowsecurity, c.relhasoi...
```

(note the differences between client and server versions)

We will need to update this also in our production images (cc @ericholscher we may need this to run DB queries from `dbshell` for the constraints)

Required by https://github.com/readthedocs/readthedocs.org/pull/7949#issuecomment-787988840