### PR TITLE
feat: add json schema

### DIFF
--- a/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
+++ b/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
@@ -92,7 +92,10 @@
             "3.3",
             "3.4",
             "3.5",
-            "3.6"
+            "pypy3.5",
+            "3.6",
+            "3.7",
+            "3.8"
           ],
           "default": "3"
         },
@@ -165,7 +168,6 @@
           "description": "The builder type for the sphinx documentation.",
           "enum": [
             "html",
-            "htmldir",
             "dirhtml",
             "singlehtml"
           ],

--- a/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
+++ b/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
@@ -1,0 +1,288 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$comment": "https://docs.readthedocs.io/en/stable/config-file/index.html",
+  "title": "Read the Docs",
+  "description": "Read the Docs configuration file.",
+  "type": "object",
+  "properties": {
+    "version": {
+      "title": "Version",
+      "description": "The version of the spec to use.",
+      "type": "string",
+      "enum": [
+        "2"
+      ]
+    },
+    "formats": {
+      "title": "Formats",
+      "description": "Formats of the documentation to be built.",
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "enum": [
+              "htmlzip",
+              "pdf",
+              "epub"
+            ]
+          }
+        },
+        {
+          "enum": [
+            "all"
+          ]
+        }
+      ],
+      "default": []
+    },
+    "conda": {
+      "title": "Conda",
+      "description": "Configuration for Conda support.",
+      "type": "object",
+      "properties": {
+        "environment": {
+          "title": "Environment",
+          "description": "The path to the Conda environment file from the root of the project.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "environment"
+      ]
+    },
+    "build": {
+      "title": "Build",
+      "description": "Configuration for the documentation build process.",
+      "type": "object",
+      "properties": {
+        "image": {
+          "title": "Image",
+          "description": "The build docker image to be used.",
+          "enum": [
+            "stable",
+            "latest"
+          ],
+          "default": "latest"
+        },
+        "apt_packages": {
+          "title": "APT Packages",
+          "description": "List of packages to be installed with apt-get.",
+          "type": "array",
+          "items": {
+            "title": "APT Package",
+            "type": "string"
+          },
+          "default": []
+        }
+      }
+    },
+    "python": {
+      "title": "Python",
+      "description": "Configuration of the Python environment to be used.",
+      "type": "object",
+      "properties": {
+        "version": {
+          "title": "Version",
+          "description": "The Python version (this depends on the build image).",
+          "type": "string",
+          "enum": [
+            "2",
+            "2.7",
+            "3",
+            "3.3",
+            "3.4",
+            "3.5",
+            "3.6"
+          ],
+          "default": "3"
+        },
+        "system_packages": {
+          "title": "System Packages",
+          "description": "Give the virtual environment access to the global site-packages directory.",
+          "type": "boolean",
+          "default": false
+        },
+        "install": {
+          "title": "Install",
+          "description": "Installation of packages and requiremens.",
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "properties": {
+                  "requirements": {
+                    "title": "Requirements",
+                    "description": "The path to the requirements file from the root of the project.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "requirements"
+                ]
+              },
+              {
+                "properties": {
+                  "path": {
+                    "title": "Path",
+                    "description": "The path to the project to be installed",
+                    "type": "string"
+                  },
+                  "method": {
+                    "title": "Method",
+                    "description": "Install using python setup.py install or pip.",
+                    "enum": [
+                      "pip",
+                      "setuptools"
+                    ],
+                    "default": "pip"
+                  },
+                  "extra_requirements": {
+                    "title": "Extra Requirements",
+                    "description": "Extra requirements sections to install in addition to the package dependencies.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "default": []
+                  }
+                },
+                "required": [
+                  "path"
+                ]
+              }
+            ]
+          }
+        }
+      }
+    },
+    "sphinx": {
+      "title": "Sphix",
+      "description": "Configuration for sphinx documentation.",
+      "type": "object",
+      "properties": {
+        "builder": {
+          "title": "Builder",
+          "description": "The builder type for the sphinx documentation.",
+          "enum": [
+            "html",
+            "htmldir",
+            "dirhtml",
+            "singlehtml"
+          ],
+          "default": "html"
+        },
+        "configuration": {
+          "title": "Configuration",
+          "description": "The path to the conf.py file.",
+          "type": "string"
+        },
+        "fail_on_warning": {
+          "title": "Fail on Warning",
+          "description": "Add the -W option to sphinx-build.",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "mkdocs": {
+      "title": "mkdocs",
+      "description": "Configuration for mkdocs documentation.",
+      "type": "object",
+      "properties": {
+        "configuration": {
+          "title": "Configuration",
+          "description": "The path to the mkdocs.yml file.",
+          "type": "string"
+        },
+        "fail_on_warning": {
+          "title": "Fail on Warning",
+          "description": "Add the --strict optio to mkdocs build.",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "submodules": {
+      "title": "Submodules",
+      "description": "Submodules configuration.",
+      "type": "object",
+      "properties": {
+        "include": {
+          "title": "Include",
+          "description": "List of submodules to be included.",
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "enum": [
+                "all"
+              ]
+            }
+          ],
+          "default": []
+        },
+        "exclude": {
+          "title": "Exclude",
+          "description": "List of submodules to be ignored.",
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            {
+              "enum": [
+                "all"
+              ]
+            }
+          ],
+          "default": []
+        },
+        "recursive": {
+          "title": "Recursive",
+          "description": "Do a recursive clone?",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "search": {
+      "title": "search",
+      "type": "object",
+      "properties": {
+        "ranking": {
+          "title": "Ranking",
+          "description": "Map of patterns to ranks.",
+          "additionalProperties": {
+            "type": "number",
+            "minimum": -10,
+            "maximum": 10
+          }
+        },
+        "ignore": {
+          "title": "Ignore",
+          "description": "List of patterns.",
+          "type": "array",
+          "items": {
+            "title": "Pattern",
+            "type": "string"
+          },
+          "default": [
+            "search.html",
+            "search/index.html",
+            "404.html",
+            "404/index.html"
+          ]
+        }
+      }
+    }
+  },
+  "required": [
+    "version"
+  ]
+}

--- a/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
+++ b/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
@@ -196,7 +196,7 @@
         },
         "fail_on_warning": {
           "title": "Fail on Warning",
-          "description": "Add the --strict optio to mkdocs build.",
+          "description": "Add the --strict option to mkdocs build.",
           "type": "boolean",
           "default": false
         }


### PR DESCRIPTION
* Closes https://github.com/readthedocs/readthedocs.org/issues/6363
  * As soon as this is merged, I'll make the PR and get it added to the JSON Schema Store catalog.
* Closes https://github.com/readthedocs/readthedocs.org/pull/6501

Assuming I've understood the YAML Schema correctly (I did read the Yamale README), I believe they should be equivalent (or at least almost equivalent.)

I made a new PR instead of reviewing an older one, as I felt there was a lot to change.

I've tested this against the following:
* https://github.com/pytube/pytube/blob/master/.readthedocs.yml
* https://github.com/Rapptz/discord.py/blob/master/.readthedocs.yml
* https://github.com/deepmind/open_spiel/blob/master/readthedocs.yml
* https://github.com/tensorlayer/hyperpose/blob/master/.readthedocs.yml
* https://github.com/deepchem/deepdock/blob/master/.readthedocs.yml

Note: Before testing I manually changed all `python.version` values to `3.6` as original values (`3.7`/`3.8`) aren't valid against the schema. (Maybe consider using `string` rather than `enum` here?)

Let me know if anything looks off to you!

#### Subtle Differences
* For paths, it just accepts any string. I could validate it against a regex? I thought maybe just leaving it as any string would be fine.
