### PR TITLE
Test proxied embed API

### DIFF
--- a/readthedocs/embed/tests/test_api.py
+++ b/readthedocs/embed/tests/test_api.py
@@ -37,6 +37,7 @@ class BaseTestEmbedAPI:
         settings.PUBLIC_DOMAIN = 'readthedocs.io'
 
     def get(self, client, *args, **kwargs):
+        """Wrapper around ``client.get`` to be overridden in the proxied api tests."""
         return client.get(*args, **kwargs)
 
     def _mock_open(self, content):

--- a/readthedocs/embed/urls.py
+++ b/readthedocs/embed/urls.py
@@ -4,5 +4,5 @@ from .views import EmbedAPI
 
 
 urlpatterns = [
-    url(r'', EmbedAPI.as_view(), name='api_embed'),
+    url(r'', EmbedAPI.as_view(), name='embed_api'),
 ]


### PR DESCRIPTION
- Changed the url name to match the others and have the same name as the
  proxied one.
- Divide the test so is easy to test the proxied version.