### PR TITLE
Use TravisCI for updating translation in Transifex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+dist: bionic
+language: python
+cache: pip
+python: '3.6'
+branches:
+  only:
+  - master
+install:
+  - pip3 install -r requirements/docs.txt -r requirements/pip.txt transifex-client
+script:
+  - cd docs
+  - sphinx-build -b gettext . _build/locale
+  - echo $'[https://www.transifex.com]\napi_hostname = https://api.transifex.com\nhostname = https://www.transifex.com\npassword = '"$TRANSIFEX_API_TOKEN"$'\nusername = api\n' > ~/.transifexrc
+  - rm .tx/config
+  - sphinx-intl create-txconfig
+  - sphinx-intl update-txconfig-resources --transifex-project-name=readthedocs-docs --locale-dir locale --pot-dir _build/locale
+after_success:
+  - tx push -s


### PR DESCRIPTION
This is to implement #4463 - auto-update of translations in Transifex via TravisCI.

**Note on TRANSIFEX_API_TOKEN:** transifex-client is set to use an API token. A maintainer of readthedocs-docs organization in Transifex needs to [generate a API token] (https://www.transifex.com/user/settings/api/) and [set it as variable in Repository Settings in Travis](https://docs.travis-ci.com/user/environment-variables/#defining-variables-in-repository-settings).

**Note on .tx/config:** The Transifex configuration file `docs/.tx/config` had to be recreated, since source files that no longer exist are note removed from the config file simply by running `sphinx-intl update-txconfig-resources`. So, `tx push -s` would complain on missing source files. This initial solution doesn't commit the changed `docs/.tx/config`. This could be implemented somehow.