### PR TITLE
UI: allow to close notifications

### DIFF
--- a/media/css/core.css
+++ b/media/css/core.css
@@ -613,7 +613,11 @@ p.build-missing { font-size: .8em; color: #9d9a55; margin: 0 0 3px; }
 
 
 /* notification box */
-.notification { padding: 5px 0; color: #a55; }
+.notification {
+    padding: 5px 0;
+    color: #a55;
+    max-width: max-content;
+}
 .notification-20,
 .notification-25,
 .notification-101,
@@ -623,6 +627,8 @@ p.build-missing { font-size: .8em; color: #9d9a55; margin: 0 0 3px; }
 
 a.notification-action {
     text-decoration: none;
+    float: right;
+    padding-left: 5px;
 }
 
 .notification-action > .icon.close:before {

--- a/media/css/core.css
+++ b/media/css/core.css
@@ -621,6 +621,14 @@ p.build-missing { font-size: .8em; color: #9d9a55; margin: 0 0 3px; }
   color: #5a5;
 }
 
+a.notification-action {
+    text-decoration: none;
+}
+
+.notification-action > .icon.close:before {
+    font-family: FontAwesome;
+    content: "\f057";
+}
 
 /* warning banner */
 

--- a/readthedocs/notifications/urls.py
+++ b/readthedocs/notifications/urls.py
@@ -1,10 +1,7 @@
-# -*- coding: utf-8 -*-
-
 """Renames for messages_extends URLs."""
 
 from django.conf.urls import url
 from messages_extends.views import message_mark_all_read, message_mark_read
-
 
 urlpatterns = [
     url(

--- a/readthedocs/templates/base.html
+++ b/readthedocs/templates/base.html
@@ -102,6 +102,11 @@
             <ul class="notifications">
               {% for message in messages %}
                 <li class="notification notification-{{ message.level }}" {% if message.pk %}data-dismiss-url="{% url 'message_mark_read' message.pk %}{% endif %}">
+                  {% if message.pk %}
+                  <a class="notification-action" href="{% url 'message_mark_read' message.pk %}">
+                    <span class="icon close" aria-label="Close notification"></span>
+                  </a>
+                  {% endif %}
                   {{ message }}
                 </li>
               {% endfor %}

--- a/readthedocs/templates/base.html
+++ b/readthedocs/templates/base.html
@@ -104,7 +104,7 @@
                 <li class="notification notification-{{ message.level }}" {% if message.pk %}data-dismiss-url="{% url 'message_mark_read' message.pk %}{% endif %}">
                   {% if message.pk %}
                   <a class="notification-action" href="{% url 'message_mark_read' message.pk %}">
-                    <span class="icon close" aria-label="Close notification"></span>
+                    <span class="icon close" aria-label="{% trans 'Close notification' %}"></span>
                   </a>
                   {% endif %}
                   {{ message }}


### PR DESCRIPTION
This is fixed on the new templates too, but we still need more work before releasing them.

![Screenshot 2021-07-14 at 11-10-43 test Read the Docs](https://user-images.githubusercontent.com/4975310/125660688-fc67f8d5-9939-41dd-acc3-93db7a7bd226.png)
![Screenshot 2021-07-14 at 11-10-21 test Read the Docs](https://user-images.githubusercontent.com/4975310/125660698-bba71829-6cf8-4cae-b944-08d2bc406191.png)


I'd put this on the other side, but we don't have something like a box for these notifications