### PR TITLE
autoscaling: remove app autoscaling tasks

### DIFF
--- a/readthedocs/builds/apps.py
+++ b/readthedocs/builds/apps.py
@@ -17,19 +17,6 @@ class Config(AppConfig):
         app.tasks.register(ArchiveBuilds)
 
         try:
-            from readthedocsext.builds.tasks import ShutdownBuilder, StopBuilder
-            app.tasks.register(ShutdownBuilder)
-            app.tasks.register(StopBuilder)
-        except (ModuleNotFoundError, ImportError):
-            log.info('ShutdownBuilder/StopBuilder task could not be imported.')
-
-        try:
-            from readthedocsext.monitoring.scaling import AutoscaleBuildersTask
-            app.tasks.register(AutoscaleBuildersTask)
-        except (ModuleNotFoundError, ImportError):
-            log.info('AutoscaleBuildersTask task could not be imported.')
-
-        try:
             from readthedocsext.monitoring.metrics.tasks import (
                 Metrics1mTask,
                 Metrics5mTask,


### PR DESCRIPTION
We are using AWS CloudWatch + ASG alarms to auto-scale our instances now.