### PR TITLE
Organizations: validate that a correct slug is generated

### DIFF
--- a/readthedocs/organizations/forms.py
+++ b/readthedocs/organizations/forms.py
@@ -28,6 +28,11 @@ class OrganizationForm(forms.ModelForm):
     :type user: django.contrib.auth.models.User
     """
 
+    # We use the organization slug + project name
+    # to form the final project slug.
+    # A valid project slug is 63 chars long.
+    name = forms.CharField(max_length=32)
+
     class Meta:
         model = Organization
         fields = ['name', 'email', 'description', 'url']
@@ -57,7 +62,11 @@ class OrganizationForm(forms.ModelForm):
         name = self.cleaned_data['name']
         if self.instance and self.instance.name and name == self.instance.name:
             return name
-        if Organization.objects.filter(slug=slugify(name)).exists():
+
+        potential_slug = slugify(name)
+        if not potential_slug:
+            raise forms.ValidationError(_('Invalid organization name'))
+        if Organization.objects.filter(slug=potential_slug).exists():
             raise forms.ValidationError(
                 _('Organization %(name)s already exists'),
                 params={'name': name},

--- a/readthedocs/organizations/forms.py
+++ b/readthedocs/organizations/forms.py
@@ -65,7 +65,7 @@ class OrganizationForm(forms.ModelForm):
 
         potential_slug = slugify(name)
         if not potential_slug:
-            raise forms.ValidationError(_('Invalid organization name'))
+            raise forms.ValidationError(_('Invalid organization name: no slug generated'))
         if Organization.objects.filter(slug=potential_slug).exists():
             raise forms.ValidationError(
                 _('Organization %(name)s already exists'),

--- a/readthedocs/organizations/models.py
+++ b/readthedocs/organizations/models.py
@@ -43,7 +43,13 @@ class Organization(models.Model):
 
     # Local
     name = models.CharField(_('Name'), max_length=100)
-    slug = models.SlugField(_('Slug'), max_length=255, unique=True)
+    slug = models.SlugField(
+        _('Slug'),
+        max_length=255,
+        unique=True,
+        null=False,
+        blank=False,
+    )
     email = models.EmailField(
         _('E-mail'),
         help_text='How can we get in touch with you?',

--- a/readthedocs/organizations/tests/test_forms.py
+++ b/readthedocs/organizations/tests/test_forms.py
@@ -127,7 +127,7 @@ class OrganizationSignupTest(OrganizationTestCase):
         }
         form = forms.OrganizationSignupForm(data, user=self.user)
         self.assertFalse(form.is_valid())
-        self.assertEqual('Invalid organization name', form.errors['name'][0])
+        self.assertEqual('Invalid organization name: no slug generated', form.errors['name'][0])
 
     def test_create_organization_with_big_name(self):
         data = {

--- a/readthedocs/organizations/tests/test_forms.py
+++ b/readthedocs/organizations/tests/test_forms.py
@@ -120,6 +120,24 @@ class OrganizationTeamMemberFormTests(OrganizationTestCase):
 
 class OrganizationSignupTest(OrganizationTestCase):
 
+    def test_create_organization_with_empy_slug(self):
+        data = {
+            'name': '往事',
+            'email': 'test@example.org',
+        }
+        form = forms.OrganizationSignupForm(data, user=self.user)
+        self.assertFalse(form.is_valid())
+        self.assertEqual('Invalid organization name', form.errors['name'][0])
+
+    def test_create_organization_with_big_name(self):
+        data = {
+            'name': 'a' * 33,
+            'email': 'test@example.org',
+        }
+        form = forms.OrganizationSignupForm(data, user=self.user)
+        self.assertFalse(form.is_valid())
+        self.assertIn('at most 32 characters', form.errors['name'][0])
+
     def test_create_organization_with_existent_slug(self):
         data = {
             'name': 'mozilla',


### PR DESCRIPTION
- Check for empty slugs
- Check for a max length of 32
  (enforced to the form level for now)