### PR TITLE
QuerySets: remove unused `detail` parameter

### DIFF
--- a/readthedocs/builds/querysets.py
+++ b/readthedocs/builds/querysets.py
@@ -58,14 +58,8 @@ class VersionQuerySetBase(models.QuerySet):
             queryset = queryset.filter(hidden=False)
         return queryset.distinct()
 
-    def api(self, user=None, detail=True):
-        if detail:
-            return self.public(user, only_active=False)
-
-        queryset = self.none()
-        if user:
-            queryset = self._add_from_user_projects(queryset, user)
-        return queryset.distinct()
+    def api(self, user=None):
+        return self.public(user, only_active=False)
 
 
 class VersionQuerySet(SettingsOverrideObject):
@@ -107,14 +101,8 @@ class BuildQuerySetBase(models.QuerySet):
             queryset = queryset.filter(project=project)
         return queryset.distinct()
 
-    def api(self, user=None, detail=True):
-        if detail:
-            return self.public(user)
-
-        queryset = self.none()
-        if user:
-            queryset = self._add_from_user_projects(queryset, user)
-        return queryset.distinct()
+    def api(self, user=None):
+        return self.public(user)
 
     def concurrent(self, project):
         """

--- a/readthedocs/projects/querysets.py
+++ b/readthedocs/projects/querysets.py
@@ -137,14 +137,8 @@ class ProjectQuerySetBase(models.QuerySet):
         """Get the projects for this user including the latest build."""
         return self.for_user(user).prefetch_latest_build()
 
-    def api(self, user=None, detail=True):
-        if detail:
-            return self.public(user)
-
-        queryset = self.none()
-        if user:
-            queryset = self._add_user_projects(queryset, user)
-        return queryset.distinct()
+    def api(self, user=None):
+        return self.public(user)
 
 
 class ProjectQuerySet(SettingsOverrideObject):

--- a/readthedocs/redirects/querysets.py
+++ b/readthedocs/redirects/querysets.py
@@ -21,7 +21,7 @@ class RedirectQuerySet(models.QuerySet):
             queryset = user_queryset | queryset
         return queryset.distinct()
 
-    def api(self, user=None, detail=True):
+    def api(self, user=None):
         queryset = self.none()
         if user:
             queryset = self._add_from_user_projects(queryset, user)

--- a/readthedocs/rtd_tests/tests/test_managers.py
+++ b/readthedocs/rtd_tests/tests/test_managers.py
@@ -257,17 +257,6 @@ class TestInternalBuildManager(TestBuildManagerBase):
         self.assertEqual(query.count(), len(builds))
         self.assertEqual(set(query), builds)
 
-    def test_api_user(self):
-        query = Build.internal.api(user=self.user, detail=False)
-        builds = {
-            self.build_private,
-            self.shared_build_private,
-            self.build_public,
-            self.shared_build_public,
-        }
-        self.assertEqual(query.count(), len(builds))
-        self.assertEqual(set(query), builds)
-
 
 class TestExternalBuildManager(TestBuildManagerBase):
 
@@ -328,17 +317,6 @@ class TestExternalBuildManager(TestBuildManagerBase):
             self.shared_build_private_external,
             self.build_public_external,
             self.another_build_public_external,
-            self.shared_build_public_external,
-        }
-        self.assertEqual(query.count(), len(builds))
-        self.assertEqual(set(query), builds)
-
-    def test_api_user(self):
-        query = Build.external.api(user=self.user, detail=False)
-        builds = {
-            self.build_private_external,
-            self.shared_build_private_external,
-            self.build_public_external,
             self.shared_build_public_external,
         }
         self.assertEqual(query.count(), len(builds))

--- a/readthedocs/rtd_tests/tests/test_version_querysets.py
+++ b/readthedocs/rtd_tests/tests/test_version_querysets.py
@@ -143,12 +143,6 @@ class VersionQuerySetTests(TestVersionQuerySetBase):
         self.assertEqual(query.count(), len(versions))
         self.assertEqual(set(query), versions)
 
-    def test_api_user(self):
-        query = Version.objects.api(user=self.user, detail=False)
-        versions = self.user_versions
-        self.assertEqual(query.count(), len(versions))
-        self.assertEqual(set(query), versions)
-
 
 class TestVersionQuerySetWithManagerBase(TestVersionQuerySetBase):
 
@@ -271,12 +265,6 @@ class VersionQuerySetWithInternalManagerTest(TestVersionQuerySetWithManagerBase)
         self.assertEqual(query.count(), len(versions))
         self.assertEqual(set(query), versions)
 
-    def test_api_user(self):
-        query = Version.internal.api(user=self.user, detail=False)
-        versions = self.user_versions
-        self.assertEqual(query.count(), len(versions))
-        self.assertEqual(set(query), versions)
-
 
 class VersionQuerySetWithExternalManagerTest(TestVersionQuerySetWithManagerBase):
 
@@ -336,17 +324,6 @@ class VersionQuerySetWithExternalManagerTest(TestVersionQuerySetWithManagerBase)
             self.external_version_public,
             self.another_external_version_public,
             self.shared_external_version_public,
-        }
-        self.assertEqual(query.count(), len(versions))
-        self.assertEqual(set(query), versions)
-
-    def test_api_user(self):
-        query = Version.external.api(user=self.user, detail=False)
-        versions = {
-            self.external_version_public,
-            self.external_version_private,
-            self.shared_external_version_public,
-            self.shared_external_version_private,
         }
         self.assertEqual(query.count(), len(versions))
         self.assertEqual(set(query), versions)


### PR DESCRIPTION
This isn't used, and is always `True`