### PR TITLE
Sync RemoteRepository for external collaborators

### DIFF
--- a/readthedocs/rtd_tests/tests/test_oauth_sync.py
+++ b/readthedocs/rtd_tests/tests/test_oauth_sync.py
@@ -169,6 +169,87 @@ class GitHubOAuthSyncTests(TestCase):
         self.assertFalse(remote_repository.private)
 
     @requests_mock.Mocker(kw='mock_request')
+    def test_sync_repositories_relation_with_organization(self, mock_request):
+        """
+        Sync repositories relations for a user where the RemoteRepository and RemoteOrganization already exist.
+
+        Note that ``repository.owner.type == 'Organzation'`` in the GitHub response.
+        """
+        self.payload_user_repos[0]['owner']['type'] = 'Organization'
+        mock_request.get('https://api.github.com/user/repos', json=self.payload_user_repos)
+
+        self.assertEqual(RemoteRepository.objects.count(), 0)
+        self.assertEqual(RemoteRepositoryRelation.objects.count(), 0)
+        self.assertEqual(RemoteOrganization.objects.count(), 0)
+
+        remote_organization = fixture.get(
+            RemoteOrganization,
+            remote_id=11111,
+            slug='organization',
+            vcs_provider='github'
+        )
+        remote_repository = fixture.get(
+            RemoteRepository,
+            remote_id=11111,
+            organization=remote_organization,
+            vcs_provider='github',
+        )
+        remote_repositories = self.service.sync_repositories()
+
+        self.assertEqual(RemoteRepository.objects.count(), 1)
+        self.assertEqual(RemoteRepositoryRelation.objects.count(), 1)
+        self.assertEqual(RemoteOrganization.objects.count(), 1)
+
+        self.assertEqual(len(remote_repositories), 1)
+        remote_repository = remote_repositories[0]
+        self.assertIsInstance(remote_repository, RemoteRepository)
+        self.assertEqual(remote_repository.full_name, 'organization/repository')
+        self.assertEqual(remote_repository.name, 'repository')
+        self.assertEqual(remote_repository.organization.slug, 'organization')
+        self.assertFalse(remote_repository.remote_repository_relations.first().admin)
+        self.assertFalse(remote_repository.private)
+
+    @requests_mock.Mocker(kw='mock_request')
+    def test_sync_repositories_moved_from_org_to_user(self, mock_request):
+        """
+        Sync repositories for a repo that was part of a GH organization and was moved to a GH user.
+
+        Note that ``repository.owner.type == 'User'`` in the GitHub response.
+        """
+        mock_request.get('https://api.github.com/user/repos', json=self.payload_user_repos)
+
+        self.assertEqual(RemoteRepository.objects.count(), 0)
+        self.assertEqual(RemoteRepositoryRelation.objects.count(), 0)
+        self.assertEqual(RemoteOrganization.objects.count(), 0)
+
+        remote_organization = fixture.get(
+            RemoteOrganization,
+            remote_id=11111,
+            slug='organization',
+            vcs_provider='github'
+        )
+        remote_repository = fixture.get(
+            RemoteRepository,
+            remote_id=11111,
+            organization=remote_organization,
+            vcs_provider='github',
+        )
+        remote_repositories = self.service.sync_repositories()
+
+        self.assertEqual(RemoteRepository.objects.count(), 1)
+        self.assertEqual(RemoteRepositoryRelation.objects.count(), 1)
+        self.assertEqual(RemoteOrganization.objects.count(), 1)
+
+        self.assertEqual(len(remote_repositories), 1)
+        remote_repository = remote_repositories[0]
+        self.assertIsInstance(remote_repository, RemoteRepository)
+        self.assertEqual(remote_repository.full_name, 'organization/repository')
+        self.assertEqual(remote_repository.name, 'repository')
+        self.assertIsNone(remote_repository.organization)
+        self.assertFalse(remote_repository.remote_repository_relations.first().admin)
+        self.assertFalse(remote_repository.private)
+
+    @requests_mock.Mocker(kw='mock_request')
     def test_sync_repositories_only_creates_one_remote_repo_per_vcs_repo(self, mock_request):
         mock_request.get('https://api.github.com/user/repos', json=self.payload_user_repos)
 


### PR DESCRIPTION
When a GitHub user does not belong to a GH organization but does have access to a particular repository inside the GH organization, the `RemoteRepositoryRelation` was not being created. This commit checks for this case and allows the creation of the `RemoteRepositoryRelation`.

Also, if the GH repository was part of a GH organization and then it's moved to a GH user account, we remove the link between ``RemoteRepository`` and ``RemoteOrganization``.
