### PR TITLE
Document new `build` specification

### DIFF
--- a/docs/config-file/v2.rst
+++ b/docs/config-file/v2.rst
@@ -320,17 +320,14 @@ build.tools
 Version specifiers for each tool. It must contain at least one tool.
 
 :Type: ``dict``
-:Keys: ``python``, ``nodejs``, ``rust``, ``golang``
+:Options: ``python``, ``nodejs``, ``rust``, ``golang``
+:Required: ``true``
 
 build.tools.python
 ``````````````````
 
-Python version to use. Supported values are:
-
-* CPython 2.7 and 3.6+
-* PyPy3.7
-* Miniconda3 4.7
-* Mambaforge 4.10
+Python version to use.
+You can use several interpretes and versions, from CPython, PyPy, Miniconda, and Mamba.
 
 .. note::
 
@@ -339,7 +336,17 @@ Python version to use. Supported values are:
    for more information.
 
 :Type: ``string``
-:Options: ``2.7``, ``3``, ``3.6``, ``3.7``, ``3.8``, ``3.9``, ``3.10``, ``pypy3.7``, ``miniconda3-4.7``, ``mambaforge-4.10``
+:Options:
+  - ``2.7``
+  - ``3``
+  - ``3.6``
+  - ``3.7``
+  - ``3.8``
+  - ``3.9``
+  - ``3.10``
+  - ``pypy3.7``
+  - ``miniconda3-4.7``
+  - ``mambaforge-4.10``
 
 build.tools.nodejs
 ``````````````````

--- a/docs/config-file/v2.rst
+++ b/docs/config-file/v2.rst
@@ -21,6 +21,13 @@ Below is an example YAML file which shows the most common configuration options:
          # Required
          version: 2
 
+         # Set the version of Python and other tools you might need
+         build:
+           os: ubuntu-20.04
+           tools:
+             python: "3.9"
+             nodejs: "16"
+
          # Build documentation in the docs/ directory with Sphinx
          sphinx:
             configuration: docs/conf.py
@@ -29,9 +36,8 @@ Below is an example YAML file which shows the most common configuration options:
          formats:
             - pdf
 
-         # Optionally set the version of Python and requirements required to build your docs
+         # Optionally declare the Python requirements required to build your docs
          python:
-            version: "3.7"
             install:
             - requirements: docs/requirements.txt
 
@@ -46,12 +52,17 @@ Below is an example YAML file which shows the most common configuration options:
          # Required
          version: 2
 
+         # Set the version of Python and other tools you might need
+         build:
+           os: ubuntu-20.04
+           tools:
+             python: "3.9"
+
          mkdocs:
            configuration: mkdocs.yml
 
-         # Optionally set the version of Python and requirements required to build your docs
+         # Optionally declare the Python requirements required to build your docs
          python:
-            version: "3.7"
             install:
             - requirements: docs/requirements.txt
 

--- a/docs/config-file/v2.rst
+++ b/docs/config-file/v2.rst
@@ -159,6 +159,16 @@ Configuration of the Python environment to be used.
          path: another/package
      system_packages: true
 
+python.version
+``````````````
+
+.. warning::
+
+   This option is now deprecated
+   and replaced by :ref:`config-file/v2:build.tools.python`.
+   See :ref:`config-file/v2:python.version (legacy)`
+   for the description of this option.
+
 python.install
 ``````````````
 

--- a/docs/config-file/v2.rst
+++ b/docs/config-file/v2.rst
@@ -359,7 +359,7 @@ You can use several interpretes and versions, from CPython, PyPy, Miniconda, and
 :Type: ``string``
 :Options:
   - ``2.7``
-  - ``3``
+  - ``3`` (last stable CPython version)
   - ``3.6``
   - ``3.7``
   - ``3.8``

