### PR TITLE
Search: small improvements

### DIFF
--- a/readthedocs/search/api.py
+++ b/readthedocs/search/api.py
@@ -316,6 +316,7 @@ class PageSearchAPIView(CachedResponseMixin, GenericAPIView):
         queryset = PageSearch(
             query=query,
             projects=projects,
+            aggregate_results=False,
             use_advanced_query=not main_project.has_feature(Feature.DEFAULT_TO_FUZZY_SEARCH),
         )
         return queryset

--- a/readthedocs/search/faceted_search.py
+++ b/readthedocs/search/faceted_search.py
@@ -27,7 +27,9 @@ class RTDFacetedSearch(FacetedSearch):
 
     """Custom wrapper around FacetedSearch."""
 
-    operators = []
+    # Search for both 'and' and 'or' operators.
+    # The score of and should be higher as it satisfies both or and and.
+    operators = ['and', 'or']
 
     # Sources to be excluded from results.
     excludes = []
@@ -44,20 +46,27 @@ class RTDFacetedSearch(FacetedSearch):
             query=None,
             filters=None,
             projects=None,
+            aggregate_results=True,
             use_advanced_query=True,
             **kwargs,
     ):
         """
         Custom wrapper around FacetedSearch.
 
+        :param string query: Query to search for
+        :param dict filters: Filters to be used with the query.
         :param projects: A dictionary of project slugs mapped to a `VersionData` object.
          Or a list of project slugs.
          Results are filter with these values.
-
         :param use_advanced_query: If `True` forces to always use
          `SimpleQueryString` for the text query object.
+        :param bool aggregate_results: If results should be aggregated,
+         this is returning the number of results within other facets.
+        :param bool use_advanced_query: Always use SimpleQueryString.
+         Set this to `False` to use the experimental fuzzy search.
         """
         self.use_advanced_query = use_advanced_query
+        self.aggregate_results = aggregate_results
         self.projects = projects or {}
 
         # Hack a fix to our broken connection pooling
@@ -141,14 +150,11 @@ class RTDFacetedSearch(FacetedSearch):
 
         - https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html  # noqa
         """
-        queries = []
-        for operator in self.operators:
-            query_string = self._get_fuzzy_query(
-                query=query,
-                fields=fields,
-                operator=operator,
-            )
-            queries.append(query_string)
+        query_string = self._get_fuzzy_query(
+            query=query,
+            fields=fields,
+        )
+        queries = [query_string]
         for field in fields:
             # Remove boosting from the field,
             # and query from the raw field.
@@ -159,7 +165,7 @@ class RTDFacetedSearch(FacetedSearch):
             queries.append(Wildcard(**kwargs))
         return queries
 
-    def _get_fuzzy_query(self, *, query, fields, operator):
+    def _get_fuzzy_query(self, *, query, fields, operator='or'):
         """
         Returns a query object used for fuzzy results.
 
@@ -209,13 +215,17 @@ class RTDFacetedSearch(FacetedSearch):
         query_tokens = set(query)
         return not tokens.isdisjoint(query_tokens)
 
+    def aggregate(self, search):
+        """Overriden to decide if we should aggregate or not."""
+        if self.aggregate_results:
+            super().aggregate(search)
+
 
 class ProjectSearch(RTDFacetedSearch):
     facets = {'language': TermsFacet(field='language')}
     doc_types = [ProjectDocument]
     index = ProjectDocument._index._name
     fields = ('name^10', 'slug^5', 'description')
-    operators = ['and', 'or']
     excludes = ['users', 'language']
 
     def query(self, search, query):
@@ -274,11 +284,6 @@ class PageSearch(RTDFacetedSearch):
         'domains.docstrings',
     ]
     fields = _outer_fields
-
-    # need to search for both 'and' and 'or' operations
-    # the score of and should be higher as it satisfies both or and and
-    operators = ['and', 'or']
-
     excludes = ['rank', 'sections', 'domains', 'commit', 'build']
 
     def total_count(self):

--- a/readthedocs/search/faceted_search.py
+++ b/readthedocs/search/faceted_search.py
@@ -143,12 +143,16 @@ class RTDFacetedSearch(FacetedSearch):
         We need to search for both "and" and "or" operators.
         The score of "and" should be higher as it satisfies both "or" and "and".
 
-        We use the Wildcard query with the query surrounded by ``*`` to match substrings.
+        We use the Wildcard query with the query suffixed by ``*`` to match substrings.
         We use the raw fields (Wildcard fields) instead of the normal field for performance.
 
         For valid options, see:
 
         - https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html  # noqa
+
+        .. note::
+
+           Doing a prefix **and** suffix search is slow on big indexes like ours.
         """
         query_string = self._get_fuzzy_query(
             query=query,
@@ -160,7 +164,7 @@ class RTDFacetedSearch(FacetedSearch):
             # and query from the raw field.
             field = re.sub(r'\^.*$', '.raw', field)
             kwargs = {
-                field: {'value': f'*{query}*'},
+                field: {'value': f'{query}*'},
             }
             queries.append(Wildcard(**kwargs))
         return queries

--- a/readthedocs/search/tests/test_api.py
+++ b/readthedocs/search/tests/test_api.py
@@ -605,12 +605,14 @@ class BaseTestDocumentSearch:
 
         results = resp.data['results']
         assert len(results) > 0
-        assert 'Support' in results[0]['title']
-        # find is more closer than index, so is listed first.
-        highlights = results[0]['blocks'][0]['highlights']
-        assert '<span>find</span>' in highlights['content'][0]
 
-        assert 'Index' in results[1]['title']
+        assert 'Index' in results[0]['title']
+        highlights = results[0]['blocks'][0]['highlights']
+        assert '<span>index</span>' in highlights['content'][0]
+
+        assert 'Guides' in results[1]['title']
+        highlights = results[1]['blocks'][0]['highlights']
+        assert '<span>index</span>' in highlights['content'][0]
 
         # Query with a partial word, but we want to match that
         search_params = {


### PR DESCRIPTION
- Document things
- Don't aggregate when we don't need to
- Don't duplicate single term queries,
  there is no need for operators for a single term.
- Move operators to the base class.
- Do prefix search only for now till we figure out a better way to have small/faster indices