### PR TITLE
Drop beta from title of build config option

### DIFF
--- a/docs/config-file/v2.rst
+++ b/docs/config-file/v2.rst
@@ -299,8 +299,8 @@ The path to the Conda environment file, relative to the root of the project.
 :Type: ``path``
 :Required: ``true``
 
-build (beta specification)
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+build
+~~~~~
 
 .. warning::
 

--- a/docs/config-file/v2.rst
+++ b/docs/config-file/v2.rst
@@ -710,7 +710,7 @@ Legacy ``build`` specification
 The legacy ``build`` specification used a different set of Docker images,
 and only allowed you to specify the Python version.
 It remains supported for backwards compatibility reasons.
-Check out the :ref:`config-file/v2:build (beta specification)` above
+Check out the :ref:`config-file/v2:build` above
 for an alternative method that is more flexible.
 
 .. code-block:: yaml


### PR DESCRIPTION
The title will eventually change to not be beta, and any existing links to this
anchor will not scroll to this section, which is always confusing. Let's drop
this early, there's already an admonition below the title.