### PR TITLE
WIP add more explicit instructions in install.html

### DIFF
--- a/docs/development/install.rst
+++ b/docs/development/install.rst
@@ -29,17 +29,18 @@ Set up your environment
 
    .. prompt:: bash
 
+      cd readthedocs.org
       pip install -r common/dockerfiles/requirements.txt
 
 #. build the Docker image for the servers:
 
-   .. warning::
-
-      This command could take a while to finish since it will download several Docker images.
-
    .. prompt:: bash
 
       inv docker.build
+
+   .. warning::
+
+      This command could take a while to finish since it will download several Docker images.
 
    .. tip::
 
@@ -84,11 +85,34 @@ Check that everything works
 #. click on the "View docs" button to browse the documentation, and verify that it works
 
 
+.. admonition:: Front End Development
+
+  If you were sent to this page from the *Front End Development Getting Started* section, you can now `go back and follow the instructions there </development/front-end.html#getting-started>`_.
+
+
+
+
 Working with Docker Compose
 ---------------------------
 
-We wrote a wrapper with ``invoke`` around ``docker-compose`` to have some shortcuts and
-save some work while typing docker compose commands. This section explains these ``invoke`` commands:
+After the initial setup you'll need to run a few commands each time.
+
+#. get the containers running:
+
+  .. prompt:: bash
+
+    inv docker.up  # Options: --no-search --no-reload
+
+#. do stuff
+
+
+List of available commands
+""""""""""""""""""""""""""
+
+.. admonition:: Note
+
+  We wrote a wrapper with ``invoke`` around ``docker-compose`` to have some shortcuts and
+  save some work while typing docker compose commands.
 
 ``inv docker.build``
     Builds the generic Docker image used by our servers (web, celery, build and proxito).

--- a/docs/development/install.rst
+++ b/docs/development/install.rst
@@ -90,24 +90,30 @@ Check that everything works
   If you were sent to this page from the *Front End Development Getting Started* section, you can now `go back and follow the instructions there </development/front-end.html#getting-started>`_.
 
 
+Common development workflow
+---------------------------
+
+After the initial setup you'll need to run a few commands each time.
+Here we list the most common workflow but keep in mind that it may differ for specific situations.
+
+#. get the containers running:
+
+   .. prompt:: bash
+
+      inv docker.up  # Options: --no-search --no-reload
+
+   .. warning::
+
+      Windows WSL users sometimes have trouble running celery and need to use the ``--no-reload`` flag to make this work.
+      Check `bellow <install.html#list-of-available-commands>`_ for more info on ``inv docker.up`` options.
+
+#. do stuff?
 
 
 Working with Docker Compose
 ---------------------------
 
-After the initial setup you'll need to run a few commands each time.
-
-#. get the containers running:
-
-  .. prompt:: bash
-
-    inv docker.up  # Options: --no-search --no-reload
-
-#. do stuff
-
-
-List of available commands
-""""""""""""""""""""""""""
+Bellow is the list of all available commands.
 
 .. admonition:: Note
 
@@ -123,7 +129,10 @@ List of available commands
     * ``--no-search`` can be passed to disable search
     * ``--init`` is used the first time this command is ran to run initial migrations, create an admin user, etc
     * ``--no-reload`` makes all celery processes and django runserver
-      to use no reload and do not watch for files changes
+      to use no reload and do not watch for files changes. 
+      
+      When using this option services have to restarted manually. Run ``inv docker.restart {containers}`` or ``inv docker.down`` + ``inv docker.up`` again to do so. 
+
 
 ``inv docker.shell``
     Opens a shell in a container (web by default).


### PR DESCRIPTION
**Changes:**
* Added some small steps.
* Moved other steps that felt a bit confusing.
* Added a pre-section on **Working with Docker Compose** to list the common steps to be repeated each time.
* Added a link back to the Front End Development page — there's a link there instructing to follow the docs here, but I don't think Front End Development needs to follow these instructions to the end, so it would be nice to send people back there when the relevant directions are over.

All of this is new to me — I'm also trying to follow the instructions in these docs — so all input is welcome!

_Built docs: https://docs--8489.org.readthedocs.build/en/8489/development/install.html_