### PR TITLE
Build environment: remove unused code

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -130,10 +130,6 @@ class BuildCommand(BuildCommandResultMixin):
         log.info("Running: '%s' [%s]", self.get_command(), self.cwd)
 
         self.start_time = datetime.utcnow()
-        stdout = subprocess.PIPE
-        stderr = subprocess.STDOUT
-        stdin = None
-
         environment = self.environment.copy()
         if 'DJANGO_SETTINGS_MODULE' in environment:
             del environment['DJANGO_SETTINGS_MODULE']
@@ -158,9 +154,9 @@ class BuildCommand(BuildCommandResultMixin):
                 # This is done here for local builds, but not for docker,
                 # as we want docker to expand inside the container
                 cwd=os.path.expandvars(self.cwd),
-                stdin=stdin,
-                stdout=stdout,
-                stderr=stderr,
+                stdin=None,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
                 env=environment,
             )
             cmd_stdout, cmd_stderr = proc.communicate()

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -25,11 +25,11 @@ from readthedocs.builds.constants import BUILD_STATE_FINISHED
 from readthedocs.builds.models import BuildCommandResultMixin
 from readthedocs.core.utils import slugify
 from readthedocs.projects.constants import LOG_TEMPLATE
-from readthedocs.projects.models import Feature
 from readthedocs.projects.exceptions import (
-    RepositoryError,
     ProjectConfigurationError,
+    RepositoryError,
 )
+from readthedocs.projects.models import Feature
 
 from .constants import (
     DOCKER_HOSTNAME_MAX_LEN,
@@ -51,7 +51,6 @@ from .exceptions import (
     VersionLockedError,
     YAMLParseError,
 )
-
 
 log = logging.getLogger(__name__)
 
@@ -81,9 +80,6 @@ class BuildCommand(BuildCommandResultMixin):
     :param shell: execute command in shell, default=False
     :param environment: environment variables to add to environment
     :type environment: dict
-    :param combine_output: combine stdout/stderr, default=True
-    :param input_data: data to pass in on stdin
-    :type input_data: str
     :param build_env: build environment to use to execute commands
     :param bin_path: binary path to add to PATH resolution
     :param description: a more grokable description of the command being run
@@ -96,8 +92,6 @@ class BuildCommand(BuildCommandResultMixin):
             cwd=None,
             shell=False,
             environment=None,
-            combine_output=True,
-            input_data=None,
             build_env=None,
             bin_path=None,
             description=None,
@@ -113,8 +107,6 @@ class BuildCommand(BuildCommandResultMixin):
         if 'PATH' in self.environment:
             raise BuildEnvironmentError('\'PATH\' can\'t be set. Use bin_path')
 
-        self.combine_output = combine_output
-        self.input_data = input_data
         self.build_env = build_env
         self.output = None
         self.error = None
@@ -122,9 +114,7 @@ class BuildCommand(BuildCommandResultMixin):
         self.end_time = None
 
         self.bin_path = bin_path
-        self.description = ''
-        if description is not None:
-            self.description = description
+        self.description = description or ''
         self.record_as_success = record_as_success
         self.exit_code = None
 
@@ -136,23 +126,13 @@ class BuildCommand(BuildCommandResultMixin):
         return '\n'.join([self.get_command(), output])
 
     def run(self):
-        """
-        Set up subprocess and execute command.
-
-        :param cmd_input: input to pass to command in STDIN
-        :type cmd_input: str
-        :param combine_output: combine STDERR into STDOUT
-        """
+        """Set up subprocess and execute command."""
         log.info("Running: '%s' [%s]", self.get_command(), self.cwd)
 
         self.start_time = datetime.utcnow()
         stdout = subprocess.PIPE
-        stderr = subprocess.PIPE
+        stderr = subprocess.STDOUT
         stdin = None
-        if self.input_data is not None:
-            stdin = subprocess.PIPE
-        if self.combine_output:
-            stderr = subprocess.STDOUT
 
         environment = self.environment.copy()
         if 'DJANGO_SETTINGS_MODULE' in environment:
@@ -183,16 +163,7 @@ class BuildCommand(BuildCommandResultMixin):
                 stderr=stderr,
                 env=environment,
             )
-            cmd_input = None
-            if self.input_data is not None:
-                cmd_input = self.input_data
-
-            if isinstance(cmd_input, str):
-                cmd_input_bytes = cmd_input.encode('utf-8')
-            else:
-                cmd_input_bytes = cmd_input
-            cmd_output = proc.communicate(input=cmd_input_bytes)
-            (cmd_stdout, cmd_stderr) = cmd_output
+            cmd_stdout, cmd_stderr = proc.communicate()
             self.output = self.sanitize_output(cmd_stdout)
             self.error = self.sanitize_output(cmd_stderr)
             self.exit_code = proc.returncode

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -1038,12 +1038,6 @@ class TestBuildCommand(TestCase):
         missing_re = re.compile(r'(?:No such file or directory|not found)')
         self.assertRegex(cmd.error, missing_re)
 
-    def test_input(self):
-        """Test input to command."""
-        cmd = BuildCommand('/bin/cat', input_data='FOOBAR')
-        cmd.run()
-        self.assertEqual(cmd.output, 'FOOBAR')
-
     def test_output(self):
         """Test output command."""
         cmd = BuildCommand(['/bin/bash', '-c', 'echo -n FOOBAR'])
@@ -1061,19 +1055,10 @@ class TestBuildCommand(TestCase):
 
     def test_error_output(self):
         """Test error output from command."""
-        # Test default combined output/error streams
         cmd = BuildCommand(['/bin/bash', '-c', 'echo -n FOOBAR 1>&2'])
         cmd.run()
         self.assertEqual(cmd.output, 'FOOBAR')
         self.assertIsNone(cmd.error)
-        # Test non-combined streams
-        cmd = BuildCommand(
-            ['/bin/bash', '-c', 'echo -n FOOBAR 1>&2'],
-            combine_output=False,
-        )
-        cmd.run()
-        self.assertEqual(cmd.output, '')
-        self.assertEqual(cmd.error, 'FOOBAR')
 
     def test_sanitize_output(self):
         cmd = BuildCommand(['/bin/bash', '-c', 'echo'])


### PR DESCRIPTION
Small things I saw while reading this code.
combine_output and input data aren't used in our code nor in docker.
 I think we can remove the non-docker implementation at some point.