### PR TITLE
Proxito: add CDN-Cache-Control headers

### DIFF
--- a/dockerfiles/nginx/proxito.conf
+++ b/dockerfiles/nginx/proxito.conf
@@ -62,6 +62,8 @@ server {
         add_header X-RTD-Project-Method $rtd_project_method always;
         set $rtd_redirect $upstream_http_x_rtd_redirect;
         add_header X-RTD-Redirect $rtd_redirect always;
+        set $cdn_cache_control $upstream_http_cdn_cache_control;
+        add_header CDN-Cache-Control $cdn_cache_control always;
         set $cache_tag $upstream_http_cache_tag;
         add_header Cache-Tag $cache_tag always;
         set $referrer_policy $upstream_http_referrer_policy;

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -246,6 +246,19 @@ class ProxitoMiddleware(MiddlewareMixin):
             # See https://tools.ietf.org/html/rfc6797
             response['Strict-Transport-Security'] = '; '.join(hsts_header_values)
 
+    def add_cache_headers(self, request, response):
+        """
+        Add Cache-Control headers.
+
+        If private projects are allowed don't cache any request at the CDN level.
+        In the future we should set this header conditionally on private/public versions,
+        and on views with/without cookies (like the footer).
+
+        See https://developers.cloudflare.com/cache/about/cdn-cache-control.
+        """
+        if settings.ALLOW_PRIVATE_REPOS:
+            response['CDN-Cache-Control'] = 'private'
+
     def process_request(self, request):  # noqa
         skip = any(
             request.path.startswith(reverse(view))
@@ -313,6 +326,7 @@ class ProxitoMiddleware(MiddlewareMixin):
 
     def process_response(self, request, response):  # noqa
         self.add_proxito_headers(request, response)
+        self.add_cache_headers(request, response)
         self.add_hsts_headers(request, response)
         self.add_user_headers(request, response)
         return response

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -257,6 +257,9 @@ class ProxitoMiddleware(MiddlewareMixin):
         See https://developers.cloudflare.com/cache/about/cdn-cache-control.
         """
         if settings.ALLOW_PRIVATE_REPOS:
+            # We use ``CDN-Cache-Control``,
+            # to control caching at the CDN level only.
+            # Caching at the browser level is fine (``Cache-Control``).
             response['CDN-Cache-Control'] = 'private'
 
     def process_request(self, request):  # noqa

--- a/readthedocs/proxito/tests/test_headers.py
+++ b/readthedocs/proxito/tests/test_headers.py
@@ -1,5 +1,4 @@
 import django_dynamic_fixture as fixture
-import pytest
 from django.test import override_settings
 from django.urls import reverse
 
@@ -128,3 +127,15 @@ class ProxitoHeaderTests(BaseDocServing):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r[http_header], http_header_value)
         self.assertEqual(r[http_header_secure], http_header_value)
+
+    @override_settings(ALLOW_PRIVATE_REPOS=False)
+    def test_cache_headers_public_projects(self):
+        r = self.client.get('/en/latest/', HTTP_HOST='project.dev.readthedocs.io')
+        self.assertEqual(r.status_code, 200)
+        self.assertNotIn('CDN-Cache-Control', r)
+
+    @override_settings(ALLOW_PRIVATE_REPOS=True)
+    def test_cache_headers_private_projects(self):
+        r = self.client.get('/en/latest/', HTTP_HOST='project.dev.readthedocs.io')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r['CDN-Cache-Control'], 'private')


### PR DESCRIPTION
This is mainly for .com,
to tell explicitly to the CDN to not cache things.

There are PRs on the ops/.com repos.