### PR TITLE
Conda: protect against None when appending core requirements

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -615,7 +615,8 @@ class Conda(PythonEnvironment):
 
             for item in dependencies:
                 if isinstance(item, dict) and 'pip' in item:
-                    pip_requirements.extend(item.get('pip', []))
+                    # NOTE: pip can be ``None``
+                    pip_requirements.extend(item.get('pip') or [])
                     dependencies.remove(item)
                     break
 


### PR DESCRIPTION
`pip` can be defined as https://github.com/LFPy/LFPy/blob/b38146fb94dc933f5c40afd872369502031b9537/doc/environment.yml#L16
Ref https://sentry.io/organizations/read-the-docs/issues/2317539725/?environment=production&project=148442&referrer=alert_email