### PR TITLE
Add documentation about webhooks for Gitea

### DIFF
--- a/docs/webhooks.rst
+++ b/docs/webhooks.rst
@@ -96,14 +96,22 @@ GitLab
 Gitea
 ~~~~~
 
+These instructions apply to any Gitea instance.
+
 .. warning::
 
    This isn't officially supported, but using the "GitHub webhook" is an effective workaround,
    because Gitea uses the same payload as GitHub. The generic webhook is not compatibile with Gitea.
+   See `issue #8364`_ for more details. Official support may be implemented in the future.
 
-* Manually create a "GitHub webhook" integration on Read the Docs
+On Read the Docs:
+
+* Manually create a "GitHub webhook" integration
   (this will show a warning about the webhook not being correctly set up,
   that will go away when the webhook is configured in Gitea)
+
+On your Gitea instance:
+
 * Go to the :guilabel:`Settings` > :guilabel:`Webhooks` page for your project on your Gitea instance
 * Create a new webhook of type "Gitea" 
 * For **URL**, use the URL of the integration on Read the Docs,
@@ -117,9 +125,11 @@ Gitea
 * Ensure **Active** is enabled; it is by default
 * Finish by clicking **Add Webhook**
 * Test the webhook with :guilabel:`Delivery test`
-* On Read the Docs, check that the warnings have disappeared and the delivery test triggered a build
 
-These instructions apply to any Gitea instance.
+Finally, on Read the Docs, check that the warnings have disappeared
+and the delivery test triggered a build.
+
+.. _issue #8364: https://github.com/readthedocs/readthedocs.org/issues/8364
 
 .. _webhook-integration-generic:
 

--- a/docs/webhooks.rst
+++ b/docs/webhooks.rst
@@ -93,6 +93,32 @@ GitLab
 * Leave the default **Push events** selected and mark **Tag push events** also
 * Finish by clicking **Add Webhook**
 
+.. _webhook-integration-gitea:
+
+Gitea
+~~~~~
+
+* Manually create a "GitHub webook" integration on Read the Docs
+  (this will show a warning about the webhook not being correctly set up,
+  that will go away when the webhook is configured in Gitea)
+* Go to the :guilabel:`Settings` > :guilabel:`Webhooks` page for your project on your Gitea instance
+* Create a new webhook of type "Gitea" 
+* For **URL**, use the URL of the integration on Read the Docs,
+  found on the :guilabel:`Admin` > :guilabel:`Integrations` page
+* Leave the default **HTTP Method** as POST
+* For **Content type**, both *application/json* and
+  *application/x-www-form-urlencoded* work
+* Leave the **Secret** field blank
+* Select **Choose events**,
+  and mark **Branch or tag creation**, **Branch or tag deletion** and **Push** events
+* Ensure **Active** is enabled; it is by default
+* Finish by clicking **Add Webhook**
+* Test the webhook with :guilabel:`Delivery test`
+* On Read the Docs, check that the warnings have disappeared and the delivery test triggered a build
+
+Please note that this applies to any Gitea instance and that the "GitHub webhook" works because Gitea uses the same payload as GitHub.
+The generic webhook is not compatibile with Gitea.
+
 .. _webhook-integration-generic:
 
 Using the generic API integration

--- a/docs/webhooks.rst
+++ b/docs/webhooks.rst
@@ -101,7 +101,7 @@ Gitea
    This isn't officially supported, but using the "GitHub webhook" is an effective workaround,
    because Gitea uses the same payload as GitHub. The generic webhook is not compatibile with Gitea.
 
-* Manually create a "GitHub webook" integration on Read the Docs
+* Manually create a "GitHub webhook" integration on Read the Docs
   (this will show a warning about the webhook not being correctly set up,
   that will go away when the webhook is configured in Gitea)
 * Go to the :guilabel:`Settings` > :guilabel:`Webhooks` page for your project on your Gitea instance

--- a/docs/webhooks.rst
+++ b/docs/webhooks.rst
@@ -93,10 +93,13 @@ GitLab
 * Leave the default **Push events** selected and mark **Tag push events** also
 * Finish by clicking **Add Webhook**
 
-.. _webhook-integration-gitea:
-
 Gitea
 ~~~~~
+
+.. warning::
+
+   This isn't officially supported, but using the "GitHub webhook" is an effective workaround,
+   because Gitea uses the same payload as GitHub. The generic webhook is not compatibile with Gitea.
 
 * Manually create a "GitHub webook" integration on Read the Docs
   (this will show a warning about the webhook not being correctly set up,
@@ -116,8 +119,7 @@ Gitea
 * Test the webhook with :guilabel:`Delivery test`
 * On Read the Docs, check that the warnings have disappeared and the delivery test triggered a build
 
-Please note that this applies to any Gitea instance and that the "GitHub webhook" works because Gitea uses the same payload as GitHub.
-The generic webhook is not compatibile with Gitea.
+These instructions apply to any Gitea instance.
 
 .. _webhook-integration-generic:
 


### PR DESCRIPTION
Following the fruitful discussion at https://github.com/readthedocs/readthedocs.org/issues/8364 I added a paragraph about setting up a webhook for Gitea projects.