### PR TITLE
Add MyST (Markdown) examples to "cross referencing with Sphinx" guide

### DIFF
--- a/docs/guides/cross-referencing-with-sphinx.rst
+++ b/docs/guides/cross-referencing-with-sphinx.rst
@@ -66,7 +66,7 @@ that will be rendered as `My target`_.
 
 You can also add explicit targets before paragraphs (or any other part of a page).
 
-Another example, here we add a target to a paragraph:
+Another example, add a target to a paragraph:
 
 .. code-block:: rst
 
@@ -111,8 +111,8 @@ that will be rendered as: `Explicit targets`_.
 Cross-referencing using roles
 -----------------------------
 
-All targets that we have seen so far can be referenced only from the same page.
-Sphinx provides some roles that allows us to reference any explicit target from any page.
+All targets seen so far can be referenced only from the same page.
+Sphinx provides some roles that allow you to reference any explicit target from any page.
 
 .. note::
 
@@ -120,7 +120,7 @@ Sphinx provides some roles that allows us to reference any explicit target from 
    all targets must be unique.
 
 You can see the complete list of cross-referencing roles at :ref:`sphinx:xref-syntax`.
-Next, we will explore the most common ones.
+Next, you will explore the most common ones.
 
 The ref role
 ~~~~~~~~~~~~
@@ -165,7 +165,7 @@ The ``doc`` role allows us to link to a page instead of just a section.
 The target name can be relative to the page where the role exists, or relative
 to your documentation's root folder (in both cases, you should omit the extension).
 
-For example, to link to a page in the same directory as this one we can use:
+For example, to link to a page in the same directory as this one you can use:
 
 .. code-block:: rst
 
@@ -182,7 +182,7 @@ That will be rendered as:
 .. tip::
 
    Using paths relative to your documentation root is recommended,
-   so we avoid changing the target name if the page is moved.
+   so you avoid changing the target name if the page is moved.
 
 The numref role
 ~~~~~~~~~~~~~~~
@@ -199,7 +199,7 @@ To activate numbered references, add this to your ``conf.py`` file:
 
 Next, ensure that an object you would like to reference has an explicit target.
 
-For example, we can create a target for the next image:
+For example, you can create a target for the next image:
 
 .. _target to image:
 
@@ -249,7 +249,7 @@ To activate the ``autosectionlabel`` extension, add this to your ``conf.py`` fil
 Sphinx will create explicit targets for all your sections,
 the name of target has the form ``{path/to/page}:{title-of-section}``.
 
-For example, we can reference the previous section using:
+For example, you can reference the previous section using:
 
 .. code-block:: rst
 
@@ -264,7 +264,7 @@ That will be rendered as:
 Invalid targets
 ---------------
 
-If we reference an invalid or undefined target Sphinx will warn us.
+If you reference an invalid or undefined target Sphinx will warn you.
 You can use the :option:`-W <sphinx:sphinx-build.-W>` option when building your docs
 to fail the build if there are any invalid references.
 On Read the Docs you can use the :ref:`config-file/v2:sphinx.fail_on_warning` option.

--- a/docs/guides/cross-referencing-with-sphinx.rst
+++ b/docs/guides/cross-referencing-with-sphinx.rst
@@ -94,19 +94,15 @@ that will be rendered as: `in-line targets`_.
 Implicit targets
 ~~~~~~~~~~~~~~~~
 
-You may also reference sections by name without explicitly giving them one by
-using *implicit targets*.
+You may also reference some objects by name
+without explicitly giving them one
+by using *implicit targets*.
 
-When we create a section,
-reStructuredText will create a target with the title as the name.
-For example, to reference the previous section we can use ```Explicit targets`_``,
-that will be rendered as: `Explicit targets`_.
+When you create a section, a footnote, or a citation,
+Sphinx will create a target with the title as the name:
 
 .. note::
 
-   `Footnotes <https://docutils.sourceforge.io/docs/user/rst/quickref.html#footnotes>`_ and
-   `citations <https://docutils.sourceforge.io/docs/user/rst/quickref.html#citations>`_
-   also create implicit targets.
 
 Cross-referencing using roles
 -----------------------------

--- a/docs/guides/cross-referencing-with-sphinx.rst
+++ b/docs/guides/cross-referencing-with-sphinx.rst
@@ -54,41 +54,71 @@ you to *reference* it from other pages. These are called **explicit targets**.
 
 For example, one way of creating an explicit target for a section is:
 
-.. code-block:: rst
+.. tabs::
 
-   .. _My target:
+   .. tab:: reStructuredText
 
-   Explicit targets
-   ~~~~~~~~~~~~~~~~
+      .. code-block:: rst
 
