### PR TITLE
Make sustainability page more visible

### DIFF
--- a/docs/sponsors.rst
+++ b/docs/sponsors.rst
@@ -11,6 +11,8 @@ Current sponsors
 
 * `AWS`_ - They cover all of our hosting expenses every month.  This is a pretty large sum of money, averaging around $5,000/mo.
 * `Cloudflare`_ - Cloudflare is providing us with an enterprise plan of their SSL for SaaS Providers product that enables us to provide SSL certificates for custom domains.
+* `Chan Zuckerberg Initiative`_ - Through their "Essential Open Source Software for Science" programme, they fund our ongoing efforts to improve scientific documentation
+  and make Read the Docs a better service for scientific projects.
 * You? (Email us at hello@readthedocs.org for more info)
 
 Past sponsors
@@ -36,6 +38,7 @@ Past sponsors
 .. _Cloudflare: https://www.cloudflare.com/
 .. _Microsoft Azure: https://azure.microsoft.com/
 .. _AWS: https://aws.amazon.com/
+.. _Chan Zuckerberg Initiative: https://chanzuckerberg.com/
 
 
 Sponsorship Information

--- a/readthedocs/templates/base.html
+++ b/readthedocs/templates/base.html
@@ -175,6 +175,9 @@
               <a href="https://docs.readthedocs.io">{% trans 'Documentation' %}</a>
             </li>
             <li>
+              <a href="https://readthedocs.org/sustainability/">{% trans 'Going Ad-free' %}</a>
+            </li>
+            <li>
               <a href="https://readthedocs.org/support/">{% trans 'Site Support' %}</a>
             </li>
             <li>

--- a/readthedocs/templates/base.html
+++ b/readthedocs/templates/base.html
@@ -166,9 +166,6 @@
               <a href="https://docs.readthedocs.io/page/intro/getting-started-with-sphinx.html">{% trans 'Getting Started Guide' %}</a>
             </li>
             <li>
-              <a href="https://docs.readthedocs.io/page/contribute.html">{% trans 'Contributing' %}</a>
-            </li>
-            <li>
               <a href="https://docs.readthedocs.io/page/team.html">{% trans 'Team' %}</a>
             </li>
             <li>

--- a/readthedocs/templates/homepage.html
+++ b/readthedocs/templates/homepage.html
@@ -137,18 +137,22 @@
     <h2>{% trans 'About Read the Docs' %}</h2>
 
     <p>
+      {% blocktrans trimmed %}
       Read the Docs has grown substantially
       since its beginning as a weekend project and is closing in on being a top-1000 site on the internet.
       Today, we:
+      {% endblocktrans %}
     </p>
 
     <!-- Updated: June 2018, pageviews June 2021 -->
+    {% blocktrans trimmed %}
     <ul class="donate-about">
       <li>Serve over <b>55 million pages</b> of documentation a month</li>
       <li>Serve over <b>40 TB</b> of documentation a month</li>
       <li>Host over <b>80,000 open source projects</b> and support over <b>100,000 users</b></li>
       <li>Are supported by a <a href="https://docs.readthedocs.io/en/latest/team.html">very small team</a> of dedicated engineers</li>
     </ul>
+    {% endblocktrans %}
 
   </section>
   <!-- Funding and Contributing -->
@@ -158,14 +162,14 @@
 
     {% url "donate" as donate_url %}
 
-    {% blocktrans trimmed %}
     <p>
+      {% blocktrans trimmed %}
       We fund our operations through <a href="https://www.ethicalads.io/advertisers/?ref=rtd">advertising</a>,
       corporate-hosted documentation with <a href="https://readthedocs.com">Read the Docs for Business</a>,
       and <a href="{{ donate_url }}">donations</a>,
       and we are supported by a number of generous <a href="https://docs.readthedocs.io/page/sponsors.html">sponsors</a>.
+      {% endblocktrans %}
     </p>
-    {% endblocktrans %}
 
     <p>
       {% blocktrans trimmed %}

