### PR TITLE
oauth webhook: check the `Project` has a `RemoteRepository`

### DIFF
--- a/readthedocs/oauth/utils.py
+++ b/readthedocs/oauth/utils.py
@@ -30,7 +30,7 @@ def update_webhook(project, integration, request=None):
         return None
 
     updated = False
-    try:
+    if project.remote_repository:
         remote_repository_relations = (
             project.remote_repository.remote_repository_relations.filter(
                 account__isnull=False,
@@ -44,8 +44,7 @@ def update_webhook(project, integration, request=None):
 
             if updated:
                 break
-
-    except Project.remote_repository.RelatedObjectDoesNotExist:
+    else:
         # The project was imported manually and doesn't have a RemoteRepository
         # attached. We do brute force over all the accounts registered for this
         # service

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -588,6 +588,32 @@ class TestPrivateViews(TestCase):
         self.assertEqual(response.status_code, 302)
         attach_webhook.assert_not_called()
 
+    def test_integration_webhooks_sync_no_remote_repository(self):
+        project = get(
+            Project,
+            slug='pip',
+            users=[self.user],
+            has_valid_webhook=True,
+        )
+        integration = get(
+            GitHubWebhook,
+            project=project,
+        )
+
+        response = self.client.post(
+            reverse(
+                'projects_integrations_webhooks_sync',
+                kwargs={
+                    'project_slug': project.slug,
+                    'integration_pk': integration.pk,
+                },
+            ),
+        )
+        project.refresh_from_db()
+
+        self.assertEqual(response.status_code, 302)
+        self.assertFalse(project.has_valid_webhook)
+
 
 @mock.patch('readthedocs.core.utils.trigger_build', mock.MagicMock())
 @mock.patch('readthedocs.projects.tasks.update_docs_task', mock.MagicMock())


### PR DESCRIPTION
Before we were catching the exception because the relationship was a OneToOne.
Now that it's a ForeignKey, the field could be `None` instead.

Fixes this issue: https://sentry.io/organizations/read-the-docs/issues/2470813831/