### PR TITLE
Docs: remove pdf format in MkdDocs example

### DIFF
--- a/docs/config-file/v2.rst
+++ b/docs/config-file/v2.rst
@@ -49,10 +49,6 @@ Below is an example YAML file which shows the most common configuration options:
          mkdocs:
            configuration: mkdocs.yml
 
-         # Optionally build your docs in additional formats such as PDF
-         formats:
-            - pdf
-
          # Optionally set the version of Python and requirements required to build your docs
          python:
             version: 3.7


### PR DESCRIPTION
We don't support pdf for MkdDocs D: