### PR TITLE
Proxito: do not log response header for each custom domain request

### DIFF
--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -188,7 +188,6 @@ class ProxitoMiddleware(MiddlewareMixin):
             # TODO: In Django 3.2 this has been upgraded to a top-level method
             # pylint: disable=protected-access
             response_headers = [header.lower() for header in response._headers.keys()]
-            log.info('Response headers=%s', response_headers)
             for http_header in request.domain.http_headers.all():
                 if http_header.name.lower() in response_headers:
                     log.error(


### PR DESCRIPTION
This is not super useful. I'm removing the log.info for now. It should be enough
by logging the extra headers added per-domain.