### PR TITLE
Add DPA to legal docs in documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -201,8 +201,6 @@ of Read the Docs and the larger software documentation ecosystem.
 
 * **Policies & Process**:
   :doc:`security` |
-  :doc:`Privacy policy <privacy-policy>` |
-  :doc:`Terms of service <terms-of-service>` |
   :doc:`DMCA takedown policy <dmca/index>` |
   :doc:`Policy for abandoned projects <abandoned-projects>` |
   :doc:`Release notes & changelog <changelog>`
@@ -220,6 +218,11 @@ of Read the Docs and the larger software documentation ecosystem.
 * **Read the Docs for Business**:
   :doc:`Support and additional features <commercial/index>`
 
+* **Legal documents**:
+  :doc:`Terms of service <terms-of-service>` |
+  :doc:`Privacy policy <privacy-policy>` |
+  :doc:`Data processing agreement <legal/dpa/index>`
+
 
 .. toctree::
    :maxdepth: 1
@@ -233,8 +236,6 @@ of Read the Docs and the larger software documentation ecosystem.
    code-of-conduct
 
    security
-   privacy-policy
-   terms-of-service
    dmca/index
    abandoned-projects
    changelog
@@ -248,3 +249,5 @@ of Read the Docs and the larger software documentation ecosystem.
    sponsors
 
    commercial/index
+
+   legal/index

--- a/docs/legal/dpa/index.rst
+++ b/docs/legal/dpa/index.rst
@@ -1,6 +1,11 @@
 Data Processing Agreement
 =========================
 
