### PR TITLE
Docker: remove `volumes=` argument when creating the container

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -1048,7 +1048,6 @@ class DockerBuildEnvironment(BuildEnvironment):
                 ),
                 name=self.container_id,
                 hostname=self.container_id,
-                volumes=self._get_binds(),
                 host_config=self.get_container_host_config(),
                 detach=True,
                 user=settings.RTD_DOCKER_USER,


### PR DESCRIPTION
`volumes=` argument is not required for our use case when calling
`create_container` if `host_config` is passed.

Besides, we were passing a dictionary when it a string o list is
expected (see the examples with `volumes=` and https://github.com/docker/docker-py/blob/96c12726fdb9b24e985b4de74d5c82145ccd8185/docker/api/container.py#L374-L375)

The combination of both `volumes=` (as a dict) plus calling
`create_container(host_config=..)` with `host_config` containing `binds` makes
my local environment to fail with:

ERROR (Build) [test-builds:latest] failed to create shim: OCI runtime create
failed: invalid mount {Destination:community_build-user-builds Type:bind
Source:/var/lib/docker/volumes/f86b268f8b853f2498eef2f7c5a76f68d3bb905490e3db142826c1a1bd752fe4/_data
Options:[rbind]}: mount destination community_build-user-builds not absolute:
unknown

By removing the `volumes=` from `create_container` builds started working again
and the issue disappeared.

https://docker-py.readthedocs.io/en/stable/api.html#docker.api.container.ContainerApiMixin.create_container