### PR TITLE
Dont mutate env vars outside the BuildEnv classes

### DIFF
--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -311,6 +311,13 @@ class SyncRepositoryMixin:
                     RepositoryError.DUPLICATED_RESERVED_VERSIONS,
                 )
 
+    def get_vcs_env_vars(self):
+        """Get environment variables to be included in the VCS setup step."""
+        env = self.get_rtd_env_vars()
+        # Don't prompt for username, this requires Git 2.3+
+        env['GIT_TERMINAL_PROMPT'] = '0'
+        return env
+
     def get_rtd_env_vars(self):
         """Get bash environment variables specific to Read the Docs."""
         env = {
@@ -370,7 +377,7 @@ class SyncRepositoryTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
                 version=self.version,
                 record=False,
                 update_on_success=False,
-                environment=self.get_rtd_env_vars(),
+                environment=self.get_vcs_env_vars(),
             )
             log.info(
                 'Running sync_repository_task: project=%s version=%s',
@@ -657,7 +664,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
             build=self.build,
             record=record,
             update_on_success=False,
-            environment=self.get_rtd_env_vars(),
+            environment=self.get_vcs_env_vars(),
         )
         self.build_start_time = environment.start_time
 

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -741,7 +741,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
         :param record: whether or not record all the commands in the ``Build``
             instance
         """
-        env_vars = self.get_env_vars()
+        env_vars = self.get_build_env_vars()
 
         if settings.DOCKER_ENABLE:
             env_cls = DockerBuildEnvironment
@@ -932,7 +932,7 @@ class UpdateDocsTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
         if commit:
             self.build['commit'] = commit
 
-    def get_env_vars(self):
+    def get_build_env_vars(self):
         """Get bash environment variables used for all builder commands."""
         env = self.get_rtd_env_vars()
 

--- a/readthedocs/rtd_tests/tests/test_builds.py
+++ b/readthedocs/rtd_tests/tests/test_builds.py
@@ -2,7 +2,6 @@ import datetime
 import os
 from unittest import mock
 
-from allauth.socialaccount.models import SocialAccount
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.utils import timezone
@@ -21,7 +20,6 @@ from readthedocs.doc_builder.config import load_yaml_config
 from readthedocs.doc_builder.environments import LocalBuildEnvironment
 from readthedocs.doc_builder.exceptions import DuplicatedBuildError
 from readthedocs.doc_builder.python_environments import Virtualenv
-from readthedocs.oauth.models import RemoteRepository
 from readthedocs.projects.models import EnvironmentVariable, Feature, Project
 from readthedocs.projects.tasks import UpdateDocsTaskStep
 from readthedocs.rtd_tests.tests.test_config_integration import create_load
@@ -363,7 +361,7 @@ class BuildEnvironmentTests(TestCase):
             ),
             'TOKEN': 'a1b2c3',
         }
-        self.assertEqual(task.get_env_vars(), env)
+        self.assertEqual(task.get_build_env_vars(), env)
 
         # mock this object to make sure that we are in a conda env
         task.config = mock.Mock(conda=True)
@@ -377,7 +375,7 @@ class BuildEnvironmentTests(TestCase):
                 'bin',
             ),
         })
-        self.assertEqual(task.get_env_vars(), env)
+        self.assertEqual(task.get_build_env_vars(), env)
 
 
 class BuildModelTests(TestCase):

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -1024,7 +1024,7 @@ class TestBuildCommand(TestCase):
         env = {'FOOBAR': 'foobar', 'BIN_PATH': 'foobar'}
         cmd = BuildCommand('echo', environment=env)
         for key in list(env.keys()):
-            self.assertEqual(cmd.environment[key], env[key])
+            self.assertEqual(cmd._environment[key], env[key])
 
     def test_result(self):
         """Test result of output using unix true/false commands."""

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -1,7 +1,6 @@
 """Git-related utilities."""
 
 import logging
-import os
 import re
 
 import git
@@ -359,11 +358,3 @@ class Backend(BaseVCS):
         except (BadName, ValueError):
             return False
         return False
-
-    @property
-    def env(self):
-        env = super().env
-        env['GIT_DIR'] = os.path.join(self.working_dir, '.git')
-        # Don't prompt for username, this requires Git 2.3+
-        env['GIT_TERMINAL_PROMPT'] = '0'
-        return env

--- a/readthedocs/vcs_support/base.py
+++ b/readthedocs/vcs_support/base.py
@@ -72,9 +72,6 @@ class BaseVCS:
         from readthedocs.doc_builder.environments import LocalBuildEnvironment
         self.environment = environment or LocalBuildEnvironment(record=False)
 
-        # Update the env variables with the proper VCS env variables
-        self.environment.environment.update(self.env)
-
     def check_working_dir(self):
         if not os.path.exists(self.working_dir):
             os.makedirs(self.working_dir)
@@ -83,10 +80,6 @@ class BaseVCS:
         """Ensures that the working dir exists and is empty."""
         shutil.rmtree(self.working_dir, ignore_errors=True)
         self.check_working_dir()
-
-    @property
-    def env(self):
-        return {}
 
     def update(self):
         """


### PR DESCRIPTION
We are mutating this variable on the environment instance, and that's being passed to the next commands.

https://github.com/readthedocs/readthedocs.org/blob/babbdf058f1ae4eade27b4ef579e6b142a5dffba/readthedocs/vcs_support/base.py#L76-L76

Previous to https://github.com/readthedocs/readthedocs.org/pull/8263 we were creating a new instance (LocalBuildEnv) so this bug wasn't visible, but now we are using the same env to be able to always execute these commands inside docker (except for gitpython that still runs outside the container).

Now I have moved the env var to avoid the prompt outside git (GIT_DIR isn't needed as explained in https://github.com/readthedocs/readthedocs.org/pull/8318#pullrequestreview-704630103) and I made environment private so isn't mutated outside the class without thinking twice (because we would never mutate a private property, right? :eyes:).

We could also maybe expose this as a property, so is read-only, but we only use this on a test.


```python
class BuildEnv:

    @property
    def environment(self):
        return self._environment
```

Fixes https://github.com/readthedocs/readthedocs.org/issues/8288
Closes https://github.com/readthedocs/readthedocs.org/pull/8318