### PR TITLE
change vieweable to viewable on  home page: issue#8346

### DIFF
--- a/readthedocs/templates/homepage.html
+++ b/readthedocs/templates/homepage.html
@@ -85,7 +85,7 @@
       <p>
         {% blocktrans trimmed %}
         We build and host your docs for the web, but they are
-        also vieweable as PDFs, as single page HTML, and for eReaders.
+        also viewable as PDFs, as single page HTML, and for eReaders.
         No additional configuration is required.
         {% endblocktrans %}
       </p>


### PR DESCRIPTION
Remove the typo error on the home page in the download section.