### PR TITLE
Docs: add space to bash code

### DIFF
--- a/docs/custom_domains.rst
+++ b/docs/custom_domains.rst
@@ -26,7 +26,7 @@ You can also host your documentation from your own domain.
 .. tabs::
 
    .. tab:: Read the Docs Community
-      
+
       In order to setup your custom domain, follow these steps:
 
       #. For a subdomain like ``docs.example.com``, add a CNAME record in your DNS that points the domain to ``readthedocs.io``.
@@ -45,7 +45,7 @@ You can also host your documentation from your own domain.
       .. prompt:: bash $, auto
 
          $ dig CNAME +short docs.fabfile.org
-         readthedocs.io.
+           readthedocs.io.
 
    .. tab:: Read the Docs for Business
 
@@ -56,7 +56,7 @@ You can also host your documentation from your own domain.
       #. Enter your domain and click on :guilabel:`Add`
       #. Follow the steps shown on the domain page.
          This will require adding 2 DNS records, one pointing your custom domain to our servers,
-         and another allowing us to provision an SSL certificate. 
+         and another allowing us to provision an SSL certificate.
 
       By default, we provide a validated SSL certificate for the domain.
       The SSL certificate issuance can take a few days,
@@ -128,7 +128,7 @@ You will need to update your CAA records to allow us to issue the certificate.
 .. _Amazon CAA guide: https://docs.aws.amazon.com/acm/latest/userguide/setup-caa.html
 
 .. note::
- 
+
    If your custom domain was previously used in GitBook, contact GitBook support (via live chat in their website)
    to remove the domain name from their DNS Zone in order for your domain name to work with Read the Docs,
    else it will always redirect to GitBook.


### PR DESCRIPTION
Otherwise this gets rendered as `eadthedocs.io.`