### PR TITLE
Builds: don't install implicit deps

### DIFF
--- a/docs/builds.rst
+++ b/docs/builds.rst
@@ -70,10 +70,74 @@ An example in code:
     we recommend you :ref:`pinning the version <guides/reproducible-builds:pinning dependencies>` of Sphinx or Mkdocs you want us to use.
     Some examples of pinning versions might be ``sphinx<2.0`` or ``mkdocs>=1.0``.
 
+Implicit dependencies
+---------------------
+
+Read the Docs install some dependencies by default.
+We recommend to :ref:`not rely on these <guides/reproducible-builds:don't rely on implicit dependencies>`,
+and always declare them when building your documentation.
+
+Python environment
+``````````````````
+
+These are the dependencies that are installed by default when using a Python environment.
+
+pip:
+  Latest version.
+
+setuptools:
+  Latest version.
+
+sphinx:
+  Projects created before Oct 20, 2020 use ``1.8.x``.
+  New projects use the latest version.
+
+mkdocs:
+  Projects created before April 3, 2019 (April 23, 2019 for :doc:`/commercial/index`) use ``0.17.3``.
+  Projects created before March 9, 2021 use ``1.0.4``.
+  New projects use the latest version.
+
+sphinx-rtd-theme:
+  Projects created before October 20, 2020 (January 21, 2021 for :doc:`/commercial/index`) use ``0.4.3``,
+  projects after that date will use the latest version.
+  Projects created after April 13, 2021 won't have this dependency installed by default.
+
+Others:
+   Projects created after April 13, 2021 won't include these dependencies.
+
+   - mock: ``1.0.1``
+   - pillow: ``5.4.1``
+   - alabaster: ``0.7.x``
+   - commonmark: ``0.8.1``
+   - recommonmark: ``0.5.0``
+
+Conda environment
+`````````````````
+
+These are the dependencies that are installed by default when using a Conda environment.
+
+conda:
+   Miniconda2 ``4.6.14``
+   (could be updated in the future to use the latest version by default).
+
+mkdocs:
+  Latest version installed via ``conda``.
+
+sphinx:
+  Latest version installed via ``conda``.
+
+Others:
+   Projects created after April 13, 2021 won't include these dependencies.
+
+   - sphinx-rtd-theme: Latest version installed via ``conda``.
+   - recommonmark: Latest version installed via ``conda``.
+   - mock: Latest version installed via ``pip``.
+   - pillow: Latest version installed via ``pip``.
+
 Build environment
 -----------------
 
-The *Sphinx* and *Mkdocs* builders set the following RTD-specific environment variables when building your documentation:
+The following RTD-specific environment variables are set when building your documentation:
 
 .. csv-table:: Environment Variables
    :header: Environment variable, Description, Example value
@@ -84,13 +148,11 @@ The *Sphinx* and *Mkdocs* builders set the following RTD-specific environment va
    ``READTHEDOCS_PROJECT``, The RTD slug of the project which is being built, ``my-example-project``
    ``READTHEDOCS_LANGUAGE``, The RTD language slug of the project which is being built, ``en``
 
-
 .. tip::
 
    In case extra environment variables are needed to the build process (like secrets, tokens, etc),
    you can add them going to :guilabel:`Admin` > :guilabel:`Environment Variables` in your project.
    See :doc:`guides/environment-variables`.
-
 
 Docker images
 -------------

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -326,37 +326,16 @@ class Virtualenv(PythonEnvironment):
             cwd='$HOME',
         )
 
-    def install_core_requirements(self):
-        """Install basic Read the Docs requirements into the virtualenv."""
-        pip_install_cmd = [
-            self.venv_bin(filename='python'),
-            '-m',
-            'pip',
-            'install',
-            '--upgrade',
-            *self._pip_cache_cmd_argument(),
-        ]
-
-        # Install latest pip and setuptools first,
-        # so it is used when installing the other requirements.
-        pip_version = self.project.get_feature_value(
-            Feature.DONT_INSTALL_LATEST_PIP,
-            # 20.3 uses the new resolver by default.
-            positive='pip<20.3',
-            negative='pip',
-        )
-        cmd = pip_install_cmd + [pip_version, 'setuptools']
-        self.build_env.run(
-            *cmd, bin_path=self.venv_bin(), cwd=self.checkout_path
-        )
-
-        requirements = [
-            'mock==1.0.1',
-            'pillow==5.4.1',
-            'alabaster>=0.7,<0.8,!=0.7.5',
-            'commonmark==0.8.1',
-            'recommonmark==0.5.0',
-        ]
+    def _get_core_requirements(self):
+        requirements = []
+        if not self.project.has_feature(Feature.DONT_INSTALL_IMPLICIT_DEPS):
+            requirements.extend([
+                'mock==1.0.1',
+                'pillow==5.4.1',
+                'alabaster>=0.7,<0.8,!=0.7.5',
+                'commonmark==0.8.1',
+                'recommonmark==0.5.0',
+            ])
 
         if self.config.doctype == 'mkdocs':
             requirements.append(
@@ -377,19 +356,50 @@ class Virtualenv(PythonEnvironment):
                     positive='sphinx',
                     negative='sphinx<2',
                 ),
-                # If defaulting to Sphinx 2+, we need to push the latest theme
-                # release as well. `<0.5.0` is not compatible with Sphinx 2+
-                self.project.get_feature_value(
-                    Feature.USE_SPHINX_LATEST,
-                    positive='sphinx-rtd-theme',
-                    negative='sphinx-rtd-theme<0.5',
-                ),
                 self.project.get_feature_value(
                     Feature.USE_SPHINX_RTD_EXT_LATEST,
                     positive='readthedocs-sphinx-ext',
                     negative='readthedocs-sphinx-ext<2.2',
                 ),
             ])
+
+            if not self.project.has_feature(Feature.DONT_INSTALL_IMPLICIT_DEPS):
+                # If defaulting to Sphinx 2+, we need to push the latest theme
+                # release as well. `<0.5.0` is not compatible with Sphinx 2+
+                requirements.append(
+                    self.project.get_feature_value(
+                        Feature.USE_SPHINX_LATEST,
+                        positive='sphinx-rtd-theme',
+                        negative='sphinx-rtd-theme<0.5',
+                    ),
+                )
+        return requirements
+
+    def install_core_requirements(self):
+        """Install basic Read the Docs requirements into the virtualenv."""
+        pip_install_cmd = [
+            self.venv_bin(filename='python'),
+            '-m',
+            'pip',
+            'install',
+            '--upgrade',
+            *self._pip_cache_cmd_argument(),
+        ]
+
+        # Install latest pip and setuptools first,
+        # so they are used when installing the other requirements.
+        pip_version = self.project.get_feature_value(
+            Feature.DONT_INSTALL_LATEST_PIP,
+            # 20.3 uses the new resolver by default.
+            positive='pip<20.3',
+            negative='pip',
+        )
+        cmd = pip_install_cmd + [pip_version, 'setuptools']
+        self.build_env.run(
+            *cmd,
+            bin_path=self.venv_bin(),
+            cwd=self.checkout_path,
+        )
 
         cmd = copy.copy(pip_install_cmd)
         if self.config.python.use_system_site_packages:
@@ -398,11 +408,12 @@ class Virtualenv(PythonEnvironment):
             # even if it is already installed system-wide (and
             # --system-site-packages is used)
             cmd.append('-I')
-        cmd.extend(requirements)
+
+        cmd.extend(self._get_core_requirements())
         self.build_env.run(
             *cmd,
             bin_path=self.venv_bin(),
-            cwd=self.checkout_path  # noqa - no comma here in py27 :/
+            cwd=self.checkout_path,
         )
 
     def install_requirements_file(self, install):
@@ -639,25 +650,29 @@ class Conda(PythonEnvironment):
                 )
 
     def _get_core_requirements(self):
-        # Use conda for requirements it packages
-        conda_requirements = [
-            'mock',
-            'pillow',
-        ]
+        # Use Conda for requirements that exist in their repositories.
+        conda_requirements = []
+        if not self.project.has_feature(Feature.DONT_INSTALL_IMPLICIT_DEPS):
+            conda_requirements.extend([
+                'mock',
+                'pillow',
+            ])
 
         if self.project.has_feature(Feature.CONDA_USES_MAMBA):
             conda_requirements.append('pip')
 
         # Install pip-only things.
-        pip_requirements = [
-            'recommonmark',
-        ]
+        pip_requirements = []
+        if not self.project.has_feature(Feature.DONT_INSTALL_IMPLICIT_DEPS):
+            pip_requirements.append('recommonmark')
 
         if self.config.doctype == 'mkdocs':
             pip_requirements.append('mkdocs')
         else:
+            conda_requirements.append('sphinx')
             pip_requirements.append('readthedocs-sphinx-ext')
-            conda_requirements.extend(['sphinx', 'sphinx_rtd_theme'])
+            if not self.project.has_feature(Feature.DONT_INSTALL_IMPLICIT_DEPS):
+                conda_requirements.append('sphinx_rtd_theme')
 
         return pip_requirements, conda_requirements
 

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1593,6 +1593,7 @@ class Feature(models.Model):
     DEFAULT_TO_MKDOCS_0_17_3 = 'default_to_mkdocs_0_17_3'
     USE_MKDOCS_LATEST = 'use_mkdocs_latest'
     USE_SPHINX_RTD_EXT_LATEST = 'rtd_sphinx_ext_latest'
+    DONT_INSTALL_IMPLICIT_DEPS = 'dont_install_implicit_deps'
 
     # Search related features
     DISABLE_SERVER_SIDE_SEARCH = 'disable_server_side_search'
@@ -1694,6 +1695,10 @@ class Feature(models.Model):
         (
             USE_SPHINX_RTD_EXT_LATEST,
             _('Use latest version of the Read the Docs Sphinx extension'),
+        ),
+        (
+            DONT_INSTALL_IMPLICIT_DEPS,
+            _('Don\'t install explicit dependencies'),
         ),
 
         # Search related features.

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -1220,8 +1220,8 @@ class TestPythonEnvironment(TestCase):
             'commonmark',
             'recommonmark',
             'sphinx',
-            'sphinx-rtd-theme',
             'readthedocs-sphinx-ext',
+            'sphinx-rtd-theme',
         ]
 
         self.assertEqual(self.build_env_mock.run.call_count, 2)


### PR DESCRIPTION
This is based on our discussion around https://github.com/readthedocs/readthedocs.org/pull/7859/.
The feature flag should be created after deploy, we can change the date
if we want.

I moved these a method `_get_core_requirements`, that could be used to implement the idea about having another class overriding this instead of several feature flags.