--- a/readthedocs/templates/homepage.html
+++ b/readthedocs/templates/homepage.html
@@ -133,6 +133,24 @@
   {% endif %}
   {% endcache %}
 
+  <section>
+    <h2>{% trans 'About Read the Docs' %}</h2>
+
+    <p>
+      Read the Docs has grown substantially
+      since its beginning as a weekend project and is closing in on being a top-1000 site on the internet.
+      Today, we:
+    </p>
+
+    <!-- Updated: June 2018, pageviews June 2021 -->
+    <ul class="donate-about">
+      <li>Serve over <b>55 million pages</b> of documentation a month</li>
+      <li>Serve over <b>40 TB</b> of documentation a month</li>
+      <li>Host over <b>80,000 open source projects</b> and support over <b>100,000 users</b></li>
+      <li>Are supported by a <a href="https://docs.readthedocs.io/en/latest/team.html">very small team</a> of dedicated engineers</li>
+    </ul>
+
+  </section>
   <!-- Funding and Contributing -->
   <section>
     <h2>{% trans "Read the Docs is funded by the community" %}</h2>

--- a/readthedocs/templates/homepage.html
+++ b/readthedocs/templates/homepage.html
@@ -160,9 +160,9 @@
 
     {% blocktrans trimmed %}
     <p>
-      We fund our operations through <a href="{{ donate_url }}">donations</a>,
-      <a href="https://www.ethicalads.io/advertisers/?ref=rtd">advertising</a>,
-      and corporate-hosted documentation with <a href="https://readthedocs.com">Read the Docs for Business</a>,
+      We fund our operations through <a href="https://www.ethicalads.io/advertisers/?ref=rtd">advertising</a>,
+      corporate-hosted documentation with <a href="https://readthedocs.com">Read the Docs for Business</a>,
+      and <a href="{{ donate_url }}">donations</a>,
       and we are supported by a number of generous <a href="https://docs.readthedocs.io/page/sponsors.html">sponsors</a>.
     </p>
     {% endblocktrans %}

--- a/readthedocs/templates/homepage.html
+++ b/readthedocs/templates/homepage.html
@@ -138,18 +138,16 @@
     <h2>{% trans "Read the Docs is funded by the community" %}</h2>
     <p>
 
-    {% url "donate" as sponsors_url %}
-    {% url "gold_detail" as gold_detail %}
+    {% url "donate" as donate_url %}
 
     {% blocktrans trimmed %}
-    Read the Docs is a huge resource that millions of developers rely on
-    for software documentation. It would not be possible without the
-    support of our
-    <a href="{{ sponsors_url }}">sponsors</a>,
-    <a href="https://www.ethicalads.io/advertisers/?ref=rtd">advertisers</a>,
-    and <a href="{{ gold_detail }}">readers like you</a>.
-    {% endblocktrans %}
+    <p>
+      We fund our operations through <a href="{{ donate_url }}">donations</a>,
+      <a href="https://www.ethicalads.io/advertisers/?ref=rtd">advertising</a>,
+      and corporate-hosted documentation with <a href="https://readthedocs.com">Read the Docs for Business</a>,
+      and we are supported by a number of generous <a href="https://docs.readthedocs.io/page/sponsors.html">sponsors</a>.
     </p>
+    {% endblocktrans %}
 
     <p>
       {% blocktrans trimmed %}

--- a/readthedocs/templates/homepage.html
+++ b/readthedocs/templates/homepage.html
@@ -166,7 +166,7 @@
       {% blocktrans trimmed %}
       We fund our operations through <a href="https://www.ethicalads.io/advertisers/?ref=rtd">advertising</a>,
       corporate-hosted documentation with <a href="https://readthedocs.com">Read the Docs for Business</a>,
-      and <a href="{{ donate_url }}">donations</a>,
+     <a href="{{ donate_url }}">donations</a>,
       and we are supported by a number of generous <a href="https://docs.readthedocs.io/page/sponsors.html">sponsors</a>.
       {% endblocktrans %}
     </p>


### PR DESCRIPTION
The first commit adds a link to the sustainability page on the footer. The second commit includes some site stats on the front page so they are also more visible.