### PR TITLE
Rework Team page

### DIFF
--- a/docs/team.rst
+++ b/docs/team.rst
@@ -15,7 +15,8 @@ We mainly fund our operations through :doc:`advertising </advertising/index>`
 and corporate-hosted documentation with `Read the Docs for Business <https://readthedocs.com/>`_,
 and we are supported by a number of generous :doc:`sponsors </sponsors>`.
 
-The :ref:`Core Team <core-team>` works full time on the service.
+The :ref:`Core Team <core-team>` works full time on the service,
+and we are also honored to have several :ref:`External Contributors <external-contributors>`.
 
 .. _core-team:
 
@@ -90,3 +91,17 @@ Advocacy, Support            Frontend
          :width: 100px
          :alt: Ana Costa
          :target: `Ana Costa`_
+
+.. _external-contributors:
+
+External Contributors
+---------------------
+
+`The code that powers the Read the Docs platform <https://github.com/readthedocs/readthedocs.org/>`_,
+as well as many other related projects in `our GitHub organization <https://github.com/readthedocs>`_,
+are :doc:`open source </open-source-philosophy>`, and therefore
+:doc:`anybody can contribute </contribute>`.
+
+Our platform code has `over a hundred
+contributors <https://github.com/readthedocs/readthedocs.org/graphs/contributors>`_,
+which makes us extremely proud and thankful.

--- a/docs/team.rst
+++ b/docs/team.rst
@@ -111,5 +111,8 @@ over the years:
 * `Aaron Carlisle`_ for `our Sphinx theme <https://github.com/readthedocs/sphinx_rtd_theme>`_.
 * `Ashley Whetter`_ for `our autoapi Sphinx extension <https://github.com/readthedocs/sphinx-autoapi>`_.
 
+We know that we're missing a large number of people who have contributed in major ways to our various projects.
+Please let us know if you feel that you should be on this list, and aren't!
+
 .. _Aaron Carlisle: https://github.com/blendify
 .. _Ashley Whetter: https://github.com/AWhetter

--- a/docs/team.rst
+++ b/docs/team.rst
@@ -11,7 +11,7 @@ Today we:
 Read the Docs is provided as a free service to the open source community,
 and we hope to maintain a reliable and stable hosting platform for years to come.
 
-There are five major parts of this work:
+The teams that we have currently created are:
 
 .. contents::
    :local:

--- a/docs/team.rst
+++ b/docs/team.rst
@@ -11,27 +11,15 @@ Today we:
 Read the Docs is provided as a free service to the open source community,
 and we hope to maintain a reliable and stable hosting platform for years to come.
 
+Staff
+-----
+
+The members of the Staff work full time on the service,
+and we are also honored to have several :ref:`external contributors <major-contributors>`.
+
 We mainly fund our operations through :doc:`advertising </advertising/index>`
 and corporate-hosted documentation with `Read the Docs for Business <https://readthedocs.com/>`_,
 and we are supported by a number of generous :doc:`sponsors </sponsors>`.
-
-The :ref:`Core Team <core-team>` works full time on the service,
-and we are also honored to have several :ref:`External Contributors <external-contributors>`.
-
-.. _core-team:
-
-Core Team
----------
-
-* The **Backend Team** folks develop the Django code that powers the backend of the project.
-* The members of the **Frontend Team** care about UX, CSS, HTML, and JavaScript,
-  and they maintain the project UI as well as the Sphinx theme.
-* As part of operating the site, members of the **Operations Team** maintain a 24/7 on-call rotation.
-  This means that folks have to be available and have their phone in service.
-* The members of the **Advocacy Team** spread the word about all the work we do,
-  and seek to understand the users priorities and feedback.
-* The **Support Team** helps our thousands of users using the service,
-  addressing tasks like resetting passwords, enable experimental features, or troubleshooting build errors.
 
 .. rst-class:: team-roster
 
@@ -48,6 +36,19 @@ Backend, Operations, Support Backend, Operations, Support
 
 Advocacy, Support            Frontend
 ============================ ============================
