### PR TITLE
Add codespell to tox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ jobs:
             source $BASH_ENV
       - run: tox -e migrations
       - run: tox -e pre-commit
+      - run: tox -e codespell
       - run: tox -e lint
       - run: tox -e docs-lint
       - run: tox -e docs

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -135,7 +135,7 @@ Version 7.1.0
 Version 7.0.0
 -------------
 
-This is our 7th major version! This is because we are upgrading to **Django 3.2 LTS**. 
+This is our 7th major version! This is because we are upgrading to **Django 3.2 LTS**.
 
 :Date: January 17, 2022
 
@@ -225,7 +225,7 @@ Version 6.3.1
 * `@stsewd <https://github.com/stsewd>`__: Custom Domain: make cname_target configurable (`#8728 <https://github.com/readthedocs/readthedocs.org/pull/8728>`__)
 * `@stsewd <https://github.com/stsewd>`__: Test external serving for projects with `--` in slug (`#8716 <https://github.com/readthedocs/readthedocs.org/pull/8716>`__)
 * `@astrojuanlu <https://github.com/astrojuanlu>`__: Add guide to migrate from reST to MyST (`#8714 <https://github.com/readthedocs/readthedocs.org/pull/8714>`__)
-* `@astrojuanlu <https://github.com/astrojuanlu>`__: Avoid future breakage of `setup.py` invokations (`#8711 <https://github.com/readthedocs/readthedocs.org/pull/8711>`__)
+* `@astrojuanlu <https://github.com/astrojuanlu>`__: Avoid future breakage of `setup.py` invocations (`#8711 <https://github.com/readthedocs/readthedocs.org/pull/8711>`__)
 * `@humitos <https://github.com/humitos>`__: structlog: migrate application code to better logging (`#8705 <https://github.com/readthedocs/readthedocs.org/pull/8705>`__)
 * `@humitos <https://github.com/humitos>`__: EmbedAPI: log success requests (`#8689 <https://github.com/readthedocs/readthedocs.org/pull/8689>`__)
 * `@ericholscher <https://github.com/ericholscher>`__: Add ability to rebuild a specific build (`#6995 <https://github.com/readthedocs/readthedocs.org/pull/6995>`__)
@@ -238,7 +238,7 @@ Version 6.3.0
 * `@humitos <https://github.com/humitos>`__: Tests: run tests with Python3.8 in CircleCI (`#8718 <https://github.com/readthedocs/readthedocs.org/pull/8718>`__)
 * `@stsewd <https://github.com/stsewd>`__: Test external serving for projects with `--` in slug (`#8716 <https://github.com/readthedocs/readthedocs.org/pull/8716>`__)
 * `@humitos <https://github.com/humitos>`__: requirements: add requests-oauthlib (`#8712 <https://github.com/readthedocs/readthedocs.org/pull/8712>`__)
-* `@astrojuanlu <https://github.com/astrojuanlu>`__: Avoid future breakage of `setup.py` invokations (`#8711 <https://github.com/readthedocs/readthedocs.org/pull/8711>`__)
+* `@astrojuanlu <https://github.com/astrojuanlu>`__: Avoid future breakage of `setup.py` invocations (`#8711 <https://github.com/readthedocs/readthedocs.org/pull/8711>`__)
 * `@humitos <https://github.com/humitos>`__: spam: fix admin filter (`#8707 <https://github.com/readthedocs/readthedocs.org/pull/8707>`__)
 * `@humitos <https://github.com/humitos>`__: oauth: sync remote repositories fix (`#8706 <https://github.com/readthedocs/readthedocs.org/pull/8706>`__)
 * `@humitos <https://github.com/humitos>`__: structlog: migrate application code to better logging (`#8705 <https://github.com/readthedocs/readthedocs.org/pull/8705>`__)
@@ -343,7 +343,7 @@ Version 6.0.0
 
 This release includes the upgrade of some base dependencies:
 
-- Python version from 3.6 to 3.8 
+- Python version from 3.6 to 3.8
 - Ubuntu version from 18.04 LTS to 20.04 LTS
 
 Starting from this release, all the Read the Docs code will be tested and QAed on these versions.
@@ -422,7 +422,7 @@ Version 5.23.5
 
 * `@humitos <https://github.com/humitos>`__: Organization: only mark artifacts cleaned as False if they are True (`#8481 <https://github.com/readthedocs/readthedocs.org/pull/8481>`__)
 * `@astrojuanlu <https://github.com/astrojuanlu>`__: Fix link to version states documentation (`#8475 <https://github.com/readthedocs/readthedocs.org/pull/8475>`__)
