### PR TITLE
Proxito: don't require the middleware for proxied apis

### DIFF
--- a/readthedocs/analytics/tests.py
+++ b/readthedocs/analytics/tests.py
@@ -8,7 +8,7 @@ from django_dynamic_fixture import get
 
 from readthedocs.builds.models import Version
 from readthedocs.projects.constants import PUBLIC
-from readthedocs.projects.models import Feature, Project
+from readthedocs.projects.models import Project
 
 from .models import PageView
 from .utils import anonymize_ip_address, anonymize_user_agent, get_client_ip

--- a/readthedocs/api/v2/proxied_urls.py
+++ b/readthedocs/api/v2/proxied_urls.py
@@ -5,8 +5,7 @@ Served from the same domain docs are served,
 so they can make use of features that require to have access to their cookies.
 """
 
-from django.conf import settings
-from django.conf.urls import include, url
+from django.conf.urls import url
 
 from readthedocs.analytics.proxied_api import AnalyticsView
 from readthedocs.api.v2.views.proxied import ProxiedEmbedAPI, ProxiedFooterHTML

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -126,6 +126,9 @@ class ProxitoMiddleware(MiddlewareMixin):
 
     """The actual middleware we'll be using in prod."""
 
+    # None of these need the proxito request middleware (response is needed).
+    # The analytics API isn't listed because it depends on the unresolver,
+    # which depends on the proxito middleware.
     skip_views = (
         'health_check',
         'footer_html',

--- a/readthedocs/rtd_tests/tests/test_footer.py
+++ b/readthedocs/rtd_tests/tests/test_footer.py
@@ -424,7 +424,7 @@ class TestVersionCompareFooter(TestCase):
 class TestFooterPerformance(TestCase):
     # The expected number of queries for generating the footer
     # This shouldn't increase unless we modify the footer API
-    EXPECTED_QUERIES = 15
+    EXPECTED_QUERIES = 12
 
     def setUp(self):
         self.pip = get(


### PR DESCRIPTION
None of these need the proxito request middleware (response is needed).

The analytics api isn't listed because it depends on the unresolver,
which depends on the proxito middleware.