### PR TITLE
codespell part 2 - Continues #8409

### DIFF
--- a/docs/guides/searching-with-readthedocs.rst
+++ b/docs/guides/searching-with-readthedocs.rst
@@ -80,7 +80,7 @@ Example queries:
 
 - https://docs.readthedocs.io/?rtd_search=reedthedcs~2
 - https://docs.readthedocs.io/?rtd_search=authentation~3
-- https://docs.readthedocs.io/?rtd_search=configuration~1
+- https://docs.readthedocs.io/?rtd_search=configurtion~1
 
 
 Build complex queries

--- a/docs/webhooks.rst
+++ b/docs/webhooks.rst
@@ -101,7 +101,7 @@ These instructions apply to any Gitea instance.
 .. warning::
 
    This isn't officially supported, but using the "GitHub webhook" is an effective workaround,
-   because Gitea uses the same payload as GitHub. The generic webhook is not compatibile with Gitea.
+   because Gitea uses the same payload as GitHub. The generic webhook is not compatible with Gitea.
    See `issue #8364`_ for more details. Official support may be implemented in the future.
 
 On Read the Docs:

--- a/readthedocs/builds/managers.py
+++ b/readthedocs/builds/managers.py
@@ -184,7 +184,7 @@ class ExternalBuildManager(SettingsOverrideObject):
 class VersionAutomationRuleManager(PolymorphicManager):
 
     """
-    Mananger for VersionAutomationRule.
+    Manager for VersionAutomationRule.
 
     .. note::
 

--- a/readthedocs/builds/migrations/0007_add-automation-rules.py
+++ b/readthedocs/builds/migrations/0007_add-automation-rules.py
@@ -25,7 +25,7 @@ class Migration(migrations.Migration):
                 ('priority', models.IntegerField(help_text='A lower number (0) means a higher priority', verbose_name='Rule priority')),
                 ('match_arg', models.CharField(help_text='Value used for the rule to match the version', max_length=255, verbose_name='Match argument')),
                 ('action', models.CharField(choices=[('activate-version', 'Activate version on match'), ('set-default-version', 'Set as default version on match')], max_length=32, verbose_name='Action')),
-                ('action_arg', models.CharField(blank=True, help_text='Value used for the action to perform an operation', max_length=255, null=True, verbose_name='Action argument')),
+                ('action_arg', models.CharField(blank=True, help_text='Value used for the action to perfom an operation', max_length=255, null=True, verbose_name='Action argument')),
                 ('version_type', models.CharField(choices=[('branch', 'Branch'), ('tag', 'Tag'), ('unknown', 'Unknown')], max_length=32, verbose_name='Version type')),
                 ('polymorphic_ctype', models.ForeignKey(editable=False, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='polymorphic_builds.versionautomationrule_set+', to='contenttypes.ContentType')),
                 ('project', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='automation_rules', to='projects.Project')),

--- a/readthedocs/builds/migrations/0007_add-automation-rules.py
+++ b/readthedocs/builds/migrations/0007_add-automation-rules.py
@@ -25,7 +25,7 @@ class Migration(migrations.Migration):
                 ('priority', models.IntegerField(help_text='A lower number (0) means a higher priority', verbose_name='Rule priority')),
                 ('match_arg', models.CharField(help_text='Value used for the rule to match the version', max_length=255, verbose_name='Match argument')),
                 ('action', models.CharField(choices=[('activate-version', 'Activate version on match'), ('set-default-version', 'Set as default version on match')], max_length=32, verbose_name='Action')),
-                ('action_arg', models.CharField(blank=True, help_text='Value used for the action to perfom an operation', max_length=255, null=True, verbose_name='Action argument')),
+                ('action_arg', models.CharField(blank=True, help_text='Value used for the action to perform an operation', max_length=255, null=True, verbose_name='Action argument')),
                 ('version_type', models.CharField(choices=[('branch', 'Branch'), ('tag', 'Tag'), ('unknown', 'Unknown')], max_length=32, verbose_name='Version type')),
                 ('polymorphic_ctype', models.ForeignKey(editable=False, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='polymorphic_builds.versionautomationrule_set+', to='contenttypes.ContentType')),
                 ('project', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='automation_rules', to='projects.Project')),

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -929,7 +929,7 @@ class Build(models.Model):
         """
         Reset the build so it can be re-used when re-trying.
 
-        Dates and states are usually overriden by the build,
+        Dates and states are usually overridden by the build,
         we care more about deleting the commands.
         """
         self.state = BUILD_STATE_TRIGGERED
@@ -1070,7 +1070,7 @@ class VersionAutomationRule(PolymorphicModel, TimeStampedModel):
     )
     action_arg = models.CharField(
         _('Action argument'),
-        help_text=_('Value used for the action to perfom an operation'),
+        help_text=_('Value used for the action to perform an operation'),
         max_length=255,
         null=True,
         blank=True,
@@ -1187,7 +1187,7 @@ class VersionAutomationRule(PolymorphicModel, TimeStampedModel):
             )
             expression = F('priority') + 1
 
-        # Put an imposible priority to avoid
+        # Put an impossible priority to avoid
         # the unique constraint (project, priority)
         # while updating.
         self.priority = total + 99
@@ -1270,7 +1270,7 @@ class RegexAutomationRule(VersionAutomationRule):
            arg to avoid ReDoS.
 
            We could use a finite state machine type of regex too,
-           but there isn't a stable library at the time of writting this code.
+           but there isn't a stable library at the time of writing this code.
         """
         try:
             match = regex.search(

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -1070,7 +1070,7 @@ class VersionAutomationRule(PolymorphicModel, TimeStampedModel):
     )
     action_arg = models.CharField(
         _('Action argument'),
-        help_text=_('Value used for the action to perform an operation'),
+        help_text=_('Value used for the action to perfom an operation'),
         max_length=255,
         null=True,
         blank=True,

--- a/readthedocs/doc_builder/config.py
+++ b/readthedocs/doc_builder/config.py
@@ -58,7 +58,7 @@ def load_yaml_config(version):
             env_config=env_config,
         )
     except ConfigFileNotFound:
