### PR TITLE
Design doc: Landing Page User Stories

### DIFF
--- a/docs/development/design/ext-theme/landing-page/user-stories.rst
+++ b/docs/development/design/ext-theme/landing-page/user-stories.rst
@@ -8,7 +8,7 @@ User sectors
 ***************
 
 +-------------------+--------------+--------------+--------------+--------------+
-| User Levels →     | Potential    | Initiate     | Intermediate | Advanced     |
+| User Levels →     | Potential    | Beginner     | Intermediate | Advanced     |
 +-------------------+              |              |              |              |
 | User Groups       |              |              |              |              |
 +===================+==============+==============+==============+==============+

--- a/docs/development/design/ext-theme/landing-page/user-stories.rst
+++ b/docs/development/design/ext-theme/landing-page/user-stories.rst
@@ -1,7 +1,7 @@
 Landing Page User Stories
 =================================================
 
-This document serves to define our standard users and to map specific user needs for  the landing page.
+This document serves to define our standard users and to map specific user needs for the landing page.
 
 
 User sectors
@@ -44,14 +44,14 @@ Potential users
   need to know if Read the Docs is easy to integrate with my tools so it helps me save time.*
 
   *I as a potential user and a Manager
-  need to know need a high level overview of how Read the Docs can be integrated with my team's tools so I can plan to make it happen.*
+  need a high level overview of how Read the Docs can be integrated with my team's tools so I can plan to make it happen.*
 
 
 Initiate users
 ^^^^^^^^^^^^^^^
 
   *I as a initiate user and a Software Engineer/Technical Writer
-  need to have my next step clearly marked so I don't loose time looking for what to do.*
+  need to have the next step clearly pointed out so I don't loose time looking for what to do.*
 
   
 Initiate Intermediate or Advanced

--- a/docs/development/design/ext-theme/landing-page/user-stories.rst
+++ b/docs/development/design/ext-theme/landing-page/user-stories.rst
@@ -1,0 +1,61 @@
+Landing Page User Stories
+=================================================
+
+This document serves to define our standard users and to map specific user needs for  the landing page.
+
+
+User sectors
+***************
+
++-------------------+--------------+--------------+--------------+--------------+
+| User Levels →     | Potential    | Initiate     | Intermediate | Advanced     |
++-------------------+              |              |              |              |
+| User Groups       |              |              |              |              |
++===================+==============+==============+==============+==============+
+| Software Engineer |              |              |              |              |
++-------------------+--------------+--------------+              |              |
+| Technical Writer  |              |              |              |              |
++-------------------+--------------+--------------+              |              |
+| Manager           |              |              |              |              |
++-------------------+--------------+--------------+--------------+--------------+
+
+
+User Stories
+************
+
+A user story is an informal, natural language description of a software feature, written from the perspective of the end user or other stakeholders. The purpose is to capture ideas about what needs to be built into the application. This will help us define specific features and goals.
+
+
+Potential users
+^^^^^^^^^^^^^^^
+
+  *I as a potential user and a Software Engineer/Technical Writer
+  need to know what Read the Docs is and how it might help me with my work.*
+
+  *I as a potential user and a Manager
+  need to know what Read the Docs is and how it might help my team workflow.*
+
+-------
+
+  *I as a potential user and a Software Engineer
+  need to know more about Read the Docs technical features and integrations, so I can know if its a good fit for my tools.*
+
+  *I as a potential user and a Technical Writer
+  need to know if Read the Docs is easy to integrate with my tools so it helps me save time.*
+
+  *I as a potential user and a Manager
+  need to know need a high level overview of how Read the Docs can be integrated with my team's tools so I can plan to make it happen.*
+
+
+Initiate users
+^^^^^^^^^^^^^^^
+
+  *I as a initiate user and a Software Engineer/Technical Writer
+  need to have my next step clearly marked so I don't loose time looking for what to do.*
+
+  
+Initiate Intermediate or Advanced
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  *I as a intermediate or advanced user
+  need to be able to able to jump fast into login or other important app pages so I can use this page as a start point without loosing time with its marketing contents.*

