### PR TITLE
APIv2: disable listing endpoints

### DIFF
--- a/readthedocs/api/v2/views/model_views.py
+++ b/readthedocs/api/v2/views/model_views.py
@@ -100,12 +100,12 @@ class DisableListEndpoint:
             {
                 'error': 'disabled',
                 'msg': (
-                    'List endpoint have been disabled: please provide a resource identifier. '
+                    'List endpoint have been disabled due to heavy resource usage. '
                     'Take into account than APIv2 is planned to be deprecated soon. '
                     'Please use APIv3: https://docs.readthedocs.io/page/api/v3.html'
                 )
             },
-            status=status.HTTP_409_CONFLICT,
+            status=status.HTTP_410_GONE,
         )
 
 

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -693,15 +693,6 @@ class APITests(TestCase):
         self.assertIn('features', resp.data)
         self.assertEqual(resp.data['features'], [feature.feature_id])
 
-    def test_project_pagination(self):
-        for _ in range(100):
-            get(Project)
-
-        resp = self.client.get('/api/v2/project/')
-        self.assertEqual(resp.status_code, 200)
-        self.assertEqual(len(resp.data['results']), 100)  # page_size
-        self.assertIn('?page=2', resp.data['next'])
-
     def test_remote_repository_pagination(self):
         account = get(SocialAccount, provider='github')
         user = get(User)

--- a/readthedocs/rtd_tests/tests/test_domains.py
+++ b/readthedocs/rtd_tests/tests/test_domains.py
@@ -170,18 +170,3 @@ class FormTests(TestCase):
         domain = form.save()
         self.assertEqual(domain.domain, 'example.com')
         self.assertFalse(domain.canonical)
-
-
-class TestAPI(TestCase):
-
-    def setUp(self):
-        self.project = get(Project)
-        self.domain = self.project.domains.create(domain='djangokong.com')
-
-    def test_basic_api(self):
-        resp = self.client.get('/api/v2/domain/')
-        self.assertEqual(resp.status_code, 200)
-        obj = json.loads(resp.content)
-        self.assertEqual(obj['results'][0]['domain'], 'djangokong.com')
-        self.assertEqual(obj['results'][0]['canonical'], False)
-        self.assertNotIn('https', obj['results'][0])

--- a/readthedocs/rtd_tests/tests/test_privacy_urls.py
+++ b/readthedocs/rtd_tests/tests/test_privacy_urls.py
@@ -381,10 +381,10 @@ class APIMixin(URLAccessMixin):
             'api_webhook_stripe': {},
         }
         self.response_data = {
-            'domain-list': {'status_code': 409},
-            'buildcommandresult-list': {'status_code': 409},
+            'domain-list': {'status_code': 410},
+            'buildcommandresult-list': {'status_code': 410},
             'build-concurrent': {'status_code': 403},
-            'build-list': {'status_code': 409},
+            'build-list': {'status_code': 410},
             'build-reset': {'status_code': 403},
             'project-sync-versions': {'status_code': 403},
             'project-token': {'status_code': 403},
@@ -405,11 +405,11 @@ class APIMixin(URLAccessMixin):
             'api_webhook_generic': {'status_code': 403},
             'api_webhook_stripe': {'status_code': 405},
             'sphinxdomain-detail': {'status_code': 404},
-            'project-list': {'status_code': 409},
+            'project-list': {'status_code': 410},
             'remoteorganization-detail': {'status_code': 404},
             'remoterepository-detail': {'status_code': 404},
             'remoteaccount-detail': {'status_code': 404},
-            'version-list': {'status_code': 409},
+            'version-list': {'status_code': 410},
         }
 
 

--- a/readthedocs/rtd_tests/tests/test_privacy_urls.py
+++ b/readthedocs/rtd_tests/tests/test_privacy_urls.py
@@ -381,7 +381,10 @@ class APIMixin(URLAccessMixin):
             'api_webhook_stripe': {},
         }
         self.response_data = {
+            'domain-list': {'status_code': 409},
+            'buildcommandresult-list': {'status_code': 409},
             'build-concurrent': {'status_code': 403},
+            'build-list': {'status_code': 409},
             'build-reset': {'status_code': 403},
             'project-sync-versions': {'status_code': 403},
             'project-token': {'status_code': 403},
@@ -402,9 +405,11 @@ class APIMixin(URLAccessMixin):
             'api_webhook_generic': {'status_code': 403},
             'api_webhook_stripe': {'status_code': 405},
             'sphinxdomain-detail': {'status_code': 404},
+            'project-list': {'status_code': 409},
             'remoteorganization-detail': {'status_code': 404},
             'remoterepository-detail': {'status_code': 404},
             'remoteaccount-detail': {'status_code': 404},
+            'version-list': {'status_code': 409},
         }
 
 


### PR DESCRIPTION
We have experienced DOS in some opportunities when hitting these endpoints
without any kind of filter. They may require a big DB query causing the site
going down.

This commit disable all listing endpoint without removing the functionability we
are currently using:

- filter versions by project slug
- getting a specific build by commit hash

On those cases where it's disabled, we return a nice message to the user
communicating that it's disabled and APIv3 should be used instead.