### PR TITLE
Build: update ca-certificates before cloning

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1642,6 +1642,7 @@ class Feature(models.Model):
     ALL_VERSIONS_IN_HTML_CONTEXT = 'all_versions_in_html_context'
     CACHED_ENVIRONMENT = 'cached_environment'
     LIMIT_CONCURRENT_BUILDS = 'limit_concurrent_builds'
+    UPDATE_CA_CERTIFICATES = 'update_ca_certificates'
 
     # Versions sync related features
     SKIP_SYNC_TAGS = 'skip_sync_tags'
@@ -1724,6 +1725,10 @@ class Feature(models.Model):
         (
             LIMIT_CONCURRENT_BUILDS,
             _('Limit the amount of concurrent builds'),
+        ),
+        (
+            UPDATE_CA_CERTIFICATES,
+            _('Update ca-certificates Ubuntu package before VCS clone'),
         ),
 
         # Versions sync related features

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -907,16 +907,17 @@ class UpdateDocsTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
         # https://community.letsencrypt.org/t/openssl-client-compatibility-changes-for-let-s-encrypt-certificates/143816
         # TODO: remove this when a newer version of ``ca-certificates`` gets
         # pre-installed in the Docker images
-        self.setup_env.run(
-            'apt-get', 'update', '--assume-yes', '--quiet',
-            user=settings.RTD_DOCKER_SUPER_USER,
-            record=False,
-        )
-        self.setup_env.run(
-            'apt-get', 'install', '--assume-yes', '--quiet', 'ca-certificates',
-            user=settings.RTD_DOCKER_SUPER_USER,
-            record=False,
-        )
+        if self.project.has_feature(Feature.UPDATE_CA_CERTIFICATES):
+            self.setup_env.run(
+                'apt-get', 'update', '--assume-yes', '--quiet',
+                user=settings.RTD_DOCKER_SUPER_USER,
+                record=False,
+            )
+            self.setup_env.run(
+                'apt-get', 'install', '--assume-yes', '--quiet', 'ca-certificates',
+                user=settings.RTD_DOCKER_SUPER_USER,
+                record=False,
+            )
 
         log.info(
             LOG_TEMPLATE,

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -901,6 +901,23 @@ class UpdateDocsTaskStep(SyncRepositoryMixin, CachedEnvironmentMixin):
         """
         environment.update_build(state=BUILD_STATE_CLONING)
 
+        # Install a newer version of ca-certificates packages because it's
+        # required for Let's Encrypt certificates
+        # https://github.com/readthedocs/readthedocs.org/issues/8555
+        # https://community.letsencrypt.org/t/openssl-client-compatibility-changes-for-let-s-encrypt-certificates/143816
+        # TODO: remove this when a newer version of ``ca-certificates`` gets
+        # pre-installed in the Docker images
+        self.setup_env.run(
+            'apt-get', 'update', '--assume-yes', '--quiet',
+            user=settings.RTD_DOCKER_SUPER_USER,
+            record=False,
+        )
+        self.setup_env.run(
+            'apt-get', 'install', '--assume-yes', '--quiet', 'ca-certificates',
+            user=settings.RTD_DOCKER_SUPER_USER,
+            record=False,
+        )
+
         log.info(
             LOG_TEMPLATE,
             {


### PR DESCRIPTION
This is a temporal solution while we decide how to fix the real problem. For
now, we are installing a newer version of `ca-certificates` before starting to
clone the repository.

Reference #8555