### PR TITLE
Requirement: ping django-redis-cache to git tag

### DIFF
--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -10,7 +10,16 @@ gunicorn==20.1.0
 
 # Version 3.0.0 drops support for Django < 3.0
 # https://github.com/sebleier/django-redis-cache/#300
-django-redis-cache==2.1.3  # pyup: ignore
+# django-redis-cache==2.1.3  # pyup: ignore
+# For some reason 2.1.3 breaks with:
+#
+# @get_client(write=True)
+# def get_or_set(self, client, key, func, timeout=DEFAULT_TIMEOUT):
+#     if not callable(func):
+#         raise Exception("Must pass in a callable")
+#
+# Looks like an older version gets installed somehow
+git+https://github.com/sebleier/django-redis-cache.git@2.1.3#egg=django-redis-cache
 
 #For resizing images
 pillow==8.3.2


### PR DESCRIPTION
For some reason django-redis-cache==2.1.3 breaks with:

```
@get_client(write=True)
def get_or_set(self, client, key, func, timeout=DEFAULT_TIMEOUT):
    if not callable(func):
        raise Exception("Must pass in a callable")
```

Looks like an older version gets installed somehow that does not contains the
code we need. So, we force it to be pinned to a git tag.