### PR TITLE
web-celery: add logging for OOM debug on suspicious tasks

### DIFF
--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -259,6 +259,9 @@ def sync_versions_task(project_pk, tags_data, branches_data, **kwargs):
     """
     project = Project.objects.get(pk=project_pk)
 
+    # TODO: remove this log once we find out what's causing OOM
+    log.info('Running readthedocs.builds.tasks.sync_versions_task. locals=%s', locals())
+
     # If the currently highest non-prerelease version is active, then make
     # the new latest version active as well.
     current_stable = project.get_original_stable_version()

--- a/readthedocs/oauth/tasks.py
+++ b/readthedocs/oauth/tasks.py
@@ -28,6 +28,10 @@ def sync_remote_repositories(user_id):
     user = User.objects.filter(pk=user_id).first()
     if not user:
         return
+
+    # TODO: remove this log once we find out what's causing OOM
+    log.info('Running readthedocs.oauth.tasks.sync_remote_repositories. locals=%s', locals())
+
     failed_services = set()
     for service_cls in registry:
         for service in service_cls.for_user(user):

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1304,6 +1304,9 @@ def fileify(version_pk, commit, build, search_ranking, search_ignore):
         return
     project = version.project
 
+    # TODO: remove this log once we find out what's causing OOM
+    log.info('Running readthedocs.projects.tasks.fileify. locals=%s', locals())
+
     if not commit:
         log.warning(
             LOG_TEMPLATE,


### PR DESCRIPTION
Add some `log.info` with the local context for this task so we can debug OOM a
little more in production code.