### PR TITLE
Logging: use %s to format the variable

### DIFF
--- a/readthedocs/api/v2/utils.py
+++ b/readthedocs/api/v2/utils.py
@@ -212,9 +212,9 @@ def delete_versions_from_db(project, tags_data, branches_data):
         .exclude(active=True)
     )
     _, deleted = to_delete_qs.delete()
-    versions_count = deleted.get('builds.Version')
+    versions_count = deleted.get('builds.Version', 0)
     log.info(
-        '(Sync Versions) Deleted Versions: project=%s versions_count=[%d]',
+        '(Sync Versions) Deleted Versions: project=%s versions_count=%s',
         project.slug, versions_count,
     )
 


### PR DESCRIPTION
Using %d was causing an issue when trying to format `None`:

```
 celery-web celery.redirected:227[19247]: WARNING Message: '(Sync Versions) Deleted Versions: project=%s versions_count=[%d]'
 celery-web Arguments: ('***************', None)
```

This commit uses %s and defaults to 0 when no versions were deleted.