### PR TITLE
Organizations: simplify querysets/managers

### DIFF
--- a/readthedocs/organizations/managers.py
+++ b/readthedocs/organizations/managers.py
@@ -31,16 +31,6 @@ class TeamManagerBase(models.Manager):
 
         return teams.distinct()
 
-    def api(self, user):
-        if user and user.is_superuser:
-            return self.get_queryset().all()
-        return self.teams_for_user(
-            user,
-            organization=None,
-            admin=True,
-            member=True,
-        )
-
     def admin(self, user, organization=None, include_all=False):
         if user.is_superuser and include_all:
             return self.get_queryset().all()

--- a/readthedocs/organizations/managers.py
+++ b/readthedocs/organizations/managers.py
@@ -7,54 +7,13 @@ from readthedocs.core.utils.extend import SettingsOverrideObject
 from .constants import ADMIN_ACCESS, READ_ONLY_ACCESS
 
 
-class RelatedOrganizationManager(models.Manager):
-
-    """Manager to control access."""
-
-    # pylint: disable=unused-argument
-    def _add_user_repos(self, queryset, user=None, admin=False, member=False):
-        from .models import Organization  # pylint: disable=cyclic-import
-        organizations = Organization.objects.for_user(user)
-        queryset = self.get_queryset().filter(organization__in=organizations)
-        return queryset
-
-    def for_admin_user(self, user):
-        projects = self.get_queryset().none()
-        return self._add_user_repos(projects, user, admin=True, member=False)
-
-    def for_user(self, user=None, include_all=False):
-        queryset = self.get_queryset().none()
-        if user and user.is_authenticated:
-            if user.is_superuser and include_all:
-                return self.get_queryset().all()
-
-            return self._add_user_repos(
-                queryset,
-                user,
-                admin=True,
-                member=True,
-            )
-        return queryset
-
-    def api(self, user=None):
-        if user and user.is_superuser:
-            return self.public(user=user, include_all=True)
-        return self._add_user_repos(
-            self.get_queryset(),
-            user=user,
-            admin=True,
-            member=True,
-        )
-
-
 class TeamManagerBase(models.Manager):
 
     """Manager to control team's access."""
 
     # pylint: disable=no-self-use
     def teams_for_user(self, user, organization, admin, member):
-        from .models import Team  # pylint: disable=cyclic-import
-        teams = Team.objects.none()
+        teams = self.get_queryset().none()
         if admin:
             # Project Team Admin
             teams |= user.teams.filter(access=ADMIN_ACCESS)
@@ -72,18 +31,9 @@ class TeamManagerBase(models.Manager):
 
         return teams.distinct()
 
-    # pylint: disable=unused-argument
-    def public(self, user=None, organization=None, only_active=True):
-        queryset = self.get_queryset().all()
-        if only_active:
-            queryset = queryset.filter(active=True)
-        if organization:
-            queryset = queryset.filter(organization=organization)
-        return queryset
-
-    def api(self, user=None):
+    def api(self, user):
         if user and user.is_superuser:
-            return self.public(user)
+            return self.get_queryset().all()
         return self.teams_for_user(
             user,
             organization=None,

--- a/readthedocs/organizations/querysets.py
+++ b/readthedocs/organizations/querysets.py
@@ -13,13 +13,13 @@ class BaseOrganizationQuerySet(models.QuerySet):
 
     """Organizations queryset."""
 
-    def for_user(self, user=None):
+    def for_user(self, user):
         # Never list all for membership
         return self.filter(
             Q(owners__in=[user]) | Q(teams__members__in=[user]),
         ).distinct()
 
-    def for_admin_user(self, user=None, include_all=False):
+    def for_admin_user(self, user, include_all=False):
         if user.is_superuser and include_all:
             return self.all()
         return self.filter(owners__in=[user],).distinct()


### PR DESCRIPTION
- `RelatedOrganizationManager` isn't used
- `TeamManager.{public,api}` aren't used. And `public` didn't make  sense, as it was listing everything by default.
- In the querysets `user` is always required.