### PR TITLE
Querysets: simplify project querysets

### DIFF
--- a/readthedocs/projects/managers.py
+++ b/readthedocs/projects/managers.py
@@ -1,25 +1,7 @@
 from django.db import models
 
-from readthedocs.core.utils.extend import (
-    get_override_class,
-    SettingsOverrideObject
-)
-from readthedocs.projects.querysets import HTMLFileQuerySet
 
-
-class HTMLFileManagerBase(models.Manager):
-
-    @classmethod
-    def from_queryset(cls, queryset_class, class_name=None):
-        queryset_class = get_override_class(
-            HTMLFileQuerySet,
-            HTMLFileQuerySet._default_class,  # pylint: disable=protected-access
-        )
-        return super().from_queryset(queryset_class, class_name)
+class HTMLFileManager(models.Manager):
 
     def get_queryset(self):
         return super().get_queryset().filter(name__endswith='.html')
-
-
-class HTMLFileManager(SettingsOverrideObject):
-    _default_class = HTMLFileManagerBase

--- a/readthedocs/projects/querysets.py
+++ b/readthedocs/projects/querysets.py
@@ -42,11 +42,10 @@ class ProjectQuerySetBase(models.QuerySet):
             queryset = self._add_user_repos(queryset, user)
         return queryset.distinct()
 
-    def private(self, user=None):
-        queryset = self.filter(privacy_level=constants.PRIVATE)
-        if user:
-            queryset = self._add_user_repos(queryset, user)
-        return queryset.distinct()
+    def for_user(self, user):
+        """Return all projects that an user belongs to."""
+        # In .org all users of a project are admins.
+        return self.for_admin_user(user)
 
     def is_active(self, project):
         """
@@ -122,7 +121,7 @@ class ProjectQuerySetBase(models.QuerySet):
 
     def dashboard(self, user):
         """Get the projects for this user including the latest build."""
-        return self.for_admin_user(user).prefetch_latest_build()
+        return self.for_user(user).prefetch_latest_build()
 
     def api(self, user=None, detail=True):
         if detail:
@@ -136,7 +135,6 @@ class ProjectQuerySetBase(models.QuerySet):
 
 class ProjectQuerySet(SettingsOverrideObject):
     _default_class = ProjectQuerySetBase
-    _override_setting = 'PROJECT_MANAGER'
 
 
 class RelatedProjectQuerySetBase(models.QuerySet):
@@ -188,7 +186,6 @@ class RelatedProjectQuerySetBase(models.QuerySet):
 
 class RelatedProjectQuerySet(SettingsOverrideObject):
     _default_class = RelatedProjectQuerySetBase
-    _override_setting = 'RELATED_PROJECT_MANAGER'
 
 
 class ParentRelatedProjectQuerySetBase(RelatedProjectQuerySetBase):
@@ -198,7 +195,6 @@ class ParentRelatedProjectQuerySetBase(RelatedProjectQuerySetBase):
 
 class ParentRelatedProjectQuerySet(SettingsOverrideObject):
     _default_class = ParentRelatedProjectQuerySetBase
-    _override_setting = 'RELATED_PROJECT_MANAGER'
 
 
 class ChildRelatedProjectQuerySetBase(RelatedProjectQuerySetBase):
@@ -208,7 +204,6 @@ class ChildRelatedProjectQuerySetBase(RelatedProjectQuerySetBase):
 
 class ChildRelatedProjectQuerySet(SettingsOverrideObject):
     _default_class = ChildRelatedProjectQuerySetBase
-    _override_setting = 'RELATED_PROJECT_MANAGER'
 
 
 class FeatureQuerySet(models.QuerySet):
@@ -222,7 +217,7 @@ class FeatureQuerySet(models.QuerySet):
         ).distinct()
 
 
-class HTMLFileQuerySetBase(models.QuerySet):
+class HTMLFileQuerySet(models.QuerySet):
 
     def internal(self):
         """
@@ -240,7 +235,3 @@ class HTMLFileQuerySetBase(models.QuerySet):
         It will only include pull request/merge request Version html files in the queries.
         """
         return self.filter(version__type=EXTERNAL)
-
-
-class HTMLFileQuerySet(SettingsOverrideObject):
-    _default_class = HTMLFileQuerySetBase

--- a/readthedocs/rtd_tests/tests/test_project_querysets.py
+++ b/readthedocs/rtd_tests/tests/test_project_querysets.py
@@ -5,7 +5,6 @@ from django.contrib.auth.models import User
 from django.test import TestCase
 from django_dynamic_fixture import get
 
-from readthedocs.builds.models import Version
 from readthedocs.projects.constants import PRIVATE, PUBLIC
 from readthedocs.projects.models import Feature, Project
 from readthedocs.projects.querysets import (
@@ -113,33 +112,6 @@ class ProjectQuerySetTests(TestCase):
         self.assertEqual(query.count(), len(self.another_user_projects))
         self.assertEqual(set(query), self.another_user_projects)
 
-    def test_private(self):
-        query = Project.objects.private()
-        projects = {
-            self.project_private,
-            self.another_project_private,
-            self.shared_project_private,
-        }
-        self.assertEqual(query.count(), len(projects))
-        self.assertEqual(set(query), projects)
-
-    def test_private_user(self):
-        query = Project.objects.private(user=self.user)
-        projects = (
-            self.user_projects |
-            {self.another_project_private}
-        )
-        self.assertEqual(query.count(), len(projects))
-        self.assertEqual(set(query), projects)
-
-        query = Project.objects.private(user=self.another_user)
-        projects = (
-            self.another_user_projects |
-            {self.project_private}
-        )
-        self.assertEqual(query.count(), len(projects))
-        self.assertEqual(set(query), projects)
-
     def test_public(self):
         query = Project.objects.public()
         projects = {
@@ -164,6 +136,17 @@ class ProjectQuerySetTests(TestCase):
             self.another_user_projects |
             {self.project}
         )
+        self.assertEqual(query.count(), len(projects))
+        self.assertEqual(set(query), projects)
+
+    def test_for_user(self):
+        query = Project.objects.for_user(user=self.user)
+        projects = self.user_projects
+        self.assertEqual(query.count(), len(projects))
+        self.assertEqual(set(query), projects)
+
+        query = Project.objects.for_user(user=self.another_user)
+        projects = self.another_user_projects
         self.assertEqual(query.count(), len(projects))
         self.assertEqual(set(query), projects)
 


### PR DESCRIPTION
- Introduce `Project.objects.for_user`.
  This is to replace the `for_team_member` method from .com
- `private` isn't used in both sites, and usually what we call private is just the use of `public` passing a user. 
- Remove unused overrides.