-Then we can reference the section using ```My target`_``,
-that will be rendered as `My target`_.
+         .. _My target:
+
+         Explicit targets
+         ~~~~~~~~~~~~~~~~
+
+         Reference `My target`_.
+
+   .. tab:: MyST (Markdown)
+
+      .. code-block:: md
+
+         (My_target)=
+         ## Explicit targets
+
+         Reference [](My_target).
+
+Then the reference will be rendered as `My target`_.
 
 You can also add explicit targets before paragraphs (or any other part of a page).
 
 Another example, add a target to a paragraph:
 
-.. code-block:: rst
+.. tabs::
 
-   .. _target to paragraph:
+   .. tab:: reStructuredText
 
-   An easy way is just to use the final link of the page/section.
-   This works, but it has some disadvantages:
+      .. code-block:: rst
 
-Then we can reference it using ```target to paragraph`_``,
-that will be rendered as: `target to paragraph`_.
+         .. _target to paragraph:
 
-We can also create _`in-line targets` within an element on your page,
+         An easy way is just to use the final link of the page/section.
+         This works, but it has :ref:`some disadvantages <target to paragraph>`:
+
+   .. tab:: MyST (Markdown)
+
+      .. code-block:: md
+
+         (target_to_paragraph)=
+
+         An easy way is just to use the final link of the page/section.
+         This works, but it has [some disadvantages](target_to_paragraph):
+
+Then the reference will be rendered as: `target to paragraph`_.
+
+You can also create _`in-line targets` within an element on your page,
 allowing you to, for example, reference text *within* a paragraph.
 
 For example, an in-line target inside a paragraph:
 
-.. code-block:: rst
+.. tabs::
 
-   We can also create _`in-line targets` within an element on your page,
-   allowing you to, for example, reference text *within* a paragraph.
+   .. tab:: reStructuredText
 
-Then we can reference it using ```in-line targets`_``,
+      .. code-block:: rst
+
+         You can also create _`in-line targets` within an element on your page,
+         allowing you to, for example, reference text *within* a paragraph.
+
+Then you can reference it using ```in-line targets`_``,
 that will be rendered as: `in-line targets`_.
 
 Implicit targets
@@ -101,8 +131,28 @@ by using *implicit targets*.
 When you create a section, a footnote, or a citation,
 Sphinx will create a target with the title as the name:
 
-.. note::
+.. tabs::
 