--- a/docs/development/design/ext-theme/landing-page/user-stories.rst
+++ b/docs/development/design/ext-theme/landing-page/user-stories.rst
@@ -47,14 +47,14 @@ Potential users
   need a high level overview of how Read the Docs can be integrated with my team's tools so I can plan to make it happen.*
 
 
-Initiate users
+Beginners
 ^^^^^^^^^^^^^^^
 
-  *I as a initiate user and a Software Engineer/Technical Writer
+  *I as a beginner and a Software Engineer/Technical Writer
   need to have the next step clearly pointed out so I don't loose time looking for what to do.*
 
   
-Initiate Intermediate or Advanced
+Intermediate or Advanced
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
   *I as a intermediate or advanced user

--- a/docs/development/design/ext-theme/landing-page/user-stories.rst
+++ b/docs/development/design/ext-theme/landing-page/user-stories.rst
@@ -25,37 +25,43 @@ User Stories
 
 A user story is an informal, natural language description of a software feature, written from the perspective of the end user or other stakeholders. The purpose is to capture ideas about what needs to be built into the application. This will help us define specific features and goals.
 
+Although there's no formality to a user story, the following template is normally useful:
+
+```
+As a <role> I want to <goal> so that I <receive benefit>
+```
+
 
 Potential users
 ^^^^^^^^^^^^^^^
 
-  *I as a potential user and a Software Engineer/Technical Writer
-  need to know what Read the Docs is and how it might help me with my work.*
+  *As a potential user and a Software Engineer/Technical Writer
+  I need to know what Read the Docs is and how it might help me with my work.*
 
-  *I as a potential user and a Manager
-  need to know what Read the Docs is and how it might help my team workflow.*
+  *As a potential user and a Manager
+  I need to know what Read the Docs is and how it might help my team workflow.*
 
 -------
 
-  *I as a potential user and a Software Engineer
-  need to know more about Read the Docs technical features and integrations, so I can know if its a good fit for my tools.*
+  *As a potential user and a Software Engineer
+  I need to know more about Read the Docs technical features and integrations, so I can know if its a good fit for my tools.*
 
-  *I as a potential user and a Technical Writer
-  need to know if Read the Docs is easy to integrate with my tools so it helps me save time.*
+  *As a potential user and a Technical Writer
+  I need to know if Read the Docs is easy to integrate with my tools so it helps me save time.*
 
-  *I as a potential user and a Manager
-  need a high level overview of how Read the Docs can be integrated with my team's tools so I can plan to make it happen.*
+  *As a potential user and a Manager
+  I need a high level overview of how Read the Docs can be integrated with my team's tools so I can plan to make it happen.*
 
 
 Beginners
 ^^^^^^^^^^^^^^^
 
-  *I as a beginner and a Software Engineer/Technical Writer
-  need to have the next step clearly pointed out so I don't loose time looking for what to do.*
+  *As a beginner and a Software Engineer/Technical Writer
+  I need to have the next step clearly pointed out so I don't loose time looking for what to do.*
 
   
 Intermediate or Advanced
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  *I as a intermediate or advanced user
-  need to be able to able to jump fast into login or other important app pages so I can use this page as a start point without loosing time with its marketing contents.*
+  *As a intermediate or advanced user
+  I need to be able to able to jump fast into login or other important app pages so that I can use this page as a start point without loosing time with its marketing contents.*


### PR DESCRIPTION
Design document for the landing page user stories.
The purpose is to gather ideas and open the debate about what needs to be built into the community site home page from the perspective of the end user.

This will help us define our standard users and map specific user needs, which will in turn allow us to better define specific features and goals.

----
Edit based on @ericholscher first comment bellow.
>  Am I trying to see if the user stories cover all the various things that users might think

I'm sure I didn't yet cover all the user needs here.
Instead I'd love to see this Design doc being used as a platform for brainstorming on those needs — _in the format of user stories_ — for the landing page. It should be a place where anyone can contribute with an informal story, written from the perspective of a user, a developer or other stakeholder, that needs to accomplish some task or goal on the landing page.

User stories do not translate directly into final features. They have the feeling of ideas in a brainstorm and can help us define future features and goals, but are not yet in any formal format.


