### PR TITLE
EmbedAPI: allow CORS for `/api/v3/embed/`

### DIFF
--- a/readthedocs/core/signals.py
+++ b/readthedocs/core/signals.py
@@ -21,6 +21,7 @@ ALLOWED_URLS = [
     '/api/v2/search',
     '/api/v2/docsearch',
     '/api/v2/embed',
+    '/api/v3/embed',
 ]
 
 webhook_github = Signal(providing_args=['project', 'data', 'event'])
@@ -76,6 +77,12 @@ def decide_if_cors(sender, request, **kwargs):  # pylint: disable=unused-argumen
         url = request.GET.get('url')
         if url:
             unresolved = unresolve(url)
+            if unresolved is None:
+                # NOTE: Embed APIv3 now supports external sites. In that case
+                # ``unresolve()`` will return None and we want to allow it
+                # since the target is a public project.
+                return True
+
             project = unresolved.project
             version_slug = unresolved.version_slug
         else:


### PR DESCRIPTION
EmbedAPIv3 supports internal and external sites.

When the site is internal, we can perform the same checks as we were doing: the
version has to be public to allow it.

On the case for external sites, we can always allow it since the site is public.