### PR TITLE
Build: use `is_active` method to know if the build should be skipped

### DIFF
--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -47,6 +47,7 @@ class ProjectAdminSerializer(ProjectSerializer):
     )
 
     environment_variables = serializers.SerializerMethodField()
+    skip = serializers.SerializerMethodField()
 
     def get_environment_variables(self, obj):
         """Get all environment variables, including public ones."""
@@ -57,6 +58,9 @@ class ProjectAdminSerializer(ProjectSerializer):
             )
             for variable in obj.environmentvariable_set.all()
         }
+
+    def get_skip(self, obj):
+        return not Project.objects.is_active(obj)
 
     class Meta(ProjectSerializer.Meta):
         fields = ProjectSerializer.Meta.fields + (

--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -60,6 +60,12 @@ class ProjectAdminSerializer(ProjectSerializer):
         }
 
     def get_skip(self, obj):
+        """
+        Override ``Project.skip`` to consider more cases whether skip a project.
+
+        We rely on ``.is_active`` manager's method here that encapsulates all
+        these possible cases.
+        """
         return not Project.objects.is_active(obj)
 
     class Meta(ProjectSerializer.Meta):


### PR DESCRIPTION
Currently we are using only `project.skip` to know if the build for this
particular project has to be skipped after the task was triggered. However, if
the if the project belongs to an organization and the organization is disabled
those builds already queued will be built.

This commit uses `is_active` for `project.skip` field in the API response, that
takes care of this case.

This helps us if we found that an organization _already_ triggered many builds
and we need to cancel all of them. With this change, just by doing
`organization.disable=True` will make kill them all at built time instead of
processing them.