### PR TITLE
Adjust Django intersphinx link to stable version.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ exclude_patterns = ['_build']
 default_role = 'obj'
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3.6/', None),
-    'django': ('https://docs.djangoproject.com/en/stable/', 'https://docs.djangoproject.com/en/stable/_objects/'),
+    'django': ('https://docs.djangoproject.com/en/2.2/', 'https://docs.djangoproject.com/en/2.2/_objects/'),
     'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
     'pip': ('https://pip.pypa.io/en/stable/', None),
     'nbsphinx': ('https://nbsphinx.readthedocs.io/en/0.8.6/', None),


### PR DESCRIPTION
Hi. I don't know if you're able to move from the 1.11 docs, but the `stable` alias always points to the latest current version (currently 3.2) Maybe that's better? 1.11 has been EOL for a while...

Please close if not appropriate. 
Thanks. 