### PR TITLE
API v3 (subprojects): filter by correct owner/organization

### DIFF
--- a/docs/api/v3.rst
+++ b/docs/api/v3.rst
@@ -909,6 +909,12 @@ Subproject create
             "alias": "subproject-alias"
         }
 
+    .. note::
+
+      ``child`` must be a project that you have access to.
+      Or if you are using :doc:`/commercial/index`,
+      additionally the project must be under the same organization as the parent project.
+
     **Example response**:
 
     `See Subproject details <#subproject-details>`_

--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -619,14 +619,8 @@ class SubprojectCreateSerializer(FlexFieldsModelSerializer):
         ]
 
     def __init__(self, *args, **kwargs):
-        # Initialize the instance with the parent Project to be used in the
-        # serializer validation. When this Serializer is rendered as a Form in
-        # BrowsableAPIRenderer, it's not initialized with the ``parent``, so we
-        # default to ``None`` because we don't need it at that point.
-        self.parent_project = kwargs.pop('parent', None)
-
         super().__init__(*args, **kwargs)
-
+        self.parent_project = self.context['parent']
         user = self.context['request'].user
         self.fields['child'].queryset = (
             self.parent_project.get_subproject_candidates(user)

--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -633,7 +633,7 @@ class SubprojectCreateSerializer(FlexFieldsModelSerializer):
         )
         # Give users a better error message.
         self.fields['child'].error_messages['does_not_exist'] = _(
-            'Project with {slug_name}={value} is not a valid subproject'
+            'Project with {slug_name}={value} is not valid as subproject'
         )
 
     def validate_alias(self, value):

--- a/readthedocs/api/v3/tests/test_subprojects.py
+++ b/readthedocs/api/v3/tests/test_subprojects.py
@@ -1,8 +1,6 @@
-from .mixins import APIEndpointMixin
 from django.urls import reverse
-import django_dynamic_fixture as fixture
 
-from readthedocs.projects.models import Project
+from .mixins import APIEndpointMixin
 
 
 class SubprojectsEndpointTests(APIEndpointMixin):
@@ -107,8 +105,8 @@ class SubprojectsEndpointTests(APIEndpointMixin):
         )
         self.assertEqual(response.status_code, 400)
         self.assertIn(
-            'Project can not be subproject of itself',
-            response.json()['child'],
+            'Project with slug=new-project is not a valid subproject',
+            response.json()['child'][0],
         )
         self.assertEqual(newproject.subprojects.count(), 0)
 
@@ -132,8 +130,8 @@ class SubprojectsEndpointTests(APIEndpointMixin):
         )
         self.assertEqual(response.status_code, 400)
         self.assertIn(
-            'Child is already a superproject',
-            response.json()['child'],
+            'Project with slug=project is not a valid subproject',
+            response.json()['child'][0],
         )
         self.assertEqual(newproject.subprojects.count(), 0)
 
@@ -157,8 +155,8 @@ class SubprojectsEndpointTests(APIEndpointMixin):
         )
         self.assertEqual(response.status_code, 400)
         self.assertIn(
-            'Child is already a subproject of another project',
-            response.json()['child'],
+            'Project with slug=subproject is not a valid subproject',
+            response.json()['child'][0],
         )
         self.assertEqual(newproject.subprojects.count(), 0)
 

--- a/readthedocs/api/v3/tests/test_subprojects.py
+++ b/readthedocs/api/v3/tests/test_subprojects.py
@@ -105,7 +105,7 @@ class SubprojectsEndpointTests(APIEndpointMixin):
         )
         self.assertEqual(response.status_code, 400)
         self.assertIn(
-            'Project with slug=new-project is not a valid subproject',
+            'Project with slug=new-project is not valid as subproject',
             response.json()['child'][0],
         )
         self.assertEqual(newproject.subprojects.count(), 0)
