### PR TITLE
URLConf: fix support for subprojects

### DIFF
--- a/readthedocs/core/resolver.py
+++ b/readthedocs/core/resolver.py
@@ -96,10 +96,19 @@ class ResolverBase:
                 '$filename',
                 '{filename}',
             )
-            url = url.replace(
-                '$subproject',
-                '{subproject_slug}',
-            )
+            # Remove the subproject from the path if
+            # we are resolving the main project.
+            # /{subproject}/foo/bar -> /foo/bar.
+            if subproject_slug:
+                url = url.replace(
+                    '$subproject',
+                    '{subproject_slug}',
+                )
+            else:
+                url = url.replace(
+                    '$subproject/',
+                    '',
+                )
             if '$' in url:
                 log.warning(
                     'Unconverted variable in a resolver URLConf: url=%s', url

--- a/readthedocs/proxito/tests/test_middleware.py
+++ b/readthedocs/proxito/tests/test_middleware.py
@@ -385,3 +385,94 @@ class MiddlewareURLConfSubprojectTests(TestCase):
             resp['X-Accel-Redirect'],
             '/proxito/media/html/subproject/testing/foodex.html',
         )
+
+        # The main project still works.
+        resp = self.client.get('/subpath/latest/en/foo.html', HTTP_HOST=self.domain)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp['X-Accel-Redirect'],
+            '/proxito/media/html/pip/latest/foo.html',
+        )
+
+        resp = self.client.get('/subpath/latest/en/foo/bar/index.html', HTTP_HOST=self.domain)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp['X-Accel-Redirect'],
+            '/proxito/media/html/pip/latest/foo/bar/index.html',
+        )
+
+    def test_serve_subprojects_from_root(self):
+        self.pip.urlconf = '$subproject/$language/$version/$filename'
+        self.pip.save()
+        resp = self.client.get('/subproject/en/testing/foodex.html', HTTP_HOST=self.domain)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp['X-Accel-Redirect'],
+            '/proxito/media/html/subproject/testing/foodex.html',
+        )
+
+        # The main project still works.
+        resp = self.client.get('/en/latest/foo.html', HTTP_HOST=self.domain)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp['X-Accel-Redirect'],
+            '/proxito/media/html/pip/latest/foo.html',
+        )
+
+        resp = self.client.get('/en/latest/foo/bar/index.html', HTTP_HOST=self.domain)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp['X-Accel-Redirect'],
+            '/proxito/media/html/pip/latest/foo/bar/index.html',
+        )
+
+    def test_middleware_urlconf_subproject_main_project_single_version(self):
+        self.pip.single_version = True
+        self.pip.save()
+        resp = self.client.get('/subpath/subproject/testing/en/foodex.html', HTTP_HOST=self.domain)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp['X-Accel-Redirect'],
+            '/proxito/media/html/subproject/testing/foodex.html',
+        )
+
+        # The main project still works.
+        resp = self.client.get('/subpath/foo.html', HTTP_HOST=self.domain)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp['X-Accel-Redirect'],
+            '/proxito/media/html/pip/latest/foo.html',
+        )
+
+        resp = self.client.get('/subpath/foo/bar/index.html', HTTP_HOST=self.domain)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp['X-Accel-Redirect'],
+            '/proxito/media/html/pip/latest/foo/bar/index.html',
+        )
+
+    def test_serve_subprojects_from_root_main_project_single_version(self):
+        self.pip.urlconf = '$subproject/$language/$version/$filename'
+        self.pip.single_version = True
+        self.pip.save()
+        resp = self.client.get('/subproject/en/testing/foodex.html', HTTP_HOST=self.domain)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp['X-Accel-Redirect'],
+            '/proxito/media/html/subproject/testing/foodex.html',
+        )
+
+        # The main project still works.
+        resp = self.client.get('/foo.html', HTTP_HOST=self.domain)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp['X-Accel-Redirect'],
+            '/proxito/media/html/pip/latest/foo.html',
+        )
+
+        resp = self.client.get('/foo/bar/index.html', HTTP_HOST=self.domain)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp['X-Accel-Redirect'],
+            '/proxito/media/html/pip/latest/foo/bar/index.html',
+        )


### PR DESCRIPTION
We were always exposing the `subproject` part in the custom URLs, that means that we are only serving subprojects,
in our proxito URLs we get around that by marking that part as optional with regex.

Here I split the patter into one url patter for the main project and the other for subprojects (we could also maybe hack this to mark it as optional in the regex pattern).

Other couple of fixes I found along the way

- The urlpattern will be used to generate both, subprojects and the main project url, we could end up generating urls like `/subprojects/None/en/latest`.
- If the urlconf would start with `$subproject/foo` the proxied api endpoint would be generated like `//_`

There are still more things to fix, like:

- Users would need to serve the main project from the subproject path (like if we have `/sub/{subproject}`, the main project would be served from `/sub/en/latest`), we could have two urlconfs, one for the main project and other for subprojects for further customization.
- Infinite redirects
- missing updates in our code to make use of the custom urlconf to generate the urls (like the ones from "view docs")
- Possible collitions, a path could match something that shouldn't

I was also thinking we could go for another implementation.
Instead of relying on the url patterns and their regexes, we could have a catch all paths url pattern (`/anything/that/isn't/the/proxied/api`), then at the view level split the components (`anything`, `that`, 'isnt', 'the', 'proxied', 'api'), and use the information from the current project being served to identify each component (if the project is single version, what part is the version, the subproject, the language, etc). Like if the project doesn't have subprojects, we know that the `projects` part is part of the path, or if the project doesn't have a translation, etc (avoiding collisions like  https://github.com/readthedocs/readthedocs.org/issues/8399). This is just an idea, and we wouldn't need to hack our middleware to make it work.