### PR TITLE
Sync versions: don't fetch/return all versions

### DIFF
--- a/readthedocs/api/v2/utils.py
+++ b/readthedocs/api/v2/utils.py
@@ -116,7 +116,7 @@ def sync_versions_to_db(project, versions, type):  # pylint: disable=redefined-b
             latest_version.save()
     if added:
         log.info(
-            '(Sync Versions) Added Versions: versions_count=%d versions=[%s] ',
+            '(Sync Versions) Added Versions: versions_count=%d versions=[%s]',
             len(added), ' '.join(added[:100]),
         )
     return added

--- a/readthedocs/api/v2/utils.py
+++ b/readthedocs/api/v2/utils.py
@@ -208,15 +208,12 @@ def delete_versions_from_db(project, tags_data, branches_data):
         )
         .exclude(active=True)
     )
-    deleted_versions = set(to_delete_qs.values_list('slug', flat=True))
-    if deleted_versions:
-        log.info(
-            '(Sync Versions) Deleted Versions: project=%s, versions=[%s]',
-            project.slug, ' '.join(deleted_versions),
-        )
-        to_delete_qs.delete()
-
-    return deleted_versions
+    _, deleted = to_delete_qs.delete()
+    versions_count = deleted.get('builds.Version')
+    log.info(
+        '(Sync Versions) Deleted Versions: project=%s versions_count=[%d]',
+        project.slug, versions_count,
+    )
 
 
 def get_deleted_active_versions(project, tags_data, branches_data):

--- a/readthedocs/api/v2/utils.py
+++ b/readthedocs/api/v2/utils.py
@@ -117,7 +117,7 @@ def sync_versions_to_db(project, versions, type):  # pylint: disable=redefined-b
     if added:
         log.info(
             '(Sync Versions) Added Versions: versions_count=%d versions=[%s]',
-            len(added), ' '.join(added[:100]),
+            len(added), ' '.join(itertools.islice(added, 100)),
         )
     return added
 

--- a/readthedocs/api/v2/utils.py
+++ b/readthedocs/api/v2/utils.py
@@ -115,7 +115,10 @@ def sync_versions_to_db(project, versions, type):  # pylint: disable=redefined-b
             latest_version.verbose_name = LATEST_VERBOSE_NAME
             latest_version.save()
     if added:
-        log.info('(Sync Versions) Added Versions: [%s] ', ' '.join(added))
+        log.info(
+            '(Sync Versions) Added Versions: versions_count=%d versions=[%s] ',
+            len(added), ' '.join(added[:100]),
+        )
     return added
 
 

--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -255,7 +255,7 @@ def sync_versions_task(project_pk, tags_data, branches_data, **kwargs):
 
     :param tags_data: List of dictionaries with ``verbose_name`` and ``identifier``.
     :param branches_data: Same as ``tags_data`` but for branches.
-    :returns: the identifiers for the versions that have been deleted.
+    :returns: `True` or `False` if the task succeeded.
     """
     project = Project.objects.get(pk=project_pk)
 
@@ -296,7 +296,7 @@ def sync_versions_task(project_pk, tags_data, branches_data, **kwargs):
         )
     except Exception:
         log.exception('Sync Versions Error')
-        return [], []
+        return False
 
     try:
         # The order of added_versions isn't deterministic.
@@ -333,3 +333,4 @@ def sync_versions_task(project_pk, tags_data, branches_data, **kwargs):
             promoted_version.active = True
             promoted_version.save()
             trigger_build(project=project, version=promoted_version)
+    return True

--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -15,10 +15,10 @@ from readthedocs.api.v2.utils import (
 )
 from readthedocs.builds.constants import (
     BRANCH,
-    EXTERNAL,
     BUILD_STATUS_FAILURE,
     BUILD_STATUS_PENDING,
     BUILD_STATUS_SUCCESS,
+    EXTERNAL,
     MAX_BUILD_COMMAND_SIZE,
     TAG,
 )
@@ -284,7 +284,7 @@ def sync_versions_task(project_pk, tags_data, branches_data, **kwargs):
         )
         added_versions.update(result)
 
-        deleted_versions = delete_versions_from_db(
+        delete_versions_from_db(
             project=project,
             tags_data=tags_data,
             branches_data=branches_data,
@@ -333,5 +333,3 @@ def sync_versions_task(project_pk, tags_data, branches_data, **kwargs):
             promoted_version.active = True
             promoted_version.save()
             trigger_build(project=project, version=promoted_version)
-
-    return list(added_versions), list(deleted_versions)


### PR DESCRIPTION
We were using this only for logging,
retrieving all versions from the db and making an string from it
may be expensive.

This may be related to the OOM error, but hard to say.
Didn't see anything else that may be causing this.