-* `@stsewd <https://github.com/stsewd>`__: OAuth models: increase avatar_url lenght (`#8472 <https://github.com/readthedocs/readthedocs.org/pull/8472>`__)
+* `@stsewd <https://github.com/stsewd>`__: OAuth models: increase avatar_url length (`#8472 <https://github.com/readthedocs/readthedocs.org/pull/8472>`__)
 * `@pzhlkj6612 <https://github.com/pzhlkj6612>`__: Docs: update the links to the dependency management content of setuptools docs (`#8470 <https://github.com/readthedocs/readthedocs.org/pull/8470>`__)
 * `@stsewd <https://github.com/stsewd>`__: Permissions: avoid using project.users, use proper permissions instead (`#8458 <https://github.com/readthedocs/readthedocs.org/pull/8458>`__)
 * `@humitos <https://github.com/humitos>`__: Docker build images: update design doc (`#8447 <https://github.com/readthedocs/readthedocs.org/pull/8447>`__)
@@ -448,7 +448,7 @@ Version 5.23.4
 * `@stsewd <https://github.com/stsewd>`__: Contact users: pass user and domain in the context (`#8430 <https://github.com/readthedocs/readthedocs.org/pull/8430>`__)
 * `@astrojuanlu <https://github.com/astrojuanlu>`__: New Read the Docs tutorial, part I (`#8428 <https://github.com/readthedocs/readthedocs.org/pull/8428>`__)
 * `@stsewd <https://github.com/stsewd>`__: Footer: remove auth block (`#8397 <https://github.com/readthedocs/readthedocs.org/pull/8397>`__)
-* `@stsewd <https://github.com/stsewd>`__: API: fix subprojects creation when organizaions are enabled (`#8393 <https://github.com/readthedocs/readthedocs.org/pull/8393>`__)
+* `@stsewd <https://github.com/stsewd>`__: API: fix subprojects creation when organizations are enabled (`#8393 <https://github.com/readthedocs/readthedocs.org/pull/8393>`__)
 * `@stsewd <https://github.com/stsewd>`__: QuerySets: remove unused overrides (`#8299 <https://github.com/readthedocs/readthedocs.org/pull/8299>`__)
 * `@stsewd <https://github.com/stsewd>`__: QuerySets: filter permissions by organizations (`#8298 <https://github.com/readthedocs/readthedocs.org/pull/8298>`__)
 

--- a/docs/dev/design/build-images.rst
+++ b/docs/dev/design/build-images.rst
@@ -265,7 +265,7 @@ and we can roll back if the new pre-compiled version was built with a problem.
 
    Installing always the latest version is harder to maintain.
    It will require building the newest version each time a new patch version is released.
-   Beacause of that, Read the Docs will always be behind official releases.
+   Because of that, Read the Docs will always be behind official releases.
    Besides, it will give projects different versions more often.
 
    Exposing to the user the patch version would require to cache many different versions ourselves,
@@ -287,7 +287,7 @@ How do we remove an old Python version?
 At some point, an old version of Python will be deprecated (eg. 3.4) and will be removed.
 To achieve this, we can just remove the pre-compiled Python version from the cache.
 
-However, unless it's strictly neeed for some specific reason, we shouldn't require to remove support for a Python version
+However, unless it's strictly need for some specific reason, we shouldn't require to remove support for a Python version
 as long as we support the Ubuntu OS version where this version was compiled for.
 
 In any case, we will know which projects are using these versions because they are pinning these specific versions in the config file.
@@ -424,10 +424,10 @@ that doesn't seem to be useful to have the same OS version with different states
 Allowing users to install extra languages by using the Config File will cover most of the support requests we have had in the past.
 It also will allow us to know more about how our users are using the platform to make future decisions based on this data.
 Exposing users how we want them to use our platform will allow us to be able to maintain it longer,
-than giving the option to select a specific Docker image by name that we can't guarrantee it will be frozen.
+than giving the option to select a specific Docker image by name that we can't guarantee it will be frozen.
 
 Finally, having the ability to deprecate and *remove* pre-built images from our builders over time,
-will reduce the maintainance work required from the the core team.
+will reduce the maintenance work required from the the core team.
 We can always support all the languages versions by installing them at build time.
 The only required pre-built image for this are the OS ``-base`` images.
 In fact, even after decided to deprecate and removed a pre-built image from the builders,