@@ -130,7 +130,7 @@ class SubprojectsEndpointTests(APIEndpointMixin):
         )
         self.assertEqual(response.status_code, 400)
         self.assertIn(
-            'Project with slug=project is not a valid subproject',
+            'Project with slug=project is not valid as subproject',
             response.json()['child'][0],
         )
         self.assertEqual(newproject.subprojects.count(), 0)
@@ -155,7 +155,7 @@ class SubprojectsEndpointTests(APIEndpointMixin):
         )
         self.assertEqual(response.status_code, 400)
         self.assertIn(
-            'Project with slug=subproject is not a valid subproject',
+            'Project with slug=subproject is not valid as subproject',
             response.json()['child'][0],
         )
         self.assertEqual(newproject.subprojects.count(), 0)

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -232,10 +232,15 @@ class SubprojectRelationshipViewSet(APIv3Settings, NestedViewSetMixin,
 
         return SubprojectSerializer
 
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context['parent'] = self._get_parent_project()
+        return context
+
     def create(self, request, *args, **kwargs):
         """Define a Project as subproject of another Project."""
         parent = self._get_parent_project()
-        serializer = self.get_serializer(parent=parent, data=request.data)
+        serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.save(parent=parent)
         headers = self.get_success_headers(serializer.data)

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -353,7 +353,7 @@ class UpdateProjectForm(
         return language
 
 
-class ProjectRelationshipBaseForm(forms.ModelForm):
+class ProjectRelationshipForm(forms.ModelForm):
 
     """Form to add/update project relationships."""
 
@@ -372,27 +372,13 @@ class ProjectRelationshipBaseForm(forms.ModelForm):
         if hasattr(self, 'instance') and self.instance.pk is not None:
             self.fields['child'].queryset = Project.objects.filter(pk=self.instance.child.pk)
         else:
-            self.fields['child'].queryset = self.get_subproject_queryset()
+            self.fields['child'].queryset = self.project.get_subproject_candidates(self.user)
 
     def clean_parent(self):
         self.project.is_valid_as_superproject(
             forms.ValidationError
         )
         return self.project
-
-    def clean_child(self):
-        """
-        Validate child is a valid subproject.
-
-        Validation is done on creation only,
-        when editing users can't change the child.
-        """
-        child = self.cleaned_data['child']
-        if self.instance.pk is None:
-            child.is_valid_as_subproject(
-                self.project, forms.ValidationError
-            )
-        return child
 
     def clean_alias(self):
         alias = self.cleaned_data['alias']
@@ -407,25 +393,6 @@ class ProjectRelationshipBaseForm(forms.ModelForm):
                 _('A subproject with this alias already exists'),
             )
         return alias
-
-    def get_subproject_queryset(self):
-        """
-        Return scrubbed subproject choice queryset.
-
-        This removes projects that are either already a subproject of another
-        project, or are a superproject, as neither case is supported.
-        """
-        queryset = (
-            Project.objects.for_admin_user(self.user)
-            .exclude(subprojects__isnull=False)
-            .exclude(superprojects__isnull=False)
-            .exclude(pk=self.project.pk)
-        )
-        return queryset
-
-
-class ProjectRelationshipForm(SettingsOverrideObject):
-    _default_class = ProjectRelationshipBaseForm
 
 
 class UserForm(forms.Form):

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1282,31 +1282,6 @@ class Project(models.Model):
                 _('Subproject nesting is not supported'),
             )
 
