### PR TITLE
Use `RemoteRepository` releation to match already imported projects

### DIFF
--- a/readthedocs/oauth/models.py
+++ b/readthedocs/oauth/models.py
@@ -200,22 +200,16 @@ class RemoteRepository(TimeStampedModel):
     def __str__(self):
         return 'Remote repository: {}'.format(self.html_url)
 
-    @property
-    def clone_fuzzy_url(self):
-        """Try to match against several permutations of project URL."""
-
     def matches(self, user):
-        """Projects that exist with repository URL already."""
-        # Support Git scheme GitHub url format that may exist in database
-        truncated_url = self.clone_url.replace('.git', '')
-        http_url = self.clone_url.replace('git://', 'https://').replace('.git', '')
+        """Existing projects connected to this RemoteRepository."""
+
+        # TODO: remove this method and refactor the API response in ``/api/v2/repos/``
+        # (or v3) to just return the linked Project (slug, url) if the ``RemoteRepository``
+        # connection exists. Note the frontend needs to be simplified as well in
+        # ``import.js`` and ``project_import.html``.
 
         projects = Project.objects.public(user).filter(
-            Q(repo=self.clone_url) |
-            Q(repo=truncated_url) |
-            Q(repo=truncated_url + '.git') |
-            Q(repo=http_url) |
-            Q(repo=http_url + '.git')
+            remote_repository=self,
         ).values('slug')
 
         return [{


### PR DESCRIPTION
Currently production code consider a project already imported if the
`Project.repo` fuzzy matches `RemoteRepository.clone_url` even if that `Project`
is not linked to any `RemoteRepository`.

This allow anyone to import a repository manually using the real GitHub URL to
"take over" that repository and avoiding the real owner of that repository to
import it from "Import Project" page because it says:

    This repository has already been imported

and linking to the project that someone's else has imported.

With the changes on this PR, we are showing that message only if the `Project`
is connected to a `RemoteRepository` which is only possible to be done by owners
of the GitHub repository.

> NOTE that this PR is based on `rel` which already have #7949 merged. We can cherry-pick this commit into `rel` and also into #7949 before merging that PR into `master`. 