+
+Teams
+~~~~~
+
+* The **Backend Team** folks develop the Django code that powers the backend of the project.
+* The members of the **Frontend Team** care about UX, CSS, HTML, and JavaScript,
+  and they maintain the project UI as well as the Sphinx theme.
+* As part of operating the site, members of the **Operations Team** maintain a 24/7 on-call rotation.
+  This means that folks have to be available and have their phone in service.
+* The members of the **Advocacy Team** spread the word about all the work we do,
+  and seek to understand the users priorities and feedback.
+* The **Support Team** helps our thousands of users using the service,
+  addressing tasks like resetting passwords, enable experimental features, or troubleshooting build errors.
 
 .. note::
 
@@ -92,10 +93,10 @@ Advocacy, Support            Frontend
          :alt: Ana Costa
          :target: `Ana Costa`_
 
-.. _external-contributors:
+.. _major-contributors:
 
-External Contributors
----------------------
+Major Contributors
+------------------
 
 `The code that powers the Read the Docs platform <https://github.com/readthedocs/readthedocs.org/>`_,
 as well as many other related projects in `our GitHub organization <https://github.com/readthedocs>`_,

--- a/docs/team.rst
+++ b/docs/team.rst
@@ -2,21 +2,98 @@ Read the Docs Team
 ==================
 
 readthedocs.org is the largest open source documentation hosting service.
-It's provided as a free service to the open source community,
-and is worked on by a community of volunteers that we're hoping to expand!
-We currently serve over 20,000,000 pageviews a month,
+Today we:
+
+* Serve over **55 million pages** of documentation a month
+* Serve over **40 TB** of documentation a month
+* Host over **80,000 open source projects** and support over **100,000 users**
+
+Read the Docs is provided as a free service to the open source community,
 and we hope to maintain a reliable and stable hosting platform for years to come.
 
-There are three major parts of this work:
+There are five major parts of this work:
 
 .. contents::
    :local:
    :depth: 1
 
-.. note:: You may notice that a number of names appear on multiple teams.
-          This is because we are lacking contributors.
-          So please be bold and contact us,
-          and we'll get you sorted into the right team.
+Backend Team
+------------
+
+The Backend Team folks develop the Django code that powers the backend of the project.
+
+Backend team members
+~~~~~~~~~~~~~~~~~~~~
+
+* `Eric Holscher`_
+* `Anthony Johnson`_
+* `Manuel Kaufmann`_
+* `Santos Gallegos`_
+
+.. rst-class:: team-roster
+
+====== ========= ======== ========
+|eric| |anthony| |manuel| |santos|
+====== ========= ======== ========
+
+Frontend Team
+-------------
+
+The members of the Frontend Team care about UX, CSS, HTML, and JavaScript,
+and they maintain the project UI as well as the Sphinx theme.
+
+Frontend team members
+~~~~~~~~~~~~~~~~~~~~~
+
+* `Eric Holscher`_
+* `Anthony Johnson`_
+* `Ana Costa`_
+
+.. rst-class:: team-roster
+
+====== ========= =====
+|eric| |anthony| |ana|
+====== ========= =====
+
+Operations Team
+---------------
+
+readthedocs.org is a service that millions of people depend on each month.
+As part of operating the site, members of the Ops Team maintain a 24/7 on-call rotation.
+This means that folks have to be available and have their phone in service.
+
+Ops team members
+~~~~~~~~~~~~~~~~
+
+* `Eric Holscher`_ (Pacific Time)
+* `Anthony Johnson`_ (Mountain Time)
+* `Santos Gallegos`_ (Ecuador Time)
+* `Manuel Kaufmann`_ (Central European Time)
+
+.. rst-class:: team-roster
+
+====== ========= ======== ========
+|eric| |anthony| |manuel| |santos|
+====== ========= ======== ========
+
+Advocacy Team
+-------------
+
+The members of the Advocacy Team spread the word about all the work we do,
+and seek to understand the users priorities and feedback.
+
+Advocacy team members
+~~~~~~~~~~~~~~~~~~~~~
+
+* `Eric Holscher`_
+* `Anthony Johnson`_
+* `Juan Luis Cano`_
+
+.. rst-class:: team-roster
+
+====== ========= ========
+|eric| |anthony| |juanlu|
+====== ========= ========
 
 Support Team
 ------------
