### PR TITLE
Lock old threads

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,34 @@
+name: 'Lock old threads'
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2
+        with:
+          issue-lock-inactive-days: '30'
+          pr-lock-inactive-days: '30'
+          issue-lock-comment: >
+            This issue has been automatically locked since there
+            has not been any recent activity after it was closed.
+            Please open a new issue for related bugs.
+          pr-lock-comment: >
+            This pull request has been automatically locked since there
+            has not been any recent activity after it was closed.
+            Please open a new issue for related bugs.
+      - name: Log processed threads
+        run: |
+          if [ '${{ steps.lock.outputs.issues }}' ]; then
+            echo "Issues:" && echo '${{ steps.lock.outputs.issues }}' | jq .
+          fi
+          if [ '${{ steps.lock.outputs.prs }}' ]; then
+            echo "Pull requests:" && echo '${{ steps.lock.outputs.prs }}' | jq .
+          fi


### PR DESCRIPTION
This enables a bot that locks issues and pull requests that were **closed** more than 30 days ago. It leaves a comment when doing so, which will trigger a notification - we can disable that, at the expense of making it less clear for outsiders why the issue was closed. It also includes a suggestion to have more output in the action logs: https://github.com/dessant/lock-threads/issues/26#issuecomment-877810915