### PR TITLE
Fix YAML extension

### DIFF
--- a/readthedocs/templates/builds/build_detail.html
+++ b/readthedocs/templates/builds/build_detail.html
@@ -165,7 +165,7 @@ $(document).ready(function () {
           <p>
             {% blocktrans trimmed with config_file_link="https://docs.readthedocs.io/page/config-file/v2.html" %}
               <strong>Configure your documentation builds!</strong>
-              Adding a <a href="{{ config_file_link }}">.readthedocs.yml</a> file to your project
+              Adding a <a href="{{ config_file_link }}">.readthedocs.yaml</a> file to your project
               is the recommended way to configure your documentation builds.
               You can declare dependencies, set up submodules, and many other great features.
             {% endblocktrans %}


### PR DESCRIPTION
"The recommended extension for files containing YAML documents is .yaml ( http://yaml.org/faq.html ) and this has been the case since at least Sep 2006 ( https://web.archive.org/web/20060924190202/http://yaml.org/faq.html )."

See #7460. Leftover from #7918