### PR TITLE
Downgrade celery and friends

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -31,8 +31,8 @@ Pygments==2.10.0
 
 # Basic tools
 redis==3.5.3
-kombu==5.2.1
-celery==5.2.0
+kombu==5.1.0
+celery==5.1.2
 
 # When upgrading to 0.43.0 we should double check the ``base.html`` change
 # described in the changelog. In previous versions, the allauth app included a


### PR DESCRIPTION
They break the local installation,
and looks like some minor versions
were released yesterday for both, kombu and redis.

https://docs.celeryproject.org/en/latest/changelog.html