### PR TITLE
BuildCommand: don't leak stacktrace to the user

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -6,7 +6,6 @@ import re
 import socket
 import subprocess
 import sys
-import traceback
 import uuid
 from datetime import datetime
 
@@ -166,8 +165,7 @@ class BuildCommand(BuildCommandResultMixin):
             self.error = self.sanitize_output(cmd_stderr)
             self.exit_code = proc.returncode
         except OSError:
-            self.error = traceback.format_exc()
-            self.output = self.error
+            log.exception("Operating system error.")
             self.exit_code = -1
         finally:
             self.end_time = datetime.utcnow()

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -7,7 +7,6 @@ Things to know:
 import hashlib
 import json
 import os
-import re
 import tempfile
 import uuid
 from unittest import mock
@@ -1038,8 +1037,10 @@ class TestBuildCommand(TestCase):
         self.assertFalse(os.path.exists(path))
         cmd = BuildCommand(path)
         cmd.run()
-        missing_re = re.compile(r'(?:No such file or directory|not found)')
-        self.assertRegex(cmd.error, missing_re)
+        self.assertEqual(cmd.exit_code, -1)
+        # There is no stacktrace here.
+        self.assertIsNone(cmd.output)
+        self.assertIsNone(cmd.error)
 
     def test_output(self):
         """Test output command."""


### PR DESCRIPTION
We don't use this in production,
but we hit this in https://github.com/readthedocs/readthedocs.org/issues/8075.