### PR TITLE
Return a 401 in proxito when a project is banned

### DIFF
--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -341,7 +341,7 @@ class TestDocServingBackends(BaseDocServing):
         self.eric.profile.banned = True
         self.eric.profile.save()
         resp = self.client.get('/en/latest/awesome.html', HTTP_HOST='project.dev.readthedocs.io')
-        self.assertEqual(resp.status_code, 403)
+        self.assertEqual(resp.status_code, 401)
 
         self.eric.profile.banned = False
         self.eric.profile.save()

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -7,6 +7,7 @@ from unittest import mock
 import django_dynamic_fixture as fixture
 from django.conf import settings
 from django.core.cache import cache
+from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -340,8 +341,8 @@ class TestDocServingBackends(BaseDocServing):
     def test_spam_fighting(self):
         self.eric.profile.banned = True
         self.eric.profile.save()
-        resp = self.client.get('/en/latest/awesome.html', HTTP_HOST='project.dev.readthedocs.io')
-        self.assertEqual(resp.status_code, 403)
+        with self.assertRaises(PermissionDenied):
+            resp = self.client.get('/en/latest/awesome.html', HTTP_HOST='project.dev.readthedocs.io')
 
         self.eric.profile.banned = False
         self.eric.profile.save()

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -7,7 +7,6 @@ from unittest import mock
 import django_dynamic_fixture as fixture
 from django.conf import settings
 from django.core.cache import cache
-from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
 from django.test.utils import override_settings
 from django.urls import reverse
@@ -341,8 +340,8 @@ class TestDocServingBackends(BaseDocServing):
     def test_spam_fighting(self):
         self.eric.profile.banned = True
         self.eric.profile.save()
-        with self.assertRaises(PermissionDenied):
-            resp = self.client.get('/en/latest/awesome.html', HTTP_HOST='project.dev.readthedocs.io')
+        resp = self.client.get('/en/latest/awesome.html', HTTP_HOST='project.dev.readthedocs.io')
+        self.assertEqual(resp.status_code, 403)
 
         self.eric.profile.banned = False
         self.eric.profile.save()

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -14,6 +14,7 @@ from django.urls import reverse
 from readthedocs.audit.models import AuditLog
 from readthedocs.builds.constants import EXTERNAL, INTERNAL, LATEST
 from readthedocs.builds.models import Version
+from readthedocs.core.models import UserProfile
 from readthedocs.projects import constants
 from readthedocs.projects.constants import (
     MKDOCS,
@@ -335,6 +336,17 @@ class TestDocServingBackends(BaseDocServing):
         self.assertIn('x-accel-redirect', resp)
         self.assertEqual(AuditLog.objects.all().count(), 1)
 
+
+    def test_spam_fighting(self):
+        self.eric.profile.banned = True
+        self.eric.profile.save()
+        resp = self.client.get('/en/latest/awesome.html', HTTP_HOST='project.dev.readthedocs.io')
+        self.assertEqual(resp.status_code, 403)
+
+        self.eric.profile.banned = False
+        self.eric.profile.save()
+        resp = self.client.get('/en/latest/awesome.html', HTTP_HOST='project.dev.readthedocs.io')
+        self.assertEqual(resp.status_code, 200)
 
 @override_settings(
     PYTHON_MEDIA=False,

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -5,7 +5,6 @@ import logging
 from urllib.parse import urlparse
 
 from readthedocs.core.resolver import resolve_path
-from django.core.exceptions import PermissionDenied
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import resolve as url_resolve
@@ -85,7 +84,7 @@ class ServeDocsBase(ServeRedirectMixin, ServeDocsMixin, View):
 
         # Return a 403 on projects that are classified as spam
         if final_project.users.filter(profile__banned=True):
-            raise PermissionDenied('Project detected as spam, refusing to serve')
+            return self._serve_401(request, final_project)
 
         # Handle requests that need canonicalizing (eg. HTTP -> HTTPS, redirect to canonical domain)
         if hasattr(request, 'canonicalize'):

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -5,7 +5,8 @@ import logging
 from urllib.parse import urlparse
 
 from readthedocs.core.resolver import resolve_path
-from django.http import Http404, HttpResponse, HttpResponseRedirect, Http403
+from django.core.exceptions import PermissionDenied
+from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import resolve as url_resolve
 from django.utils.decorators import method_decorator
@@ -84,7 +85,7 @@ class ServeDocsBase(ServeRedirectMixin, ServeDocsMixin, View):
 
         # Return a 403 on projects that are classified as spam
         if final_project.users.filter(profile__banned=True):
-            raise Http403('Project detected as spam, refusing to serve')
+            raise PermissionDenied('Project detected as spam, refusing to serve')
 
         # Handle requests that need canonicalizing (eg. HTTP -> HTTPS, redirect to canonical domain)
         if hasattr(request, 'canonicalize'):


### PR DESCRIPTION
This will allow us to instantly cut off doc serving for banned projects.
It hopefully won't increase the query load in proxito too much,
but seems worth it in this case at least until we figure out deletion.