### PR TITLE
Fix GitHub permissions required

### DIFF
--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -53,7 +53,7 @@ GitHub
   *application/x-www-form-urlencoded* work
 * Leave the **Secrets** field blank
 * Select **Let me select individual events**,
-  and mark **Branch or tag creation**, **Branch or tag deletion** and **Pushes** events
+  and mark **Branch or tag creation**, **Branch or tag deletion**, **Pull Requests** and **Pushes** events
 * Ensure **Active** is enabled; it is by default
 * Finish by clicking **Add webhook**.  You may be prompted to enter your GitHub password to confirm your action.
 


### PR DESCRIPTION
These docs were out of date with our code:

https://github.com/readthedocs/readthedocs.org/blob/d6f7347f82d7b3e210cd7e7e84d860282dd029f8/readthedocs/oauth/services/github.py#L208