+.. note::
+    This agreement can be included with any subscription on |com_brand|.
+    Contact us at <privacy@readthedocs.com> to include this in your
+    subscription agreement.
+
 This Data Processing Agreement (“\ **DPA**\ ”) is an addendum to the
 Terms of Service (“\ **Agreement**\ ”) between Read the Docs, Inc.,
 along with our affiliates and subsidiaries (collectively, “\ **Read the

--- a/docs/legal/dpa/index.rst
+++ b/docs/legal/dpa/index.rst
@@ -1,0 +1,406 @@
+Data Processing Agreement
+=========================
+
+This Data Processing Agreement (“\ **DPA**\ ”) is an addendum to the
+Terms of Service (“\ **Agreement**\ ”) between Read the Docs, Inc.,
+along with our affiliates and subsidiaries (collectively, “\ **Read the
+Docs**,” “\ **us**,” or “\ **we**\ ”) and the organization subscribing
+to our Services (“\ **Organization**\ ”). This DPA takes effect on the
+date Organization signs up for Services, and governs the collection,
+processing, or receipt of Personal Data by Read the Docs on behalf of
+the Organization in the course of providing the Services. Terms not
+defined herein shall have the meaning as set forth in the Agreement. If
+you have questions or would like to receive a signed copy of this DPA,
+please contact us at ``privacy@readthedocs.com``.
+
+
+Definitions
+-----------
+
+
+a. “\ **Applicable Laws**\ ” means all laws, rules, regulations, and
+   orders applicable to the subject matter herein, including without
+   limitation Data Protection Laws.
+
+b. “\ **California Personal Information**\ ” means Personal Data
+   that is subject to the protection of the CCPA.
+
+c. "**CCPA**" means California Civil Code Sec. 1798.100 *et seq*.
+   (also known as the California Consumer Privacy Act of 2018).
+
+d. "**Consumer**", "**Business**", "**Sell**", and "**Service
+   Provider**" shall have the meanings given to them in the CCPA.
+
+e. “\ **Controller**\ ”, “\ **Data Subject**\ ”,
+   “\ **Processing**\ ”, and “\ **Processor**\ ” shall have the
+   meanings given to them in the General Data Protection Regulation
+   (Regulation (EU) 2016/679 of the European Parliament and of the
+   Council together with any subordinate legislation or regulation
+   implementing the General Data Protection Regulation) or
+   “\ **GDPR**.”
+
+f. **“Controller-to-Processor SCCs”** means the Standard Contractual
+   Clauses (Processors) in the Annex to the European Commission
+   `Decision of February 5,
+   2010 <https://eur-lex.europa.eu/legal-content/EN/TXT/PDF/?uri=CELEX:32010D0087&from=EN>`__,
+   as may be amended or replaced from time to time by the European
+   Commission.
+
+g. “\ **Organization Data**\ ” means all Personal Data, including
+   without limitation California Personal Information and European
+   Personal Data, Processed by Read the Docs on behalf of
+   Organization pursuant to the Agreement.
+
+h. “\ **Data Protection Laws**\ ” means all applicable worldwide
+   legislation relating to data protection and privacy that apply to
+   the respective Party in its role of Processing Personal Data in
+   question under the Agreement, including without limitation
+   European Data Protection Laws and the CCPA; in each case as
+   amended, superseded, or replaced from time to time.
+
+i. “\ **Data Subject**\ ” means the Consumer or other individual to
+   whom Personal Data relates.
+
+j. “\ **European Data**\ ” means Personal Data that is subject to
+   the protection of European Data Protection Laws.
+
+k. "**European Data Protection Laws**" means data protection laws
+   applicable in Europe, including: (i) Regulation 2016/679 of the
+   European Parliament and of the Council on the protection of
+   natural persons with regard to the processing of personal data
+   and on the free movement of such data (GDPR); (ii) Directive
+   2002/58/EC concerning the processing of personal data and the
+   protection of privacy in the electronic communications sector;
+   and (iii) applicable national implementations of (i) and (ii); or
+   (iii) in respect of the United Kingdom, any applicable national
+   legislation that replaces or converts in domestic law the GDPR or
+   any other law relating to data and privacy as a consequence of
+   the United Kingdom leaving the European Union; and (iv) Swiss
+   Federal Data Protection Act on 19 June 1992 and its Ordinance; in
+   each case, as may be amended, superseded or replaced.
+
+l. “\ **Instructions**\ ” means the written, documented instructions
+   issued by Organization to Read the Docs, and directing Read the
+   Docs to perform a specific or general action regarding Personal
+   Data for the purpose of providing the Services to Organization.
+   The Parties agree that the Agreement (including this DPA),
+   together with Organization's use of the Services in accordance
+   with the Agreement, constitute Organization’s complete and final
+   Instructions to Read the Docs in relation to the Processing of
+   Organization Data, and additional Instructions outside the scope
+   of the Instructions shall require prior written agreement between
+   Read the Docs and Organization.
+
+m. “\ **Personal Data**\ ” means any information relating to an
+   identified or identifiable individual where such information is
+   contained within Organization Data and is protected similarly as
+   personal data, personal information, or personally identifiable
+   information under applicable Data Protection Laws.
+
+n. “\ **Personal Data Breach**\ ” means a breach of security leading
+   to the accidental or unlawful destruction, loss, alteration,
+   unauthorized disclosure of, or access to, Personal Data
+   transmitted, stored, or otherwise Processed by Read the Docs
+   and/or its Sub-Processors in connection with the provision of the
+   Services. Personal Data Breach does not include unsuccessful
+   attempts or activities that do not compromise the security of
+   Personal Data, including unsuccessful log-in attempts, pings,
+   port scans, denial of service attacks, and other network attacks
+   on firewalls or networked systems.
+
+o. “\ **Sub-Processor**\ ” means any entity that provides processing
+   services to Read the Docs in furtherance of Read the Docs’s
+   processing of Organization Data.
+
+Nature, Purpose, and Subject Matter
+-----------------------------------
+
+The nature, purpose, and subject matter of Read the Docs’s data processing
+activities performed as part of the Services are set out in the Agreement. The
+Organization Data that may be processed may relate to Data Subjects, such as the
+Organization’s users, employees, and individual users of Read the Docs’s website
+or other Services (each a “\ **User**\ ”).  Categories of Personal Data
+Processed may include identifiers, internet activity, education or
+employment-related information, commercial information, and any other Personal
+Data that may be processed pursuant to the Agreement.
+
+Duration
+--------
+
+The term of this DPA shall follow the term of the Agreement. Read the Docs will
+Process Personal Data for the duration of the Agreement, unless otherwise agreed
+in writing.
+
+Processing of Organization Data
+-------------------------------
+
+Read the Docs shall process Organization Data only for the purposes described in
+the Agreement (including this DPA) or as otherwise agreed within the scope of
+Organization’s lawful Instructions, except where and to the extent otherwise
+required by Applicable Law. If Read the Docs is collecting Personal Data from
+Users on behalf of Organization, Read the Docs shall follow Organization’s
+Instructions regarding such Personal Data collection. Read the Docs shall inform
+Organization without delay if, in Read the Docs’s opinion, an Instruction
+violates applicable Data Protection Laws and, where necessary, cease all
+Processing until Organization issues new Instructions with which Read the Docs
+is able to comply. If this provision is invoked, Read the Docs will not be
+liable to Organization under the Agreement for any failure to perform the
+Services until such time as Organization issues new lawful Instructions.
+
+Confidentiality
+---------------
+
+Read the Docs shall ensure that any personnel who Read the Docs authorizes to
+Process Organization Data on its behalf is subject to appropriate
+confidentiality obligations (whether a contractual or statutory duty) with
+respect to that Organization Data. Additionally, Read the Docs shall take
+reasonable steps to ensure that (i) persons employed by Read the Docs and (ii)
+other persons engaged to perform on Read the Docs’s behalf comply with the terms
+of the Agreement.
+
+Organization Responsibilities
+-----------------------------
+
+Within the scope of the Agreement (including this DPA) and in Organization’s use
+of the Services, Organization shall take sole responsibility for: (i) the
+accuracy, quality, and legality of Organization Data and the means by which
+Organization acquired Personal Data; (ii) complying with all necessary
+transparency and lawfulness requirements under applicable Data Protection Laws
+for the collection and use of the Personal Data, including obtaining any
+necessary consents and authorizations; (iii) ensuring Organization has the right
+to transfer, or provide access to, the Personal Data to Read the Docs for
+Processing in accordance with the terms of the Agreement (including this DPA);
+(iv) ensuring that Organization’s Instructions to Read the Docs regarding the
+Processing of Organization Data comply with Applicable Laws; and (v) complying
+with all Applicable Laws (including Data Protection Laws) applicable to
+Organization’s use of the Services, including without limitation Applicable Laws
+relating to Organization’s Processing of Personal Data, providing notice and
+obtaining consents, and the Instructions it issues to Read the Docs.
+Organization shall inform Read the Docs without undue delay if it is not able to
+comply with this section or applicable Data Protection Laws. For the avoidance
+of doubt, Read the Docs is not responsible for compliance with any Data
+Protection Laws applicable to Organization or Organization's industry that are
+not generally applicable to Read the Docs.
+
+Sub-Processors
+--------------
+
+Organization agrees that Read the Docs may engage Sub-Processors to Process
+Organization Data. Where Read the Docs engages Sub-Processors, Read the Docs
+will impose data protection terms on the Sub-Processors that provide at least
+the same level of protection for Personal Data as those in this DPA, to the
+extent applicable to the nature of the services provided by such Sub-Processors.
+Read the Docs will remain responsible for each Sub-Processor’s compliance with
+the obligations of this DPA and for any acts or omissions of such Sub-Processor
+that cause Read the Docs to breach any of its obligations under this DPA. Read
+the Docs will maintain a current list of the Sub-processors engaged to Process
+Organization Data (“\ **Sub-Processor List**\ ”), which Read the Docs shall make
+available to Organization upon written request.
+
+.. toctree::
+    :hidden:
+
+    subprocessors
+
+.. See also is used here to avoid altering the legal text to add the link
+
+.. seealso::
+    :doc:`Read the Docs Sub-Processor List <subprocessors>` for an up-to-date
+    list of the sub-processors we use for hosting services.
+
+Security
+--------
+
+Taking into account the state of the art, the costs of implementation and the
+nature, scope, context and purposes of Processing as well as the risk of varying
+likelihood and severity for the rights and freedoms of natural persons, Read the
+Docs shall, in relation to the Organization Data, maintain appropriate technical
+and organizational security measures designed to protect against unauthorized or
+accidental access, loss, alteration, disclosure or destruction of Organization
+Data. In assessing the appropriate level of security, Read the Docs shall take
+specifically into account the risks that are presented by Processing, in
+particular from a Personal Data Breach. Upon request, Read the Docs shall
+provide Organization with a summary of Read the Docs’s security policies
+applicable to the Services.
+
+Data Transfers
+--------------
+
+Organization acknowledges and agrees that Read the Docs may access and Process
+Personal Data on a global basis as necessary to provide the Services in
+accordance with the Agreement, and in particular that Personal Data will be
+transferred to and Processed by Read the Docs in the United States and to other
+jurisdictions where Read the Docs’s Sub-Processors have operations.
+
+Data Subject Requests
+---------------------
+
+As part of the Services, Read the Docs provides Organization and with certain
+controls by which the Organization may access, correct, delete, or restrict
+Organization Data, which Organization may use to assist it in connection with
+its obligations under Data Protection Laws, including its obligations relating
+to responding to requests from Data Subjects to exercise their rights under
+applicable Data Protection Laws ("**Data Subject Requests**"). To the extent
+that Organization is unable to independently address a Data Subject Request
+through the Services, then upon Organization’s written request Read the Docs
+shall provide reasonable assistance to Organization to respond to any Data
+Subject Requests or requests from data protection authorities relating to the
+Processing of Organization Data under the Agreement. Organization shall
+reimburse Read the Docs for the commercially reasonable costs arising from this
+assistance. If a Data Subject Request or other communication regarding the
+Processing of Organization Data under the Agreement is made directly to Read the
+Docs, Read the Docs will promptly inform Organization and will advise the Data
+Subject to submit their request to Organization. Organization shall be solely
+responsible for responding substantively to any such Data Subject Requests or
+communications involving Personal Data.
+
+Data Protection Impact Assessment and Prior Consultation
+--------------------------------------------------------
+
+To the extent Read the Docs is required under Data Protection Law, Read the Docs
+shall (at Organization's expense) provide reasonably requested information
+regarding Read the Docs’s processing of Organization Data under the Agreement to
+enable Organization to carry out data protection impact assessments or prior
+consultations with data protection authorities as required by law.
+
+Deletion or Return of Personal Data
+-----------------------------------
+
+Upon termination or expiration of the Agreement, Read the Docs will delete or
+return all Organization Data Processed pursuant to this DPA in accordance with
+Organization’s reasonable Instructions. The requirements of this section shall
+not apply to the extent that Read the Docs is required by Applicable Law to
+retain some or all of the Organization Data, or to Organization Data Read the
+Docs has archived on back-up systems, which data Read the Docs shall securely
+isolate and protect from any further Processing and delete in accordance with
+Read the Docs’s deletion practices.
+
+Demonstration of Compliance
+---------------------------
+
+Upon Organization's written request, Read the Docs shall make available to
+Organization (on a confidential basis) all information reasonably necessary, and
+allow for and contribute to audits, to demonstrate Read the Docs’s compliance
+with this DPA, provided Organization shall not exercise this right more than
+once per year. Organization shall take all reasonable measures to limit any
+impact on Read the Docs by combining several information and/or audit requests
+carried out on behalf of Organization in one single audit.
+
+European Data
+-------------
+
+This Section 15 applies only with respect to Processing of European Data by Read
+the Docs.
+
+a. **Roles of the Parties.** When Processing European Data under the
+   Agreement, the Parties acknowledge and agree that Organization is
+   the Controller and Read the Docs is the Processor.
+
+b. **Sub-Processors.** In addition to the provisions of Section 7,
+   Read the Docs will notify Organization of any changes to
+   Sub-processors engaged to Process European Data by updating the
+   Sub-Processor List and posting the changes for Organization’s
+   review. Organization may object to the engagement of a new
+   Sub-Processor on reasonable grounds relating to the protection of
+   Personal Data within 30 days after posting the updated
+   Sub-Processor List. If Organization so objects, the Parties will
+   discuss Organization's concerns in good faith with a view to
+   achieving a commercially reasonable resolution. If no such
+   resolution can be reached, Read the Docs will, at its sole
+   discretion, either not appoint the new Sub-Processor, or permit
+   Organization to suspend or terminate the Agreement without
+   liability to either party (but without prejudice to any fees
+   incurred by Organization prior to suspension or termination).
+
+c. **Data Transfers.** In addition to Section 9, for transfers of
+   European Personal Data to Read the Docs for processing by Read
+   the Docs in a jurisdiction other than a jurisdiction in the EU,
+   the EEA, or the European Commission-approved countries providing
+   “adequate” data protection, Read the Docs agrees it will (i) use
+   the form of the Controller-to-Processor SCCs or (ii) provide at
+   least the same level of privacy protection for European Personal
+   Data as required under the U.S.-EU and U.S.-Swiss Privacy Shield
+   frameworks, as applicable. If such data transfers rely on
+   Controller-to-Processor SCCs to enable the lawful transfer of
+   European Personal Data, as set forth in the preceding sentence,
+   the Parties agree that Data Subjects for whom Read the Docs
+   Processes European Personal Data are third-party beneficiaries
+   under the Controller-to-Processor SCCs. If Read the Docs is
+   unable or becomes unable to comply with these requirements, then
+   (a) Read the Docs shall notify Organization of such inability and
+   (b) any movement of European Personal Data to a non-EU country
+   requires the prior written consent of Organization.
+
+d. **Data Protection Impact Assessments and Consultation with
+   Supervisory Authorities.** To the extent that the required
+   information is reasonably available to Read the Docs, and
+   Organization does not otherwise have access to the required
+   information, Read the Docs will provide reasonable assistance to
+   Organization with any data protection impact assessments, and
+   prior consultations with supervisory authorities or other
+   competent data privacy authorities to the extent required by
+   European Data Protection Laws.
+
+California Personal Information
+-------------------------------
+
+This Section 16 applies only with respect to Processing of California Personal
+Information by Read the Docs in Read the Docs’s capacity as a Service Provider.
+
+a. **Roles of the Parties.** When Processing California Personal
+   Information in accordance with Organization's Instructions, the
+   Parties acknowledge and agree that Organization is a Business and
+   Read the Docs is the Service Provider for the purposes of the
+   CCPA. Additionally, for the purposes of interpreting this DPA
+   with respect to Processing of California Personal Information,
+   the term “Controller” is replaced with “Business” and “Processor”
+   is replaced with “Service Provider” wherever those terms appear
+   in Sections 2 through 14 and Section 17 of this DPA.
+
+b. **Responsibilities.** The Parties agree that Read the Docs will
+   process Users’ California Personal Information as a Service
+   Provider strictly for the business purpose of performing the
+   Services under the Agreement and as set forth in Read the Docs’s
+   Privacy Policy. The Parties agree that Read the Docs shall not
+   (i) “sell” or “share” Users’ California Personal Information (as
+   those terms are defined in the CCPA); (ii) retain, use, or
+   disclose Users’ California Personal Information for a commercial
+   purpose other than for such business purpose or as otherwise
+   permitted by the CCPA; or (iii) retain, use, or disclose Users’
+   California Personal Information outside of the direct business
+   relationship between Organization and Read the Docs.
+
+c. **Certification.** Read the Docs hereby certifies that it
+   understands and will comply with the restrictions of Section
+   16(b).
+
+d. **No CCPA Sale.** The Parties agree that Organization does not
+   sell California Personal Information to Read the Docs because, as
+   a Service Provider, Read the Docs may only use California
+   Personal Information for the purposes of providing the Services
+   to Organization.
+
+General
+-------
+
+Organization represents that it is authorized to, and hereby agrees to, enter
+into and be bound by this DPA for and on behalf of itself and each of its
+affiliates and subsidiaries, thereby establishing a separate DPA between Read
+the Docs and Organization and each of Organization’s affiliates and subsidiaries
+subject to the Agreement, as applicable. The relationship between Parties is
+that of independent contractors, and nothing herein shall be interpreted to
+constitute the Parties as partners, joint venturers, principal-agent, or
+otherwise participants in a common undertaking, or, except as expressly provided
+herein, allow either Party to create or assume any obligation on behalf of the
+other for any purpose whatsoever. The limitations of liability set forth in the
+Agreement shall apply to Read the Docs’s liability arising out of or relating to
+this DPA and the Standard Contractual Clauses (where applicable), taken in the
+aggregate along with the Agreement and any other agreement between the Parties.
+In case of any conflict or inconsistency with the terms of the Agreement, this
+DPA shall take precedence over the terms of the Agreement to the extent of such
+conflict or inconsistency. If any individual provisions of this DPA are
+determined to be invalid or unenforceable, the validity and enforceability of
+the other provisions of this DPA shall not be affected. We periodically update
+this Agreement. If you are a current Organization, you will be informed of any
+modification by email, alert on the Organization dashboard or portal or by other
+means.

--- a/docs/legal/dpa/index.rst
+++ b/docs/legal/dpa/index.rst
@@ -7,7 +7,7 @@ Data Processing Agreement
     subscription agreement.
 
 This Data Processing Agreement (“\ **DPA**\ ”) is an addendum to the
-Terms of Service (“\ **Agreement**\ ”) between Read the Docs, Inc.,
+Master Services Agreement (“\ **Agreement**\ ”) between Read the Docs, Inc.,
 along with our affiliates and subsidiaries (collectively, “\ **Read the
 Docs**,” “\ **us**,” or “\ **we**\ ”) and the organization subscribing
 to our Services (“\ **Organization**\ ”). This DPA takes effect on the
@@ -236,6 +236,24 @@ Personal Data on a global basis as necessary to provide the Services in
 accordance with the Agreement, and in particular that Personal Data will be
 transferred to and Processed by Read the Docs in the United States and to other
 jurisdictions where Read the Docs’s Sub-Processors have operations.
+
+Personal Data Breaches
+----------------------
+
+If Read the Docs becomes aware of any Personal Data Breach involving
+Organization Data, Read the Docs will promptly, and in no case more than five
+calendar days after becoming aware, notify Organization in writing of the
+Personal Data Breach. Following such notification, to the extent required by
+applicable Data Protection Laws, Read the Docs will: (a) provide Organization
+with timely information relating to such Personal Data Breach as it becomes
+known or is reasonably requested by Organization; and (b) upon Organization’s
+request, provide Organization with commercially reasonable assistance as
+necessary to enable Organization to notify authorities and/or affected Data
+Subjects. Each Party shall be solely responsible for all costs, damages, and
+liabilities incurred as the result of a Personal Data Breach of the Party’s own
+information system and shall, at the other Party’s request and cost, provide the
+other Party with reasonable assistance to investigate, respond to, and mitigate
+the effects of a Breach of the other Party’s information system.
 
 Data Subject Requests
 ---------------------

--- a/docs/legal/dpa/index.rst
+++ b/docs/legal/dpa/index.rst
@@ -3,7 +3,7 @@ Data Processing Agreement
 
 .. note::
     This agreement can be included with any subscription on |com_brand|.
-    Contact us at <privacy@readthedocs.com> to include this in your
+    Contact us at privacy@readthedocs.com to include this in your
     subscription agreement.
 
 This Data Processing Agreement (“\ **DPA**\ ”) is an addendum to the
@@ -16,12 +16,10 @@ processing, or receipt of Personal Data by Read the Docs on behalf of
 the Organization in the course of providing the Services. Terms not
 defined herein shall have the meaning as set forth in the Agreement. If
 you have questions or would like to receive a signed copy of this DPA,
-please contact us at ``privacy@readthedocs.com``.
+please contact us at privacy@readthedocs.com.
 
-
-Definitions
------------
-
+1. Definitions
+--------------
 
 a. “\ **Applicable Laws**\ ” means all laws, rules, regulations, and
    orders applicable to the subject matter herein, including without
@@ -117,8 +115,8 @@ o. “\ **Sub-Processor**\ ” means any entity that provides processing
    services to Read the Docs in furtherance of Read the Docs’s
    processing of Organization Data.
 
-Nature, Purpose, and Subject Matter
------------------------------------
+2. Nature, Purpose, and Subject Matter
+--------------------------------------
 
 The nature, purpose, and subject matter of Read the Docs’s data processing
 activities performed as part of the Services are set out in the Agreement. The
@@ -129,15 +127,15 @@ Processed may include identifiers, internet activity, education or
 employment-related information, commercial information, and any other Personal
 Data that may be processed pursuant to the Agreement.
 
-Duration
---------
+3. Duration
+-----------
 
 The term of this DPA shall follow the term of the Agreement. Read the Docs will
 Process Personal Data for the duration of the Agreement, unless otherwise agreed
 in writing.
 
-Processing of Organization Data
--------------------------------
+4. Processing of Organization Data
+----------------------------------
 
 Read the Docs shall process Organization Data only for the purposes described in
 the Agreement (including this DPA) or as otherwise agreed within the scope of
@@ -152,8 +150,8 @@ is able to comply. If this provision is invoked, Read the Docs will not be
 liable to Organization under the Agreement for any failure to perform the
 Services until such time as Organization issues new lawful Instructions.
 
-Confidentiality
----------------
+5. Confidentiality
+------------------
 
 Read the Docs shall ensure that any personnel who Read the Docs authorizes to
 Process Organization Data on its behalf is subject to appropriate
@@ -163,8 +161,8 @@ reasonable steps to ensure that (i) persons employed by Read the Docs and (ii)
 other persons engaged to perform on Read the Docs’s behalf comply with the terms
 of the Agreement.
 
-Organization Responsibilities
------------------------------
+6. Organization Responsibilities
+--------------------------------
 
 Within the scope of the Agreement (including this DPA) and in Organization’s use
 of the Services, Organization shall take sole responsibility for: (i) the
@@ -187,8 +185,8 @@ of doubt, Read the Docs is not responsible for compliance with any Data
 Protection Laws applicable to Organization or Organization's industry that are
 not generally applicable to Read the Docs.
 
-Sub-Processors
---------------
+7. Sub-Processors
+-----------------
 
 Organization agrees that Read the Docs may engage Sub-Processors to Process
 Organization Data. Where Read the Docs engages Sub-Processors, Read the Docs
@@ -213,8 +211,8 @@ available to Organization upon written request.
     :doc:`Read the Docs Sub-Processor List <subprocessors>` for an up-to-date
     list of the sub-processors we use for hosting services.
 
-Security
---------
+8. Security
+-----------
 
 Taking into account the state of the art, the costs of implementation and the
 nature, scope, context and purposes of Processing as well as the risk of varying
@@ -228,8 +226,8 @@ particular from a Personal Data Breach. Upon request, Read the Docs shall
 provide Organization with a summary of Read the Docs’s security policies
 applicable to the Services.
 
-Data Transfers
---------------
+9. Data Transfers
+-----------------
 
 Organization acknowledges and agrees that Read the Docs may access and Process
 Personal Data on a global basis as necessary to provide the Services in
@@ -237,8 +235,8 @@ accordance with the Agreement, and in particular that Personal Data will be
 transferred to and Processed by Read the Docs in the United States and to other
 jurisdictions where Read the Docs’s Sub-Processors have operations.
 
-Personal Data Breaches
-----------------------
+10. Personal Data Breaches
+--------------------------
 
 If Read the Docs becomes aware of any Personal Data Breach involving
 Organization Data, Read the Docs will promptly, and in no case more than five
@@ -255,8 +253,8 @@ information system and shall, at the other Party’s request and cost, provide t
 other Party with reasonable assistance to investigate, respond to, and mitigate
 the effects of a Breach of the other Party’s information system.
 
-Data Subject Requests
----------------------
+11. Data Subject Requests
+-------------------------
 
 As part of the Services, Read the Docs provides Organization and with certain
 controls by which the Organization may access, correct, delete, or restrict
@@ -277,8 +275,8 @@ Subject to submit their request to Organization. Organization shall be solely
 responsible for responding substantively to any such Data Subject Requests or
 communications involving Personal Data.
 
-Data Protection Impact Assessment and Prior Consultation
---------------------------------------------------------
+12. Data Protection Impact Assessment and Prior Consultation
+------------------------------------------------------------
 
 To the extent Read the Docs is required under Data Protection Law, Read the Docs
 shall (at Organization's expense) provide reasonably requested information
@@ -286,8 +284,8 @@ regarding Read the Docs’s processing of Organization Data under the Agreement 
 enable Organization to carry out data protection impact assessments or prior
 consultations with data protection authorities as required by law.
 
-Deletion or Return of Personal Data
------------------------------------
+13. Deletion or Return of Personal Data
+---------------------------------------
 
 Upon termination or expiration of the Agreement, Read the Docs will delete or
 return all Organization Data Processed pursuant to this DPA in accordance with
@@ -298,8 +296,8 @@ Docs has archived on back-up systems, which data Read the Docs shall securely
 isolate and protect from any further Processing and delete in accordance with
 Read the Docs’s deletion practices.
 
-Demonstration of Compliance
----------------------------
+14. Demonstration of Compliance
+-------------------------------
 
 Upon Organization's written request, Read the Docs shall make available to
 Organization (on a confidential basis) all information reasonably necessary, and
@@ -309,8 +307,8 @@ once per year. Organization shall take all reasonable measures to limit any
 impact on Read the Docs by combining several information and/or audit requests
 carried out on behalf of Organization in one single audit.
 
-European Data
--------------
+15. European Data
+-----------------
 
 This Section 15 applies only with respect to Processing of European Data by Read
 the Docs.
@@ -364,8 +362,8 @@ d. **Data Protection Impact Assessments and Consultation with
    competent data privacy authorities to the extent required by
    European Data Protection Laws.
 
-California Personal Information
--------------------------------
+16. California Personal Information
+-----------------------------------
 
 This Section 16 applies only with respect to Processing of California Personal
 Information by Read the Docs in Read the Docs’s capacity as a Service Provider.
@@ -403,8 +401,8 @@ d. **No CCPA Sale.** The Parties agree that Organization does not
    Personal Information for the purposes of providing the Services
    to Organization.
 
-General
--------
+17. General
+-----------
 
 Organization represents that it is authorized to, and hereby agrees to, enter
 into and be bound by this DPA for and on behalf of itself and each of its

--- a/docs/legal/dpa/subprocessors.rst
+++ b/docs/legal/dpa/subprocessors.rst
@@ -1,0 +1,62 @@
+Sub-Processor List
+==================
+
+:Effective: April 16, 2021
+:Last updated: April 16, 2021
+
+Read the Docs for Business uses services from the following sub-processors to
+provide documentation hosting services. This document supplements :doc:`our Data
+Processing Agreement <index>` and may be separately updated on a periodic basis.
+A sub-processor is a third party data processor who has or potentially will have
+access to or will process personal data.
+
+.. seealso::
+    Previous versions of this document, as well as the change history to this
+    document, are available `on GitHub`_
+
+.. _on GitHub: https://github.com/readthedocs/readthedocs.org/commits/master/docs/legal/dpa/subprocessors.rst
+
+Infrastructure
+--------------
+
+Amazon Web Services, Inc.
+    Cloud infrastructure provider.
+
+Serivces
+--------
+
+Elasticsearch B.V.
+    Hosted ElasticSearch services for documentation search. Search indexes do
+    not include user data.
+
+Sendgrid, Inc.
+    Provides email delivery to dashboard and admin users for site notifications
+    and other generated messages. The body of notification emails can include
+    user information, including email address.
+
+Google Analytics
+    Website analtyics for dashboard and documentation sites.
+
+Monitoring
+----------
+
+New Relic
+    Application performance analytics. Data collected can include
+    user data and visitor data used within application code.
+
+Sentry
+    Error analytics service used to log and track application errors. Error
+    reports can include arguments passed to application code, which can include
+    user and visitor data.
+
+Support
+-------
+
+Intercom, Inc.
+    Dashboard user reporting and analytics. Data collected can include user
+    information like email address and IP address. This is only used on our
+    application dashboard and is not used on documentation sites.
+
+FrontApp, Inc.
+    Customer email support service. Can have access to user data, including user
+    email and IP address, and stores communications related to user data.

--- a/docs/legal/dpa/subprocessors.rst
+++ b/docs/legal/dpa/subprocessors.rst
@@ -22,7 +22,7 @@ Infrastructure
 Amazon Web Services, Inc.
     Cloud infrastructure provider.
 
-Serivces
+Services
 --------
 
 Elasticsearch B.V.

--- a/docs/legal/dpa/subprocessors.rst
+++ b/docs/legal/dpa/subprocessors.rst
@@ -36,6 +36,11 @@ Sendgrid, Inc.
 
 Google Analytics
     Website analtyics for dashboard and documentation sites.
+    
+Stripe Inc.
+    Subscription payment provider. Data collected can include user data necessary
+    to process payment transactions, however this data is not processed directly
+    by Read the Docs.
 
 Monitoring
 ----------

--- a/docs/legal/index.rst
+++ b/docs/legal/index.rst
@@ -1,0 +1,24 @@
+Legal documents
+===============
+
+Here is some of the fine print used by |org_brand| and |com_brand|:
+
+.. toctree::
+    :glob:
+    :hidden:
+
+    ../terms-of-service
+    ../privacy-policy
+    dpa/index
+
+:doc:`../terms-of-service`
+    The terms of service for using |org_brand| and |com_brand|. You may instead
+    have a master services agreement for your subscription if you have a custom
+    or enterprise contract.
+
+:doc:`../privacy-policy`
+    Our policy on collecting, storing, and protecting user and visitor data.
+
+:doc:`dpa/index`
+    For GDPR and CCPA compliance, we provide a data privacy agreement for
+    |com_brand| customers.

--- a/docs/legal/index.rst
+++ b/docs/legal/index.rst
@@ -7,18 +7,18 @@ Here is some of the fine print used by |org_brand| and |com_brand|:
     :glob:
     :hidden:
 
-    ../terms-of-service
-    ../privacy-policy
+    /terms-of-service
+    /privacy-policy
     dpa/index
 
-:doc:`../terms-of-service`
+:doc:`/terms-of-service`
     The terms of service for using |org_brand| and |com_brand|. You may instead
     have a master services agreement for your subscription if you have a custom
     or enterprise contract.
 
-:doc:`../privacy-policy`
+:doc:`/privacy-policy`
     Our policy on collecting, storing, and protecting user and visitor data.
 
-:doc:`dpa/index`
+:doc:`/legal/dpa/index`
     For GDPR and CCPA compliance, we provide a data privacy agreement for
     |com_brand| customers.


### PR DESCRIPTION
Slightly reorganizes some of our legal docs under a separate path, but doesn't move some of the files yet.

This is our DPA from our lawyers, pandoc reformatted to reST. We wouldn't use this for esign, but the source of an esign/click-through version would be the same as this file.

The agreement isn't necessary to review. The most helpful thing to review are the doc changes and the subprocessor list and list information.