### PR TITLE
Docs: update the links to the dependency management content of setuptools docs

### DIFF
--- a/docs/config-file/v1.rst
+++ b/docs/config-file/v1.rst
@@ -259,5 +259,5 @@ Behind the scene the following Pip command will be run:
 
 
 .. _environment file: https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#creating-an-environment-from-an-environment-yml-file
-.. _extra requirements: https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies
-.. _package default dependencies: https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-dependencies
+.. _extra requirements: https://setuptools.readthedocs.io/en/latest/userguide/dependency_management.html#optional-dependencies
+.. _package default dependencies: https://setuptools.readthedocs.io/en/latest/userguide/dependency_management.html#declaring-required-dependency

--- a/docs/config-file/v2.rst
+++ b/docs/config-file/v2.rst
@@ -224,8 +224,8 @@ The installation method.
 
 `Extra requirements`_ section to install in addition to the `package dependencies`_.
 
-.. _Extra Requirements: https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies
-.. _package dependencies: https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-dependencies
+.. _Extra Requirements: https://setuptools.readthedocs.io/en/latest/userguide/dependency_management.html#optional-dependencies
+.. _package dependencies: https://setuptools.readthedocs.io/en/latest/userguide/dependency_management.html#declaring-required-dependency
 
 .. warning::
 


### PR DESCRIPTION
Hi.

Please note that I didn't modify the names of these hyperlinks because I have no idea what their new names should be. For example, the section name of https://setuptools.readthedocs.io/en/latest/userguide/dependency_management.html#optional-dependencies is "Optional dependencies" and the name of the link should match it, but this phrase is in the section about "extra_requirements", so I think it might confuse users.

What's your opinion?