### PR TITLE
Write the modified conda env to a temporary file

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -771,7 +771,8 @@ class Conda(PythonEnvironment):
             dependencies.append(pip_dependencies)
             dependencies.extend(conda_requirements)
             environment.update({'dependencies': dependencies})
-            _, output_filename = tempfile.mkstemp(dir=Path(self.checkout_path) / ".." / "..", suffix=".yml")
+            _, output_filename = tempfile.mkstemp(dir=Path(self.checkout_path) / ".." / "..",
+                                                  suffix=".yml")
             try:
                 outputfile = codecs.open(
                     output_filename,

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -9,6 +9,8 @@ import logging
 import os
 import shutil
 import tarfile
+import tempfile
+from pathlib import Path
 
 import yaml
 from django.conf import settings
@@ -689,9 +691,12 @@ class Conda(PythonEnvironment):
         if self.project.has_feature(Feature.UPDATE_CONDA_STARTUP):
             self._update_conda_startup()
 
+        conda_env_file = self.config.conda.environment
         if self.project.has_feature(Feature.CONDA_APPEND_CORE_REQUIREMENTS):
-            self._append_core_requirements()
-            self._show_environment_yaml()
+            conda_env_file = self._append_core_requirements()
+            log.warning("Exists: %s", Path(conda_env_file).exists())
+            self._show_environment_yaml(conda_env_file)
+            log.warning(self.config)
 
         if all([
                 # The project has CONDA_USES_MAMBA feature enabled and,
@@ -710,16 +715,17 @@ class Conda(PythonEnvironment):
             '--name',
             self.version.slug,
             '--file',
-            self.config.conda.environment,
+            conda_env_file,
             bin_path=None,  # Don't use conda bin that doesn't exist yet
             cwd=self.checkout_path,
         )
 
-    def _show_environment_yaml(self):
+    def _show_environment_yaml(self, conda_env_file=None):
         """Show ``environment.yml`` file in the Build output."""
+        conda_env_file = conda_env_file or self.config.conda.environment
         self.build_env.run(
             'cat',
-            self.config.conda.environment,
+            conda_env_file,
             cwd=self.checkout_path,
         )
 
@@ -767,16 +773,16 @@ class Conda(PythonEnvironment):
             dependencies.append(pip_dependencies)
             dependencies.extend(conda_requirements)
             environment.update({'dependencies': dependencies})
+            _, output_filename = tempfile.mkstemp(dir=Path(self.checkout_path) / ".." / "..", suffix=".yml")
             try:
                 outputfile = codecs.open(
-                    os.path.join(
-                        self.checkout_path,
-                        self.config.conda.environment,
-                    ),
+                    output_filename,
                     encoding='utf-8',
                     mode='w',
                 )
                 yaml.safe_dump(environment, outputfile)
+
+                return output_filename
             except IOError:
                 log.warning(
                     'There was an error while writing the new Conda '

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -694,9 +694,7 @@ class Conda(PythonEnvironment):
         conda_env_file = self.config.conda.environment
         if self.project.has_feature(Feature.CONDA_APPEND_CORE_REQUIREMENTS):
             conda_env_file = self._append_core_requirements()
-            log.warning("Exists: %s", Path(conda_env_file).exists())
             self._show_environment_yaml(conda_env_file)
-            log.warning(self.config)
 
         if all([
                 # The project has CONDA_USES_MAMBA feature enabled and,


### PR DESCRIPTION
This is a stab in the dark at fixing #8201 

It attempts to save the conda env file to a location outside of the checkout so that it doesn't interfere with the checkout / version number.