### PR TITLE
Python Environment: Use latest theme on all sphinx versions

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -1,4 +1,4 @@
-"""An abstraction over virtualenv and Conda environments."""
+sphinx-rtd-theme"""An abstraction over virtualenv and Conda environments."""
 
 import codecs
 import copy
@@ -377,12 +377,15 @@ class Virtualenv(PythonEnvironment):
                     positive='sphinx',
                     negative='sphinx<2',
                 ),
-                # If defaulting to Sphinx 2+, we need to push the latest theme
-                # release as well. `<0.5.0` is not compatible with Sphinx 2+
+                # When using sphinx<2 use a theme version that is supported.
+                # While sphinx-rtd-theme 0.5.2 supports sphinx<2 and sphinx>2,
+                # support for sphinx<2 will be removed in the future.
+                # In that case we may need to modify the versions here
+                # or handle sphinx compatibility in the theme.
                 self.project.get_feature_value(
                     Feature.USE_SPHINX_LATEST,
                     positive='sphinx-rtd-theme',
-                    negative='sphinx-rtd-theme<0.5',
+                    negative='sphinx-rtd-theme<0.6',
                 ),
                 self.project.get_feature_value(
                     Feature.USE_SPHINX_RTD_EXT_LATEST,

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -1,4 +1,4 @@
-sphinx-rtd-theme"""An abstraction over virtualenv and Conda environments."""
+"""An abstraction over virtualenv and Conda environments."""
 
 import codecs
 import copy


### PR DESCRIPTION
The latest theme version is compatible with all sphinx versions.
This should fix https://github.com/readthedocs/readthedocs.org/issues/8070

In the future, we will want to modify the version number used for old sphinx versions once sphinx 1.x is dropped by the theme.
This likely won't happen until `sphinx-rtd-theme 2.0` see https://github.com/readthedocs/sphinx_rtd_theme/issues/1086

I haven't tested this yet, but in the future, this may not be needed at all as we can handle dependency versions within the theme itself.