### PR TITLE
Correct an example

### DIFF
--- a/docs/guides/cross-referencing-with-sphinx.rst
+++ b/docs/guides/cross-referencing-with-sphinx.rst
@@ -102,7 +102,7 @@ Another example, add a target to a paragraph:
          An easy way is just to use the final link of the page/section.
          This works, but it has [some disadvantages](target_to_paragraph):
 
-Then the reference will be rendered as: `target to paragraph`_.
+Then the reference will be rendered as: `some disadvantages <target to paragraph>`_.
 
 You can also create _`in-line targets` within an element on your page,
 allowing you to, for example, reference text *within* a paragraph.


### PR DESCRIPTION
The example on https://docs.readthedocs.io/en/stable/guides/cross-referencing-with-sphinx.html was the opposite of what it means. It shows how to have a text distinct from the link, and as the result show the text being the link. I correct it (hopefully) by copying the example code in the result part.