@@ -34,102 +111,46 @@ Support team members
 
 * `Eric Holscher`_ (Pacific Time)
 * `Anthony Johnson`_ (Mountain Time)
-* `Manuel Kaufmann`_ (Central Time)
-* Your Name Here
+* `Santos Gallegos`_ (Ecuador Time)
+* `Manuel Kaufmann`_ (Central European Time)
+* `Juan Luis Cano`_ (Central European Time)
 
-**Please don't email us personally for support on Read the Docs.** You can email support@readthedocs.org for any issues you may have. 
-
-Joining the support team
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-The best place to start would be to start addressing some of the issues in our issue tracker.
-We have our support policies quite well documented in our :doc:`/contribute`.
-**Be bold**.
-Start trying to reproduce issues that people have,
-or talk to them to get more information.
-After you get the hang of things,
-we'll happily give you the ability to tag and close issues by joining our Support Team.
-
-
-Operations Team
----------------
-
-readthedocs.org is a service that millions of people depend on each month.
-As part of operating the site,
-we maintain a 24/7 on-call rotation.
-This means that folks have to be available and have their phone in service.
-
-Ops team members
-~~~~~~~~~~~~~~~~
-
-* `Eric Holscher`_ (Pacific Time)
-* `Anthony Johnson`_ (Mountain Time)
-* `Matt Robenolt`_ (Pacific Time)
-* Your Name Here
-
-Feel free to ask any of us if you have questions or want to join!
-
-Joining the ops team
-~~~~~~~~~~~~~~~~~~~~
-
-We are always looking for more people to share the on-call responsibility.
-If you are on-call for your job already,
-we'd love to piggy back on that duty as well.
-
-You can email us at dev@readthedocs.org if you want to join our operations team.
-Because of the sensitive nature (API tokens, secret keys, SSL certs, etc.) of the work,
-we keep a private GitHub repository with the operations code & documentation.
-
-The tools that we use are:
-
-* Salt
-* Nagios
-* Graphite/Grafana
-* Nginx
-* Postgres
-* Django
-* Celery
-
-It's fine if you aren't familiar with all of these things,
-but are willing to help with part of it!
-
-**Please reach out if you want to share the on-call responsibility**.
-It really is an important job,
-and we'd love to have it be more geographically distributed.
-
-Development Team
-----------------
-
-Also known as the "Core Team" in other projects.
-These folks have the ability to commit code to the project.
-
-Dev team members
-~~~~~~~~~~~~~~~~
-
-* `Eric Holscher`_
-* `Anthony Johnson`_
-* `Manuel Kaufmann`_
-* `David Fischer`_
-* `Santos Gallegos`_
-* Your name here
-
-Feel free to ask any of us if you have questions or want to join!
-
-Joining the dev team
-~~~~~~~~~~~~~~~~~~~~
-
-We try to be pretty flexible with who we allow on the development team.
-The best path is to send a few pull requests,
-and follow up to make sure they get merged successfully.
-You can check out our :doc:`contribute` to get more information,
-and find issues that need to be addressed.
-After that,
-feel free to ask for a commit bit.
-
+**Please don't email us personally for support on Read the Docs.**
+You can `use our support form <https://readthedocs.org/support/>`_ for any issues you may have.
 
 .. _Eric Holscher: https://github.com/ericholscher
 .. _Anthony Johnson: https://github.com/agjohnson
 .. _Manuel Kaufmann: https://github.com/humitos
-.. _David Fischer: https://github.com/davidfischer
 .. _Santos Gallegos: https://github.com/stsewd
