### PR TITLE
Search: show only results from the current role_name being filtered

### DIFF
--- a/readthedocs/search/faceted_search.py
+++ b/readthedocs/search/faceted_search.py
@@ -357,12 +357,25 @@ class PageSearch(RTDFacetedSearch):
             query=query,
             fields=fields,
         )
+        bool_query = Bool(should=queries)
 
         raw_fields = [
             # Remove boosting from the field
             re.sub(r'\^.*$', '', field)
             for field in fields
         ]
+
+        # The ``post_filter`` filter will only filter documents
+        # at the parent level (domains is a nested document),
+        # resulting in results with domains that don't match the current
+        # role_name being filtered, so we need to force filtering by role_name
+        # on the ``domains`` document here. See #8268.
+        # TODO: We should use a flattened document instead
+        # to avoid this kind of problems and have faster queries.
+        role_name = self.filter_values.get('role_name')
+        if path == 'domains' and role_name:
+            role_name_query = Bool(must=Terms(**{'domains.role_name': role_name}))
+            bool_query = Bool(must=[role_name_query, bool_query])
 
         highlight = dict(
             self._highlight_options,
@@ -375,7 +388,7 @@ class PageSearch(RTDFacetedSearch):
         return Nested(
             path=path,
             inner_hits={'highlight': highlight},
-            query=Bool(should=queries),
+            query=bool_query,
         )
 
     def _get_script_score(self):

--- a/readthedocs/search/tests/test_views.py
+++ b/readthedocs/search/tests/test_views.py
@@ -251,19 +251,17 @@ class TestPageSearch:
             search_params=search_params
         )
         new_role_names_facets = new_facets['role_name']
-        # there is only one result with role_name='py:class'
-        # in `signals` page
+        # All results from domains  should have role_name='py:class'.
         assert len(new_results) == 1
-        first_result = new_results[0]  # first result
-        blocks = first_result['blocks']  # blocks of first results
-        assert len(blocks) >= 1
-        inner_hit_0 = blocks[0]  # first inner_hit
-        assert inner_hit_0['type'] == 'domain'
-        assert inner_hit_0['role'] == confval_facet
+        first_result = new_results[0]
+        blocks = first_result['blocks']
+        for block in blocks:
+            assert block['type'] == 'domain'
+            assert block['role'] == confval_facet
 
         for facet in new_role_names_facets:
             if facet[0] == confval_facet:
-                assert facet[2] == True  # because 'std:confval' filter is active
+                assert facet[2] == True  # because 'py:class' filter is active
             else:
                 assert facet[2] == False
 


### PR DESCRIPTION
TLDR; show only domains that match the selected role_name.

### before

there are `http:get` roles mixed with `http:post`  (mixed with results from top docs)

![Screenshot 2021-08-31 at 18-42-38 Search project Read the Docs](https://user-images.githubusercontent.com/4975310/131589560-28666b20-8c25-401d-8fd6-5500fc38160e.png)

### now

there are only domains with `http:post` in the results (mixed with results from top docs)

![Screenshot 2021-08-31 at 18-11-32 Search project Read the Docs](https://user-images.githubusercontent.com/4975310/131589307-5b50c546-7254-4050-87e6-b993a75034b8.png)

Long version, see the comment in the code and https://github.com/readthedocs/readthedocs.org/issues/8268#issuecomment-909630027.

Closes https://github.com/readthedocs/readthedocs.org/issues/8268