### PR TITLE
Permissions: avoid using project.users, use proper permissions instead

### DIFF
--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -376,7 +376,7 @@ def send_build_status(build_pk, commit, status, link_to_build=False):
     if provider_name in [GITHUB_BRAND, GITLAB_BRAND]:
         # get the service class for the project e.g: GitHubService.
         service_class = build.project.git_service_class()
-        users = build.project.users.all()
+        users = AdminPermission.admins(build.project)
 
         if build.project.remote_repository:
             remote_repository = build.project.remote_repository

--- a/readthedocs/notifications/views.py
+++ b/readthedocs/notifications/views.py
@@ -78,7 +78,7 @@ class SendNotificationView(FormView):
 
         For example, this could be made to return project owners with::
 
-            for owner in project.users.all():
+            for owner in AdminPermission.members(project):
                 yield owner
 
         :param obj: object from queryset, type is dependent on model class

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -6,7 +6,6 @@ import re
 
 from allauth.socialaccount.models import SocialToken
 from allauth.socialaccount.providers.github.views import GitHubOAuth2Adapter
-
 from django.conf import settings
 from django.urls import reverse
 from requests.exceptions import RequestException
@@ -17,13 +16,11 @@ from readthedocs.builds.constants import (
     BUILD_STATUS_SUCCESS,
     SELECT_BUILD_STATUS,
 )
+from readthedocs.core.permissions import AdminPermission
 from readthedocs.integrations.models import Integration
 
 from ..constants import GITHUB
-from ..models import (
-    RemoteOrganization,
-    RemoteRepository,
-)
+from ..models import RemoteOrganization, RemoteRepository
 from .base import Service, SyncServiceError
 
 log = logging.getLogger(__name__)
@@ -547,7 +544,7 @@ class GitHubService(Service):
             if settings.DONT_HIT_DB and not force_local:
                 token = api.project(project.pk).token().get()['token']
             else:
-                for user in project.users.all():
+                for user in AdminPermission.admins(project):
                     tokens = SocialToken.objects.filter(
                         account__user=user,
                         app__provider=cls.adapter.provider_id,

--- a/readthedocs/projects/notifications.py
+++ b/readthedocs/projects/notifications.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from django.http import HttpRequest
 from django.utils.translation import ugettext_lazy as _
 from messages_extends.constants import ERROR_PERSISTENT
+from readthedocs.core.permissions import AdminPermission
 
 from readthedocs.notifications import Notification, SiteNotification
 from readthedocs.notifications.constants import REQUIREMENT
@@ -50,8 +51,8 @@ class DeprecatedViewNotification(Notification):
         :type projects: [:py:class:`Project`]
         """
         for project in projects:
-            # Send one notification to each owner of the project
-            for user in project.users.all():
+            # Send one notification to each admin of the project
+            for user in AdminPermission.admins(project):
                 notification = cls(
                     context_object=project,
                     request=HttpRequest(),

--- a/readthedocs/projects/templatetags/projects_tags.py
+++ b/readthedocs/projects/templatetags/projects_tags.py
@@ -2,8 +2,8 @@
 
 from django import template
 
+from readthedocs.core.permissions import AdminPermission
 from readthedocs.projects.version_handling import comparable_version
-
 
 register = template.Library()
 
@@ -23,5 +23,5 @@ def sort_version_aware(versions):
 
 @register.filter
 def is_project_user(user, project):
-    """Return if user is a member of project.users."""
-    return user in project.users.all()
+    """Checks if the user has access to the project."""
+    return user in AdminPermission.members(project)


### PR DESCRIPTION
One step further to fully depreate the signals in .com
that add owners to a project.