### PR TITLE
Use independent Docker image to build assets

### DIFF
--- a/dockerfiles/docker-compose-assets.yml
+++ b/dockerfiles/docker-compose-assets.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  assets:
+    image: node:8.16
+    volumes:
+      - ${PWD}:/usr/src/app/readthedocs.org
+    working_dir: /usr/src/app/readthedocs.org

--- a/docs/development/front-end.rst
+++ b/docs/development/front-end.rst
@@ -55,16 +55,7 @@ in.
 Getting Started
 ---------------
 
-You will need a working version of Node (tested with ``v10.17.0``) and NPM to get started.
-We won't cover that here, as it varies from platform to platform.
-
-To install these tools and dependencies::
-
-    npm install
-
-Next, install front end dependencies::
-
-    bower install
+You will need to follow our :doc:`guide to install a development Read the Docs instance </development/standards>` first.
 
 The sources for our bundles are found in the per-application path
 ``static-src``, which has the same directory structure as ``static``. Files in
@@ -72,26 +63,14 @@ The sources for our bundles are found in the per-application path
 Don't edit files in ``static`` directly, unless you are sure there isn't a
 source file that will compile over your changes.
 
-To test changes while developing, which will watch source files for changes and
-compile as necessary, you can run `Gulp`_ with our development target::
+To compile your changes and make them available in the application you need to run::
 
-    npm run dev
+    inv docker.buildassets
 
-Once you are satisfied with your changes, finalize the bundles (this will
-minify library sources)::
+Once you are happy with your changes,
+make sure to check in both files under ``static`` and ``static-src``,
+and commit those.
 
-    npm run build
-
-If you updated any of our vendor libraries, compile those::
-
-    npm run vendor
-
-Make sure to check in both files under ``static`` and ``static-src``.
-
-.. note::
-
-    We run Gulp  through an ``npm`` script in order to ensure
-    that the correct version from ``package.json`` is used.
 
 Making Changes
 --------------

--- a/docs/development/standards.rst
+++ b/docs/development/standards.rst
@@ -175,6 +175,9 @@ save some work while typing docker compose commands. This section explains these
 
     * ``--only-latest`` does not pull ``stable`` and ``testing`` images.
 
+``inv docker.buildassets``
+    Build all the assets and "deploy" them to the storage.
+
 Adding a new Python dependency
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -228,11 +228,6 @@ gulp.task('build', function (done) {
     es
         .merge(Object.keys(sources).map(function (n) {
             return build_app_sources(n, true);
-        }))
-        .pipe(es.wait(function (err, body) {
-            gulp_util.log('Collecting static files');
-            run('./manage.py collectstatic --noinput')
-                .exec('', function (err) { done(err); });
         }));
 });
 


### PR DESCRIPTION
Currently to build assets we need to install nodejs locally, install all the
node packages locally and call `npm ci && bower update && npm run build`. This
has some downsides due that all of this commands are not ran inside the docker
container:

- we need to have all the Python requirements installed locally
- `manage.py collectstatic` is run in the host machine
- all the static files are not copied to the S3 storage backend
- we don't know what version of `nodejs` is the valid one

To avoid all of these issues, this commit creates a new invoke task:

   inv docker.buildassets

which pins the version of node used, runs all the node commands in an isolated
docker container and finally runs `manage.py collectstatic --noinput` inside the
`web` container, which will copy all the new assets to the S3 storage backend
automatically for us.

(requires a PR in readthedocs/common repository: https://github.com/readthedocs/common/pull/85)