### PR TITLE
Schema: fix version type

### DIFF
--- a/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
+++ b/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
@@ -8,9 +8,9 @@
     "version": {
       "title": "Version",
       "description": "The version of the spec to use.",
-      "type": "string",
+      "type": "number",
       "enum": [
-        "2"
+        2
       ]
     },
     "formats": {


### PR DESCRIPTION
This should be a number,
otherwise you are required to put `"2"`.

/cc @SethFalco