+   .. tab:: reStructuredText
+
+      .. code-block:: rst
+
+         For example, to reference the previous section
+         you can use `Explicit targets`_.
+
+   .. tab:: MyST (Markdown)
+
+      .. code-block:: md
+
+         For example, to reference the previous section
+         you can use [](#explicit-targets).
+
+      .. note::
+
+         This requires setting ``myst_heading_anchors = 2`` in your ``conf.py``,
+         see :ref:`myst-parser:syntax/header-anchors`.
+
+The reference will be rendered as: `Explicit targets`_.
 
 Cross-referencing using roles
 -----------------------------
@@ -123,11 +173,22 @@ The ref role
 
 The ``ref`` role can be used to reference any explicit targets. For example:
 
-.. code-block:: rst
+.. tabs::
 
-   - :ref:`my target`.
-   - :ref:`Target to paragraph <target to paragraph>`.
-   - :ref:`Target inside a paragraph <in-line targets>`.
+   .. tab:: reStructuredText
+
+      .. code-block:: rst
+
+         - :ref:`my target`.
+         - :ref:`Target to paragraph <target to paragraph>`.
+         - :ref:`Target inside a paragraph <in-line targets>`.
+
+   .. tab:: MyST (Markdown)
+
+      .. code-block:: md
+
+         - {ref}`my target`.
+         - {ref}`Target to paragraph <target_to_paragraph>`.
 
 That will be rendered as:
 
@@ -163,11 +224,23 @@ to your documentation's root folder (in both cases, you should omit the extensio
 
 For example, to link to a page in the same directory as this one you can use:
 
-.. code-block:: rst
+.. tabs::
 
-   - :doc:`intersphinx`
-   - :doc:`/guides/intersphinx`
-   - :doc:`Custom title </guides/intersphinx>`
+   .. tab:: reStructuredText
+
+      .. code-block:: rst
+
+         - :doc:`intersphinx`
+         - :doc:`/guides/intersphinx`
+         - :doc:`Custom title </guides/intersphinx>`
+
+   .. tab:: MyST (Markdown)
+
+      .. code-block:: md
+
+         - {doc}`intersphinx`
+         - {doc}`/guides/intersphinx`
+         - {doc}`Custom title </guides/intersphinx>`
 
 That will be rendered as:
 
@@ -206,16 +279,32 @@ For example, you can create a target for the next image:
 
    Link me!
 
-.. code-block:: rst
+.. tabs::
 
-   .. _target to image:
+   .. tab:: reStructuredText
 
-   .. figure:: /img/logo.png
-      :alt: Logo
-      :align: center
-      :width: 240px
+      .. code-block:: rst
 
-      Link me!
+         .. _target to image:
+
+         .. figure:: /img/logo.png
+            :alt: Logo
+            :align: center
+            :width: 240px
+
+            Link me!
+
+   .. tab:: MyST (Markdown)
+
+      .. code-block:: md
+
+         (target_to_image)=
+
+         ```{figure} /img/logo.png
+         :alt: Logo
+         :align: center
+         :width: 240px
+         ```
 
 Finally, reference it using ``:numref:`target to image```,
 that will be rendered as ``Fig. N``.
@@ -247,10 +336,21 @@ the name of target has the form ``{path/to/page}:{title-of-section}``.
 
 For example, you can reference the previous section using:
 
-.. code-block:: rst
+.. tabs::
 
-   - :ref:`guides/cross-referencing-with-sphinx:explicit targets`.
-   - :ref:`Custom title <guides/cross-referencing-with-sphinx:explicit targets>`.
+   .. tab:: reStructuredText
+
+      .. code-block:: rst
+
+         - :ref:`guides/cross-referencing-with-sphinx:explicit targets`.
+         - :ref:`Custom title <guides/cross-referencing-with-sphinx:explicit targets>`.
+
+   .. tab:: MyST (Markdown)
+
+      .. code-block:: md
+
+         - {ref}`guides/cross-referencing-with-sphinx:explicit targets`.
+         - {ref}`Custom title <guides/cross-referencing-with-sphinx:explicit targets>`.
 
 That will be rendered as:
 
@@ -260,7 +360,7 @@ That will be rendered as:
 Invalid targets
 ---------------
 
-If you reference an invalid or undefined target Sphinx will warn you.
+If you reference an invalid or undefined target Sphinx will warn us.
 You can use the :option:`-W <sphinx:sphinx-build.-W>` option when building your docs
 to fail the build if there are any invalid references.
 On Read the Docs you can use the :ref:`config-file/v2:sphinx.fail_on_warning` option.

--- a/docs/guides/cross-referencing-with-sphinx.rst
+++ b/docs/guides/cross-referencing-with-sphinx.rst
@@ -14,16 +14,22 @@ This works, but it has some disadvantages:
 - There is no easy way to link to specific sections like paragraphs, figures, or code blocks.
 - URL links only work for the html version of your documentation.
 
-reStructuredText has a built-in way to linking to elements,
-and Sphinx extends this to make it even more powerful!
-Some advantages of using reStructuredText's references:
+Instead, Sphinx offers a powerful way to linking to the different elements of the document,
+called *cross-references*.
+Some advantages of using them:
 
 - Use a human-readable name of your choice, instead of a URL.
 - Portable between formats: html, PDF, ePub.
 - Sphinx will warn you of invalid references.
 - You can cross reference more than just pages and section headers.
 
-This page describes some best-practices for cross-referencing with Sphinx.
+This page describes some best-practices for cross-referencing with Sphinx
+with two markup options: reStructuredText and MyST (Markdown).
+
+- If you are not familiar with reStructuredText,
+  check :doc:`sphinx:usage/restructuredtext/basics` for a quick introduction.
+- If you want to learn more about the MyST Markdown dialect,
+  check out :doc:`myst-parser:syntax/syntax`.
 
 .. contents:: Table of contents
    :local:
@@ -37,11 +43,6 @@ Getting started
 
 Explicit targets
 ~~~~~~~~~~~~~~~~
-
-.. note::
-
-   If you are not familiar with reStructuredText,
-   check :doc:`sphinx:usage/restructuredtext/basics` for a quick introduction.
 
 Cross referencing in Sphinx uses two components, **references** and **targets**.
 


### PR DESCRIPTION
This adds MyST (Markdown) examples to "cross-referencing with Sphinx" guide by using https://pypi.org/project/sphinx-tabs/, similarly to how we did in #8283. Basically all our reST samples are in our Sphinx guides - I started with one of them in this pull request to make reviews easier, but I can add a couple more guides. 

While I was at it, I also reworded some parts to use second person and to clarify the role of reStructuredText vs Sphinx and put it on the same ground as MyST.

Got into a couple of rabbit holes while doing it, for example https://github.com/executablebooks/mdit-py-plugins/issues/28. Also, "in-line" references are not supported at the moment, we didn't open an issue for it.