### PR TITLE
Builds: prevent code injection in cwd

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -323,7 +323,7 @@ class Virtualenv(PythonEnvironment):
             # Don't use virtualenv bin that doesn't exist yet
             bin_path=None,
             # Don't use the project's root, some config files can interfere
-            cwd='$HOME',
+            cwd=None,
         )
 
     def install_core_requirements(self):

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -441,6 +441,7 @@ class CommunityBaseSettings(Settings):
     # https://docs.docker.com/engine/reference/run/#user
     RTD_DOCKER_USER = 'docs:docs'
     RTD_DOCKER_SUPER_USER = 'root:root'
+    RTD_DOCKER_WORKDIR = '/home/docs/'
 
     RTD_DOCKER_COMPOSE = False
 


### PR DESCRIPTION
This isn't a vulnerability since this command is executed inside
a container with a unprivileged user.

I have replaced the usage of manual `cd` with using the `workdir`
option from docker. This option doesn't support env vars expansion
(which is safer), so I had to introduce a new setting.

There is a PR to update usage of `$HOME` in .com