### PR TITLE
Add templatetag to filter by admin projects

### DIFF
--- a/readthedocs/core/templatetags/privacy_tags.py
+++ b/readthedocs/core/templatetags/privacy_tags.py
@@ -1,14 +1,11 @@
-# -*- coding: utf-8 -*-
-
 """Template tags to query projects by privacy."""
 
 from django import template
-from django.db.models import Exists, OuterRef, Subquery, Prefetch
+from django.db.models import Exists, OuterRef
 
 from readthedocs.builds.models import Build
 from readthedocs.core.permissions import AdminPermission
 from readthedocs.projects.models import Project
-
 
 register = template.Library()
 
@@ -21,6 +18,15 @@ def is_admin(user, project):
 @register.filter
 def is_member(user, project):
     return AdminPermission.is_member(user, project)
+
+
+@register.filter
+def projects_admin(user, privacy_level=None):
+    """List all projects where user is admin."""
+    query = Project.objects.for_admin_user(user)
+    if privacy_level:
+        query = query.filter(privacy_level=privacy_level)
+    return query
 
 
 @register.simple_tag(takes_context=True)


### PR DESCRIPTION
This templatetag will be used in the email we are going
to send to owners of private projects.

```markdown
## Which projects will be affected?

The following projects will be affected by this change:

{% load privacy_tags %}{% for project in user|projects_admin:'private' %}- [{{ project.slug }}]({{ domain }}{% url 'projects_detail' project.slug %})
{% endfor %}
```

Could also just be added in util01 before sending the email, but could be useful in the future.