### PR TITLE
Redirect users to appropriate support channels using template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,3 +1,8 @@
+---
+name: Bug report
+about: Report some incorrect or unexpected behavior
+---
+
 ## Details
 
 * Read the Docs project URL:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,13 @@
+contact_links:
+- name: User support
+  url: https://readthedocs.org/support/
+  about: |
+    If you need a specific request for your project or account,
+    like more resources, a specific feature flag,
+    change of the project slug or username, etc
+- name: Security issue
+  url: https://docs.readthedocs.io/en/stable/security.html#reporting-a-security-issue
+  about: |
+    If you believe you’ve discovered a security issue at Read the Docs,
+    please contact us at security@readthedocs.org, optionally using our
+    PGP key (see link for detailed instructions)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,9 +5,3 @@ contact_links:
     If you need a specific request for your project or account,
     like more resources, a specific feature flag,
     change of the project slug or username, etc
-- name: Security issue
-  url: https://docs.readthedocs.io/en/stable/security.html#reporting-a-security-issue
-  about: |
-    If you believe you’ve discovered a security issue at Read the Docs,
-    please contact us at security@readthedocs.org, optionally using our
-    PGP key (see link for detailed instructions)


### PR DESCRIPTION
This prompts users with the following dialogue before opening a new issue on this repository:

![Screenshot 2021-07-26 at 12-46-37 New Issue · astrojuanlu readthedocs org](https://user-images.githubusercontent.com/316517/126977163-a632a0d7-ee18-4e51-bdd5-6e6fda1a3a7b.png)

(see it in action on my fork)

What do folks think about this?