### PR TITLE
EmbedAPIv3: proxy URLs to be available under `/_/`

### DIFF
--- a/readthedocs/api/v3/proxied_urls.py
+++ b/readthedocs/api/v3/proxied_urls.py
@@ -1,0 +1,16 @@
+"""
+Proxied API URLs.
+
+Served from the same domain docs are served,
+so they can make use of features that require to have access to their cookies.
+"""
+
+from django.conf.urls import url
+
+from readthedocs.api.v3.proxied_views import ProxiedEmbedAPI
+
+api_proxied_urls = [
+    url(r'embed/', ProxiedEmbedAPI.as_view(), name='embed_api_v3'),
+]
+
+urlpatterns = api_proxied_urls

--- a/readthedocs/api/v3/proxied_views.py
+++ b/readthedocs/api/v3/proxied_views.py
@@ -1,0 +1,14 @@
+from readthedocs.core.utils.extend import SettingsOverrideObject
+from readthedocs.embed.v3.views import EmbedAPIBase
+
+
+class ProxiedEmbedAPIBase(EmbedAPIBase):
+
+    # DRF has BasicAuthentication and SessionAuthentication as default classes.
+    # We don't support neither in the community site.
+    authentication_classes = []
+
+
+class ProxiedEmbedAPI(SettingsOverrideObject):
+
+    _default_class = ProxiedEmbedAPIBase

--- a/readthedocs/proxito/urls.py
+++ b/readthedocs/proxito/urls.py
@@ -97,6 +97,14 @@ proxied_urls = [
         ),
         include('readthedocs.api.v2.proxied_urls'),
     ),
+
+    # /_/api/v3/
+    url(
+        r'^{DOC_PATH_PREFIX}api/v3/'.format(
+            DOC_PATH_PREFIX=DOC_PATH_PREFIX,
+        ),
+        include('readthedocs.api.v3.proxied_urls'),
+    ),
 ]
 
 core_urls = [


### PR DESCRIPTION
Follow the same pattern than with APIv2 to access EmbedAPI under `<docs.domain.org>/_/api/v3/embed/`