### PR TITLE
QuerySets: check for .is_superuser instead of has_perm

### DIFF
--- a/readthedocs/builds/querysets.py
+++ b/readthedocs/builds/querysets.py
@@ -6,11 +6,13 @@ from django.db import models
 from django.db.models import Q
 from django.utils import timezone
 
+from readthedocs.builds.constants import (
+    BUILD_STATE_FINISHED,
+    BUILD_STATE_TRIGGERED,
+)
 from readthedocs.core.utils.extend import SettingsOverrideObject
 from readthedocs.projects import constants
 from readthedocs.projects.models import Project
-
-from .constants import BUILD_STATE_FINISHED, BUILD_STATE_TRIGGERED
 
 log = logging.getLogger(__name__)
 
@@ -25,7 +27,7 @@ class VersionQuerySetBase(models.QuerySet):
     use_for_related_fields = True
 
     def _add_user_repos(self, queryset, user):
-        if user.has_perm('builds.view_version'):
+        if user.is_superuser:
             return self.all()
         if user.is_authenticated:
             projects_pk = user.projects.all().values_list('pk', flat=True)
@@ -72,8 +74,8 @@ class BuildQuerySetBase(models.QuerySet):
 
     use_for_related_fields = True
 
-    def _add_user_repos(self, queryset, user=None):
-        if user.has_perm('builds.view_version'):
+    def _add_user_repos(self, queryset, user):
+        if user.is_superuser:
             return self.all()
         if user.is_authenticated:
             projects_pk = user.projects.all().values_list('pk', flat=True)
@@ -163,8 +165,8 @@ class RelatedBuildQuerySetBase(models.QuerySet):
 
     use_for_related_fields = True
 
-    def _add_user_repos(self, queryset, user=None):
-        if user.has_perm('builds.view_version'):
+    def _add_user_repos(self, queryset, user):
+        if user.is_superuser:
             return self.all()
         if user.is_authenticated:
             projects_pk = user.projects.all().values_list('pk', flat=True)

--- a/readthedocs/projects/querysets.py
+++ b/readthedocs/projects/querysets.py
@@ -6,8 +6,7 @@ from django.db.models import OuterRef, Prefetch, Q, Subquery
 
 from readthedocs.builds.constants import EXTERNAL
 from readthedocs.core.utils.extend import SettingsOverrideObject
-
-from . import constants
+from readthedocs.projects import constants
 
 
 class ProjectQuerySetBase(models.QuerySet):
@@ -17,7 +16,7 @@ class ProjectQuerySetBase(models.QuerySet):
     use_for_related_fields = True
 
     def _add_user_repos(self, queryset, user):
-        if user.has_perm('projects.view_project'):
+        if user.is_superuser:
             return self.all()
         if user.is_authenticated:
             user_queryset = user.projects.all()
@@ -157,8 +156,8 @@ class RelatedProjectQuerySetBase(models.QuerySet):
     use_for_related_fields = True
     project_field = 'project'
 
-    def _add_user_repos(self, queryset, user=None):
-        if user.has_perm('projects.view_project'):
+    def _add_user_repos(self, queryset, user):
+        if user.is_superuser:
             return self.all()
         if user.is_authenticated:
             projects_pk = user.projects.all().values_list('pk', flat=True)


### PR DESCRIPTION
We use the is_superuser check in .com,
while we check for has_perm in .org.

These checks are only for the api user,
and has_perm always returns true for superusers.
I have checked and our api users are superusers,
so all good.

Also, user is always required.