### PR TITLE
Embed: fix paths that start with `/`

### DIFF
--- a/readthedocs/embed/tests/test_api.py
+++ b/readthedocs/embed/tests/test_api.py
@@ -170,6 +170,45 @@ class BaseTestEmbedAPI:
         assert response.data == expected
 
     @pytest.mark.parametrize(
+        'path, docname',
+        [
+            ('index.html', 'index'),
+            ('index/', 'index'),
+            ('index//', 'index'),
+            ('/index.html', 'index'),
+            ('/index/', 'index'),
+            ('/index//', 'index'),
+            ('guides/users/index.html', 'guides/users/index'),
+            ('guides/users/', 'guides/users'),
+            ('/guides/users/', 'guides/users'),
+        ]
+    )
+    @mock.patch('readthedocs.embed.views.build_media_storage')
+    def test_embed_dir_path(self, storage_mock, path, docname, client):
+        json_file = data_path / 'sphinx/latest/page.json'
+        html_file = data_path / 'sphinx/latest/page.html'
+
+        self._patch_sphinx_json_file(
+            storage_mock=storage_mock,
+            json_file=json_file,
+            html_file=html_file,
+        )
+
+        response = self.get(
+            client,
+            reverse('embed_api'),
+            {
+                'project': self.project.slug,
+                'version': self.version.slug,
+                'path': path,
+                'section': 'title-one',
+            }
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['meta']['doc'] == docname
+
+    @pytest.mark.parametrize(
         'section',
         [
             'i-need-secrets-or-environment-variables-in-my-build',

--- a/readthedocs/embed/views.py
+++ b/readthedocs/embed/views.py
@@ -165,10 +165,7 @@ class EmbedAPIBase(CachedResponseMixin, APIView):
 
         # Update doc from path
         if path:
-            if path.endswith('/'):
-                doc = doc.path.rstrip('/')
-            else:
-                doc = path.split('.html', 1)[0]
+            doc = re.sub(r'(.+)\.html$', r'\1', path.strip('/'))
 
         response = do_embed(
             project=project,

--- a/readthedocs/embed/views.py
+++ b/readthedocs/embed/views.py
@@ -163,7 +163,8 @@ class EmbedAPIBase(CachedResponseMixin, APIView):
                 status=status.HTTP_400_BAD_REQUEST
             )
 
-        # Update doc from path
+        # Generate the docname from path
+        # by removing the ``.html`` extension and trailing ``/``.
         if path:
             doc = re.sub(r'(.+)\.html$', r'\1', path.strip('/'))
 


### PR DESCRIPTION
can't wait to get rid of docnames :D

Ref https://sentry.io/organizations/read-the-docs/issues/2360423193/?environment=production&project=161479