### PR TITLE
Search: remove additional fields

### DIFF
--- a/readthedocs/search/faceted_search.py
+++ b/readthedocs/search/faceted_search.py
@@ -144,7 +144,6 @@ class RTDFacetedSearch(FacetedSearch):
         The score of "and" should be higher as it satisfies both "or" and "and".
 
         We use the Wildcard query with the query suffixed by ``*`` to match substrings.
-        We use the raw fields (Wildcard fields) instead of the normal field for performance.
 
         For valid options, see:
 
@@ -161,8 +160,7 @@ class RTDFacetedSearch(FacetedSearch):
         queries = [query_string]
         for field in fields:
             # Remove boosting from the field,
-            # and query from the raw field.
-            field = re.sub(r'\^.*$', '.raw', field)
+            field = re.sub(r'\^.*$', '', field)
             kwargs = {
                 field: {'value': f'{query}*'},
             }
@@ -365,13 +363,6 @@ class PageSearch(RTDFacetedSearch):
             re.sub(r'\^.*$', '', field)
             for field in fields
         ]
-
-        # Highlight from the raw fields too, if it is a single term.
-        if self._is_single_term(query):
-            raw_fields.extend([
-                re.sub(r'\^.*$', '.raw', field)
-                for field in fields
-            ])
 
         highlight = dict(
             self._highlight_options,

--- a/readthedocs/search/serializers.py
+++ b/readthedocs/search/serializers.py
@@ -12,25 +12,14 @@ from functools import namedtuple
 from operator import attrgetter
 from urllib.parse import urlparse
 
-from django.shortcuts import get_object_or_404
 from rest_framework import serializers
 
-from readthedocs.core.resolver import resolve
 from readthedocs.projects.constants import MKDOCS, SPHINX_HTMLDIR
 from readthedocs.projects.models import Project
 
-
-# Structure used for storing cached data of a version mostly.
+# Structures used for storing cached data of a version mostly.
 ProjectData = namedtuple('ProjectData', ['version', 'alias'])
 VersionData = namedtuple('VersionData', ['slug', 'docs_url'])
-
-
-def get_raw_field(obj, field, default=None):
-    """Get the ``raw`` version of this field or fallback to the original field."""
-    return (
-        getattr(obj, f'{field}.raw', default)
-        or getattr(obj, field, default)
-    )
 
 
 class ProjectHighlightSerializer(serializers.Serializer):
@@ -40,13 +29,13 @@ class ProjectHighlightSerializer(serializers.Serializer):
     description = serializers.SerializerMethodField()
 
     def get_name(self, obj):
-        return list(get_raw_field(obj, 'name', []))
+        return list(getattr(obj, 'name', []))
 
     def get_slug(self, obj):
-        return list(get_raw_field(obj, 'slug', []))
+        return list(getattr(obj, 'slug', []))
 
     def get_description(self, obj):
-        return list(get_raw_field(obj, 'description', []))
+        return list(getattr(obj, 'description', []))
 
 
 class ProjectSearchSerializer(serializers.Serializer):
@@ -64,7 +53,7 @@ class PageHighlightSerializer(serializers.Serializer):
     title = serializers.SerializerMethodField()
 
     def get_title(self, obj):
-        return list(get_raw_field(obj, 'title', []))
+        return list(getattr(obj, 'title', []))
 
 
 class PageSearchSerializer(serializers.Serializer):
@@ -186,10 +175,10 @@ class DomainHighlightSerializer(serializers.Serializer):
     content = serializers.SerializerMethodField()
 
     def get_name(self, obj):
-        return list(get_raw_field(obj, 'domains.name', []))
+        return list(getattr(obj, 'domains.name', []))
 
     def get_content(self, obj):
-        return list(get_raw_field(obj, 'domains.docstrings', []))
+        return list(getattr(obj, 'domains.docstrings', []))
 
 
 class DomainSearchSerializer(serializers.Serializer):
@@ -208,10 +197,10 @@ class SectionHighlightSerializer(serializers.Serializer):
     content = serializers.SerializerMethodField()
 
     def get_title(self, obj):
-        return list(get_raw_field(obj, 'sections.title', []))
+        return list(getattr(obj, 'sections.title', []))
 
     def get_content(self, obj):
-        return list(get_raw_field(obj, 'sections.content', []))
+        return list(getattr(obj, 'sections.content', []))
 
 
 class SectionSearchSerializer(serializers.Serializer):


### PR DESCRIPTION
This is a partial revert of
https://github.com/readthedocs/readthedocs.org/pull/7613.
Turns out, having more fields increase the size of the index,
and that makes all queries slower, even if they aren't using the new
field.