### PR TITLE
Build: remove after_vcs signal

### DIFF
--- a/readthedocs/projects/signals.py
+++ b/readthedocs/projects/signals.py
@@ -3,7 +3,6 @@
 import django.dispatch
 
 before_vcs = django.dispatch.Signal(providing_args=['version', 'environmemt'])
-after_vcs = django.dispatch.Signal(providing_args=['version'])
 
 before_build = django.dispatch.Signal(providing_args=['version', 'environmemt'])
 after_build = django.dispatch.Signal(providing_args=['version'])


### PR DESCRIPTION
If the API fails, we end up without a self.version.
We could check if it exists, but this signal isn't used,
so I'm removing it.

Note, this signal was used to stop the ssh agent in .com,
but we have migrated to start the ssh agent inside the container,
so the ssh agent is killed when the container is killed.

ref https://sentry.io/organizations/read-the-docs/issues/2031190901/?project=148442&query=is%3Aunresolved