### PR TITLE
Downgrade taggit

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -84,7 +84,7 @@ textblob==0.15.3
 django-annoying==0.10.6
 django-messages-extends==0.6.2
 djangorestframework-jsonp==1.0.2
-django-taggit==1.5.0
+django-taggit==1.4.0
 dj-pagination==2.5.0
 
 # Version comparison stuff


### PR DESCRIPTION
1.5.0 has an corrupted file for the ukrnian translation.
It should be fixed in 1.5.1, but just reverting to the old one
for sake of deployment.