### PR TITLE
psycopg2: pin to a compatible version with Django 2.2

### DIFF
--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -1,7 +1,11 @@
 # Requirements for our production systems
 
 -r pip.txt
-psycopg2==2.9.1
+
+# psycopg2 2.9 is not compatible with Django 2.2
+# https://github.com/readthedocs/readthedocs.org/issues/8334
+psycopg2==2.8.6  # pyup: ignore
+
 gunicorn==20.1.0
 
 # Version 3.0.0 drops support for Django < 3.0

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -2,7 +2,9 @@
 
 -r pip.txt
 # https://www.psycopg.org/docs/install.html#psycopg-vs-psycopg-binary
-psycopg2-binary==2.9.1
+# psycopg2 2.9 is not compatible with Django 2.2
+# https://github.com/readthedocs/readthedocs.org/issues/8334
+psycopg2-binary==2.8.6  # pyup: ignore
 
 # Version 3.0.0 drops support for Django < 3.0
 # https://github.com/sebleier/django-redis-cache/#300


### PR DESCRIPTION
We upgraded to latest psycopg2 in #8293 to a version that's incompatible with
Django 2.2. This commit downgrades it to a compatible version.

Closes #8334