### PR TITLE
Feature flag: remove EXTERNAL_BUILD

### DIFF
--- a/docs/guides/feature-flags.rst
+++ b/docs/guides/feature-flags.rst
@@ -47,8 +47,6 @@ e.g. python-reno release notes manager is known to do that
 
 ``USE_TESTING_BUILD_IMAGE``: :featureflags:`USE_TESTING_BUILD_IMAGE`
 
-``EXTERNAL_VERSION_BUILD``: :featureflags:`EXTERNAL_VERSION_BUILD`
-
 ``LIST_PACKAGES_INSTALLED_ENV``: :featureflags:`LIST_PACKAGES_INSTALLED_ENV`
 
 ``DONT_CREATE_INDEX``: :featureflags:`DONT_CREATE_INDEX`

--- a/readthedocs/api/v2/views/integrations.py
+++ b/readthedocs/api/v2/views/integrations.py
@@ -409,12 +409,7 @@ class GitHubWebhookView(WebhookMixin, APIView):
             return self.sync_versions_response(self.project)
 
         # Handle pull request events
-        if all([
-                self.project.has_feature(Feature.EXTERNAL_VERSION_BUILD),
-                self.project.external_builds_enabled,
-                event == GITHUB_PULL_REQUEST,
-                action,
-        ]):
+        if self.project.external_builds_enabled and event == GITHUB_PULL_REQUEST:
             if (
                 action in
                 [
@@ -569,11 +564,7 @@ class GitLabWebhookView(WebhookMixin, APIView):
             except KeyError:
                 raise ParseError('Parameter "ref" is required')
 
-        if (
-            self.project.has_feature(Feature.EXTERNAL_VERSION_BUILD) and
-            self.project.external_builds_enabled and
-            event == GITLAB_MERGE_REQUEST and action
-        ):
+        if self.project.external_builds_enabled and event == GITLAB_MERGE_REQUEST:
             if (
                 action in
                 [

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -273,10 +273,6 @@ class ProjectAdvancedForm(HideProtectedLevelMixin, ProjectTriggerBuildMixin, Pro
         else:
             self.fields['default_version'].widget.attrs['readonly'] = True
 
-        # Enable PR builder option on projects w/ feature flag
-        if not self.instance.has_feature(Feature.EXTERNAL_VERSION_BUILD):
-            self.fields.pop('external_builds_enabled')
-
     def clean_conf_py_file(self):
         filename = self.cleaned_data.get('conf_py_file', '').strip()
         if filename and 'conf.py' not in filename:

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1569,7 +1569,6 @@ class Feature(models.Model):
     DONT_SHALLOW_CLONE = 'dont_shallow_clone'
     USE_TESTING_BUILD_IMAGE = 'use_testing_build_image'
     CLEAN_AFTER_BUILD = 'clean_after_build'
-    EXTERNAL_VERSION_BUILD = 'external_version_build'
     UPDATE_CONDA_STARTUP = 'update_conda_startup'
     CONDA_APPEND_CORE_REQUIREMENTS = 'conda_append_core_requirements'
     CONDA_USES_MAMBA = 'conda_uses_mamba'
@@ -1633,10 +1632,6 @@ class Feature(models.Model):
         (
             CLEAN_AFTER_BUILD,
             _('Clean all files used in the build process'),
-        ),
-        (
-            EXTERNAL_VERSION_BUILD,
-            _('Enable project to build on pull/merge requests'),
         ),
         (
             UPDATE_CONDA_STARTUP,


### PR DESCRIPTION
This is already the default in both sites.
We already migrated projects to use the project setting.