### PR TITLE
API (v2): use empty list in serializer's exclude

### DIFF
--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -120,7 +120,7 @@ class BuildCommandSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = BuildCommandResult
-        exclude = ('')
+        exclude = []
 
 
 class BuildSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
We were using an empty string :D