--- a/docs/config-file/v2.rst
+++ b/docs/config-file/v2.rst
@@ -688,7 +688,6 @@ Schema
 You can see the complete schema
 `here <https://github.com/readthedocs/readthedocs.org/blob/master/readthedocs/rtd_tests/fixtures/spec/v2/schema.json>`_.
 
-.. _new-build:
 
 Legacy ``build`` specification
 ------------------------------
@@ -775,7 +774,7 @@ Changes
 - The ``build.image`` setting has been replaced by ``build.os``.
   See :ref:`config-file/v2:build.os`.
   Alternatively, you can use the legacy ``build.image``
-  that now only has two options: ``latest`` (default) and ``stable``.
+  that now has only two options: ``latest`` (default) and ``stable``.
 - The settings ``python.setup_py_install`` and ``python.pip_install`` were replaced by ``python.install``.
   And now it accepts a path to the package.
   See :ref:`config-file/v2:Packages`.

--- a/docs/config-file/v2.rst
+++ b/docs/config-file/v2.rst
@@ -686,7 +686,7 @@ Schema
 ------
 
 You can see the complete schema
-`here <https://github.com/readthedocs/readthedocs.org/blob/master/readthedocs/rtd_tests/fixtures/spec/v2/schema.yml>`_.
+`here <https://github.com/readthedocs/readthedocs.org/blob/master/readthedocs/rtd_tests/fixtures/spec/v2/schema.json>`_.
 
 .. _new-build:
 

--- a/docs/config-file/v2.rst
+++ b/docs/config-file/v2.rst
@@ -315,6 +315,10 @@ Configuration for the documentation build process.
    python:
      version: "3.7"
 
+.. note::
+
+   Check out the :ref:`new-build` below for an alternative method
+   that is more flexible.
 
 build.image
 ```````````
@@ -635,6 +639,112 @@ Schema
 
 You can see the complete schema
 `here <https://github.com/readthedocs/readthedocs.org/blob/master/readthedocs/rtd_tests/fixtures/spec/v2/schema.yml>`_.
+
+.. _new-build:
+
+New ``build`` specification
+---------------------------
+
+.. warning::
+
+   This functionality is in beta. If you find any inconsistencies
+   or have feedback, please `open an
+   issue <https://github.com/readthedocs/readthedocs.org/issues/>`_.
+
+Read the Docs has introduced a more flexible ``build`` specification
+that allows you to use a more recent base image
+and control the versions of several tools:
+Python, Node.js, Rust, and Go.
+
+To opt in, specify the ``build.os`` setting
+and declare at least one tool version inside the ``build.tools`` key,
+as follows: 
+
+.. code-block:: yaml
+
+   version: 2
+
+   build:
+     os: ubuntu-20.04
+     tools:
+       python: 3.9
+       nodejs: 16
+       rust: 1.55
+       golang: 1.17
+
+The new ``build`` specification also supports
+the ``apt_packages`` key described above.
+
+.. warning::
+
+   The keys ``build.os`` and ``python.version`` cannot be used at the same time.
+   Doing so will error the build.
+
+build (new)
+~~~~~~~~~~~
+
+Configuration for the documentation build process.
+
+build.os
+````````
+
+The Docker image used for building the docs.
+
+:Type: ``string``
+:Options: ``ubuntu-20.04``
+:Default: ``ubuntu-20.04``
+
+build.tools
+```````````
+
+Version specifiers for each tool. It must contain at least one tool.
+All tools are managed with `asdf <https://asdf-vm.com/>`_.
+
+:Type: ``dict``
+:Keys: ``python``, ``nodejs``, ``rust``, ``golang``
+
+build.tools.python
+``````````````````
+
+Python version to use. Supported values are:
+
+* CPython 2.7 and 3.6+
+* PyPy3.7
+* Miniconda3 4.7
+* Mambaforge 4.10
+
+.. note::
+
+   If you use Miniconda3 or Mambaforge, you can select the Python version
+   using the ``environment.yml`` file. See our :doc:`/guides/conda` guide
+   for more information.
+
+:Type: ``string``
+:Options: ``2.7``, ``3``, ``3.6``, ``3.7``, ``3.8``, ``3.9``, ``3.10``, ``pypy3.7``, ``miniconda3-4.7``, ``mambaforge-4.10``
+
+build.tools.nodejs
+``````````````````
+
+Node.js version to use.
+
+:Type: ``string``
+:Options: ``14``, ``16``
+
+build.tools.rust
+````````````````
+
+Rust version to use.
+
+:Type: ``string``
+:Options: ``1.55``
+
+build.tools.golang
+``````````````````
+
+Go version to use.
+
+:Type: ``string``
+:Options: ``1.17``
 
 Migrating from v1
 -----------------

