### PR TITLE
Use email from DEFAULT_FROM_EMAIL to contact users

### DIFF
--- a/readthedocs/core/utils/contact.py
+++ b/readthedocs/core/utils/contact.py
@@ -32,7 +32,7 @@ def contact_users(
 
     :returns: A dictionary with a list of sent/failed emails/notifications.
     """
-    from_email = from_email or settings.SUPPORT_EMAIL
+    from_email = from_email or settings.DEFAULT_FROM_EMAIL
     sent_emails = set()
     failed_emails = set()
     sent_notifications = set()


### PR DESCRIPTION
This setting includes the name, not just the email. We may want to change this value in our ops repos.