### PR TITLE
Docker: use the correct image tag

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -527,7 +527,7 @@ class CommunityBaseSettings(Settings):
     RTD_DOCKER_BUILD_SETTINGS = {
         # Mapping of build.os options to docker image.
         'os': {
-            'ubuntu-20.04': f'{DOCKER_DEFAULT_IMAGE}:ubuntu20',
+            'ubuntu-20.04': f'{DOCKER_DEFAULT_IMAGE}:ubuntu-20.04',
         },
         # Mapping of build.tools options to specific versions.
         'tools': {


### PR DESCRIPTION
We changed this from `ubuntu20` to `ubuntu-20.04` and there was a missing change
here.