### PR TITLE
Embed: Allow to override embed view for proxied use

### DIFF
--- a/readthedocs/api/v2/proxied_urls.py
+++ b/readthedocs/api/v2/proxied_urls.py
@@ -9,14 +9,13 @@ from django.conf import settings
 from django.conf.urls import include, url
 
 from readthedocs.analytics.proxied_api import AnalyticsView
+from readthedocs.api.v2.views.proxied import ProxiedEmbedAPI, ProxiedFooterHTML
 from readthedocs.search.proxied_api import ProxiedPageSearchAPIView
-
-from .views.proxied import ProxiedFooterHTML
 
 api_footer_urls = [
     url(r'footer_html/', ProxiedFooterHTML.as_view(), name='footer_html'),
     url(r'search/$', ProxiedPageSearchAPIView.as_view(), name='search_api'),
-    url(r'embed/', include('readthedocs.embed.urls')),
+    url(r'embed/', ProxiedEmbedAPI.as_view(), name='embed_api'),
     url(r'analytics/$', AnalyticsView.as_view(), name='analytics_api'),
 ]
 

--- a/readthedocs/api/v2/views/proxied.py
+++ b/readthedocs/api/v2/views/proxied.py
@@ -1,6 +1,6 @@
+from readthedocs.api.v2.views.footer_views import BaseFooterHTML
 from readthedocs.core.utils.extend import SettingsOverrideObject
-
-from .footer_views import BaseFooterHTML
+from readthedocs.embed.views import EmbedAPIBase
 
 
 class BaseProxiedFooterHTML(BaseFooterHTML):
@@ -13,3 +13,15 @@ class BaseProxiedFooterHTML(BaseFooterHTML):
 class ProxiedFooterHTML(SettingsOverrideObject):
 
     _default_class = BaseProxiedFooterHTML
+
+
+class ProxiedEmbedAPIBase(EmbedAPIBase):
+
+    # DRF has BasicAuthentication and SessionAuthentication as default classes.
+    # We don't support neither in the community site.
+    authentication_classes = []
+
+
+class ProxiedEmbedAPI(SettingsOverrideObject):
+
+    _default_class = ProxiedEmbedAPIBase

--- a/readthedocs/rtd_tests/tests/test_imported_file.py
+++ b/readthedocs/rtd_tests/tests/test_imported_file.py
@@ -180,6 +180,8 @@ class ImportedFileTests(TestCase):
         self.assertNotEqual(ImportedFile.objects.get(name='test.html').md5, 'c7532f22a052d716f7b2310fb52ad981')
         self.assertEqual(ImportedFile.objects.count(), 2)
 
+    @override_settings(PRODUCTION_DOMAIN='readthedocs.org')
+    @override_settings(RTD_INTERSPHINX_URL='https://readthedocs.org')
     @mock.patch('readthedocs.projects.tasks.os.path.exists')
     def test_create_intersphinx_data(self, mock_exists):
         mock_exists.return_Value = True
@@ -254,7 +256,7 @@ class ImportedFileTests(TestCase):
             mock_fetch_inventory.assert_called_once()
             self.assertRegex(
                 mock_fetch_inventory.call_args[0][2],
-                '^https://{}/media/.*/objects.inv$'.format(settings.PRODUCTION_DOMAIN)
+                r'^https://readthedocs\.org/media/.*/objects\.inv$'
             )
         self.assertEqual(ImportedFile.objects.count(), 2)
 


### PR DESCRIPTION
And fix tests in .com.

Currently we are using the same view for the normal api and the proxied
api. This isn't correct as we don't have the auth backends in the
normal view. There is a change in .com as well.