### PR TITLE
Fix undefined names

### DIFF
--- a/readthedocs/search/tests/test_views.py
+++ b/readthedocs/search/tests/test_views.py
@@ -411,7 +411,7 @@ class TestPageSearch:
         assert len(version_facets) == 4
 
         project_versions = [v.slug for v in versions] + [LATEST]
-        assert sorted(project_versions) == sorted(resulted_version_facets)
+        assert sorted(project_versions) == sorted(version_facets_str)
 
     def test_file_search_subprojects(self, client, all_projects, es_index):
         """

--- a/readthedocs/settings/proxito/base.py
+++ b/readthedocs/settings/proxito/base.py
@@ -5,6 +5,9 @@ Some of these settings will eventually be backported into the main settings file
 but currently we have them to be able to run the site with the old middleware for
 a staged rollout of the proxito code.
 """
+import logging
+
+log = logging.getLogger(__name__)
 
 
 class CommunityProxitoSettingsMixin:

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ commands =
     ./manage.py makemigrations --check --dry-run
 
 [testenv:docs-lint]
-description = "run linter (rstcheck) to ensure there aren't errors on our docs"
+description = run linter (rstcheck) to ensure there aren't errors on our docs
 deps = -r{toxinidir}/requirements/docs.txt
 changedir = {toxinidir}/docs
 commands =
@@ -65,7 +65,6 @@ commands =
     --profile-path={toxinidir} \
     --profile=prospector \
     --die-on-tool-error {posargs}
-    flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 
 [testenv:eslint]
 whitelist_externals = npm

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ commands =
     ./manage.py makemigrations --check --dry-run
 
 [testenv:docs-lint]
-description = run linter (rstcheck) to ensure there aren't errors on our docs
+description = "run linter (rstcheck) to ensure there aren't errors on our docs"
 deps = -r{toxinidir}/requirements/docs.txt
 changedir = {toxinidir}/docs
 commands =
@@ -65,6 +65,7 @@ commands =
     --profile-path={toxinidir} \
     --profile=prospector \
     --die-on-tool-error {posargs}
+    flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 
 [testenv:eslint]
 whitelist_externals = npm


### PR DESCRIPTION
Fixes: https://github.com/readthedocs/readthedocs.org/commit/72e2ae55554e8a58c731c9ec6a82d334a0fc3b5a

[`flake8`](https://pypi.org/project/flake8) detected _undefined names_ in Python code.

The readthedocs/search/tests/test_views.py test is marked `xfail` which is why we have not seen this issue.

https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.