-        # Dafault to use v1 with some defaults from the web interface
+        # Default to use v1 with some defaults from the web interface
         # if we don't find a configuration file.
         config = BuildConfigV1(
             env_config=env_config,

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -462,7 +462,7 @@ class Virtualenv(PythonEnvironment):
             '-m',
             'pip',
             'list',
-            # Inlude pre-release versions.
+            # Include pre-release versions.
             '--pre',
         ]
         self.build_env.run(

--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -12,7 +12,7 @@
 # conf.py.tmpl file found in the readthedocs.org codebase:
 # https://github.com/rtfd/readthedocs.org/blob/master/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
 #
-# Note: this file should't rely on extra depencies.
+# Note: this file shouldn't rely on extra dependencies.
 
 import importlib
 import sys

--- a/readthedocs/rtd_tests/fixtures/spec/v2/schema.yml
+++ b/readthedocs/rtd_tests/fixtures/spec/v2/schema.yml
@@ -117,7 +117,7 @@ mkdocs:
   # Default: rtd will try to find it
   configuration: path(required=False)
 
-  # Add the --strict optio to mkdocs build
+  # Add the --strict option to mkdocs build
   # Default: false
   fail_on_warning: bool(required=False)
 

--- a/readthedocs/rtd_tests/tests/projects/test_version_sorting.py
+++ b/readthedocs/rtd_tests/tests/projects/test_version_sorting.py
@@ -96,7 +96,7 @@ class SortVersionsTest(TestCase):
 
     def test_sort_git_master_and_latest(self):
         """
-        The branch named master should havea a higher priority
+        The branch named master should have a higher priority
         than latest, ideally users should only have one of the two activated.
         """
         identifiers = ['latest', 'master', '1.0', '2.0', '1.1', '1.9', '1.10']

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -1443,7 +1443,7 @@ class IntegrationsTests(TestCase):
         self.assertEqual(resp.status_code, 200)
 
     def test_github_sync_on_push_event(self, trigger_build):
-        """Sync if the webhook doesn't have the create/delete events, but we recieve a push event with created/deleted."""
+        """Sync if the webhook doesn't have the create/delete events, but we receive a push event with created/deleted."""
         integration = Integration.objects.create(
             project=self.project,
             integration_type=Integration.GITHUB_WEBHOOK,

--- a/readthedocs/rtd_tests/tests/test_notifications.py
+++ b/readthedocs/rtd_tests/tests/test_notifications.py
@@ -163,7 +163,7 @@ class NotificationBackendTests(TestCase):
         self.assertEqual(PersistentMessage.objects.count(), 0)
 
         # We should never be adding persistent messages for anonymous users.
-        # Make sure message_extends sitll throws an exception here
+        # Make sure message_extends still throws an exception here
         with self.assertRaises(NotImplementedError):
             backend.send(notify)
 

--- a/readthedocs/rtd_tests/tests/test_sync_versions.py
+++ b/readthedocs/rtd_tests/tests/test_sync_versions.py
@@ -1254,7 +1254,7 @@ class TestStableVersion(TestCase):
             self.pip.get_stable_version().identifier,
         )
 
-        # There arent others stable slugs like stable_a
+        # There aren't others stable slugs like stable_a
         other_stable = self.pip.versions.filter(
             slug__startswith='stable_',
         )
@@ -1338,7 +1338,7 @@ class TestStableVersion(TestCase):
             'origin/stable',
             self.pip.get_stable_version().identifier,
         )
-        # There arent others stable slugs like stable_a
+        # There aren't others stable slugs like stable_a
         other_stable = self.pip.versions.filter(
             slug__startswith='stable_',
         )
@@ -1431,7 +1431,7 @@ class TestLatestVersion(TestCase):
             version_latest.identifier,
         )
 
-        # There arent others latest slugs like latest_a
+        # There aren't others latest slugs like latest_a
         other_latest = self.pip.versions.filter(
             slug__startswith='latest_',
         )
@@ -1484,7 +1484,7 @@ class TestLatestVersion(TestCase):
             version_latest.identifier,
         )
 
-        # There arent others latest slugs like latest_a
+        # There aren't others latest slugs like latest_a
         other_latest = self.pip.versions.filter(
             slug__startswith='latest_',
         )


### PR DESCRIPTION
Continues #8409

[codespell --ignore-words-list="ba,configurtion,ded,hel,perfom,wile" --skip="*.css,*.fjson,*.js,*.json,*.po,*.svg" ./d* ./readthedocs/b* ./readthedocs/d* ./readthedocs/r*](https://pypi.org/project/codespell)

Also undid a deliberate misspelling `configurtion` discussed at https://github.com/readthedocs/readthedocs.org/pull/8409#pullrequestreview-731868885