### PR TITLE
Domain: allow to disable domain creation/update

### DIFF
--- a/readthedocs/projects/views/base.py
+++ b/readthedocs/projects/views/base.py
@@ -3,6 +3,7 @@
 """Mix-in classes for project views."""
 import logging
 from datetime import timedelta
+from functools import lru_cache
 
 from django.conf import settings
 from django.http import HttpResponseRedirect
@@ -12,7 +13,6 @@ from django.utils import timezone
 
 from ..exceptions import ProjectSpamError
 from ..models import Project
-
 
 log = logging.getLogger(__name__)
 
@@ -64,6 +64,7 @@ class ProjectAdminMixin:
         self.project = self.get_project()
         return self.model.objects.filter(project=self.project)
 
+    @lru_cache(maxsize=1)
     def get_project(self):
         """Return project determined by url kwarg."""
         if self.project_url_field not in self.kwargs:

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -9,6 +9,7 @@ from django.contrib import messages
 from django.db.models import Count
 from django.http import (
     Http404,
+    HttpResponse,
     HttpResponseBadRequest,
     HttpResponseNotAllowed,
     HttpResponseRedirect,
@@ -730,8 +731,18 @@ class DomainMixin(ProjectAdminMixin, PrivateViewMixin):
     def get_success_url(self):
         return reverse('projects_domains', args=[self.get_project().slug])
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        project = self.get_project()
+        context['enabled'] = self._is_enabled(project)
+        return context
 
-class DomainList(DomainMixin, ListViewWithForm):
+    def _is_enabled(self, project):
+        """Should we allow custom domains for this project?"""
+        return False
+
+
+class DomainListBase(DomainMixin, ListViewWithForm):
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
@@ -746,19 +757,36 @@ class DomainList(DomainMixin, ListViewWithForm):
         return ctx
 
 
+class DomainList(SettingsOverrideObject):
+
+    _default_class = DomainListBase
+
+
 class DomainCreateBase(DomainMixin, CreateView):
-    pass
+
+    def post(self, request, *args, **kwargs):
+        project = self.get_project()
+        if self._is_enabled(project):
+            return super().post(request, *args, **kwargs)
+        return HttpResponse('Action not allowed', status=401)
 
 
 class DomainCreate(SettingsOverrideObject):
+
     _default_class = DomainCreateBase
 
 
 class DomainUpdateBase(DomainMixin, UpdateView):
-    pass
+
+    def post(self, request, *args, **kwargs):
+        project = self.get_project()
+        if self._is_enabled(project):
+            return super().post(request, *args, **kwargs)
+        return HttpResponse('Action not allowed', status=401)
 
 
 class DomainUpdate(SettingsOverrideObject):
+
     _default_class = DomainUpdateBase
 
 

--- a/readthedocs/templates/projects/domain_form.html
+++ b/readthedocs/templates/projects/domain_form.html
@@ -21,6 +21,13 @@
 {% endblock %}
 
 {% block project_edit_content %}
+
+  {% if not enabled %}
+    {% block disabled %}
+      {% include 'projects/includes/feature_disabled.html' with project=project %}
+    {% endblock %}
+  {% endif %}
+
   {% if domain.domainssl %}
     {# This references optional code to get the SSL certificate status #}
     <p>

--- a/readthedocs/templates/projects/domain_list.html
+++ b/readthedocs/templates/projects/domain_list.html
@@ -34,10 +34,17 @@
   {% endif %}
 
   <h3> {% trans "Add new Domain" %} </h3>
-  <form method="post" action="{% url 'projects_domains_create' project.slug %}">{% csrf_token %}
-    {{ form.as_p }}
-    <p>
-      <input style="display: inline;" type="submit" value="{% trans "Add" %}">
-    </p>
-  </form>
+
+  {% if not enabled %}
+    {% block disabled %}
+      {% include 'projects/includes/feature_disabled.html' with project=project %}
+    {% endblock %}
+  {% else %}
+    <form method="post" action="{% url 'projects_domains_create' project.slug %}">{% csrf_token %}
+      {{ form.as_p }}
+      <p>
+        <input style="display: inline;" type="submit" value="{% trans "Add" %}">
+      </p>
+    </form>
+  {% endif %}
 {% endblock %}

--- a/readthedocs/templates/projects/includes/feature_disabled.html
+++ b/readthedocs/templates/projects/includes/feature_disabled.html
@@ -1,3 +1,3 @@
 <p class="empty">
-  This is a beta feature, it can be enabled by <a href="mailto:{{ SUPPORT_EMAIL }}">asking support</a>.
+  This is a beta feature, it can be enabled by <a href="{% url 'support' %}">contacting support</a>.
 </p>


### PR DESCRIPTION
This is to have better validation in .com.
We still allow to delete them.

We override these templates in .com completely, so there aren't any visual changes... I could just remove the disable blocks, but better to leave them just in case.