--- a/docs/user/faq.rst
+++ b/docs/user/faq.rst
@@ -347,7 +347,7 @@ According to `its own documentation <https://jupyterbook.org/>`_,
 
 Even though `Jupyter Book leverages Sphinx "for almost everything that it
 does" <https://jupyterbook.org/explain/sphinx.html#jupyter-book-is-a-distribution-of-sphinx>`_,
-it purposedly hides Sphinx ``conf.py`` files from the user,
+it purposely hides Sphinx ``conf.py`` files from the user,
 and instead generates them on the fly from its declarative ``_config.yml``.
 As a result, you need to follow some extra steps
 to make Jupyter Book work on Read the Docs.

--- a/readthedocs/builds/querysets.py
+++ b/readthedocs/builds/querysets.py
@@ -233,7 +233,7 @@ class BuildQuerySet(models.QuerySet):
         log.info(
             'Concurrent builds.',
             project_slug=project.slug,
-            concurent=concurrent,
+            concurrent=concurrent,
             max_concurrent=max_concurrent,
         )
         if concurrent >= max_concurrent:

--- a/readthedocs/conftest.py
+++ b/readthedocs/conftest.py
@@ -23,5 +23,5 @@ def clear_cache():
     """
     # Code run before each test
     yield
-    # Code run afer each test
+    # Code run after each test
     cache.clear()

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -483,7 +483,7 @@ class BuildEnvironment(BaseEnvironment):
     :param version: Project version that is being built
     :param build: Build instance
     :param environment: shell environment variables
-    :param record: whether or not record a build commands in the databse via
+    :param record: whether or not record a build commands in the database via
     the API. The only case where we want this to be `False` is when
     instantiating this class from `sync_repository_task` because it's a
     background task that does not expose commands to the user.

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -164,7 +164,7 @@ class PythonEnvironment:
                     '-U',
                     'virtualenv',
                     # We cap setuptools to avoid breakage of projects
-                    # relying on setup.py invokations,
+                    # relying on setup.py invocations,
                     # see https://github.com/readthedocs/readthedocs.org/issues/8659
                     'setuptools<58.3.0',
                 ]

--- a/readthedocs/oauth/tasks.py
+++ b/readthedocs/oauth/tasks.py
@@ -64,7 +64,7 @@ def sync_remote_repositories_organizations(organization_slugs=None):
 
     It will trigger one `sync_remote_repositories` task per user.
 
-    :param organization_slugs: list containg organization's slugs to sync. If
+    :param organization_slugs: list containing organization's slugs to sync. If
     not passed, all organizations with ALLAUTH SSO enabled will be synced
 
     :type organization_slugs: list

--- a/readthedocs/organizations/views/private.py
+++ b/readthedocs/organizations/views/private.py
@@ -48,7 +48,7 @@ class CreateOrganizationSignup(PrivateViewMixin, OrganizationView, CreateView):
 
         .. note::
 
-            This method is overriden here from
+            This method is overridden here from
             ``OrganizationView.get_success_url`` because that method
             redirects to Organization's Edit page.
         """

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -84,11 +84,11 @@ log = structlog.get_logger(__name__)
 class TaskData:
 
     """
-    Object to store all data related to a Celery task excecution.
+    Object to store all data related to a Celery task execution.
 
-    We use this object from inside the task to store data while we are runnig
+    We use this object from inside the task to store data while we are running
     the task. This is to avoid using `self.` inside the task due to its
-    limitations: it's instanciated once and that instance is re-used for all
+    limitations: it's instantiated once and that instance is re-used for all
     the tasks ran. This could produce sharing instance state between two
     different and unrelated tasks.
 
@@ -422,7 +422,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
             )
 
         # NOTE: why we wouldn't have `self.data.build_commit` here?
-        # This attribute is set when we get it after clonning the repository
+        # This attribute is set when we get it after cloning the repository
         #
         # Oh, I think this is to differentiate a task triggered with
         # `Build.commit` than a one triggered just with the `Version` to build

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -278,7 +278,7 @@ class TestBuildTask(BuildEnvironmentBase):
 
         # TODO: assert the verb and the path for each API call as well
 
-        # Update build state: clonning
+        # Update build state: cloning
         assert self.requests_mock.request_history[3].json() == {
             'id': 1,
             'state': 'cloning',

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -176,7 +176,7 @@ class TestFullDocServing(BaseDocServing):
         """
         Test external version serving with projects with `--` in their slug.
 
