### PR TITLE
Canonicalize all proxito slashes

### DIFF
--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -8,7 +8,7 @@ Additional processing is done to get the project from the URL in the ``views.py`
 import logging
 import sys
 import re
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import urlparse
 
 from django.conf import settings
 from django.shortcuts import render, redirect
@@ -180,7 +180,7 @@ class ProxitoMiddleware(MiddlewareMixin):
             url_parsed = urlparse(request.get_full_path())
             clean_path = re.sub('//+', '/', url_parsed.path)
             new_parsed = url_parsed._replace(path=clean_path)
-            return redirect(urlunparse(new_parsed))
+            return redirect(new_parsed.geturl())
 
         log.debug('Proxito Project: slug=%s', ret)
 

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -8,6 +8,7 @@ Additional processing is done to get the project from the URL in the ``views.py`
 import logging
 import sys
 import re
+from urllib.parse import urlparse, urlunparse
 
 from django.conf import settings
 from django.shortcuts import render, redirect
@@ -176,7 +177,10 @@ class ProxitoMiddleware(MiddlewareMixin):
 
         if '//' in request.path:
             # Remove multiple slashes from URL's
-            return redirect(re.sub('//+', '/', request.get_full_path()))
+            url_parsed = urlparse(request.get_full_path())
+            clean_path = re.sub('//+', '/', url_parsed.path)
+            new_parsed = url_parsed._replace(path=clean_path)
+            return redirect(urlunparse(new_parsed))
 
         log.debug('Proxito Project: slug=%s', ret)
 

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -7,9 +7,10 @@ Additional processing is done to get the project from the URL in the ``views.py`
 """
 import logging
 import sys
+import re
 
 from django.conf import settings
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.utils.deprecation import MiddlewareMixin
 from django.urls import reverse
 
@@ -172,6 +173,10 @@ class ProxitoMiddleware(MiddlewareMixin):
         # Handle returning a response
         if hasattr(ret, 'status_code'):
             return ret
+
+        if '//' in request.path:
+            # Remove multiple slashes from URL's
+            return redirect(re.sub('//+', '/', request.get_full_path()))
 
         log.debug('Proxito Project: slug=%s', ret)
 

--- a/readthedocs/proxito/tests/test_redirects.py
+++ b/readthedocs/proxito/tests/test_redirects.py
@@ -130,3 +130,26 @@ class RedirectTests(BaseDocServing):
             'https://project.dev.readthedocs.io/en/latest/test.html',
         )
 
+    def test_slash_redirect(self):
+        host = 'project.dev.readthedocs.io'
+
+        url = '/en/latest////awesome.html'
+        resp = self.client.get(url, HTTP_HOST=host)
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(
+            resp['Location'], '/en/latest/awesome.html',
+        )
+
+        url = '///en/latest////awesome.html'
+        resp = self.client.get(url, HTTP_HOST=host)
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(
+            resp['Location'], '/en/latest/awesome.html',
+        )
+
+        url = '///en/latest////awesome///index.html'
+        resp = self.client.get(url, HTTP_HOST=host)
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(
+            resp['Location'], '/en/latest/awesome/index.html',
+        )

--- a/readthedocs/proxito/tests/test_redirects.py
+++ b/readthedocs/proxito/tests/test_redirects.py
@@ -153,3 +153,25 @@ class RedirectTests(BaseDocServing):
         self.assertEqual(
             resp['Location'], '/en/latest/awesome/index.html',
         )
+
+        url = '///en/latest////awesome///index.html?foo=bar'
+        resp = self.client.get(url, HTTP_HOST=host)
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(
+            resp['Location'], '/en/latest/awesome/index.html?foo=bar',
+        )
+
+        url = '///en/latest////awesome///'
+        resp = self.client.get(url, HTTP_HOST=host)
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(
+            resp['Location'], '/en/latest/awesome/',
+        )
+
+        # Don't change the values of params
+        url = '///en/latest////awesome///index.html?foo=bar//bas'
+        resp = self.client.get(url, HTTP_HOST=host)
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(
+            resp['Location'], '/en/latest/awesome/index.html?foo=bar//bas',
+        )


### PR DESCRIPTION
This is currently broken,
eg. this URL works:
https://docs.readthedocs.io/en/latest///index.html