-.. _Matt Robenolt: https://github.com/mattrobenolt
+.. _Juan Luis Cano: https://github.com/astrojuanlu
+.. _Ana Costa: https://github.com/nienn
+
+.. |eric| image:: https://avatars.githubusercontent.com/u/25510?v=4
+          :width: 100px
+          :alt: Eric Holscher
+          :target: `Eric Holscher`_
+
+.. |anthony| image:: https://avatars.githubusercontent.com/u/1140183?v=4
+             :width: 100px
+             :alt: Anthony Johnson
+             :target: `Anthony Johnson`_
+
+.. |manuel| image:: https://avatars.githubusercontent.com/u/244656?v=4
+            :width: 100px
+            :alt: Manuel Kaufmann
+            :target: `Manuel Kaufmann`_
+
+.. |santos| image:: https://avatars.githubusercontent.com/u/4975310?v=4
+            :width: 100px
+            :alt: Santos Gallegos
+            :target: `Santos Gallegos`_
+
+.. |juanlu| image:: https://avatars.githubusercontent.com/u/316517?v=4
+            :width: 100px
+            :alt: Juan Luis Cano
+            :target: `Juan Luis Cano`_
+
+.. |ana| image:: https://avatars.githubusercontent.com/u/4049894?v=4
+         :width: 100px
+         :alt: Ana Costa
+         :target: `Ana Costa`_

--- a/docs/team.rst
+++ b/docs/team.rst
@@ -11,112 +11,48 @@ Today we:
 Read the Docs is provided as a free service to the open source community,
 and we hope to maintain a reliable and stable hosting platform for years to come.
 
-The teams that we have currently created are:
+We mainly fund our operations through :doc:`advertising </advertising/index>`
+and corporate-hosted documentation with `Read the Docs for Business <https://readthedocs.com/>`_,
+and we are supported by a number of generous :doc:`sponsors </sponsors>`.
 
-.. contents::
-   :local:
-   :depth: 1
+The :ref:`Core Team <core-team>` works full time on the service.
 
-Backend Team
-------------
+.. _core-team:
 
-The Backend Team folks develop the Django code that powers the backend of the project.
+Core Team
+---------
 
-Backend team members
-~~~~~~~~~~~~~~~~~~~~
-
-* `Eric Holscher`_
-* `Anthony Johnson`_
-* `Manuel Kaufmann`_
-* `Santos Gallegos`_
-
-.. rst-class:: team-roster
-
-====== ========= ======== ========
-|eric| |anthony| |manuel| |santos|
-====== ========= ======== ========
-
-Frontend Team
--------------
-
-The members of the Frontend Team care about UX, CSS, HTML, and JavaScript,
-and they maintain the project UI as well as the Sphinx theme.
-
-Frontend team members
-~~~~~~~~~~~~~~~~~~~~~
-
-* `Eric Holscher`_
-* `Anthony Johnson`_
-* `Ana Costa`_
+* The **Backend Team** folks develop the Django code that powers the backend of the project.
+* The members of the **Frontend Team** care about UX, CSS, HTML, and JavaScript,
+  and they maintain the project UI as well as the Sphinx theme.
+* As part of operating the site, members of the **Operations Team** maintain a 24/7 on-call rotation.
+  This means that folks have to be available and have their phone in service.
+* The members of the **Advocacy Team** spread the word about all the work we do,
+  and seek to understand the users priorities and feedback.
+* The **Support Team** helps our thousands of users using the service,
+  addressing tasks like resetting passwords, enable experimental features, or troubleshooting build errors.
 
 .. rst-class:: team-roster
 
-====== ========= =====
-|eric| |anthony| |ana|
-====== ========= =====
+============================ ============================
+|eric| Eric Holscher         |anthony| Anthony Johnson
+============================ ============================
+*All teams*                  *All teams*
 
-Operations Team
----------------
+|manuel| Manuel Kaufmann     |santos| Santos Gallegos
 
-readthedocs.org is a service that millions of people depend on each month.
-As part of operating the site, members of the Ops Team maintain a 24/7 on-call rotation.
-This means that folks have to be available and have their phone in service.
+Backend, Operations, Support Backend, Operations, Support
 
