### PR TITLE
Add link to redirect docs

### DIFF
--- a/readthedocs/templates/projects/project_redirects.html
+++ b/readthedocs/templates/projects/project_redirects.html
@@ -71,7 +71,9 @@
 
 {% block project_edit_content %}
   <p class="help_text">
-    {% trans "Add redirects for your project. This allows you to fix links to old pages that are 404ing." %}
+    {% blocktrans trimmed with docs_url='https://docs.readthedocs.io/page/user-defined-redirects.html' %}
+        Add redirects for your project. This allows you to fix links to old pages that are 404ing. <a href="{{ docs_url }}">Learn more</a>.
+    {% endblocktrans %}
   </p>
 
   {% if redirects|length > 0 %}


### PR DESCRIPTION
Inspired by what's done on the `projects/domain_list.html` template:

https://github.com/readthedocs/readthedocs.org/blob/e0e6602b23345b65ff67478a8f2d2d4c90ea8b6b/readthedocs/templates/projects/domain_list.html#L16-L18

See https://github.com/readthedocs/readthedocs.org/issues/8264#issuecomment-871115620 for some context.