### PR TITLE
Footer: return well formed html

### DIFF
--- a/media/css/readthedocs-doc-embed.css
+++ b/media/css/readthedocs-doc-embed.css
@@ -24,6 +24,10 @@
     margin: 0;
 }
 
+.rtd-current-item {
+    font-weight: bold;
+}
+
 
 /* Fix RTD theme bottom margin */
 .rst-content .line-block {

--- a/readthedocs/api/v2/templates/restapi/footer.html
+++ b/readthedocs/api/v2/templates/restapi/footer.html
@@ -18,18 +18,19 @@
         <dt>{% trans "Languages" %}</dt>
 
         {# Output the main project language since it isn't included in translations list #}
-        {% if main_project.language == current_language %} <strong> {% endif %}
-        <dd><a href="{{ main_project.get_docs_url }}{{ path }}">{{ main_project.language }}</a></dd>
-        {% if main_project.language == current_language %} </strong> {% endif %}
+        
+        <dd {% if main_project.language == current_language %} class="rtd-current-item" {% endif %}>
+          <a href="{{ main_project.get_docs_url }}{{ path }}">{{ main_project.language }}</a>
+        </dd>
 
         {# regroup to make language_list unique per language #}
         {% regroup translations by language as language_list %}
         {% for group in language_list %}
         {% for translation in group.list %}
         {% if translation.language != main_project.language %}
-        {% if translation.language == current_language %} <strong> {% endif %}
-        <dd><a href="{{ translation.get_docs_url }}{{ path }}">{{ translation.language }}</a></dd>
-        {% if translation.language == current_language %} </strong> {% endif %}
+        <dd {% if translation.language == current_language %} class="rtd-current-item" {% endif %}>
+          <a href="{{ translation.get_docs_url }}{{ path }}">{{ translation.language }}</a>
+        </dd>
         {% endif %}
         {% endfor %}
         {% endfor %}
@@ -40,9 +41,9 @@
       <dl>
         <dt>{% trans "Versions" %}</dt>
         {% for version in versions %}
-        {% if version.verbose_name == current_version %} <strong> {% endif %}
-        <dd><a href="{{ version.get_subdomain_url }}{{ path|default_if_none:"" }}">{{ version.slug }}</a></dd>
-        {% if version.verbose_name == current_version %} </strong> {% endif %}
+        <dd {% if version.verbose_name == current_version %} class="rtd-current-item" {% endif %}>
+          <a href="{{ version.get_subdomain_url }}{{ path|default_if_none:"" }}">{{ version.slug }}</a>
+        </dd>
         {% endfor %}
       </dl>
       {% endif %}


### PR DESCRIPTION
We shouldn't use strong tags to surround a dd tag, use css instead.

Closes https://github.com/readthedocs/readthedocs.org/issues/7903