### PR TITLE
Fix issue with PR build hostname parsing

### DIFF
--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -86,7 +86,7 @@ def map_host_to_project_slug(request):  # pylint: disable=too-many-return-statem
         # Serve custom versions on external-host-domain
         if external_domain_parts == host_parts[1:]:
             try:
-                project_slug, version_slug = host_parts[0].split('--', 1)
+                project_slug, version_slug = host_parts[0].rsplit('--', 1)
                 request.external_domain = True
                 request.host_version_slug = version_slug
                 log.debug('Proxito External Version Domain: host=%s', host)


### PR DESCRIPTION
Given a hostname `slug--bug--1.org.readthedocs.build`, the current
parsing code will give a project slug of `slug` and a version slug of
`bug--1`. This was a valid slug creation pattern for a short while,
though we have changed the behavior of the slugging to not produce slugs
with consecutive dashes.

rsplit here searches for the right most instance of double slugs

Fixes #8699 