-        Some old projects may have been created with a slug containg `--`,
+        Some old projects may have been created with a slug containing `--`,
         our current code doesn't allow these type of slugs.
         """
         fixture.get(

--- a/readthedocs/search/tests/data/docs/support.json
+++ b/readthedocs/search/tests/data/docs/support.json
@@ -5,7 +5,7 @@
         {
             "id": "usage-questions",
             "title": "Usage Questions",
-            "content": "For help, Stack Overflow is the palce. Tag questions with read-the-docs so other folks can find them easily.. Good questions for Stack Overflow would be:. “What is the best way to structure the table of contents across a project?”. “How do I structure translations inside of my project for easiest contribution from users?”. “How do I use Sphinx to use SVG images in HTML output but PNG in PDF output?”"
+            "content": "For help, Stack Overflow is the place. Tag questions with read-the-docs so other folks can find them easily.. Good questions for Stack Overflow would be:. “What is the best way to structure the table of contents across a project?”. “How do I structure translations inside of my project for easiest contribution from users?”. “How do I use Sphinx to use SVG images in HTML output but PNG in PDF output?”"
         },
         {
             "id": "community-support",

--- a/readthedocs/search/tests/data/pipeline/signals.json
+++ b/readthedocs/search/tests/data/pipeline/signals.json
@@ -34,6 +34,6 @@
     ],
     "domain_data": {
         "celery.worker.control.Panel": "Global registry of remote control commands",
-        "celery.platforms.Pidfile.remove_if_stale": "Remove the lock if the process isn’t running. I.e. process does not respons to signal"
+        "celery.platforms.Pidfile.remove_if_stale": "Remove the lock if the process isn’t running. I.e. process does not respond to signal"
     }
 }

--- a/readthedocs/subscriptions/models.py
+++ b/readthedocs/subscriptions/models.py
@@ -160,7 +160,7 @@ class Subscription(models.Model):
     .. note::
 
         ``status``, ``trial_end_date`` and maybe other fields are updated by
-        Stripe by hitting a webhook in our service hanlded by
+        Stripe by hitting a webhook in our service handled by
         ``StripeEventView``.
     """
 

--- a/scripts/compile_version_upload_s3.sh
+++ b/scripts/compile_version_upload_s3.sh
@@ -6,7 +6,7 @@
 # This script automates the process to build and upload a Python/Node/Rust/Go
 # version and upload it to S3 making it available for the builders. When a
 # pre-compiled version is available in the cache, builds are faster because they
-# don't have to donwload and compile the requested version.
+# don't have to download and compile the requested version.
 #
 #
 # LOCAL DEVELOPMENT ENVIRONMENT

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,17 +6,14 @@ description = Read the Docs builds and hosts documentation
 author = Read the Docs, Inc
 author_email = dev@readthedocs.com
 url = http://readthedocs.org
-classifiers = 
+classifiers =
 	Development Status :: 5 - Production/Stable
 	Environment :: Web Environment
 	Intended Audience :: Developers
 	License :: OSI Approved :: MIT License
 	Operating System :: OS Independent
 	Programming Language :: Python
-	Programming Language :: Python :: 2.7
-	Programming Language :: Python :: 3.4
-	Programming Language :: Python :: 3.5
-	Programming Language :: Python :: 3.6
+	Programming Language :: Python :: 3.8
 	Framework :: Django
 
 [options]
@@ -28,3 +25,6 @@ zip_safe = False
 github_owner = readthedocs
 github_repo = readthedocs.org
 
+[codespell]
+ignore-words-list = ba,configurtion,ded,hel,perfom,wile
+skip = *.css,*.fjson,*.js,*.po,*.svg

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,12 @@ commands =
         export DJANGO_SETTINGS_MODULE=readthedocs.settings.proxito.test; \
         pytest --cov-report= --cov-config {toxinidir}/.coveragerc --cov=. --cov-append -m proxito --suppress-no-test-exit-code {posargs}'
 
+[testenv:codespell]
+description = discover typos with codespell
+deps = codespell
+commands =
+    codespell --config={toxinidir}/setup.cfg
+
 [testenv:docs]
 description = Build readthedocs user documentation
 changedir = {toxinidir}/docs
@@ -74,7 +80,7 @@ commands =
     ./manage.py makemigrations --check --dry-run
 
 [testenv:docs-lint]
-description = run linter (rstcheck) to ensure there aren't errors on our docs
+description = "run linter (rstcheck) to ensure there aren't errors on our docs"
 deps = -r{toxinidir}/requirements/docs.txt
 changedir = {toxinidir}/docs
 commands =


### PR DESCRIPTION
Add [codespell](https://pypi.org/project/codespell) to our `tox` testing to ensure that we do not have regressions on the typo fixes in #8409, #8419, #8420, and #8421.