### PR TITLE
Add custom team img styling

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,0 +1,5 @@
+.team-roster a img {
+  border-radius: 50%;
+  box-shadow: 0 0 0 7px #fff, 0 0 0 8px #cecece;
+  margin: 9px 17px 9px 3px;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,6 +93,7 @@ gettext_compact = False
 
 html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']
+html_css_files = ['css/custom.css']
 html_js_files = ['js/expand_tabs.js']
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_logo = 'img/logo.svg'


### PR DESCRIPTION
Adds a custom `.css` file with styling for the team images created with PR #8441.

**Without custom style:**
![before](https://user-images.githubusercontent.com/4049894/132244657-f5c7aec9-dd0a-439c-9f18-479246f4dfdd.png)

**With custom style:**
![after](https://user-images.githubusercontent.com/4049894/132244430-0ea5f906-9843-4047-8e02-1623c2b71903.png)
