### PR TITLE
Add page and page_size to server side api documentation

### DIFF
--- a/docs/server-side-search.rst
+++ b/docs/server-side-search.rst
@@ -90,6 +90,8 @@ This is ``https://docs.readthedocs.io/_/api/v2/search`` for the ``docs`` project
    :query q: Search query
    :query project: Project slug
    :query version: Version slug
+   :query page: Jump to a specific page
+   :query page_size: Limits the results per page, default is 50
 
    .. Response
 


### PR DESCRIPTION
The `page` and `page_size` query parameters were missing from the Server Side API documentation, so this PR should fix https://github.com/readthedocs/readthedocs.org/issues/8006