### PR TITLE
Update gitter channel name

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -16,7 +16,7 @@ Get in touch
 
 .. _StackOverFlow: https://stackoverflow.com/questions/tagged/read-the-docs
 .. _on GitHub: https://github.com/readthedocs/readthedocs.org
-.. _Gitter: https://gitter.im/rtfd/readthedocs.org
+.. _Gitter: https://gitter.im/readthedocs/community
 
 Contributing to development
 ---------------------------


### PR DESCRIPTION
The old channel goes back to our old repository name, and all new Gitter
channels are under out GitHub/Gitter community namespace `readthedocs`.
There are a few channels there, but this is the most general channel.