-    def is_valid_as_subproject(self, parent, error_class):
-        """
-        Checks if the project can be a subproject.
-
-        This is used to handle form and serializer validations
-        if check fails returns ValidationError using to the error_class passed
-        """
-        # Check the child project is not a subproject already
-        if self.superprojects.exists():
-            raise error_class(
-                _('Child is already a subproject of another project'),
-            )
-
-        # Check the child project is already a superproject
-        if self.subprojects.exists():
-            raise error_class(
-                _('Child is already a superproject'),
-            )
-
-        # Check the parent and child are not the same project
-        if parent.slug == self.slug:
-            raise error_class(
-                _('Project can not be subproject of itself'),
-            )
-
     def get_subproject_candidates(self, user):
         """
         Get a queryset of projects that would be valid as a subproject for this project.
@@ -1320,6 +1295,8 @@ class Project(models.Model):
         If the project belongs to an organization,
         we only allow projects under the same organization as subprojects,
         otherwise only projects that don't belong to an organization.
+
+        Both projects need to share the same owner/admin.
         """
         organization = self.organizations.first()
         queryset = (

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1307,6 +1307,30 @@ class Project(models.Model):
                 _('Project can not be subproject of itself'),
             )
 
+    def get_subproject_candidates(self, user):
+        """
+        Get a queryset of projects that would be valid as a subproject for this project.
+
+        This excludes:
+
+        - The project itself
+        - Projects that are already a subproject of another project
+        - Projects that are a superproject.
+
+        If the project belongs to an organization,
+        we only allow projects under the same organization as subprojects,
+        otherwise only projects that don't belong to an organization.
+        """
+        organization = self.organizations.first()
+        queryset = (
+            Project.objects.for_admin_user(user)
+            .filter(organizations=organization)
+            .exclude(subprojects__isnull=False)
+            .exclude(superprojects__isnull=False)
+            .exclude(pk=self.pk)
+        )
+        return queryset
+
 
 class APIProject(Project):
 

--- a/readthedocs/rtd_tests/tests/test_subprojects.py
+++ b/readthedocs/rtd_tests/tests/test_subprojects.py
@@ -1,13 +1,9 @@
-from unittest import mock
-
 import django_dynamic_fixture as fixture
 from django.contrib.auth.models import User
 from django.test import TestCase
-from django.test.utils import override_settings
 
 from readthedocs.projects.forms import ProjectRelationshipForm
 from readthedocs.projects.models import Project, ProjectRelationship
-from readthedocs.rtd_tests.utils import create_user
 
 
 class SubprojectFormTests(TestCase):
@@ -73,7 +69,7 @@ class SubprojectFormTests(TestCase):
             r'Select a valid choice.',
         )
         self.assertEqual(
-            [proj_id for (proj_id, __) in form.fields['child'].choices],
+            [proj_id for (proj_id, _) in form.fields['child'].choices],
             [''],
         )
 
@@ -124,7 +120,7 @@ class SubprojectFormTests(TestCase):
         # The subsubproject is valid here, as far as the child check is
         # concerned, but the parent check should fail.
         self.assertEqual(
-            [proj_id for (proj_id, __) in form.fields['child'].choices],
+            [proj_id for (proj_id, _) in form.fields['child'].choices],
             ['', subsubproject.pk],
         )
         form.full_clean()
@@ -153,7 +149,7 @@ class SubprojectFormTests(TestCase):
             user=user,
         )
         self.assertEqual(
-            [proj_id for (proj_id, __) in form.fields['child'].choices],
+            [proj_id for (proj_id, _) in form.fields['child'].choices],
             [''],
         )
 
@@ -218,6 +214,10 @@ class SubprojectFormTests(TestCase):
             user=user,
         )
         self.assertFalse(form.is_valid())
+        self.assertIn(
+            'Select a valid choice',
+            form.errors['child'][0],
+        )
         self.assertNotIn(
             project.id,
             [proj_id for (proj_id, __) in form.fields['child'].choices],


### PR DESCRIPTION
One downside is that the error message isn't specific like before, but I have changed it to be a little more friendly than the default one. The form doesn't list invalid subprojects as options, so I have removed the clean_child from there, as the form already validates that the child should be in the queryset. This doesn't require overrides in .com anymore. There are tests for organizations in .com...

Closes https://github.com/readthedocs/readthedocs.org/issues/8395