### PR TITLE
Querysets: remove private and for_project

### DIFF
--- a/readthedocs/builds/querysets.py
+++ b/readthedocs/builds/querysets.py
@@ -48,16 +48,6 @@ class VersionQuerySetBase(models.QuerySet):
             queryset = queryset.filter(hidden=False)
         return queryset.distinct()
 
-    def private(self, user=None, project=None, only_active=True):
-        queryset = self.filter(privacy_level__in=[constants.PRIVATE])
-        if user:
-            queryset = self._add_user_repos(queryset, user)
-        if project:
-            queryset = queryset.filter(project=project)
-        if only_active:
-            queryset = queryset.filter(active=True)
-        return queryset.distinct()
-
     def api(self, user=None, detail=True):
         if detail:
             return self.public(user, only_active=False)
@@ -66,13 +56,6 @@ class VersionQuerySetBase(models.QuerySet):
         if user:
             queryset = self._add_user_repos(queryset, user)
         return queryset.distinct()
-
-    def for_project(self, project):
-        """Return all versions for a project, including translations."""
-        return self.filter(
-            models.Q(project=project) |
-            models.Q(project__main_language_project=project),
-        )
 
 
 class VersionQuerySet(SettingsOverrideObject):

--- a/readthedocs/projects/querysets.py
+++ b/readthedocs/projects/querysets.py
@@ -163,18 +163,7 @@ class RelatedProjectQuerySetBase(models.QuerySet):
         return queryset
 
     def public(self, user=None, project=None):
-        kwargs = {'%s__privacy_level' % self.project_field: constants.PUBLIC}
-        queryset = self.filter(**kwargs)
-        if user:
-            queryset = self._add_user_repos(queryset, user)
-        if project:
-            queryset = queryset.filter(project=project)
-        return queryset.distinct()
-
-    def private(self, user=None, project=None):
-        kwargs = {
-            '%s__privacy_level' % self.project_field: constants.PRIVATE,
-        }
+        kwargs = {f'{self.project_field}__privacy_level': constants.PUBLIC}
         queryset = self.filter(**kwargs)
         if user:
             queryset = self._add_user_repos(queryset, user)

--- a/readthedocs/rtd_tests/tests/test_privacy.py
+++ b/readthedocs/rtd_tests/tests/test_privacy.py
@@ -1,6 +1,6 @@
 import logging
-
 from unittest import mock
+
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -9,7 +9,6 @@ from readthedocs.builds.constants import LATEST
 from readthedocs.builds.models import Build, Version
 from readthedocs.projects.forms import UpdateProjectForm
 from readthedocs.projects.models import Project
-
 
 log = logging.getLogger(__name__)
 
@@ -309,7 +308,7 @@ class PrivacyTests(TestCase):
         self.assertEqual(r._headers['x-accel-redirect'][1], '/proxito/media/htmlzip/django-kong/latest/django-kong.zip')
         self.assertEqual(r._headers['content-disposition'][1], 'filename=django-kong-readthedocs-io-en-latest.zip')
 
-# Build Filtering
+    # Build Filtering
 
     def test_build_filtering(self):
         kong = self._create_kong('public', 'private')
@@ -331,11 +330,3 @@ class PrivacyTests(TestCase):
         self.client.login(username='tester', password='test')
         r = self.client.get('/projects/django-kong/builds/')
         self.assertNotContains(r, 'test-slug')
-
-    def test_queryset_chaining(self):
-        """Test that manager methods get set on related querysets."""
-        kong = self._create_kong('public', 'private')
-        self.assertEqual(
-            kong.versions.private().get(slug='latest').slug,
-            'latest',
-        )

--- a/readthedocs/rtd_tests/tests/test_version_querysets.py
+++ b/readthedocs/rtd_tests/tests/test_version_querysets.py
@@ -130,35 +130,6 @@ class VersionQuerySetTests(TestVersionQuerySetBase):
         self.assertEqual(query.count(), len(versions))
         self.assertEqual(set(query), versions)
 
