### PR TITLE
Update development/standards guide

### DIFF
--- a/docs/development/standards.rst
+++ b/docs/development/standards.rst
@@ -74,7 +74,7 @@ After cloning ``readthedocs.org`` repository, you need to
 
    .. prompt:: bash
 
-      git clone --recurse-submodules git@github.com:readthedocs/readthedocs.org.git
+      git clone --recurse-submodules https://github.com/readthedocs/readthedocs.org/
 
 #. install the requirements from ``common`` submodule:
 
@@ -178,7 +178,7 @@ save some work while typing docker compose commands. This section explains these
 Adding a new Python dependency
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The Docker image for the servers is built with the requirements defined in the checked out branch.
+The Docker image for the servers is built with the requirements defined in the current checked out branch.
 In case you need to add a new Python dependency while developing,
 you can use the ``common/dockerfiles/entrypoints/common.sh`` script as shortcut.
 

--- a/docs/development/standards.rst
+++ b/docs/development/standards.rst
@@ -13,9 +13,6 @@ Core team members expect to have a development environment that closely
 approximates our production environment, in order to spot bugs and logical
 inconsistencies before they make their way to production.
 
-Currently, core team members are migrating to a Docker Compose based
-solution that is not yet recommended for contributing to development.
-
 This solution gives us many features that allows us to have an
 environment closer to production:
 
@@ -72,6 +69,12 @@ After cloning ``readthedocs.org`` repository, you need to
 
 
 #. install `Docker <https://www.docker.com/>`_ following `their installation guide <https://docs.docker.com/install/>`_.
+
+#. clone the ``readthedocs.org`` repository:
+
+   .. prompt:: bash
+
+      git clone --recurse-submodules git@github.com:readthedocs/readthedocs.org.git
 
 #. install the requirements from ``common`` submodule:
 
@@ -158,6 +161,10 @@ save some work while typing docker compose commands. This section explains these
        you can run ``inv docker.attach web`` and jump into a pdb session
        (it also works with ipdb and pdb++)
 
+    .. tip::
+
+       You can hit CTRL-p CTRL-p to detach it without stopping the running process.
+
 ``inv docker.test``
     Runs all the test suites inside the container.
 
@@ -171,7 +178,7 @@ save some work while typing docker compose commands. This section explains these
 Adding a new Python dependency
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The Docker image for the servers is built with the requirements defined in the ``master`` branch.
+The Docker image for the servers is built with the requirements defined in the checked out branch.
 In case you need to add a new Python dependency while developing,
 you can use the ``common/dockerfiles/entrypoints/common.sh`` script as shortcut.
 
@@ -184,7 +191,7 @@ To do this, add the ``pip`` command required for your dependency in ``common.sh`
    # common.sh
    pip install my-dependency==1.2.3
 
-Once the PR that adds this dependency was merged into ``master``, you can rebuild the image
+Once the PR that adds this dependency was merged, you can rebuild the image
 so the dependency is added to the Docker image itself and it's not needed to be installed
 each time the container spins up.
 


### PR DESCRIPTION
- remove mention that this guide is not good for contributors; they should be
using this setup instead of the old one

- add `git clone` step that automatically clone the `common` submodule

- tip for dettach an attached session

- remove mention to `master` branch; we build from checked out branch now