--- a/docs/config-file/v2.rst
+++ b/docs/config-file/v2.rst
@@ -138,7 +138,6 @@ Configuration of the Python environment to be used.
    version: 2
 
    python:
-     version: "3.7"
      install:
        - requirements: docs/requirements.txt
        - method: pip
@@ -148,24 +147,6 @@ Configuration of the Python environment to be used.
        - method: setuptools
          path: another/package
      system_packages: true
-
-python.version
-``````````````
-
-The Python version (this depends on :ref:`config-file/v2:build.image`).
-
-:Type: ``string``
-:Default: ``3``
-
-.. note::
-
-   Make sure to use quotes (``"``) to make it a string.
-   We previously supported using numbers here,
-   but that approach is deprecated.
-.. warning::
-
-   If you are using a :ref:`Conda <config-file/v2:conda>` environment to manage
-   the build, this setting will not have any effect, as the Python version is managed by Conda.
 
 python.install
 ``````````````
@@ -266,11 +247,6 @@ Give the virtual environment access to the global site-packages directory.
 :Type: ``bool``
 :Default: ``false``
 
-Depending on the :ref:`config-file/v2:build.image`,
-Read the Docs includes some libraries like scipy, numpy, etc.
-That you can access to them by enabling this option.
-See :doc:`/builds` for more details.
-
 .. warning::
 
   If you are using a :ref:`Conda <config-file/v2:conda>` environment
@@ -297,43 +273,97 @@ The path to the Conda environment file, relative to the root of the project.
 :Type: ``path``
 :Required: ``true``
 
-build
-~~~~~
+build (beta specification)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. warning::
+
+   This functionality is in beta. If you find any inconsistencies
+   or have feedback, please `open an
+   issue <https://github.com/readthedocs/readthedocs.org/issues/>`_.
 
 Configuration for the documentation build process.
+This allows you to specify the base Read the Docs image
+used to build the documentation,
+and control the versions of several tools:
+Python, Node.js, Rust, and Go.
 
 .. code-block:: yaml
 
    version: 2
 
    build:
-     image: latest
-     apt_packages:
-       - libclang
-       - cmake
+     os: ubuntu-20.04
+     tools:
+       python: "3.9"
+       nodejs: "16"
+       rust: "1.55"
+       golang: "1.17"
 
-   python:
-     version: "3.7"
+build.os
+````````
+
+The Docker image used for building the docs.
+Image names refer to the operating system Read the Docs uses to build them.
 
 .. note::
 
-   Check out the :ref:`new-build` below for an alternative method
-   that is more flexible.
-
-build.image
-```````````
-
-The Docker image used for building the docs.
+   Arbitrary Docker images are not supported.
 
 :Type: ``string``
-:Options: ``stable``, ``latest``
-:Default: ``latest``
+:Options: ``ubuntu-20.04``
+:Default: ``ubuntu-20.04``
 
-Each image support different Python versions and has different packages installed,
-as defined here:
+build.tools
+```````````
 
-* `stable <https://github.com/readthedocs/readthedocs-docker-images/tree/releases/5.x>`_: :buildpyversions:`stable`
-* `latest <https://github.com/readthedocs/readthedocs-docker-images/tree/releases/6.x>`_: :buildpyversions:`latest`
+Version specifiers for each tool. It must contain at least one tool.
+
+:Type: ``dict``
+:Keys: ``python``, ``nodejs``, ``rust``, ``golang``
+
+build.tools.python
+``````````````````
+
+Python version to use. Supported values are:
+
+* CPython 2.7 and 3.6+
+* PyPy3.7
+* Miniconda3 4.7
+* Mambaforge 4.10
+
+.. note::
+
+   If you use Miniconda3 or Mambaforge, you can select the Python version
+   using the ``environment.yml`` file. See our :doc:`/guides/conda` guide
+   for more information.
+
+:Type: ``string``
+:Options: ``2.7``, ``3``, ``3.6``, ``3.7``, ``3.8``, ``3.9``, ``3.10``, ``pypy3.7``, ``miniconda3-4.7``, ``mambaforge-4.10``
+
+build.tools.nodejs
+``````````````````
+
+Node.js version to use.
+
+:Type: ``string``
+:Options: ``14``, ``16``
+
+build.tools.rust
+````````````````
+
+Rust version to use.
+
+:Type: ``string``
+:Options: ``1.55``
+
+build.tools.golang
+``````````````````
+
+Go version to use.
+
+:Type: ``string``
+:Options: ``1.17``
 
 build.apt_packages
 ``````````````````
@@ -642,37 +672,29 @@ You can see the complete schema
 
 .. _new-build:
 
-New ``build`` specification
----------------------------
+Legacy ``build`` specification
+------------------------------
 
-.. warning::
-
-   This functionality is in beta. If you find any inconsistencies
-   or have feedback, please `open an
-   issue <https://github.com/readthedocs/readthedocs.org/issues/>`_.
-
-Read the Docs has introduced a more flexible ``build`` specification
-that allows you to use a more recent base image
-and control the versions of several tools:
-Python, Node.js, Rust, and Go.
-
-To opt in, specify the ``build.os`` setting
-and declare at least one tool version inside the ``build.tools`` key,
-as follows: 
+The legacy ``build`` specification used a different set of Docker images,
+and only allowed you to specify the Python version.
+It remains supported for backwards compatibility reasons.
+Check out the :ref:`config-file/v2:build (beta specification)` above
+for an alternative method that is more flexible.
 
 .. code-block:: yaml
 
    version: 2
 
    build:
-     os: ubuntu-20.04
-     tools:
-       python: 3.9
-       nodejs: 16
-       rust: 1.55
-       golang: 1.17
+     image: latest
+     apt_packages:
+       - libclang
+       - cmake
 
-The new ``build`` specification also supports
+   python:
+     version: "3.7"
+
+The legacy ``build`` specification also supports
 the ``apt_packages`` key described above.
 
 .. warning::
@@ -680,71 +702,42 @@ the ``apt_packages`` key described above.
    The keys ``build.os`` and ``python.version`` cannot be used at the same time.
    Doing so will error the build.
 
-build (new)
-~~~~~~~~~~~
+build (legacy)
+~~~~~~~~~~~~~~
 
-Configuration for the documentation build process.
-
-build.os
-````````
+build.image (legacy)
+````````````````````
 
 The Docker image used for building the docs.
 
 :Type: ``string``
-:Options: ``ubuntu-20.04``
-:Default: ``ubuntu-20.04``
+:Options: ``stable``, ``latest``
+:Default: ``latest``
 
-build.tools
-```````````
+Each image support different Python versions and has different packages installed,
+as defined here:
 
-Version specifiers for each tool. It must contain at least one tool.
-All tools are managed with `asdf <https://asdf-vm.com/>`_.
+* `stable <https://github.com/readthedocs/readthedocs-docker-images/tree/releases/5.x>`_: :buildpyversions:`stable`
+* `latest <https://github.com/readthedocs/readthedocs-docker-images/tree/releases/6.x>`_: :buildpyversions:`latest`
 
-:Type: ``dict``
-:Keys: ``python``, ``nodejs``, ``rust``, ``golang``
+python.version (legacy)
+```````````````````````
 
-build.tools.python
-``````````````````
+The Python version (this depends on :ref:`config-file/v2:build.image (legacy)`).
 
-Python version to use. Supported values are:
-
-* CPython 2.7 and 3.6+
-* PyPy3.7
-* Miniconda3 4.7
-* Mambaforge 4.10
+:Type: ``string``
+:Default: ``3``
 
 .. note::
 
-   If you use Miniconda3 or Mambaforge, you can select the Python version
-   using the ``environment.yml`` file. See our :doc:`/guides/conda` guide
-   for more information.
+   Make sure to use quotes (``"``) to make it a string.
+   We previously supported using numbers here,
+   but that approach is deprecated.
 
-:Type: ``string``
-:Options: ``2.7``, ``3``, ``3.6``, ``3.7``, ``3.8``, ``3.9``, ``3.10``, ``pypy3.7``, ``miniconda3-4.7``, ``mambaforge-4.10``
+.. warning::
 
-build.tools.nodejs
-``````````````````
-
-Node.js version to use.
-
-:Type: ``string``
-:Options: ``14``, ``16``
-
-build.tools.rust
-````````````````
-
-Rust version to use.
-
-:Type: ``string``
-:Options: ``1.55``
-
-build.tools.golang
-``````````````````
-
-Go version to use.
-
-:Type: ``string``
-:Options: ``1.17``
+   If you are using a :ref:`Conda <config-file/v2:conda>` environment to manage
+   the build, this setting will not have any effect, as the Python version is managed by Conda.
 
 Migrating from v1
 -----------------
@@ -760,8 +753,10 @@ Changes
   See :ref:`config-file/v2:Requirements file`.
 - The setting ``conda.file`` was renamed to ``conda.environment``.
   See :ref:`config-file/v2:conda.environment`.
-- The ``build.image`` setting now only has two options: ``latest`` (default) and ``stable``.
-  See :ref:`config-file/v2:build.image`.
+- The ``build.image`` setting has been replaced by ``build.os``.
+  See :ref:`config-file/v2:build.os`.
+  Alternatively, you can use the legacy ``build.image``
+  that now only has two options: ``latest`` (default) and ``stable``.
 - The settings ``python.setup_py_install`` and ``python.pip_install`` were replaced by ``python.install``.
   And now it accepts a path to the package.
   See :ref:`config-file/v2:Packages`.

--- a/docs/config-file/v2.rst
+++ b/docs/config-file/v2.rst
@@ -699,7 +699,8 @@ the ``apt_packages`` key described above.
 
 .. warning::
 
-   The keys ``build.os`` and ``python.version`` cannot be used at the same time.
+   When using the new speficiation,
+   the ``build.os`` and ``python.version`` options cannot be used.
    Doing so will error the build.
 
 build (legacy)

--- a/docs/config-file/v2.rst
+++ b/docs/config-file/v2.rst
@@ -312,7 +312,7 @@ Image names refer to the operating system Read the Docs uses to build them.
 
 :Type: ``string``
 :Options: ``ubuntu-20.04``
-:Default: ``ubuntu-20.04``
+:Required: ``true``
 
 build.tools
 ```````````


### PR DESCRIPTION
I decided to add a new section after the current keys to simplify how we present this information, but there are other alternatives.

On the other hand, I have highlighted that "this is beta", since that is my current understanding of the functionality. If this is incorrect, I'll be happy to remove the admonition.

I chose the word "new" because I assume that, at some point in the future, we will reorder this documentation and declare the current one "legacy". However, [it might be a bad idea](https://ddbeck.com/new-is-a-mark/). If we expect this to last long (and it is often the case that we don't expect things to last long, but they do), we should choose a better name.