### PR TITLE
Docs: fix typo in config-file/v2.rst

### DIFF
--- a/docs/config-file/v2.rst
+++ b/docs/config-file/v2.rst
@@ -3,7 +3,7 @@ Configuration File V2
 
 Read the Docs supports configuring your documentation builds with a YAML file.
 The :doc:`configuration file <index>` must be in the root directory of your project
-an be named ``.readthedocs.yaml``.
+and be named ``.readthedocs.yaml``.
 
 All options are applied to the version containing this file.
 Below is an example YAML file which shows the most common configuration options:


### PR DESCRIPTION
> The configuration file must be in the root directory of your project an be named `.readthedocs.yaml`.

an -> and