### PR TITLE
Fix typos discovered by codespell in /docs

### DIFF
--- a/docs/api/v3.rst
+++ b/docs/api/v3.rst
@@ -158,7 +158,7 @@ Projects list
                     "home": "https://pip.pypa.io/"
                 },
                 "tags": [
-                    "disutils",
+                    "distutils",
                     "easy_install",
                     "egg",
                     "setuptools",
@@ -259,7 +259,7 @@ Project details
                 "home": "https://pip.pypa.io/"
             },
             "tags": [
-                "disutils",
+                "distutils",
                 "easy_install",
                 "egg",
                 "setuptools",
@@ -917,7 +917,7 @@ Subproject create
     :>json string alias: optional slug alias to be used in the URL (e.g ``/projects/<alias>/en/latest/``).
                          If not provided, child project's slug is used as alias.
 
-    :statuscode 201: Subproject created sucessfully
+    :statuscode 201: Subproject created successfully
 
 
 Subproject delete
@@ -1015,7 +1015,7 @@ Translations listing
                     "home": "https://pip.pypa.io/"
                 },
                 "tags": [
-                    "disutils",
+                    "distutils",
                     "easy_install",
                     "egg",
                     "setuptools",

--- a/docs/commercial/sharing.rst
+++ b/docs/commercial/sharing.rst
@@ -47,7 +47,7 @@ Once the person you send the link to clicks the link,
 they will have access to the documentation while their browser window is open.
 
 If you want to link to a specific page,
-you can do this by passing the ``next`` query paramater in the URL.
+you can do this by passing the ``next`` query parameter in the URL.
 For example ``https://mydocs.readthedocs-hosted.com/_/sharing/xxxxxxxxx?next=/en/latest/page.html``.
 
 .. tip::

--- a/docs/development/design/apiv3.rst
+++ b/docs/development/design/apiv3.rst
@@ -38,7 +38,7 @@ Goals
 Non-Goals
 ---------
 
-* Filter by arbitrary and non-useful fields
+* Filter by arbitrary and useless fields
 
   * "Builds with ``exit_code=1``"
   * "Builds containing ``ERROR`` on their output"

--- a/docs/development/design/build-images.rst
+++ b/docs/development/design/build-images.rst
@@ -64,7 +64,7 @@ Non goals
 ---------
 
 * allow creation/usage of custom Docker images
-* allow to execute arbitraty commands via hooks (eg. ``pre_build``)
+* allow to execute arbitrary commands via hooks (eg. ``pre_build``)
 
 
 New build image structure

--- a/docs/development/design/embed-api.rst
+++ b/docs/development/design/embed-api.rst
@@ -66,7 +66,7 @@ and replace all the relative links from its content making them absolute.
    Any other case outside this contract will be considered *special* and will be implemented
    only under ``?doctool=``, ``?version=`` and ``?writer=`` arguments.
 
-If no ``id`` selector is sent to the request, the content of the first meaningfull HTML tag
+If no ``id`` selector is sent to the request, the content of the first meaningful HTML tag
 (``<main>``, ``<div role="main">`` or other well-defined standard tags) identifier found is returned.
 
 
@@ -221,7 +221,7 @@ The whole logic should be the same, the only difference would be where the sourc
 
 .. warning::
 
-   We should be carefull with the URL received from the user because those may be internal URLs and we could be leaking some data.
+   We should be careful with the URL received from the user because those may be internal URLs and we could be leaking some data.
    Example: ``?url=http://localhost/some-weird-endpoint`` or ``?url=http://169.254.169.254/latest/meta-data/``
    (see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html).
 

--- a/docs/development/search-integration.rst
+++ b/docs/development/search-integration.rst
@@ -89,7 +89,7 @@ Sections
 
 Sections are ``h`` tags, and sections of the same level should be neighbors.
 Additionally, sections should have an unique ``id`` attribute per page (this is used to link to the section).
-All content bellow the section, till the new section will be indexed as part of the section. Example:
+All content below the section, till the new section will be indexed as part of the section. Example:
 
 .. code-block:: html
    :emphasize-lines: 2-10
@@ -124,7 +124,7 @@ All content bellow the section, till the new section will be indexed as part of 
 
 Sections can be inside till two nested tags (and have nested sections),
 and its immediate parent can contain the ``id`` attribute.
-Note that the section content still needs to be bellow the ``h`` tag. Example:
+Note that the section content still needs to be below the ``h`` tag. Example:
 
 .. code-block:: html
    :emphasize-lines: 3-11,14-21

--- a/docs/gsoc.rst
+++ b/docs/gsoc.rst
@@ -103,7 +103,7 @@ Build a new Sphinx theme
 
 Sphinx v2 will introduce a new format for themes,
 supporting HTML5 and new markup.
-We are hoping to buid a new Sphinx theme that supports this new structure.
+We are hoping to build a new Sphinx theme that supports this new structure.
 
 This project would include:
 

--- a/docs/guides/conda.rst
+++ b/docs/guides/conda.rst
@@ -79,7 +79,7 @@ conda also needs to know which channels to use, and which ones take precedence.
 If not specified, conda will use ``defaults``, the channel maintained by Anaconda Inc.
 and subject to `Anaconda Terms of Service`_. It contains well-tested versions of the most widely used
 packages. However, some packages are not available on the ``defaults`` channel,
-and even if they are, they might not be on their lastest versions.
+and even if they are, they might not be on their latest versions.
 
 As an alternative, there are channels maintained by the community that have a broader selection
 of packages and more up-to-date versions of them, the most popular one being ``conda-forge``.
@@ -108,7 +108,7 @@ Mixing conda and pip packages
 -----------------------------
 
 There are valid reasons to use pip inside a conda environment: some dependency
-might not be avaliable yet as a conda package in any channel,
+might not be available yet as a conda package in any channel,
 or you might want to avoid precompiled binaries entirely.
 In either case, it is possible to specify the subset of packages
 that will be installed with pip in the ``environment.yml`` file. For example:

--- a/docs/guides/deprecating-content.rst
+++ b/docs/guides/deprecating-content.rst
@@ -74,7 +74,7 @@ For example:
       ranking:
          api/v1.html: -1
 
-This wont hide results from that page, but it will give priority to results from other pages.
+This won't hide results from that page, but it will give priority to results from other pages.
 
 .. TODO: mention search.ignore when it's implemented.
 

--- a/docs/guides/private-python-packages.rst
+++ b/docs/guides/private-python-packages.rst
@@ -42,7 +42,7 @@ See :doc:`using environment variables in Read the Docs </guides/environment-vari
    and including a dollar sign and curly brackets around the name (``${API_TOKEN}``)
    for :ref:`pip to be able to recognize them <pip:using environment variables>`.
 
-Bellow you can find how to get a personal access token from our supported providers.
+Below you can find how to get a personal access token from our supported providers.
 We will be using environment variables for the token.
 
 GitHub

--- a/docs/guides/searching-with-readthedocs.rst
+++ b/docs/guides/searching-with-readthedocs.rst
@@ -80,7 +80,7 @@ Example queries:
 
 - https://docs.readthedocs.io/?rtd_search=reedthedcs~2
 - https://docs.readthedocs.io/?rtd_search=authentation~3
-- https://docs.readthedocs.io/?rtd_search=configurtion~1
+- https://docs.readthedocs.io/?rtd_search=configuration~1
 
 
 Build complex queries

--- a/docs/roadmap.rst
+++ b/docs/roadmap.rst
@@ -58,7 +58,7 @@ release number.
 
 Group milestones are blocks of work that will have priority in the future, but
 aren't included on point releases yet. When the core team does decide to make
-these milestones a priorty, they will be moved into point release milestones.
+these milestones a priority, they will be moved into point release milestones.
 
 .. _semantic versioning: https://semver.org
 

--- a/docs/webhooks.rst
+++ b/docs/webhooks.rst
@@ -223,7 +223,7 @@ In addition to :ref:`no longer supporting GitHub Services <webhook-github-servic
 we have decided to no longer support several other legacy incoming webhook
 endpoints that were used before we introduced project webhook integrations. When
 we introduced our webhook integrations, we added several features and improved
-security for incoming webhooks and these features were not added to our leagcy
+security for incoming webhooks and these features were not added to our legacy
 incoming webhooks. New projects have not been able to use our legacy incoming
 webhooks since, however if you have a project that has been established for a
 while, you may still be using these endpoints.


### PR DESCRIPTION
[`codespell --ignore-words-list="hel,wile" --skip="*.css,*.js,*.po" ./docs`](https://pypi.org/project/codespell)