### PR TITLE
Search: use doctype from indexed pages instead of the db

### DIFF
--- a/readthedocs/search/api.py
+++ b/readthedocs/search/api.py
@@ -189,7 +189,6 @@ class PageSearchAPIView(CachedResponseMixin, GenericAPIView):
                    alias='alias',
                    version=VersionData(
                         "latest",
-                        "sphinx",
                         "https://requests.readthedocs.io/en/latest/",
                     ),
                ),
@@ -197,7 +196,6 @@ class PageSearchAPIView(CachedResponseMixin, GenericAPIView):
                    alias=None,
                    version=VersionData(
                        "latest",
-                       "sphinx_htmldir",
                        "https://requests-oauth.readthedocs.io/en/latest/",
                    ),
                ),
@@ -215,7 +213,6 @@ class PageSearchAPIView(CachedResponseMixin, GenericAPIView):
                 alias=None,
                 version=VersionData(
                     slug=main_version.slug,
-                    doctype=main_version.documentation_type,
                     docs_url=main_project.get_docs_url(version_slug=main_version.slug),
                 ),
             )
@@ -246,7 +243,6 @@ class PageSearchAPIView(CachedResponseMixin, GenericAPIView):
                 project_alias = subproject.superprojects.values_list('alias', flat=True).first()
                 version_data = VersionData(
                     slug=version.slug,
-                    doctype=version.documentation_type,
                     docs_url=url,
                 )
                 projects_data[subproject.slug] = ProjectData(

--- a/readthedocs/search/serializers.py
+++ b/readthedocs/search/serializers.py
@@ -22,7 +22,7 @@ from readthedocs.projects.models import Project
 
 # Structure used for storing cached data of a version mostly.
 ProjectData = namedtuple('ProjectData', ['version', 'alias'])
-VersionData = namedtuple('VersionData', ['slug', 'docs_url', 'doctype'])
+VersionData = namedtuple('VersionData', ['slug', 'docs_url'])
 
 
 class ProjectHighlightSerializer(serializers.Serializer):
@@ -89,7 +89,6 @@ class PageSearchSerializer(serializers.Serializer):
             version_data = VersionData(
                 slug=obj.version,
                 docs_url=docs_url,
-                doctype=None,
             )
             projects_data[obj.project] = ProjectData(
                 alias=project_alias,
@@ -126,7 +125,7 @@ class PageSearchSerializer(serializers.Serializer):
 
             # Generate an appropriate link for the doctypes that use htmldir,
             # and always end it with / so it goes directly to proxito.
-            if project_data.version.doctype in {SPHINX_HTMLDIR, MKDOCS}:
+            if obj.doctype in {SPHINX_HTMLDIR, MKDOCS}:
                 path = re.sub('(^|/)index.html$', '/', path)
 
             return docs_url.rstrip('/') + '/' + path.lstrip('/')

--- a/readthedocs/search/tests/test_api.py
+++ b/readthedocs/search/tests/test_api.py
@@ -410,6 +410,11 @@ class BaseTestDocumentSearch:
         project.versions.update(documentation_type=doctype)
         version = project.versions.all().first()
 
+        # Refresh index
+        version_files = HTMLFile.objects.all().filter(version=version)
+        for f in version_files:
+            PageDocument().update(f)
+
         search_params = {
             'project': project.slug,
             'version': version.slug,
@@ -427,6 +432,11 @@ class BaseTestDocumentSearch:
         project = Project.objects.get(slug='docs')
         project.versions.update(documentation_type=doctype)
         version = project.versions.all().first()
+
+        # Refresh index
+        version_files = HTMLFile.objects.all().filter(version=version)
+        for f in version_files:
+            PageDocument().update(f)
 
         search_params = {
             'project': project.slug,
@@ -446,6 +456,11 @@ class BaseTestDocumentSearch:
         project.versions.update(documentation_type=doctype)
         version = project.versions.all().first()
 
+        # Refresh index
+        version_files = HTMLFile.objects.all().filter(version=version)
+        for f in version_files:
+            PageDocument().update(f)
+
         search_params = {
             'project': project.slug,
             'version': version.slug,
@@ -463,6 +478,11 @@ class BaseTestDocumentSearch:
         project = Project.objects.get(slug='docs')
         project.versions.update(documentation_type=doctype)
         version = project.versions.all().first()
+
+        # Refresh index
+        version_files = HTMLFile.objects.all().filter(version=version)
+        for f in version_files:
+            PageDocument().update(f)
 
         search_params = {
             'project': project.slug,
@@ -482,6 +502,11 @@ class BaseTestDocumentSearch:
         project.versions.update(documentation_type=doctype)
         version = project.versions.all().first()
 
+        # Refresh index
+        version_files = HTMLFile.objects.all().filter(version=version)
+        for f in version_files:
+            PageDocument().update(f)
+
         search_params = {
             'project': project.slug,
             'version': version.slug,
@@ -499,6 +524,11 @@ class BaseTestDocumentSearch:
         project = Project.objects.get(slug='docs')
         project.versions.update(documentation_type=doctype)
         version = project.versions.all().first()
+
+        # Refresh index
+        version_files = HTMLFile.objects.all().filter(version=version)
+        for f in version_files:
+            PageDocument().update(f)
 
         search_params = {
             'project': project.slug,

--- a/readthedocs/search/views.py
+++ b/readthedocs/search/views.py
@@ -57,16 +57,10 @@ class SearchView(View):
         return project
 
     def _get_project_data(self, project, version_slug):
-        version_doctype = (
-            project.versions
-            .values_list('documentation_type', flat=True)
-            .get(slug=version_slug)
-        )
         docs_url = project.get_docs_url(version_slug=version_slug)
         version_data = VersionData(
             slug=version_slug,
             docs_url=docs_url,
-            doctype=version_doctype,
         )
         project_data = {
             project.slug: ProjectData(


### PR DESCRIPTION
Since we did a re-index, we can use this value from the page instead
of querying from the db, now all results will have correct urls for the
given doctype :)

Closes https://github.com/readthedocs/readthedocs.org/issues/7762