### PR TITLE
Fixes typo in getting-started-with-sphinx:

### DIFF
--- a/docs/intro/getting-started-with-sphinx.rst
+++ b/docs/intro/getting-started-with-sphinx.rst
@@ -102,7 +102,7 @@ Then in your ``conf.py``:
 
 .. code-block:: python
 
-   extensions = ['myst-parser']
+   extensions = ['myst_parser']
 
 .. warning::
 


### PR DESCRIPTION
Replaces `myst-parser` -> `myst_parser` in `conf.py`