### PR TITLE
Disable FLOC by introducing permissions policy header

### DIFF
--- a/dockerfiles/nginx/proxito.conf
+++ b/dockerfiles/nginx/proxito.conf
@@ -66,6 +66,8 @@ server {
         add_header Cache-Tag $cache_tag always;
         set $referrer_policy $upstream_http_referrer_policy;
         add_header Referrer-Policy $referrer_policy always;
+        set $permissions_policy $upstream_http_permissions_policy;
+        add_header Permissions-Policy $permissions_policy always;
     }
 
     # Serve 404 pages here

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -99,6 +99,12 @@ class CommunityBaseSettings(Settings):
         "/admin/",
     )
 
+    # Permissions Policy
+    # https://github.com/adamchainz/django-permissions-policy
+    PERMISSIONS_POLICY = {
+        "interest-cohort": [],
+    }
+
     # Read the Docs
     READ_THE_DOCS_EXTENSIONS = ext
     RTD_LATEST = 'latest'
@@ -228,6 +234,7 @@ class CommunityBaseSettings(Settings):
         'corsheaders.middleware.CorsMiddleware',
         'csp.middleware.CSPMiddleware',
         'readthedocs.core.middleware.ReferrerPolicyMiddleware',
+        'django_permissions_policy.PermissionsPolicyMiddleware',
     )
 
     AUTHENTICATION_BACKENDS = (

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -115,3 +115,5 @@ django-debug-toolbar==3.2.1
 
 # For enabling content-security-policy
 django-csp==3.7
+# For setting the permissions-policy security header
+django-permissions-policy==4.0.0


### PR DESCRIPTION
This PR introduces the Permissions-Policy header ([MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy)) which controls the features that a webpage is allowed to use. For example, Permissions-Policy could be used to disable access to the JS geolocation APIs or the accelerometer.

This PR, however, only uses Permissions-Policy to disable [FLOC](https://github.com/WICG/floc) a new JS API in Chrome that can be used to categorize users together into cohorts with machine learning so they can be targeted with ads. FLOC will be disabled on the RTD dashboard as well as on documentation sites. There are a few reasons for this but the biggest is probably that FLOC has some privacy issues and can aid in fingerprinting users (see the [EFF's coverage](https://www.eff.org/deeplinks/2021/03/googles-floc-terrible-idea)). While Read the Docs does display advertising on our documentation sites, we are quite explicit in the [methods we use to target advertising](https://docs.readthedocs.io/en/stable/advertising/advertising-details.html#our-targeting-details) -- basically just contextual targeting -- and FLOC definitely crosses into behavioral targeting and targeting ads based on past actions rather than content/context.