### PR TITLE
Improve contributing docs, take 2

### DIFF
--- a/docs/development/install.rst
+++ b/docs/development/install.rst
@@ -70,6 +70,20 @@ Set up your environment
 #. go to http://community.dev.readthedocs.io to access your local instance of Read the Docs.
 
 
+Check that everything works
+---------------------------
+
+#. go to http://community.dev.readthedocs.io and check that the appearance and style looks correct
+   (otherwise the MinIO buckets might be misconfigured, see above)
+
+#. login as ``admin`` /  ``admin`` and verify that the project list appears
+
+#. go to the "Read the Docs" project, click on the "Build version" button to build ``latest``,
+   and wait until it finishes
+
+#. click on the "View docs" button to browse the documentation, and verify that it works
+
+
 Working with Docker Compose
 ---------------------------
 

--- a/docs/development/install.rst
+++ b/docs/development/install.rst
@@ -62,13 +62,10 @@ Set up your environment
 
    * go to http://localhost:9000/ (MinIO S3 storage backend)
    * login as ``admin`` / ``password``
-   * click "..." next to the bucket name and then "Edit Policy"
-   * give "Read Only" access on all the buckets (``static`` and ``media``)
-
-   .. note::
-
-      ``media`` bucket may be created after the first build is finished.
-      You will need to repeat this step after that.
+   * click "..." next to the ``static`` bucket name and then "Edit Policy"
+   * leave "prefix" empty and click "Add" to give "Read Only" access on the ``static`` bucket
+   * click on the "+" icon on the bottom-right corner, then "Create bucket" with the name ``media``,
+     hit Enter on the keyboard, and repeat the operation above to give "Read Only" access to it
 
 #. go to http://community.dev.readthedocs.io to access your local instance of Read the Docs.
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,8 @@ setenv =
 passenv = CI TRAVIS TRAVIS_*
 deps = -r{toxinidir}/requirements/testing.txt
 changedir = {toxinidir}/readthedocs
+basepython =
+    python3.6
 commands =
     /bin/sh -c '\
         export DJANGO_SETTINGS_MODULE=readthedocs.settings.test; \


### PR DESCRIPTION
- Force Python 3.6 on tox, for those using it (to avoid installation issues of dependencies and also to match the version we are currently using)
- Add more detail to MinIO instructions (do not assume that the user knows how MinIO works)
- Add post-install, verification steps

~This should be ready to go, but at the moment I am not able to complete the steps because of a local error:~ _(Edit: Figured it out, fix to follow)_