### PR TITLE
PR build status: re-try up to 3 times if it fails for some reason

### DIFF
--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -346,7 +346,11 @@ def sync_versions_task(project_pk, tags_data, branches_data, **kwargs):
     return True
 
 
-@app.task(queue='web')
+@app.task(
+    max_retries=3,
+    default_retry_delay=60,
+    queue='web'
+)
 def send_build_status(build_pk, commit, status, link_to_build=False):
     """
     Send Build Status to Git Status API for project external versions.
@@ -367,7 +371,7 @@ def send_build_status(build_pk, commit, status, link_to_build=False):
 
     provider_name = build.project.git_provider_name
 
-    log.info('Sending build status. build=%s, project=%s', build.pk, build.project.slug)
+    log.info('Sending build status. build=%s project=%s', build.pk, build.project.slug)
 
     if provider_name in [GITHUB_BRAND, GITLAB_BRAND]:
         # get the service class for the project e.g: GitHubService.
@@ -445,7 +449,7 @@ def send_build_status(build_pk, commit, status, link_to_build=False):
             notification.send()
 
         log.info(
-            'No social account or repository permission available for %s',
+            'No social account or repository permission available. project=%s',
             build.project.slug
         )
         return False


### PR DESCRIPTION
Sometimes it happens that the task fail for some reason and people don't get the
PR status updated for RTD build. This commit adds a retry up to 3 times to avoid
these cases.

Closes #8177