### PR TITLE
Remove clickjacking middleware for proxito

### DIFF
--- a/readthedocs/settings/proxito/base.py
+++ b/readthedocs/settings/proxito/base.py
@@ -31,6 +31,7 @@ class CommunityProxitoSettingsMixin:
 
         middleware_to_remove = (
             'csp.middleware.CSPMiddleware',
+            'django.middleware.clickjacking.XFrameOptionsMiddleware',
         )
         for mw in middleware_to_remove:
             if mw in classes:


### PR DESCRIPTION
This was getting set and not passed through nginx,
but with our last deploy it is now getting set.
We can optionally turn this on for docs pages,
but we don't want it on everywhere by default.