### PR TITLE
Embed: add cache tags

### DIFF
--- a/readthedocs/embed/tests/test_api.py
+++ b/readthedocs/embed/tests/test_api.py
@@ -220,6 +220,7 @@ class TestEmbedAPI:
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data == expected
+        assert response['Cache-tag'] == 'project,project-latest'
 
     @mock.patch('readthedocs.embed.views.build_media_storage')
     def test_embed_mkdocs(self, storage_mock, client):

--- a/readthedocs/embed/views.py
+++ b/readthedocs/embed/views.py
@@ -16,6 +16,7 @@ from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from readthedocs.api.v2.mixins import CachedResponseMixin
 from readthedocs.api.v2.permissions import IsAuthorizedToViewVersion
 from readthedocs.builds.constants import EXTERNAL
 from readthedocs.core.resolver import resolve
@@ -80,7 +81,7 @@ def clean_links(obj, url):
     return obj
 
 
-class EmbedAPIBase(APIView):
+class EmbedAPIBase(CachedResponseMixin, APIView):
 
     # pylint: disable=line-too-long
 


### PR DESCRIPTION
This doesn't require any other changes in our purging code,
as this is purged when the project or version changes.