### PR TITLE
Set up bump2version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,5 @@
 import os
 import sys
-from configparser import RawConfigParser
 
 import sphinx_rtd_theme
 
@@ -12,13 +11,6 @@ from django.utils import timezone
 
 import django
 django.setup()
-
-
-def get_version():
-    """Return package version from setup.cfg."""
-    config = RawConfigParser()
-    config.read(os.path.join('..', 'setup.cfg'))
-    return config.get('metadata', 'version')
 
 
 sys.path.append(os.path.abspath('_ext'))
@@ -44,7 +36,7 @@ project = 'Read the Docs'
 copyright = '2010-{}, Read the Docs, Inc & contributors'.format(
     timezone.now().year
 )
-version = get_version()
+version = "5.23.1"
 release = version
 exclude_patterns = ['_build']
 default_role = 'obj'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "readthedocs",
-  "version": "5.17.0",
+  "version": "5.23.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "readthedocs",
-  "version": "5.23.0",
-  "description": "Read the Docs build dependencies",
-  "author": "Anthony Johnson <anthony@readthedocs.com>",
+  "version": "5.23.1",
+  "description": "Read the Docs",
+  "author": "Read the Docs, Inc <dev@readthedocs.com>",
   "scripts": {
     "build": "gulp build",
     "dev": "gulp dev",

--- a/readthedocs/__init__.py
+++ b/readthedocs/__init__.py
@@ -2,4 +2,4 @@
 
 """Read the Docs."""
 
-__version__ = 5.23.1
+__version__ = "5.23.1"

--- a/readthedocs/__init__.py
+++ b/readthedocs/__init__.py
@@ -2,20 +2,4 @@
 
 """Read the Docs."""
 
-import os.path
-
-from configparser import RawConfigParser
-
-
-def get_version(setupcfg_path):
-    """Return package version from setup.cfg."""
-    config = RawConfigParser()
-    config.read(setupcfg_path)
-    return config.get('metadata', 'version')
-
-
-__version__ = get_version(
-    os.path.abspath(
-        os.path.join(os.path.dirname(__file__), '..', 'setup.cfg'),
-    ),
-)
+__version__ = 5.23.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,37 @@
+[bumpversion]
+current_version = 5.23.1
+commit = false
+tag = false
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>[a-z]+)(?P<dev>\d+))?
+serialize = 
+	{major}.{minor}.{patch}{release}{dev}
+	{major}.{minor}.{patch}
+
+# Bump2version alters this file to track the version, and always moves the block
+# above to the top of the file.
+[bumpversion:part:release]
+optional_value = release
+first_value = alpha
+values = 
+	alpha
+	rc
+	release
+
+[bumpversion:part:dev]
+first_value = 1
+
+[bumpversion:file:setup.cfg]
+
+[bumpversion:file:readthedocs/__init__.py]
+
+[bumpversion:file:package.json]
+search = "version": "{current_version}",
+replace = "version": "{new_version}",
+
+[bumpversion:file:package-lock.json]
+search = "version": "{current_version}",
+replace = "version": "{new_version}",
+
 [metadata]
 name = readthedocs
 version = 5.23.1
@@ -27,4 +61,3 @@ zip_safe = False
 [tool:release]
 github_owner = readthedocs
 github_repo = readthedocs.org
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 current_version = 5.23.1
 commit = false
 tag = false
+allow_dirty = true
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>[a-z]+)(?P<dev>\d+))?
 serialize = 
 	{major}.{minor}.{patch}{release}{dev}
@@ -14,7 +15,6 @@ optional_value = release
 first_value = alpha
 values = 
 	alpha
-	rc
 	release
 
 [bumpversion:part:dev]


### PR DESCRIPTION
I mentioned this a while ago in `common`, but bump2version (not bumpversion!)
makes managing version numbers around a lot of files pretty nice. This is copied
from sphinx_rtd_theme.

For example, the version now is 5.24.1. The workflow for versioning would be:

If we only merge bug fixes in for a release, we would run `bump2version patch`.
This would give `5.24.2alpha1`.

If we merged a feature into a release, we would run `bump2version minor`. This
would give `5.25.0alpha1`.

If we merged a backwards incompatible change in, we would run `bump2version major`.
This would give `6.0.0alpha1`.

When we go to release, we would run `bump2version release`, which drops the `alpha`.
We could be bumping the version number up as we merge PRs, or this could be on
our release procedures still too.

Alternatively, we don't even need the alpha designation and can configure this
all as release time procedures instead.