### PR TITLE
Remove IRC from our docs

### DIFF
--- a/docs/code-of-conduct.rst
+++ b/docs/code-of-conduct.rst
@@ -16,14 +16,14 @@ it in the spirit in which it’s intended - a guide to make it easier to
 enrich all of us and the technical communities in which we participate.
 
 This code of conduct applies to all spaces managed by the Read the Docs project.
-This includes IRC, the mailing lists, the
+This includes live chat, mailing lists, the
 issue tracker, and any other forums created by the project
 team which the community uses for communication. In addition, violations
 of this code outside these spaces may affect a person's ability to
 participate within them.
 
 If you believe someone is violating the code of conduct, we ask that you
-report it by emailing dev@readthedocs.org. 
+report it by emailing dev@readthedocs.org.
 
 -  **Be friendly and patient.**
 -  **Be welcoming.** We strive to be a community that welcomes and

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -13,12 +13,10 @@ Get in touch
 - Ask usage questions ("How do I?") on `StackOverflow`_.
 - Report bugs, suggest features or view the source code `on GitHub`_.
 - Discuss topics on `Gitter`_.
-- On IRC find us at `#readthedocs`_.
 
 .. _StackOverFlow: https://stackoverflow.com/questions/tagged/read-the-docs
 .. _on GitHub: https://github.com/readthedocs/readthedocs.org
 .. _Gitter: https://gitter.im/rtfd/readthedocs.org
-.. _#readthedocs: irc://irc.freenode.net/readthedocs
 
 Contributing to development
 ---------------------------


### PR DESCRIPTION
We haven't used this actively in years,
but freenode is now lost :(