-    def test_private(self):
-        query = Version.objects.private()
-        versions = {
-            self.version_private,
-            self.another_version_private,
-            self.shared_version_private,
-        }
-        self.assertEqual(query.count(), len(versions))
-        self.assertEqual(set(query), versions)
-
-    def test_private_user(self):
-        query = Version.objects.private(user=self.user)
-        versions = (
-            self.user_versions |
-            {self.another_version_private}
-        )
-        self.assertEqual(query.count(), len(versions))
-        self.assertEqual(set(query), versions)
-
-    def test_private_project(self):
-        query = Version.objects.private(user=self.user, project=self.project)
-        versions = {
-            self.version,
-            self.version_latest,
-            self.version_private,
-        }
-        self.assertEqual(query.count(), len(versions))
-        self.assertEqual(set(query), versions)
-
     def test_api(self):
         query = Version.objects.api()
         versions = {
@@ -175,22 +146,6 @@ class VersionQuerySetTests(TestVersionQuerySetBase):
     def test_api_user(self):
         query = Version.objects.api(user=self.user, detail=False)
         versions = self.user_versions
-        self.assertEqual(query.count(), len(versions))
-        self.assertEqual(set(query), versions)
-
-    def test_for_project(self):
-        self.another_project.main_language_project = self.project
-        self.another_project.save()
-
-        query = Version.objects.for_project(self.project)
-        versions = {
-            self.version,
-            self.version_latest,
-            self.version_private,
-            self.another_version,
-            self.another_version_latest,
-            self.another_version_private,
-        }
         self.assertEqual(query.count(), len(versions))
         self.assertEqual(set(query), versions)
 
@@ -303,35 +258,6 @@ class VersionQuerySetWithInternalManagerTest(TestVersionQuerySetWithManagerBase)
         self.assertEqual(query.count(), len(versions))
         self.assertEqual(set(query), versions)
 
-    def test_private(self):
-        query = Version.internal.private()
-        versions = {
-            self.version_private,
-            self.another_version_private,
-            self.shared_version_private,
-        }
-        self.assertEqual(query.count(), len(versions))
-        self.assertEqual(set(query), versions)
-
-    def test_private_user(self):
-        query = Version.internal.private(user=self.user)
-        versions = (
-            self.user_versions |
-            {self.another_version_private}
-        )
-        self.assertEqual(query.count(), len(versions))
-        self.assertEqual(set(query), versions)
-
-    def test_private_project(self):
-        query = Version.internal.private(user=self.user, project=self.project)
-        versions = {
-            self.version,
-            self.version_latest,
-            self.version_private,
-        }
-        self.assertEqual(query.count(), len(versions))
-        self.assertEqual(set(query), versions)
-
     def test_api(self):
         query = Version.internal.api()
         versions = {
@@ -348,22 +274,6 @@ class VersionQuerySetWithInternalManagerTest(TestVersionQuerySetWithManagerBase)
     def test_api_user(self):
         query = Version.internal.api(user=self.user, detail=False)
         versions = self.user_versions
-        self.assertEqual(query.count(), len(versions))
-        self.assertEqual(set(query), versions)
-
-    def test_for_project(self):
-        self.another_project.main_language_project = self.project
-        self.another_project.save()
-
-        query = Version.internal.for_project(self.project)
-        versions = {
-            self.version,
-            self.version_latest,
-            self.version_private,
-            self.another_version,
-            self.another_version_latest,
-            self.another_version_private,
-        }
         self.assertEqual(query.count(), len(versions))
         self.assertEqual(set(query), versions)
 
@@ -420,37 +330,6 @@ class VersionQuerySetWithExternalManagerTest(TestVersionQuerySetWithManagerBase)
         self.assertEqual(query.count(), len(versions))
         self.assertEqual(set(query), versions)
 
-    def test_private(self):
-        query = Version.external.private()
-        versions = {
-            self.external_version_private,
-            self.another_external_version_private,
-            self.shared_external_version_private,
-        }
-        self.assertEqual(query.count(), len(versions))
-        self.assertEqual(set(query), versions)
-
-    def test_private_user(self):
-        query = Version.external.private(user=self.user)
-        versions = {
-            self.external_version_public,
-            self.external_version_private,
-            self.another_external_version_private,
-            self.shared_external_version_public,
-            self.shared_external_version_private,
-        }
-        self.assertEqual(query.count(), len(versions))
-        self.assertEqual(set(query), versions)
-
-    def test_private_project(self):
-        query = Version.external.private(user=self.user, project=self.project)
-        versions = {
-            self.external_version_public,
-            self.external_version_private,
-        }
-        self.assertEqual(query.count(), len(versions))
-        self.assertEqual(set(query), versions)
-
     def test_api(self):
         query = Version.external.api()
         versions = {
@@ -468,20 +347,6 @@ class VersionQuerySetWithExternalManagerTest(TestVersionQuerySetWithManagerBase)
             self.external_version_private,
             self.shared_external_version_public,
             self.shared_external_version_private,
-        }
-        self.assertEqual(query.count(), len(versions))
-        self.assertEqual(set(query), versions)
-
-    def test_for_project(self):
-        self.another_project.main_language_project = self.project
-        self.another_project.save()
-
-        query = Version.external.for_project(self.project)
-        versions = {
-            self.external_version_public,
-            self.external_version_private,
-            self.another_external_version_public,
-            self.another_external_version_private,
         }
         self.assertEqual(query.count(), len(versions))
         self.assertEqual(set(query), versions)


### PR DESCRIPTION
These aren't used, and I don't see them being used in the future.

- private: there isn't a part of our code were we want to list
  all private versions, instead we may want to use `public(user)`.
- for_project: this was listing all versions from a project and its
  translation. Not sure were we would want that, but isn't used.

The private queryset from projects is being removed in https://github.com/readthedocs/readthedocs.org/pull/8154