### PR TITLE
Add a feature flag to install docutils<0.18 on sphinx 2 projects

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -523,8 +523,10 @@ class Virtualenv(PythonEnvironment):
                 ),
             ])
 
-            # Install a non-broken docutils when we install sphinx<2, and have the feature flag enabled
-            if self.project.has_feature(Feature.DOCUTILS_017) and not self.project.has_feature(Feature.USE_SPHINX_LATEST):
+            # Install a non-broken docutils when we install sphinx<2,
+            # and have the feature flag enabled
+            if self.project.has_feature(Feature.DOCUTILS_017)
+                and not self.project.has_feature(Feature.USE_SPHINX_LATEST):
                 requirements.extend(['docutils<0.18'])
 
         cmd = copy.copy(pip_install_cmd)

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -523,6 +523,10 @@ class Virtualenv(PythonEnvironment):
                 ),
             ])
 
+            # Install a non-broken docutils when we install sphinx<2, and have the feature flag enabled
+            if self.project.has_feature(Feature.DOCUTILS_017) and not self.project.has_feature(Feature.USE_SPHINX_LATEST):
+                requirements.extend(['docutils<0.18'])
+
         cmd = copy.copy(pip_install_cmd)
         if self.config.python.use_system_site_packages:
             # Other code expects sphinx-build to be installed inside the

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1804,6 +1804,7 @@ class Feature(models.Model):
     DEFAULT_TO_MKDOCS_0_17_3 = 'default_to_mkdocs_0_17_3'
     USE_MKDOCS_LATEST = 'use_mkdocs_latest'
     USE_SPHINX_RTD_EXT_LATEST = 'rtd_sphinx_ext_latest'
+    DOCUTILS_017 = 'use_docutils_017'
 
     # Search related features
     DISABLE_SERVER_SIDE_SEARCH = 'disable_server_side_search'


### PR DESCRIPTION
This will hopefully allow us to roll out changes to fix old sphinx projects that are broken.

The rollout plan will be:

* Deploy this change
* Apply it to known broken projects, to ensure it fixes the issue and doesn't cause new ones
* Apply it to a sample of projects, and ensure they continue to build
* Roll it out as a default to all projects, but it will only apply to ones not using sphinx latest