### PR TITLE
QuerySets: refactor _add_user_repos

### DIFF
--- a/readthedocs/builds/querysets.py
+++ b/readthedocs/builds/querysets.py
@@ -182,7 +182,7 @@ class RelatedBuildQuerySet(models.QuerySet):
 
     .. note::
 
-       This is currently used for ``BuildCommandViewSet`` from api v2 only.
+       This is only used for ``BuildCommandViewSet`` from api v2.
        Which is being used to upload build command results from the builders.
     """
 

--- a/readthedocs/builds/querysets.py
+++ b/readthedocs/builds/querysets.py
@@ -26,7 +26,15 @@ class VersionQuerySetBase(models.QuerySet):
 
     use_for_related_fields = True
 
-    def _add_user_repos(self, queryset, user):
+    def _add_from_user_projects(self, queryset, user, admin=False, member=False):
+        """
+        Add related objects from projects where `user` is an `admin` or a `member`.
+
+        .. note::
+
+           In .org all users are admin and member of a project.
+           This will change with organizations soon.
+        """
         if user.is_superuser:
             return self.all()
         if user.is_authenticated:
@@ -39,7 +47,7 @@ class VersionQuerySetBase(models.QuerySet):
                include_hidden=True, only_built=False):
         queryset = self.filter(privacy_level=constants.PUBLIC)
         if user:
-            queryset = self._add_user_repos(queryset, user)
+            queryset = self._add_from_user_projects(queryset, user)
         if project:
             queryset = queryset.filter(project=project)
         if only_active:
@@ -56,7 +64,7 @@ class VersionQuerySetBase(models.QuerySet):
 
         queryset = self.none()
         if user:
-            queryset = self._add_user_repos(queryset, user)
+            queryset = self._add_from_user_projects(queryset, user)
         return queryset.distinct()
 
 
@@ -74,7 +82,15 @@ class BuildQuerySetBase(models.QuerySet):
 
     use_for_related_fields = True
 
-    def _add_user_repos(self, queryset, user):
+    def _add_from_user_projects(self, queryset, user, admin=False, member=False):
+        """
+        Add related objects from projects where `user` is an `admin` or a `member`.
+
+        .. note::
+
+           In .org all users are admin and member of a project.
+           This will change with organizations soon.
+        """
         if user.is_superuser:
             return self.all()
         if user.is_authenticated:
@@ -86,7 +102,7 @@ class BuildQuerySetBase(models.QuerySet):
     def public(self, user=None, project=None):
         queryset = self.filter(version__privacy_level=constants.PUBLIC)
         if user:
-            queryset = self._add_user_repos(queryset, user)
+            queryset = self._add_from_user_projects(queryset, user)
         if project:
             queryset = queryset.filter(project=project)
         return queryset.distinct()
@@ -97,7 +113,7 @@ class BuildQuerySetBase(models.QuerySet):
 
         queryset = self.none()
         if user:
-            queryset = self._add_user_repos(queryset, user)
+            queryset = self._add_from_user_projects(queryset, user)
         return queryset.distinct()
 
     def concurrent(self, project):
@@ -159,13 +175,20 @@ class BuildQuerySet(SettingsOverrideObject):
     _default_class = BuildQuerySetBase
 
 
-class RelatedBuildQuerySetBase(models.QuerySet):
+class RelatedBuildQuerySet(models.QuerySet):
 
-    """For models with association to a project through :py:class:`Build`."""
+    """
+    For models with association to a project through :py:class:`Build`.
+
+    .. note::
+
+       This is currently used for ``BuildCommandViewSet`` from api v2 only.
+       Which is being used to upload build command results from the builders.
+    """
 
     use_for_related_fields = True
 
-    def _add_user_repos(self, queryset, user):
+    def _add_from_user_projects(self, queryset, user):
         if user.is_superuser:
             return self.all()
         if user.is_authenticated:
@@ -174,18 +197,11 @@ class RelatedBuildQuerySetBase(models.QuerySet):
             queryset = user_queryset | queryset
         return queryset
 
-    def public(self, user=None, project=None):
+    def public(self, user=None):
         queryset = self.filter(build__version__privacy_level=constants.PUBLIC)
         if user:
-            queryset = self._add_user_repos(queryset, user)
-        if project:
-            queryset = queryset.filter(build__project=project)
+            queryset = self._add_from_user_projects(queryset, user)
         return queryset.distinct()
 
     def api(self, user=None):
         return self.public(user)
-
-
-class RelatedBuildQuerySet(SettingsOverrideObject):
-    _default_class = RelatedBuildQuerySetBase
-    _override_setting = 'RELATED_BUILD_MANAGER'

--- a/readthedocs/redirects/querysets.py
+++ b/readthedocs/redirects/querysets.py
@@ -3,20 +3,18 @@
 import logging
 
 from django.db import models
-from django.db.models import Value, CharField, Q, F
-
-from readthedocs.core.utils.extend import SettingsOverrideObject
+from django.db.models import CharField, F, Q, Value
 
 log = logging.getLogger(__name__)
 
 
-class RedirectQuerySetBase(models.QuerySet):
+class RedirectQuerySet(models.QuerySet):
 
     """Redirects take into account their own privacy_level setting."""
 
     use_for_related_fields = True
 
-    def _add_user_repos(self, queryset, user):
+    def _add_from_user_projects(self, queryset, user):
         if user.is_authenticated:
             projects_pk = user.projects.all().values_list('pk', flat=True)
             user_queryset = self.filter(project__in=projects_pk)
@@ -26,7 +24,7 @@ class RedirectQuerySetBase(models.QuerySet):
     def api(self, user=None, detail=True):
         queryset = self.none()
         if user:
-            queryset = self._add_user_repos(queryset, user)
+            queryset = self._add_from_user_projects(queryset, user)
         return queryset
 
     def get_redirect_path_with_status(self, path, full_path=None, language=None, version_slug=None):
@@ -88,7 +86,3 @@ class RedirectQuerySetBase(models.QuerySet):
             if new_path:
                 return new_path, redirect.http_status
         return (None, None)
-
-
-class RedirectQuerySet(SettingsOverrideObject):
-    _default_class = RedirectQuerySetBase

--- a/readthedocs/rtd_tests/tests/test_project_querysets.py
+++ b/readthedocs/rtd_tests/tests/test_project_querysets.py
@@ -79,18 +79,6 @@ class ProjectQuerySetTests(TestCase):
         self.assertEqual(ChildRelatedProjectQuerySet.project_field, 'child')
         self.assertTrue(ChildRelatedProjectQuerySet.use_for_related_fields)
 
-    def test_subproject_queryset_as_manager_gets_correct_class(self):
-        mgr = ChildRelatedProjectQuerySet.as_manager()
-        self.assertEqual(
-            mgr.__class__.__name__,
-            'ManagerFromChildRelatedProjectQuerySetBase',
-        )
-        mgr = ParentRelatedProjectQuerySet.as_manager()
-        self.assertEqual(
-            mgr.__class__.__name__,
-            'ManagerFromParentRelatedProjectQuerySetBase',
-        )
-
     def test_is_active(self):
         project = get(Project, skip=False)
         self.assertTrue(Project.objects.is_active(project))

--- a/readthedocs/rtd_tests/tests/test_project_querysets.py
+++ b/readthedocs/rtd_tests/tests/test_project_querysets.py
@@ -79,6 +79,18 @@ class ProjectQuerySetTests(TestCase):
         self.assertEqual(ChildRelatedProjectQuerySet.project_field, 'child')
         self.assertTrue(ChildRelatedProjectQuerySet.use_for_related_fields)
 
+    def test_subproject_queryset_as_manager_gets_correct_class(self):
+        mgr = ChildRelatedProjectQuerySet.as_manager()
+        self.assertEqual(
+            mgr.__class__.__name__,
+            'ManagerFromChildRelatedProjectQuerySet',
+        )
+        mgr = ParentRelatedProjectQuerySet.as_manager()
+        self.assertEqual(
+            mgr.__class__.__name__,
+            'ManagerFromParentRelatedProjectQuerySet',
+        )
+
     def test_is_active(self):
         project = get(Project, skip=False)
         self.assertTrue(Project.objects.is_active(project))


### PR DESCRIPTION
Get ready for sharing more code,
mainly rename `_add_user_repos` to `_add_from_user_projects` and
`_add_user_projects`.

Start accepting admin and member attributes where needed,
these aren't used here yet, but they will.

I have removed some overrides that weren't needed or weren't overridden
in .com.

And for my next trick/PR, I'd try to move some overrides into .org :D