-Ops team members
-~~~~~~~~~~~~~~~~
+|juanlu| Juan Luis Cano      |ana| Ana Costa
 
-* `Eric Holscher`_ (Pacific Time)
-* `Anthony Johnson`_ (Mountain Time)
-* `Santos Gallegos`_ (Ecuador Time)
-* `Manuel Kaufmann`_ (Central European Time)
+Advocacy, Support            Frontend
+============================ ============================
 
-.. rst-class:: team-roster
+.. note::
 
-====== ========= ======== ========
-|eric| |anthony| |manuel| |santos|
-====== ========= ======== ========
-
-Advocacy Team
--------------
-
-The members of the Advocacy Team spread the word about all the work we do,
-and seek to understand the users priorities and feedback.
-
-Advocacy team members
-~~~~~~~~~~~~~~~~~~~~~
-
-* `Eric Holscher`_
-* `Anthony Johnson`_
-* `Juan Luis Cano`_
-
-.. rst-class:: team-roster
-
-====== ========= ========
-|eric| |anthony| |juanlu|
-====== ========= ========
-
-Support Team
-------------
-
-Read the Docs has thousands of users who depend on it everyday.
-Every day at least one of them has an issue that needs to be addressed by a site admin.
-This might include tasks like:
-
-* Resetting a password
-* Asking for a project name to be released
-* Troubleshooting build errors
-
-Support team members
-~~~~~~~~~~~~~~~~~~~~
-
-* `Eric Holscher`_ (Pacific Time)
-* `Anthony Johnson`_ (Mountain Time)
-* `Santos Gallegos`_ (Ecuador Time)
-* `Manuel Kaufmann`_ (Central European Time)
-* `Juan Luis Cano`_ (Central European Time)
-
-**Please don't email us personally for support on Read the Docs.**
-You can `use our support form <https://readthedocs.org/support/>`_ for any issues you may have.
+   **Please don't email us personally for support on Read the Docs.**
+   You can `use our support form <https://readthedocs.org/support/>`_
+   for any issues you may have.
 
 .. _Eric Holscher: https://github.com/ericholscher
 .. _Anthony Johnson: https://github.com/agjohnson

--- a/docs/team.rst
+++ b/docs/team.rst
@@ -105,3 +105,11 @@ are :doc:`open source </open-source-philosophy>`, and therefore
 Our platform code has `over a hundred
 contributors <https://github.com/readthedocs/readthedocs.org/graphs/contributors>`_,
 which makes us extremely proud and thankful.
+In addition, several contributors have performed ongoing maintenance on several subprojects
+over the years:
+
+* `Aaron Carlisle`_ for `our Sphinx theme <https://github.com/readthedocs/sphinx_rtd_theme>`_.
+* `Ashley Whetter`_ for `our autoapi Sphinx extension <https://github.com/readthedocs/sphinx-autoapi>`_.
+
+.. _Aaron Carlisle: https://github.com/blendify
+.. _Ashley Whetter: https://github.com/AWhetter


### PR DESCRIPTION
Finally, I updated the Team page to better reflect the reality 🎉 

- Alignment with newly-created GitHub teams (Backend, Frontend, Avocacy, Ops)
- Update company figures
- Remove text inviting people to join to focus more on the core teams
- Add avatars

Happy to read comments about my implementation of the avatars. I have no idea why, the HTML table has uneven column widths. I added a custom class in case @readthedocs/frontend can lend a hand shrinking the columns to the content.

On the other hand, I hardcoded the avatar URLs rather than requesting them using a REST API, because I don't think they will change much and also this doesn't require any JavaScript or complex Sphinx logic.

And finally, I wanted the substitution to be a `figure` so I could include the name below, but I couldn't make it work. `.. figure` needs a blank line before the caption text, which does not get on well with the substitution syntax.

![Screenshot 2021-08-24 at 17-01-00 Read the Docs Team — Read the Docs 5 23 2 documentation](https://user-images.githubusercontent.com/316517/130640608-d7098d16-45f8-42d6-a037-d310b802d334.png)
