### PR TITLE
Spam: use 410 - Gone status code when blocked

### DIFF
--- a/readthedocs/proxito/views/mixins.py
+++ b/readthedocs/proxito/views/mixins.py
@@ -180,7 +180,7 @@ class ServeDocsMixin:
         if 'readthedocsext.spamfighting' in settings.INSTALLED_APPS:
             from readthedocsext.spamfighting.utils import is_serve_docs_denied  # noqa
             if is_serve_docs_denied(project):
-                return render(request, template_name='spam.html', status=401)
+                return render(request, template_name='spam.html', status=410)
 
 
 class ServeRedirectMixin:

--- a/readthedocs/templates/spam.html
+++ b/readthedocs/templates/spam.html
@@ -26,7 +26,7 @@
             <p>Read the Docs has marked this content as spam and is not serving it anymore.</p>
             {# We can't use url templatetag here because the URL is not defined in El Proxito #}
             <p>Please <a href="https://{{ PUBLIC_DOMAIN }}/support/">contact us</a> if you think this is a mistake.</p>
-            <p style="color: #666;">401 - Unauthorized</p>
+            <p style="color: #666;">410 - Gone</p>
         </main>
     </body>
 </html>


### PR DESCRIPTION
Return 401 - Gone when we detect a spam project and block the doc serving.