### PR TITLE
Build: improve list_packages_installed

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -462,6 +462,8 @@ class Virtualenv(PythonEnvironment):
             '-m',
             'pip',
             'list',
+            # Inlude pre-release versions.
+            '--pre',
         ]
         self.build_env.run(
             *args,
@@ -712,8 +714,10 @@ class Conda(PythonEnvironment):
     def list_packages_installed(self):
         """List packages installed in conda."""
         args = [
-            'conda',
+            self.conda_bin_name(),
             'list',
+            '--name',
+            self.version.slug,
         ]
         self.build_env.run(
             *args,


### PR DESCRIPTION
- Use --pre, so all packages are listed.
- Use conda_bin_name so it works with mamba (tested it and mamba
  supports list)
- Use the environment name (the version slug is used)