### PR TITLE
Requirement: update orjson

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -57,8 +57,8 @@ pyquery==1.4.3
 # NOTE: this dep can be removed in python 3.7 in favor of ``date.fromisoformat``
 python-dateutil==2.8.2
 
-# Ignoring orjson for now because it makes Travis to fail
-orjson==2.0.7  # pyup: ignore
+# Version 3.6.3 is not available for Python 3.6
+orjson==3.6.1  # pyup: ignore
 
 # Utils
 django-gravatar2==1.4.4


### PR DESCRIPTION
We had it pinned because it made Travis to fail, but we are on CircleCI now.
Let's see if we can make it work with the latest version of it.

We need to update it because `cargo` is failing to install this package due that
it doesn't find some dependencies.

<details>
<summary>Click for detailed output</summary>

```
Collecting orjson==2.0.7
  Using cached orjson-2.0.7.tar.gz (480 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... error
    ERROR: Command errored out with exit status 1:
     command: /tmp/env/bin/python3 /tmp/env/lib/python3.9/site-packages/pip/_vendor/pep517/_in_process.py prepare_metadata_for_build_wheel /tmp/tmpfqrzpjwz
         cwd: /tmp/pip-install-g2bmyvoy/orjson
    Complete output (43 lines):
    info: syncing channel updates for 'nightly-x86_64-unknown-linux-gnu'
    info: latest update on 2021-09-14, rust version 1.57.0-nightly (9bb77da74 2021-09-13)
    info: downloading component 'cargo'
    info: downloading component 'clippy'
    info: downloading component 'rust-docs'
    info: downloading component 'rust-std'
    info: downloading component 'rustc'
    info: downloading component 'rustfmt'
    info: installing component 'cargo'
    info: installing component 'clippy'
    info: installing component 'rust-docs'
    info: installing component 'rust-std'
    info: installing component 'rustc'
    info: installing component 'rustfmt'
    💥 pyo3-pack failed
      Caused by: Cargo metadata failed: Error during execution of `cargo metadata`:     Updating crates.io index
        Updating git repository `https://github.com/PyO3/pyo3.git`
        Updating git repository `https://github.com/ijl/json.git`
    error: failed to get `serde_json` as a dependency of package `orjson v2.0.7 (/tmp/pip-install-g2bmyvoy/orjson)`
    
    Caused by:
      failed to load source for dependency `serde_json`
    
    Caused by:
      Unable to update https://github.com/ijl/json.git?rev=2c0c55b628c9177543283a1535549e1dcb6a870a
    
    Caused by:
      failed to clone into: /home/humitos/.asdf/installs/rust/1.54.0/git/db/json-240b451de80eb693
    
    Caused by:
      failed to authenticate when downloading repository
    
      * attempted to find username/password via git's `credential.helper` support, but failed
    
      if the git CLI succeeds then `net.git-fetch-with-cli` may help here
      https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
    
    Caused by:
      failed to acquire username/password from local configuration
    
    Checking for Rust toolchain....
    Running `pyo3-pack pep517 write-dist-info --metadata-directory /tmp/pip-modern-metadata-ncn2r3wa --manylinux=off --rustc-extra-args=-C target-feature=+sse2 --strip=on`
    Error: Command '['pyo3-pack', 'pep517', 'write-dist-info', '--metadata-directory', '/tmp/pip-modern-metadata-ncn2r3wa', '--manylinux=off', '--rustc-extra-args=-C target-feature=+sse2', '--strip=on']' returned non-zero exit status 1.
    ----------------------------------------
ERROR: Command errored out with exit status 1: /tmp/env/bin/python3 /tmp/env/lib/python3.9/site-packages/pip/_vendor/pep517/_in_process.py prepare_metadata_for_build_wheel /tmp/tmpfqrzpjwz Check the logs for full command output.
```

</details>