### PR TITLE
Contact users: Allow to pass additional context to each email

### DIFF
--- a/readthedocs/core/templatetags/privacy_tags.py
+++ b/readthedocs/core/templatetags/privacy_tags.py
@@ -20,15 +20,6 @@ def is_member(user, project):
     return AdminPermission.is_member(user, project)
 
 
-@register.filter
-def projects_admin(user, privacy_level=None):
-    """List all projects where user is admin."""
-    query = Project.objects.for_admin_user(user)
-    if privacy_level:
-        query = query.filter(privacy_level=privacy_level)
-    return query
-
-
 @register.simple_tag(takes_context=True)
 def get_public_projects(context, user):
     # 'Exists()' checks if the project has any good builds.

--- a/readthedocs/core/utils/contact.py
+++ b/readthedocs/core/utils/contact.py
@@ -18,6 +18,7 @@ def contact_users(
     email_content=None,
     from_email=None,
     notification_content=None,
+    context_function=None,
     dryrun=True,
 ):
     """
@@ -28,6 +29,8 @@ def contact_users(
     :param string email_content: Email content (markdown)
     :param string from_email: Email to sent from (Test Support <support@test.com>)
     :param string notification_content: Content for the sticky notification (markdown)
+    :param context_function: A callable that will receive an user
+     and return a dict of additional context to be used in the email/notification content
     :param bool dryrun: If `True` don't sent the email or notification, just print the content
 
     The `email_content` and `notification_content` contents will be rendered using
@@ -41,6 +44,7 @@ def contact_users(
     :returns: A dictionary with a list of sent/failed emails/notifications.
     """
     from_email = from_email or settings.DEFAULT_FROM_EMAIL
+    context_function = context_function or (lambda user: {})
     sent_emails = set()
     failed_emails = set()
     sent_notifications = set()
@@ -58,16 +62,22 @@ def contact_users(
     class TempNotification(SiteNotification):
 
         def render(self, *args, **kwargs):
+            context = {
+                'user': self.user,
+                'domain': f'https://{settings.PRODUCTION_DOMAIN}',
+            }
+            context.update(context_function(self.user))
             return markdown.markdown(
-                notification_template.render(
-                    Context({
-                        'user': self.user,
-                        'domain': f'https://{settings.PRODUCTION_DOMAIN}',
-                    })
-                )
+                notification_template.render(Context(context))
             )
 
     for user in users.iterator():
+        context = {
+            'user': user,
+            'domain': f'https://{settings.PRODUCTION_DOMAIN}',
+        }
+        context.update(context_function(user))
+
         if notification_content:
             notification = TempNotification(
                 user=user,
@@ -78,12 +88,7 @@ def contact_users(
                     backend.send(notification)
                 else:
                     pprint(markdown.markdown(
-                        notification_template.render(
-                            Context({
-                                'user': user,
-                                'domain': f'https://{settings.PRODUCTION_DOMAIN}',
-                            })
-                        )
+                        notification_template.render(Context(context))
                     ))
             except Exception:
                 log.exception('Notification failed to send')
@@ -103,10 +108,7 @@ def contact_users(
 
             # First render the markdown context.
             email_txt_content = email_template.render(
-                Context({
-                    'user': user,
-                    'domain': f'https://{settings.PRODUCTION_DOMAIN}',
-                })
+                Context(context)
             )
             email_html_content = markdown.markdown(email_txt_content)
 


### PR DESCRIPTION
Instead of creating custom templatetags for each email,
we can just pass a custom function.