### PR TITLE
Footer: remove auth block

### DIFF
--- a/readthedocs/api/v2/templates/restapi/footer.html
+++ b/readthedocs/api/v2/templates/restapi/footer.html
@@ -127,10 +127,8 @@
       </dl>
       {% endblock %}
 
-      {% block auth %}
-      {% endblock %}
-
       <hr/>
+
       {% block footer %}
         <small>
           <span>{% trans "Hosted by" %} <a href="https://readthedocs.org">Read the Docs</a></span>


### PR DESCRIPTION
This isn't needed anymore,
since we are overriding the footer block instead.