### PR TITLE
Proxito: redirect to main project from subprojects

### DIFF
--- a/readthedocs/proxito/tests/test_redirects.py
+++ b/readthedocs/proxito/tests/test_redirects.py
@@ -55,6 +55,57 @@ class RedirectTests(BaseDocServing):
             r['Location'], 'https://project.dev.readthedocs.io/projects/subproject/',
         )
 
+    def test_subproject_redirect(self):
+        r = self.client.get('/', HTTP_HOST='subproject.dev.readthedocs.io')
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(
+            r['Location'], 'https://project.dev.readthedocs.io/projects/subproject/en/latest/',
+        )
+
+        r = self.client.get('/en/latest/', HTTP_HOST='subproject.dev.readthedocs.io')
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(
+            r['Location'], 'https://project.dev.readthedocs.io/projects/subproject/en/latest/',
+        )
+
+        r = self.client.get('/en/latest/foo/bar', HTTP_HOST='subproject.dev.readthedocs.io')
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(
+            r['Location'], 'https://project.dev.readthedocs.io/projects/subproject/en/latest/foo/bar',
+        )
+
+        self.domain.canonical = True
+        self.domain.save()
+        r = self.client.get('/en/latest/foo/bar', HTTP_HOST='subproject.dev.readthedocs.io')
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(
+            r['Location'], 'https://docs1.example.com/projects/subproject/en/latest/foo/bar',
+        )
+
+    def test_single_version_subproject_redirect(self):
+        self.subproject.single_version = True
+        self.subproject.save()
+
+        r = self.client.get('/', HTTP_HOST='subproject.dev.readthedocs.io')
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(
+            r['Location'], 'https://project.dev.readthedocs.io/projects/subproject/',
+        )
+
+        r = self.client.get('/foo/bar/', HTTP_HOST='subproject.dev.readthedocs.io')
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(
+            r['Location'], 'https://project.dev.readthedocs.io/projects/subproject/foo/bar/',
+        )
+
+        self.domain.canonical = True
+        self.domain.save()
+        r = self.client.get('/foo/bar', HTTP_HOST='subproject.dev.readthedocs.io')
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(
+            r['Location'], 'https://docs1.example.com/projects/subproject/foo/bar',
+        )
+
     def test_root_redirect_with_query_params(self):
         r = self.client.get('/?foo=bar', HTTP_HOST='project.dev.readthedocs.io')
         self.assertEqual(r.status_code, 302)

--- a/readthedocs/rtd_tests/tests/test_footer.py
+++ b/readthedocs/rtd_tests/tests/test_footer.py
@@ -7,15 +7,12 @@ from django.urls import reverse
 from django_dynamic_fixture import get
 from rest_framework.test import APIRequestFactory
 
-from readthedocs.api.v2.views.footer_views import (
-    FooterHTML,
-    get_version_compare_data,
-)
+from readthedocs.api.v2.views.footer_views import get_version_compare_data
 from readthedocs.builds.constants import BRANCH, EXTERNAL, LATEST, TAG
 from readthedocs.builds.models import Version
 from readthedocs.core.middleware import ReadTheDocsSessionMiddleware
 from readthedocs.projects.constants import PUBLIC
-from readthedocs.projects.models import Feature, Project
+from readthedocs.projects.models import Project
 
 
 class BaseTestFooterHTML:
@@ -427,7 +424,7 @@ class TestVersionCompareFooter(TestCase):
 class TestFooterPerformance(TestCase):
     # The expected number of queries for generating the footer
     # This shouldn't increase unless we modify the footer API
-    EXPECTED_QUERIES = 14
+    EXPECTED_QUERIES = 15
 
     def setUp(self):
         self.pip = get(
@@ -485,7 +482,6 @@ class TestFooterPerformance(TestCase):
             canonical=True,
         )
 
-        # Setting up a custom domain increases only one query.
-        with self.assertNumQueries(self.EXPECTED_QUERIES + 1):
+        with self.assertNumQueries(self.EXPECTED_QUERIES):
             response = self.client.get(self.url, HTTP_HOST=domain)
             self.assertContains(response, domain)


### PR DESCRIPTION
This introduces one more query for normal serving, except when a custom domain is used, there the queries are the same, I think this is fine.

Closes https://github.com/readthedocs/readthedocs.org/issues/7881
We can revert https://github.com/readthedocs/readthedocs.org/pull/7880/
after releasing this.