### PR TITLE
structlog: migrate application code to better logging

### DIFF
--- a/readthedocs/analytics/utils.py
+++ b/readthedocs/analytics/utils.py
@@ -4,7 +4,7 @@
 
 import hashlib
 import ipaddress
-import logging
+import structlog
 
 import requests
 from django.conf import settings
@@ -13,7 +13,7 @@ from django.utils.encoding import force_bytes, force_text
 from user_agents import parse
 
 
-log = logging.getLogger(__name__)  # noqa
+log = structlog.get_logger(__name__)  # noqa
 
 
 def get_client_ip(request):
@@ -79,7 +79,7 @@ def send_to_analytics(data):
         data['ua'] = anonymize_user_agent(data['ua'])
 
     resp = None
-    log.debug('Sending data to analytics: %s', data)
+    log.debug('Sending data to analytics.', data=data)
     try:
         resp = requests.post(
             'https://www.google-analytics.com/collect',

--- a/readthedocs/api/v2/client.py
+++ b/readthedocs/api/v2/client.py
@@ -1,6 +1,6 @@
 """Simple client to access our API with Slumber credentials."""
 
-import logging
+import structlog
 
 import requests
 from django.conf import settings
@@ -10,7 +10,7 @@ from urllib3.util.retry import Retry
 
 from .adapters import TimeoutHostHeaderSSLAdapter, TimeoutHTTPAdapter
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class DrfJsonSerializer(serialize.JsonSerializer):
@@ -63,9 +63,9 @@ def setup_api():
     }
     if settings.SLUMBER_USERNAME and settings.SLUMBER_PASSWORD:
         log.debug(
-            'Using slumber v2 with user %s, pointed at %s',
-            settings.SLUMBER_USERNAME,
-            settings.SLUMBER_API_HOST,
+            'Using slumber v2.',
+            username=settings.SLUMBER_USERNAME,
+            api_host=settings.SLUMBER_API_HOST,
         )
         session.auth = (settings.SLUMBER_USERNAME, settings.SLUMBER_PASSWORD)
     else:

--- a/readthedocs/api/v2/mixins.py
+++ b/readthedocs/api/v2/mixins.py
@@ -1,6 +1,6 @@
-import logging
+import structlog
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class CachedResponseMixin:

--- a/readthedocs/api/v2/views/footer_views.py
+++ b/readthedocs/api/v2/views/footer_views.py
@@ -1,6 +1,6 @@
 """Endpoint to generate footer HTML."""
 
-import logging
+import structlog
 import re
 from functools import lru_cache
 
@@ -24,7 +24,7 @@ from readthedocs.projects.version_handling import (
     parse_version_failsafe,
 )
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 def get_version_compare_data(project, base_version=None):

--- a/readthedocs/api/v2/views/model_views.py
+++ b/readthedocs/api/v2/views/model_views.py
@@ -1,7 +1,7 @@
 """Endpoints for listing Projects, Versions, Builds, etc."""
 
 import json
-import logging
+import structlog
 
 from allauth.socialaccount.models import SocialAccount
 from django.conf import settings
@@ -40,7 +40,7 @@ from ..utils import (
     RemoteProjectPagination,
 )
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class PlainTextBuildRenderer(BaseRenderer):
@@ -269,8 +269,8 @@ class BuildViewSet(DisableListEndpoint, UserSelectViewSet):
                     data['commands'] = json.loads(json_resp)
                 except Exception:
                     log.exception(
-                        'Failed to read build data from storage. path=%s.',
-                        storage_path,
+                        'Failed to read build data from storage.',
+                        path=storage_path,
                     )
         return Response(data)
 

--- a/readthedocs/api/v2/views/task_views.py
+++ b/readthedocs/api/v2/views/task_views.py
@@ -1,6 +1,6 @@
 """Endpoints relating to task/job status, etc."""
 
-import logging
+import structlog
 
 from django.urls import reverse
 from redis import ConnectionError
@@ -12,7 +12,7 @@ from readthedocs.core.utils.tasks import TaskNoPermission, get_public_task_data
 from readthedocs.oauth import tasks
 
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 SUCCESS_STATES = ('SUCCESS',)
 FAILURE_STATES = (

--- a/readthedocs/audit/apps.py
+++ b/readthedocs/audit/apps.py
@@ -1,10 +1,10 @@
 """Audit module."""
 
-import logging
+import structlog
 
 from django.apps import AppConfig
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class AuditConfig(AppConfig):

--- a/readthedocs/builds/apps.py
+++ b/readthedocs/builds/apps.py
@@ -1,9 +1,9 @@
-import logging
+import structlog
 
 from django.apps import AppConfig
 from django.utils.translation import ugettext_lazy as _
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class Config(AppConfig):

--- a/readthedocs/builds/automation_actions.py
+++ b/readthedocs/builds/automation_actions.py
@@ -8,12 +8,12 @@ Each function will receive the following args:
 - action_arg: An additional argument to apply the action
 """
 
-import logging
+import structlog
 
 from readthedocs.core.utils import trigger_build
 from readthedocs.projects.constants import PRIVATE, PUBLIC
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 def activate_version(version, match_result, action_arg, *args, **kwargs):
@@ -72,8 +72,9 @@ def delete_version(version, match_result, action_arg, *args, **kwargs):
     """Delete a version if isn't marked as the default version."""
     if version.project.default_version == version.slug:
         log.info(
-            "Skipping deleting default version. project=%s version=%s",
-            version.project.slug, version.slug,
+            "Skipping deleting default version.",
+            project_slug=version.project.slug,
+            version_slug=version.slug,
         )
         return
     version.delete()

--- a/readthedocs/builds/filters.py
+++ b/readthedocs/builds/filters.py
@@ -1,4 +1,4 @@
-import logging
+import structlog
 
 from django.forms.widgets import HiddenInput
 from django.utils.translation import ugettext_lazy as _
@@ -6,7 +6,7 @@ from django_filters import CharFilter, ChoiceFilter, FilterSet
 
 from readthedocs.builds.constants import BUILD_STATE_FINISHED
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class BuildListFilter(FilterSet):

--- a/readthedocs/builds/managers.py
+++ b/readthedocs/builds/managers.py
@@ -1,6 +1,6 @@
 """Build and Version class model Managers."""
 
-import logging
+import structlog
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
@@ -18,7 +18,7 @@ from readthedocs.builds.constants import (
 from readthedocs.builds.querysets import VersionQuerySet
 from readthedocs.core.utils.extend import get_override_class
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 __all__ = ['VersionManager']
@@ -78,7 +78,7 @@ class VersionManager(models.Manager):
         try:
             return super().get(**kwargs)
         except ObjectDoesNotExist:
-            log.warning('Version not found for given kwargs. %s', kwargs)
+            log.warning('Version not found for given kwargs.', kwargs=kwargs)
 
 
 class InternalVersionManager(VersionManager):

--- a/readthedocs/builds/querysets.py
+++ b/readthedocs/builds/querysets.py
@@ -1,6 +1,6 @@
 """Build and Version QuerySet classes."""
 import datetime
-import logging
+import structlog
 
 from django.db import models
 from django.db.models import Q
@@ -16,7 +16,7 @@ from readthedocs.core.utils.extend import SettingsOverrideObject
 from readthedocs.projects import constants
 from readthedocs.projects.models import Project
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 __all__ = ['VersionQuerySet', 'BuildQuerySet', 'RelatedBuildQuerySet']
@@ -231,10 +231,10 @@ class BuildQuerySet(models.QuerySet):
 
         max_concurrent = Project.objects.max_concurrent_builds(project)
         log.info(
-            'Concurrent builds. project=%s running=%s max=%s',
-            project.slug,
-            concurrent,
-            max_concurrent,
+            'Concurrent builds.',
+            project_slug=project.slug,
+            concurent=concurrent,
+            max_concurrent=max_concurrent,
         )
         if concurrent >= max_concurrent:
             limit_reached = True

--- a/readthedocs/builds/storage.py
+++ b/readthedocs/builds/storage.py
@@ -1,4 +1,4 @@
-import logging
+import structlog
 from pathlib import Path
 
 from django.conf import settings
@@ -6,7 +6,7 @@ from django.core.exceptions import SuspiciousFileOperation
 from django.core.files.storage import FileSystemStorage
 from storages.utils import get_available_overwrite_name, safe_join
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class BuildMediaStorageMixin:
@@ -59,7 +59,7 @@ class BuildMediaStorageMixin:
         if path in ('', '/'):
             raise SuspiciousFileOperation('Deleting all storage cannot be right')
 
-        log.debug('Deleting directory %s from media storage', path)
+        log.debug('Deleting path from media storage', path=path)
         folders, files = self.listdir(self._dirpath(path))
         for folder_name in folders:
             if folder_name:
@@ -76,7 +76,11 @@ class BuildMediaStorageMixin:
         :param source: the source path on the local disk
         :param destination: the destination path in storage
         """
-        log.debug('Copying source directory %s to media storage at %s', source, destination)
+        log.debug(
+            'Copying source directory to media storage',
+            source=source,
+            destination=destination,
+        )
         source = Path(source)
         for filepath in source.iterdir():
             sub_destination = self.join(destination, filepath.name)
@@ -101,8 +105,9 @@ class BuildMediaStorageMixin:
             raise SuspiciousFileOperation('Syncing all storage cannot be right')
 
         log.debug(
-            'Syncing to media storage. source=%s destination=%s',
-            source, destination,
+            'Syncing to media storage.',
+            source=source,
+            destination=destination,
         )
         source = Path(source)
         copied_files = set()
@@ -126,7 +131,7 @@ class BuildMediaStorageMixin:
         for filename in dest_files:
             if filename not in copied_files:
                 filepath = self.join(destination, filename)
-                log.debug('Deleting file from media storage. file=%s', filepath)
+                log.debug('Deleting file from media storage.', filepath=filepath)
                 self.delete(filepath)
 
     def join(self, directory, filepath):
@@ -136,7 +141,7 @@ class BuildMediaStorageMixin:
         if top in ('', '/'):
             raise SuspiciousFileOperation('Iterating all storage cannot be right')
 
-        log.debug('Walking %s in media storage', top)
+        log.debug('Walking path in media storage', path=top)
         folders, files = self.listdir(self._dirpath(top))
 
         yield top, folders, files

--- a/readthedocs/builds/views.py
+++ b/readthedocs/builds/views.py
@@ -1,6 +1,6 @@
 """Views for builds app."""
 
-import logging
+import structlog
 import textwrap
 from urllib.parse import urlparse
 
@@ -21,7 +21,7 @@ from readthedocs.core.utils import trigger_build
 from readthedocs.doc_builder.exceptions import BuildEnvironmentError
 from readthedocs.projects.models import Project
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class BuildBase:
@@ -81,11 +81,11 @@ class BuildTriggerMixin:
             if build_to_retrigger:
                 commit_to_retrigger = build_to_retrigger.commit
                 log.info(
-                    'Re-triggering build. project=%s version=%s commit=%s build=%s',
-                    project.slug,
-                    version.slug,
-                    build_to_retrigger.commit,
-                    build_to_retrigger.pk
+                    'Re-triggering build.',
+                    project_slug=project.slug,
+                    version_slug=version.slug,
+                    build_commit=build_to_retrigger.commit,
+                    build_id=build_to_retrigger.pk,
                 )
         else:
             # Use generic query when triggering a normal build

--- a/readthedocs/core/adapters.py
+++ b/readthedocs/core/adapters.py
@@ -1,7 +1,7 @@
 """Allauth overrides."""
 
 import json
-import logging
+import structlog
 
 from allauth.account.adapter import DefaultAccountAdapter
 from django.conf import settings
@@ -11,7 +11,7 @@ from django.utils.encoding import force_text
 from readthedocs.core.utils import send_email
 from readthedocs.organizations.models import TeamMember
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class AccountAdapter(DefaultAccountAdapter):
@@ -40,8 +40,8 @@ class AccountAdapter(DefaultAccountAdapter):
                 del context[key]
         if removed_keys:
             log.debug(
-                'Removed context we were unable to serialize: %s',
-                removed_keys,
+                'Removed context we were unable to serialize.',
+                removed_keys=removed_keys,
             )
 
         send_email(

--- a/readthedocs/core/forms.py
+++ b/readthedocs/core/forms.py
@@ -1,6 +1,6 @@
 """Forms for core app."""
 
-import logging
+import structlog
 
 from django import forms
 from django.contrib.auth.models import User
@@ -11,7 +11,7 @@ from readthedocs.core.history import set_change_reason
 
 from .models import UserProfile
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class UserProfileForm(forms.ModelForm):

--- a/readthedocs/core/history.py
+++ b/readthedocs/core/history.py
@@ -1,4 +1,4 @@
-import logging
+import structlog
 from functools import partial
 
 from django import forms
@@ -8,7 +8,7 @@ from simple_history.admin import SimpleHistoryAdmin
 from simple_history.models import HistoricalRecords
 from simple_history.utils import update_change_reason
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 def set_change_reason(instance, reason):
@@ -46,8 +46,8 @@ def safe_update_change_reason(instance, reason):
         update_change_reason(instance=instance, reason=reason)
     except Exception:
         log.exception(
-            'An error occurred while updating the change reason of the instance: obj=%s',
-            instance,
+            'An error occurred while updating the change reason of the instance.',
+            instance=instance,
         )
 
 

--- a/readthedocs/core/logs.py
+++ b/readthedocs/core/logs.py
@@ -1,4 +1,7 @@
+from io import StringIO
+
 import structlog
+from structlog.dev import _pad
 
 from django_structlog.middlewares.request import RequestMiddleware
 
@@ -70,8 +73,131 @@ class NewRelicProcessor:
         return event_dict
 
 
+class SysLogRenderer(structlog.dev.ConsoleRenderer):
+    def __call__(self, logger, name, event_dict):
+        sio = StringIO()
+
+        # ``readthedocs`` as programname is required because it's used by
+        # syslog to filter messages and send them to different files.
+        # https://www.rsyslog.com/doc/master/configuration/properties.html#message-properties
+        sio.write("readthedocs")
+
+        process_id = event_dict.pop("process_id", None)
+        if process_id is not None:
+            sio.write(
+                "["
+                + str(process_id)
+                + "]"
+            )
+
+        # syslog tag delimiter
+        sio.write(": ")
+
+        ts = event_dict.pop("timestamp", None)
+        if ts is not None:
+            sio.write(
+                # can be a number if timestamp is UNIXy
+                self._styles.timestamp
+                + str(ts)
+                + self._styles.reset
+                + " "
+            )
+
+        level = event_dict.pop("level", None)
+        if level is not None:
+            sio.write(
+                "["
+                + self._level_to_color.get(level, "")
+                + _pad(level, self._longest_level)
+                + self._styles.reset
+                + "] "
+            )
+
+        # force event to str for compatibility with standard library
+        event = event_dict.pop("event", None)
+        if not isinstance(event, str):
+            event = str(event)
+
+        if event_dict:
+            event = _pad(event, self._pad_event) + self._styles.reset + " "
+        else:
+            event += self._styles.reset
+        sio.write(self._styles.bright + event)
+
+        logger_name = event_dict.pop("logger", None)
+        if logger_name is None:
+            logger_name = event_dict.pop("logger_name", None)
+
+        line_number = event_dict.pop("line_number", None)
+        if logger_name is not None:
+            sio.write(
+                "["
+                + self._styles.logger_name
+                + self._styles.bright
+                + logger_name
+                + self._styles.reset
+                + ":"
+                + str(line_number)
+                + "] "
+            )
+
+        stack = event_dict.pop("stack", None)
+        exc = event_dict.pop("exception", None)
+        exc_info = event_dict.pop("exc_info", None)
+
+        event_dict_keys = event_dict.keys()
+        if self._sort_keys:
+            event_dict_keys = sorted(event_dict_keys)
+
+        sio.write(
+            " ".join(
+                self._styles.kv_key
+                + key
+                + self._styles.reset
+                + "="
+                + self._styles.kv_value
+                + self._repr(event_dict[key])
+                + self._styles.reset
+                for key in event_dict_keys
+            )
+        )
+
+        if stack is not None:
+            sio.write("\n" + stack)
+            if exc_info or exc is not None:
+                sio.write("\n\n" + "=" * 79 + "\n")
+
+        if exc_info:
+            if not isinstance(exc_info, tuple):
+                exc_info = sys.exc_info()
+
+            self._exception_formatter(sio, exc_info)
+        elif exc is not None:
+            if self._exception_formatter is not plain_traceback:
+                warnings.warn(
+                    "Remove `format_exc_info` from your processor chain "
+                    "if you want pretty exceptions."
+                )
+            sio.write("\n" + exc)
+
+        return sio.getvalue()
+
+
+class SysLogProcessor:
+
+    def __call__(self, logger, method_name, event_dict):
+        record = event_dict.get('_record', None)
+        if record is None:
+            return event_dict
+
+        event_dict.update({
+            'process_id': record.process,
+            'line_number': record.lineno,
+        })
+        return event_dict
+
+
 shared_processors = [
-    structlog.processors.TimeStamper(fmt='iso'),
     structlog.stdlib.add_logger_name,
     structlog.stdlib.add_log_level,
     structlog.stdlib.PositionalArgumentsFormatter(),

--- a/readthedocs/core/logs.py
+++ b/readthedocs/core/logs.py
@@ -78,7 +78,8 @@ structlog.configure(
         structlog.stdlib.add_log_level,
         structlog.stdlib.PositionalArgumentsFormatter(),
         structlog.processors.StackInfoRenderer(),
-        structlog.processors.format_exc_info,
+        # Remove `format_exc_info` from your processor chain if you want pretty exceptions.
+        # structlog.processors.format_exc_info,
         structlog.processors.UnicodeDecoder(),
         structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
     ],

--- a/readthedocs/core/logs.py
+++ b/readthedocs/core/logs.py
@@ -69,20 +69,21 @@ class NewRelicProcessor:
         event_dict.update(output)
         return event_dict
 
+shared_processors = [
+    structlog.processors.TimeStamper(fmt='iso'),
+    structlog.stdlib.add_logger_name,
+    structlog.stdlib.add_log_level,
+    structlog.stdlib.PositionalArgumentsFormatter(),
+    structlog.processors.StackInfoRenderer(),
+    structlog.processors.UnicodeDecoder(),
+]
 
 structlog.configure(
-    processors=[
+    processors=list([
         structlog.stdlib.filter_by_level,
-        structlog.processors.TimeStamper(fmt='iso'),
-        structlog.stdlib.add_logger_name,
-        structlog.stdlib.add_log_level,
-        structlog.stdlib.PositionalArgumentsFormatter(),
-        structlog.processors.StackInfoRenderer(),
-        # Remove `format_exc_info` from your processor chain if you want pretty exceptions.
-        # structlog.processors.format_exc_info,
-        structlog.processors.UnicodeDecoder(),
+        *shared_processors,
         structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
-    ],
+    ]),
     context_class=structlog.threadlocal.wrap_dict(dict),
     logger_factory=structlog.stdlib.LoggerFactory(),
     wrapper_class=structlog.stdlib.BoundLogger,

--- a/readthedocs/core/logs.py
+++ b/readthedocs/core/logs.py
@@ -1,7 +1,10 @@
+import sys
+import warnings
+
 from io import StringIO
 
 import structlog
-from structlog.dev import _pad
+from structlog.dev import _pad, plain_traceback
 
 from django_structlog.middlewares.request import RequestMiddleware
 

--- a/readthedocs/core/logs.py
+++ b/readthedocs/core/logs.py
@@ -69,6 +69,7 @@ class NewRelicProcessor:
         event_dict.update(output)
         return event_dict
 
+
 shared_processors = [
     structlog.processors.TimeStamper(fmt='iso'),
     structlog.stdlib.add_logger_name,

--- a/readthedocs/core/management/commands/clean_builds.py
+++ b/readthedocs/core/management/commands/clean_builds.py
@@ -2,7 +2,7 @@
 
 """Clean up stable build paths per project version."""
 
-import logging
+import structlog
 from datetime import timedelta
 
 from django.core.management.base import BaseCommand
@@ -12,7 +12,7 @@ from django.utils import timezone
 from readthedocs.builds.models import Build, Version
 
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class Command(BaseCommand):
@@ -51,17 +51,18 @@ class Command(BaseCommand):
                 latest_build = version.builds.latest('date')
                 if latest_build.date > max_date:
                     log.warning(
-                        '%s is newer than %s',
-                        latest_build,
-                        max_date,
+                        'Latest build is newer.',
+                        build_id=latest_build.pk,
+                        date=latest_build.date,
+                        max_date=max_date,
                     )
                 path = version.get_build_path()
                 if path is not None:
                     log.info(
-                        'Found stale build path for %s at %s, last used on %s',
-                        version,
-                        path,
-                        latest_build.date,
+                        'Found stale build path for version at path, last used on date.',
+                        version_slug=version.slug,
+                        path=path,
+                        date=latest_build.date,
                     )
                     if not options['dryrun']:
                         version.clean_build_path()

--- a/readthedocs/core/management/commands/contact_owners.py
+++ b/readthedocs/core/management/commands/contact_owners.py
@@ -1,4 +1,4 @@
-import logging
+import structlog
 import sys
 from pathlib import Path
 from pprint import pprint
@@ -14,7 +14,7 @@ from readthedocs.projects.models import Project
 
 User = get_user_model()  # noqa
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class Command(BaseCommand):

--- a/readthedocs/core/management/commands/pull.py
+++ b/readthedocs/core/management/commands/pull.py
@@ -2,7 +2,7 @@
 
 """Trigger build for project slug."""
 
-import logging
+import structlog
 
 from django.core.management.base import LabelCommand
 
@@ -10,7 +10,7 @@ from readthedocs.builds.constants import LATEST
 from readthedocs.projects import tasks, utils
 
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class Command(LabelCommand):

--- a/readthedocs/core/middleware.py
+++ b/readthedocs/core/middleware.py
@@ -1,4 +1,4 @@
-import logging
+import structlog
 import time
 
 from django.conf import settings
@@ -13,9 +13,7 @@ from django.utils.cache import patch_vary_headers
 from django.utils.http import http_date
 from django.utils.translation import ugettext_lazy as _
 
-log = logging.getLogger(__name__)
-
-LOG_TEMPLATE = '(Middleware) %(msg)s [%(host)s%(path)s]'
+log = structlog.get_logger(__name__)
 
 
 class ReadTheDocsSessionMiddleware(SessionMiddleware):

--- a/readthedocs/core/resolver.py
+++ b/readthedocs/core/resolver.py
@@ -1,6 +1,6 @@
 """URL resolver for documentation."""
 
-import logging
+import structlog
 from urllib.parse import urlunparse
 
 from django.conf import settings
@@ -8,7 +8,7 @@ from django.conf import settings
 from readthedocs.core.utils.extend import SettingsOverrideObject
 from readthedocs.builds.constants import EXTERNAL
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class ResolverBase:
@@ -102,7 +102,7 @@ class ResolverBase:
             )
             if '$' in url:
                 log.warning(
-                    'Unconverted variable in a resolver URLConf: url=%s', url
+                    'Unconverted variable in a resolver URLConf.', url=url,
                 )
 
         return url.format(

--- a/readthedocs/core/signals.py
+++ b/readthedocs/core/signals.py
@@ -1,6 +1,6 @@
 """Signal handling for core app."""
 
-import logging
+import structlog
 
 from corsheaders import signals
 from django.conf import settings
@@ -17,7 +17,7 @@ from readthedocs.builds.models import Version
 from readthedocs.core.unresolver import unresolve
 from readthedocs.projects.models import Project
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 ALLOWED_URLS = [
     '/api/v2/footer_html',

--- a/readthedocs/core/tasks.py
+++ b/readthedocs/core/tasks.py
@@ -2,7 +2,7 @@
 
 """Basic tasks."""
 
-import logging
+import structlog
 
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
@@ -14,7 +14,7 @@ from messages_extends.models import Message as PersistentMessage
 from readthedocs.worker import app
 
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 EMAIL_TIME_LIMIT = 30
 
@@ -60,7 +60,7 @@ def send_email_task(
         # TypeError is raised when ``template_html`` is ``None``
         pass
     msg.send()
-    log.info('Sent email to recipient: %s', recipient)
+    log.info('Sent email to recipient.', recipient=recipient)
 
 
 @app.task(queue='web')

--- a/readthedocs/core/unresolver.py
+++ b/readthedocs/core/unresolver.py
@@ -1,4 +1,4 @@
-import logging
+import structlog
 from collections import namedtuple
 from urllib.parse import urlparse
 
@@ -10,7 +10,7 @@ from readthedocs.proxito.middleware import map_host_to_project_slug
 from readthedocs.proxito.views.mixins import ServeDocsMixin
 from readthedocs.proxito.views.utils import _get_project_data_from_request
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 UnresolvedObject = namedtuple(
     'Unresolved', 'project, language_slug, version_slug, filename, fragment')
@@ -80,9 +80,11 @@ class UnresolverBase:
             filename += 'index.html'
 
         log.info(
-            'Unresolver parsed: '
-            'project=%s lang_slug=%s version_slug=%s filename=%s',
-            final_project.slug, lang_slug, version_slug, filename
+            'Unresolver parsed.',
+            project_slug=final_project.slug,
+            lang_slug=lang_slug,
+            version_slug=version_slug,
+            filename=filename,
         )
         return UnresolvedObject(final_project, lang_slug, version_slug, filename, parsed.fragment)
 

--- a/readthedocs/core/utils/contact.py
+++ b/readthedocs/core/utils/contact.py
@@ -1,4 +1,4 @@
-import logging
+import structlog
 from pprint import pprint
 
 import markdown
@@ -10,7 +10,7 @@ from messages_extends import constants as message_constants
 from readthedocs.notifications import SiteNotification
 from readthedocs.notifications.backends import SiteBackend
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 def contact_users(
@@ -101,8 +101,10 @@ def contact_users(
                 failed_notifications.add(user.username)
             else:
                 log.info(
-                    'Successfully set notification (%s/%s). user=%s',
-                    count, total, user,
+                    'Successfully set notification.',
+                    user_username=user.username,
+                    count=count,
+                    total=total,
                 )
                 sent_notifications.add(user.username)
 
@@ -145,7 +147,7 @@ def contact_users(
                 log.exception('Email failed to send')
                 failed_emails.update(emails)
             else:
-                log.info('Email sent (%s/%s). emails=%s', count, total, emails)
+                log.info('Email sent.', emails=emails, count=count, total=total)
                 sent_emails.update(emails)
 
     return {

--- a/readthedocs/core/views/__init__.py
+++ b/readthedocs/core/views/__init__.py
@@ -5,7 +5,7 @@ Including the main homepage, documentation and header rendering,
 and server errors.
 """
 
-import logging
+import structlog
 
 from django.conf import settings
 from django.http import Http404, JsonResponse
@@ -17,7 +17,7 @@ from readthedocs.core.utils.general import wipe_version_via_slugs
 from readthedocs.core.mixins import PrivateViewMixin
 from readthedocs.projects.models import Project
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class NoProjectException(Exception):

--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -4,7 +4,7 @@ MkDocs_ backend for building docs.
 .. _MkDocs: http://www.mkdocs.org/
 """
 
-import logging
+import structlog
 import os
 
 import yaml
@@ -16,7 +16,7 @@ from readthedocs.doc_builder.exceptions import MkDocsYAMLParseError
 from readthedocs.projects.constants import MKDOCS, MKDOCS_HTML
 from readthedocs.projects.models import Feature
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 def get_absolute_static_url():
@@ -59,8 +59,8 @@ class BaseMkdocs(BaseBuilder):
         if self.project.has_feature(Feature.MKDOCS_THEME_RTD):
             self.DEFAULT_THEME_NAME = 'readthedocs'
             log.warning(
-                'Project using readthedocs theme as default for MkDocs: slug=%s',
-                self.project.slug,
+                'Project using readthedocs theme as default for MkDocs.',
+                project_slug=self.project.slug,
             )
         else:
             self.DEFAULT_THEME_NAME = 'mkdocs'
@@ -107,9 +107,9 @@ class BaseMkdocs(BaseBuilder):
 
         except IOError:
             log.info(
-                'Creating default MkDocs config file for project: %s:%s',
-                self.project.slug,
-                self.version.slug,
+                'Creating default MkDocs config file for project.',
+                project_slug=self.project.slug,
+                version_slug=self.version.slug,
             )
             return {
                 'site_name': self.version.project.name,

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -5,7 +5,7 @@ Sphinx_ backend for building docs.
 """
 import codecs
 import itertools
-import logging
+import structlog
 import os
 import shutil
 import zipfile
@@ -31,7 +31,7 @@ from ..environments import BuildCommand, DockerBuildCommand
 from ..exceptions import BuildEnvironmentError
 from ..signals import finalize_sphinx_context_data
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class BaseSphinx(BaseBuilder):
@@ -63,9 +63,9 @@ class BaseSphinx(BaseBuilder):
     def _write_config(self, master_doc='index'):
         """Create ``conf.py`` if it doesn't exist."""
         log.info(
-            'Creating default Sphinx config file for project: %s:%s',
-            self.project.slug,
-            self.version.slug,
+            'Creating default Sphinx config file for project.',
+            project_slug=self.project.slug,
+            version_slug=self.version.slug,
         )
         docs_dir = self.docs_dir()
         conf_template = render_to_string(
@@ -138,9 +138,9 @@ class BaseSphinx(BaseBuilder):
                 subproject_urls = self.project.get_subproject_urls()
             except ConnectionError:
                 log.exception(
-                    'Timeout while fetching versions/downloads/subproject_urls for Sphinx context. '
-                    'project: %s version: %s',
-                    self.project.slug, self.version.slug,
+                    'Timeout while fetching versions/downloads/subproject_urls for Sphinx context.',
+                    project_slug=self.project.slug,
+                    version_slug=self.version.slug,
                 )
 
         build_id = self.build_env.build.get('id')
@@ -391,7 +391,7 @@ class LocalMediaBuilder(BaseSphinx):
 
     @restoring_chdir
     def move(self, **__):
-        log.info('Creating zip file from %s', self.old_artifact_path)
+        log.info('Creating zip file from path.', path=self.old_artifact_path)
         target_file = os.path.join(
             self.target,
             '{}.zip'.format(self.project.slug),

--- a/readthedocs/doc_builder/base.py
+++ b/readthedocs/doc_builder/base.py
@@ -1,6 +1,6 @@
 """Base classes for Builders."""
 
-import logging
+import structlog
 import os
 import shutil
 from functools import wraps
@@ -8,7 +8,7 @@ from functools import wraps
 from readthedocs.projects.models import Feature
 
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 def restoring_chdir(fn):
@@ -73,8 +73,8 @@ class BaseBuilder:
         if os.path.exists(self.old_artifact_path):
             if os.path.exists(self.target):
                 shutil.rmtree(self.target)
-            log.info('Copying %s on the local filesystem', self.type)
-            log.debug('Ignoring patterns %s', self.ignore_patterns)
+            log.info('Copying output type on the local filesystem.', output_type=self.type)
+            log.debug('Ignoring patterns.', patterns=self.ignore_patterns)
             shutil.copytree(
                 self.old_artifact_path,
                 self.target,
@@ -87,7 +87,7 @@ class BaseBuilder:
         """Clean the path where documentation will be built."""
         if os.path.exists(self.old_artifact_path):
             shutil.rmtree(self.old_artifact_path)
-            log.info('Removing old artifact path: %s', self.old_artifact_path)
+            log.info('Removing old artifact path.', path=self.old_artifact_path)
 
     def docs_dir(self, docs_dir=None, **__):
         """Handle creating a custom docs_dir if it doesn't exist."""

--- a/readthedocs/doc_builder/constants.py
+++ b/readthedocs/doc_builder/constants.py
@@ -2,13 +2,13 @@
 
 """Doc build constants."""
 
-import logging
+import structlog
 import re
 
 from django.conf import settings
 
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 PDF_RE = re.compile('Output written on (.*?)')
 

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -5,7 +5,7 @@ import copy
 import hashlib
 import itertools
 import json
-import logging
+import structlog
 import os
 import shutil
 import tarfile
@@ -21,11 +21,10 @@ from readthedocs.doc_builder.config import load_yaml_config
 from readthedocs.doc_builder.constants import DOCKER_IMAGE
 from readthedocs.doc_builder.environments import DockerBuildEnvironment
 from readthedocs.doc_builder.loader import get_builder_class
-from readthedocs.projects.constants import LOG_TEMPLATE
 from readthedocs.projects.models import Feature
 from readthedocs.storage import build_tools_storage
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class PythonEnvironment:
@@ -51,12 +50,9 @@ class PythonEnvironment:
         )
         if os.path.exists(build_dir):
             log.info(
-                LOG_TEMPLATE,
-                {
-                    'project': self.project.slug,
-                    'version': self.version.slug,
-                    'msg': 'Removing existing build directory',
-                }
+                'Removing existing build directory',
+                project_slug=self.project.slug,
+                version_slug=self.version.slug,
             )
             shutil.rmtree(build_dir)
 
@@ -65,12 +61,9 @@ class PythonEnvironment:
         # Handle deleting old venv dir
         if os.path.exists(venv_dir):
             log.info(
-                LOG_TEMPLATE,
-                {
-                    'project': self.project.slug,
-                    'version': self.version.slug,
-                    'msg': 'Removing existing venv directory',
-                }
+                'Removing existing venv directory',
+                project_slug=self.project.slug,
+                version_slug=self.version.slug,
             )
             shutil.rmtree(venv_dir)
 
@@ -131,11 +124,11 @@ class PythonEnvironment:
                     )
             else:
                 log.debug(
-                    'Cached version for tool not found. os=%s tool=%s version=% filename=%s',
-                    self.config.build.os,
-                    tool,
-                    full_version,
-                    tool_path,
+                    'Cached version for tool not found.',
+                    os=self.config.build.os,
+                    tool=tool,
+                    full_version=full_version,
+                    tool_path=tool_path,
                 )
                 # If the tool version selected is not available from the
                 # cache we compile it at build time
@@ -677,12 +670,9 @@ class Conda(PythonEnvironment):
         if os.path.exists(version_path):
             # Re-create conda directory each time to keep fresh state
             log.info(
-                LOG_TEMPLATE,
-                {
-                    'project': self.project.slug,
-                    'version': self.version.slug,
-                    'msg': 'Removing existing conda directory',
-                },
+                'Removing existing conda directory',
+                project_slug=self.project.slug,
+                version_slug=self.version.slug,
             )
             shutil.rmtree(version_path)
 

--- a/readthedocs/embed/v3/views.py
+++ b/readthedocs/embed/v3/views.py
@@ -66,7 +66,7 @@ class EmbedAPIBase(CachedResponseMixin, APIView):
         cache_key = f'embed-api-{url}'
         cached_response = cache.get(cache_key)
         if cached_response:
-            log.debug('Cached response. url=%s', url)
+            log.debug('Cached response.', url=url)
             return cached_response
 
         response = requests.get(url, timeout=settings.RTD_EMBED_API_DEFAULT_REQUEST_TIMEOUT)
@@ -103,7 +103,7 @@ class EmbedAPIBase(CachedResponseMixin, APIView):
             with build_media_storage.open(file_path) as fd:  # pylint: disable=invalid-name
                 return fd.read()
         except Exception:  # noqa
-            log.warning('Unable to read file. file_path=%s', file_path)
+            log.warning('Unable to read file.', file_path=file_path)
 
         return None
 
@@ -248,7 +248,7 @@ class EmbedAPIBase(CachedResponseMixin, APIView):
                 if re.match(allowed_domain, domain):
                     break
             else:
-                log.info('Domain not allowed. domain=%s url=%s', domain, url)
+                log.info('Domain not allowed.', domain=domain, url=url)
                 return Response(
                     {
                         'error': (
@@ -264,7 +264,7 @@ class EmbedAPIBase(CachedResponseMixin, APIView):
             cache.get_or_set(cache_key, 0, timeout=settings.RTD_EMBED_API_DOMAIN_RATE_LIMIT_TIMEOUT)
             cache.incr(cache_key)
             if cache.get(cache_key) > settings.RTD_EMBED_API_DOMAIN_RATE_LIMIT:
-                log.warning('Too many requests for this domain. domain=%s', domain)
+                log.warning('Too many requests for this domain.', domain=domain)
                 return Response(
                     {
                         'error': (
@@ -289,7 +289,7 @@ class EmbedAPIBase(CachedResponseMixin, APIView):
                 doctoolversion,
             )
         except requests.exceptions.TooManyRedirects:
-            log.exception('Too many redirects. url=%s', url)
+            log.exception('Too many redirects.', url=url)
             return Response(
                 {
                     'error': (
@@ -304,7 +304,7 @@ class EmbedAPIBase(CachedResponseMixin, APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         except Exception:  # noqa
-            log.exception('There was an error reading the URL requested. url=%s', url)
+            log.exception('There was an error reading the URL requested.', url=url)
             return Response(
                 {
                     'error': (
@@ -316,7 +316,7 @@ class EmbedAPIBase(CachedResponseMixin, APIView):
             )
 
         if not content_requested:
-            log.warning('Identifier not found. url=%s fragment=%s', url, fragment)
+            log.warning('Identifier not found.', url=url, fragment=fragment)
             return Response(
                 {
                     'error': (

--- a/readthedocs/embed/views.py
+++ b/readthedocs/embed/views.py
@@ -233,7 +233,7 @@ def _get_doc_content(project, version, doc):
         with build_media_storage.open(file_path) as file:
             return json.load(file)
     except Exception:  # noqa
-        log.warning('Unable to read file. file_path=%s', file_path)
+        log.warning('Unable to read file.', file_path=file_path)
 
     return None
 
@@ -279,8 +279,9 @@ def parse_sphinx(content, section, url):
                 break
         except Exception:  # noqa
             log.info(
-                'Failed to query section. url=%s id=%s',
-                url, element_id,
+                'Failed to query section.',
+                url=url,
+                element_id=element_id,
             )
 
     if not query_result:

--- a/readthedocs/notifications/notification.py
+++ b/readthedocs/notifications/notification.py
@@ -2,7 +2,7 @@
 
 """Support for templating of notifications."""
 
-import logging
+import structlog
 from readthedocs.core.context_processors import readthedocs_processor
 
 from django.conf import settings
@@ -15,7 +15,7 @@ from . import constants
 from .backends import send_notification
 
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class Notification:
@@ -172,16 +172,16 @@ class SiteNotification(Notification):
                 else:
                     # log the error but not crash
                     log.error(
-                        "Notification %s has no key '%s' for %s messages",
-                        self.__class__.__name__,
-                        self.reason,
-                        'success' if self.success else 'failure',
+                        "Notification has no key for messages",
+                        notification=self.__class__.__name__,
+                        key=self.reason,
+                        message='success' if self.success else 'failure',
                     )
             else:
                 log.error(
-                    '%s.%s_message is a dictionary but no reason was provided',
-                    self.__class__.__name__,
-                    'success' if self.success else 'failure',
+                    '{message} is a dictionary but no reason was provided',
+                    notification=self.__class__.__name__,
+                    message='success' if self.success else 'failure',
                 )
         else:
             msg = message

--- a/readthedocs/oauth/migrations/0003_move_github.py
+++ b/readthedocs/oauth/migrations/0003_move_github.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 import gc
 import json
-import logging
+import structlog
 
 from django.db import migrations
 
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 def chunks(queryset, chunksize=1000):
@@ -50,7 +50,7 @@ def forwards_move_repos(apps, schema_editor):
         except:
             pass
         new_org.save()
-        log.info('Migrated organization: %s', org.name)
+        log.info('Migrated organization.', organization_slug=org.slug)
 
     for org in chunks(BitbucketTeam.objects.all()):
         new_org = RemoteOrganization.objects.using(db).create(
@@ -70,7 +70,7 @@ def forwards_move_repos(apps, schema_editor):
         except:
             pass
         new_org.save()
-        log.info('Migrated organization: %s', org.name)
+        log.info('Migrated organization.', organization_slug=org.slug)
 
     # Now repositories
     GithubProject = apps.get_model('oauth', 'GithubProject')
@@ -110,7 +110,7 @@ def forwards_move_repos(apps, schema_editor):
         except (SyntaxError, ValueError):
             pass
         new_repo.save()
-        log.info('Migrated project: %s', project.name)
+        log.info('Migrated project.', project_slug=project.slug)
 
     for project in chunks(BitbucketProject.objects.all()):
         new_repo = RemoteRepository.objects.using(db).create(
@@ -151,7 +151,7 @@ def forwards_move_repos(apps, schema_editor):
         except (SyntaxError, ValueError):
             pass
         new_repo.save()
-        log.info('Migrated project: %s', project.name)
+        log.info('Migrated project.', project_slug=project.slug)
 
 
 def reverse_move_repos(apps, schema_editor):

--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -1,6 +1,6 @@
 """OAuth utility functions."""
 
-import logging
+import structlog
 from datetime import datetime
 
 from allauth.socialaccount.models import SocialAccount
@@ -17,7 +17,7 @@ from readthedocs.oauth.models import (
 )
 
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class SyncServiceError(Exception):
@@ -134,7 +134,7 @@ class Service:
                 datetime.fromtimestamp(data['expires_at']),
             )
             token.save()
-            log.info('Updated token %s:', token)
+            log.info('Updated token.', token=token)
 
         return _updater
 
@@ -173,7 +173,7 @@ class Service:
             return results
         # Catch specific exception related to OAuth
         except InvalidClientIdError:
-            log.warning('access_token or refresh_token failed: %s', url)
+            log.warning('access_token or refresh_token failed.', url=url)
             raise Exception('You should reconnect your account')
         # Catch exceptions with request or deserializing JSON
         except (RequestException, ValueError):
@@ -184,9 +184,9 @@ class Service:
             except ValueError:
                 debug_data = resp.content
             log.debug(
-                'Paginate failed at %s with response: %s',
-                url,
-                debug_data,
+                'Paginate failed at URL.',
+                url=url,
+                debug_data=debug_data,
             )
 
         return []

--- a/readthedocs/oauth/tasks.py
+++ b/readthedocs/oauth/tasks.py
@@ -1,6 +1,6 @@
 """Tasks for OAuth services."""
 
-import logging
+import structlog
 
 from allauth.socialaccount.providers import registry as allauth_registry
 from django.contrib.auth.models import User
@@ -22,7 +22,7 @@ from readthedocs.worker import app
 from .services import registry
 
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 @PublicTask.permission_check(user_id_matches)
@@ -33,7 +33,7 @@ def sync_remote_repositories(user_id):
         return
 
     # TODO: remove this log once we find out what's causing OOM
-    log.info('Running readthedocs.oauth.tasks.sync_remote_repositories. locals=%s', locals())
+    log.info('Running readthedocs.oauth.tasks.sync_remote_repositories.', locals=locals())
 
     failed_services = set()
     for service_cls in registry:
@@ -67,9 +67,9 @@ def sync_remote_repositories_organizations(organization_slugs=None):
     if organization_slugs:
         query = Organization.objects.filter(slug__in=organization_slugs)
         log.info(
-            'Triggering SSO re-sync for organizations. slugs=%s count=%s',
-            organization_slugs,
-            query.count(),
+            'Triggering SSO re-sync for organizations.',
+            organization_slugs=organization_slugs,
+            count=query.count(),
         )
     else:
         query = (
@@ -78,17 +78,17 @@ def sync_remote_repositories_organizations(organization_slugs=None):
             .values_list('organization', flat=True)
         )
         log.info(
-            'Triggering SSO re-sync for all organizations. count=%s',
-            query.count(),
+            'Triggering SSO re-sync for all organizations.',
+            count=query.count(),
         )
 
     n_task = -1
     for organization in query:
         members = AdminPermission.members(organization)
         log.info(
-            'Triggering SSO re-sync for organization. organization=%s users=%s',
-            organization.slug,
-            members.count(),
+            'Triggering SSO re-sync for organization.',
+            organization_slug=organization.slug,
+            count=members.count(),
         )
         for user in members:
             n_task += 1

--- a/readthedocs/oauth/utils.py
+++ b/readthedocs/oauth/utils.py
@@ -1,6 +1,6 @@
 """Support code for OAuth, including webhook support."""
 
-import logging
+import structlog
 
 from django.contrib import messages
 from django.utils.translation import ugettext_lazy as _
@@ -14,7 +14,7 @@ from readthedocs.oauth.services import (
 from readthedocs.projects.models import Project
 
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 SERVICE_MAP = {
     Integration.GITHUB_WEBHOOK: GitHubService,

--- a/readthedocs/organizations/signals.py
+++ b/readthedocs/organizations/signals.py
@@ -1,6 +1,6 @@
 """Organization signals."""
 
-import logging
+import structlog
 
 from allauth.account.signals import user_signed_up
 from django.db.models import Count
@@ -20,7 +20,7 @@ from readthedocs.projects.models import Project
 
 from .tasks import mark_organization_assets_not_cleaned as mark_organization_assets_not_cleaned_task
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 # pylint: disable=unused-argument
@@ -50,7 +50,7 @@ def remove_organization_completely(sender, instance, using, **kwargs):
     - Artifacts (HTML, PDF, etc)
     """
     organization = instance
-    log.info('Removing Organization %s completely', organization.slug)
+    log.info('Removing organization completely', organization_slug=organization.slug)
 
     # ``Project`` has a ManyToMany relationship with ``Organization``. We need
     # to be sure that the projects we are deleting here belongs only to the

--- a/readthedocs/organizations/tasks.py
+++ b/readthedocs/organizations/tasks.py
@@ -1,12 +1,12 @@
 """Organization's tasks related."""
 
-import logging
+import structlog
 
 from readthedocs.builds.models import Build
 from readthedocs.worker import app
 
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 @app.task(queue='web')
@@ -15,11 +15,11 @@ def mark_organization_assets_not_cleaned(build_pk):
     try:
         build = Build.objects.get(pk=build_pk)
     except Build.DoesNotExist:
-        log.info("Build does not exist. build=%s", build_pk)
+        log.info("Build does not exist.", build_pk=build_pk)
         return
 
     organization = build.project.organizations.first()
     if organization and organization.artifacts_cleaned:
-        log.info("Marking organization as not cleaned. organization=%s", organization.slug)
+        log.info("Marking organization as not cleaned.", origanization_slug=organization.slug)
         organization.artifacts_cleaned = False
         organization.save()

--- a/readthedocs/organizations/utils.py
+++ b/readthedocs/organizations/utils.py
@@ -1,17 +1,17 @@
 """Utilities for organizations."""
 
-import logging
+import structlog
 
 from readthedocs.core.utils import send_email
 
 
 # pylint: disable=invalid-name
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 def send_team_invite_email(invite, request):
     """Send an organization team invite email."""
-    log.info('Sending team invite for %s to %s', invite.team, invite.email)
+    log.info('Sending team invite.', team=invite.team, email=invite.email)
     send_email(
         invite.email,
         subject='Join your team at Read the Docs',
@@ -30,9 +30,9 @@ def send_team_invite_email(invite, request):
 def send_team_add_email(team_member, request):
     """Send an organization team add email."""
     log.info(
-        'Sending team add notification for %s to %s',
-        team_member.team,
-        team_member.member.email,
+        'Sending team add notification.',
+        team=team_member.team,
+        email=team_member.member.email,
     )
     send_email(
         team_member.member.email,

--- a/readthedocs/organizations/views/public.py
+++ b/readthedocs/organizations/views/public.py
@@ -1,6 +1,6 @@
 """Views that don't require login."""
 # pylint: disable=too-many-ancestors
-import logging
+import structlog
 
 from django.db.models import F
 from django.http import HttpResponseRedirect
@@ -19,7 +19,7 @@ from readthedocs.organizations.views.base import (
 )
 from readthedocs.projects.models import Project
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class OrganizationTemplateView(CheckOrganizationsEnabled, TemplateView):

--- a/readthedocs/payments/utils.py
+++ b/readthedocs/payments/utils.py
@@ -7,7 +7,7 @@ These are mostly one-off functions. Define the bulk of Stripe operations on
 :py:class:`readthedocs.payments.forms.StripeResourceMixin`.
 """
 
-import logging
+import structlog
 
 import stripe
 
@@ -15,7 +15,7 @@ from django.conf import settings
 
 
 stripe.api_key = settings.STRIPE_SECRET
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 def delete_customer(customer_id):
@@ -25,8 +25,8 @@ def delete_customer(customer_id):
         return customer.delete()
     except stripe.error.InvalidRequestError:
         log.exception(
-            'Customer not deleted. Customer not found on Stripe. customer=%s',
-            customer_id,
+            'Customer not deleted. Customer not found on Stripe.',
+            stripe_customer=customer_id,
         )
 
 
@@ -39,8 +39,7 @@ def cancel_subscription(customer_id, subscription_id):
             return subscription.delete()
     except stripe.error.StripeError:
         log.exception(
-            'Subscription not cancelled. Customer/Subscription not found on Stripe. '
-            'customer=%s subscription=%s',
-            customer_id,
-            subscription_id,
+            'Subscription not cancelled. Customer/Subscription not found on Stripe. ',
+            stripe_customer=customer_id,
+            stripe_subscription=subscription_id,
         )

--- a/readthedocs/projects/constants.py
+++ b/readthedocs/projects/constants.py
@@ -303,8 +303,6 @@ PROGRAMMING_LANGUAGES = (
     ('other', 'Other'),
 )
 
-LOG_TEMPLATE = '(Build) [%(project)s:%(version)s] %(msg)s'
-
 PROJECT_PK_REGEX = r'(?:[-\w]+)'
 PROJECT_SLUG_REGEX = r'(?:[-\w]+)'
 

--- a/readthedocs/projects/filters.py
+++ b/readthedocs/projects/filters.py
@@ -1,11 +1,11 @@
-import logging
+import structlog
 
 from django.db.models import Count, F, Max
 from django.forms.widgets import HiddenInput
 from django.utils.translation import ugettext_lazy as _
 from django_filters import CharFilter, ChoiceFilter, FilterSet, OrderingFilter
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class VersionSortOrderingFilter(OrderingFilter):

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -2,7 +2,7 @@
 import fnmatch
 import hashlib
 import hmac
-import logging
+import structlog
 import os
 import re
 from shlex import quote
@@ -62,7 +62,7 @@ from .constants import (
     MEDIA_TYPES,
 )
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 def default_privacy_level():
@@ -657,8 +657,9 @@ class Project(models.Model):
 
         if '\\$' in to_convert:
             log.warning(
-                'Unconverted variable in a project URLConf: project=%s to_convert=%s',
-                self, to_convert
+                'Unconverted variable in a project URLConf.',
+                project_slug=self.slug,
+                to_convert=to_convert,
             )
         return to_convert
 

--- a/readthedocs/projects/utils.py
+++ b/readthedocs/projects/utils.py
@@ -1,13 +1,13 @@
 """Utility functions used by projects."""
 
 import csv
-import logging
+import structlog
 import os
 
 from django.conf import settings
 from django.http import StreamingHttpResponse
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 # TODO make this a classmethod of Version

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -1,6 +1,6 @@
 """Project views for authenticated users."""
 
-import logging
+import structlog
 
 from allauth.socialaccount.models import SocialAccount
 from django.conf import settings
@@ -80,7 +80,7 @@ from readthedocs.projects.views.mixins import (
 )
 from readthedocs.search.models import SearchQuery
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class ProjectDashboard(PrivateViewMixin, ListView):
@@ -212,7 +212,7 @@ class ProjectVersionEditMixin(ProjectVersionMixin):
         version = form.save()
         if form.has_changed():
             if 'active' in form.changed_data and version.active is False:
-                log.info('Removing files for version %s', version.slug)
+                log.info('Removing files for version.', version_slug=version.slug)
                 tasks.clean_project_resources(
                     version.project,
                     version,
@@ -241,7 +241,7 @@ class ProjectVersionDeleteHTML(ProjectVersionMixin, GenericModelView):
         if not version.active:
             version.built = False
             version.save()
-            log.info('Removing files for version %s', version.slug)
+            log.info('Removing files for version.', version_slug=version.slug)
             tasks.clean_project_resources(
                 version.project,
                 version,

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -2,7 +2,7 @@
 
 import hashlib
 import json
-import logging
+import structlog
 import mimetypes
 import operator
 import os
@@ -42,8 +42,8 @@ from readthedocs.storage import build_media_storage
 from ..constants import PRIVATE
 from .base import ProjectOnboardMixin
 
-log = logging.getLogger(__name__)
-search_log = logging.getLogger(__name__ + '.search')
+log = structlog.get_logger(__name__)
+search_log = structlog.get_logger(__name__ + '.search')
 mimetypes.add_type('application/epub+zip', '.epub')
 
 

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -5,10 +5,11 @@ This is used to take the request and map the host to the proper project slug.
 
 Additional processing is done to get the project from the URL in the ``views.py`` as well.
 """
-import logging
 import re
 import sys
 from urllib.parse import urlparse
+
+import structlog
 
 from django.conf import settings
 from django.shortcuts import redirect, render
@@ -18,7 +19,7 @@ from django.utils.deprecation import MiddlewareMixin
 from readthedocs.projects.models import Domain, Project, ProjectRelationship
 from readthedocs.proxito import constants
 
-log = logging.getLogger(__name__)  # noqa
+log = structlog.get_logger(__name__)  # noqa
 
 
 def map_host_to_project_slug(request):  # pylint: disable=too-many-return-statements
@@ -52,7 +53,7 @@ def map_host_to_project_slug(request):  # pylint: disable=too-many-return-statem
         project_slug = request.META['HTTP_X_RTD_SLUG'].lower()
         if Project.objects.filter(slug=project_slug).exists():
             request.rtdheader = True
-            log.info('Setting project based on X_RTD_SLUG header: %s', project_slug)
+            log.info('Setting project based on X_RTD_SLUG header.', project_slug=project_slug)
             return project_slug
 
     if public_domain in host or host == 'proxito':
@@ -60,24 +61,24 @@ def map_host_to_project_slug(request):  # pylint: disable=too-many-return-statem
         if public_domain_parts == host_parts[1:]:
             project_slug = host_parts[0]
             request.subdomain = True
-            log.debug('Proxito Public Domain: host=%s', host)
+            log.debug('Proxito Public Domain.', host=host)
             if Domain.objects.filter(project__slug=project_slug).filter(
                 canonical=True,
                 https=True,
             ).exists():
-                log.debug('Proxito Public Domain -> Canonical Domain Redirect: host=%s', host)
+                log.debug('Proxito Public Domain -> Canonical Domain Redirect.', host=host)
                 request.canonicalize = constants.REDIRECT_CANONICAL_CNAME
             elif (
                 ProjectRelationship.objects.
                 filter(child__slug=project_slug).exists()
             ):
-                log.debug('Proxito Public Domain -> Subproject Main Domain Redirect: host=%s', host)
+                log.debug('Proxito Public Domain -> Subproject Main Domain Redirect.', host=host)
                 request.canonicalize = constants.REDIRECT_SUBPROJECT_MAIN_DOMAIN
             return project_slug
 
         # TODO: This can catch some possibly valid domains (docs.readthedocs.io.com) for example
         # But these feel like they might be phishing, etc. so let's block them for now.
-        log.warning('Weird variation on our hostname: host=%s', host)
+        log.warning('Weird variation on our hostname.', host=host)
         return render(
             request, 'core/dns-404.html', context={'host': host}, status=400
         )
@@ -89,10 +90,10 @@ def map_host_to_project_slug(request):  # pylint: disable=too-many-return-statem
                 project_slug, version_slug = host_parts[0].split('--', 1)
                 request.external_domain = True
                 request.host_version_slug = version_slug
-                log.debug('Proxito External Version Domain: host=%s', host)
+                log.debug('Proxito External Version Domain.', host=host)
                 return project_slug
             except ValueError:
-                log.warning('Weird variation on our hostname: host=%s', host)
+                log.warning('Weird variation on our hostname.', host=host)
                 return render(
                     request, 'core/dns-404.html', context={'host': host}, status=400
                 )
@@ -103,11 +104,11 @@ def map_host_to_project_slug(request):  # pylint: disable=too-many-return-statem
         project_slug = domain.project.slug
         request.cname = True
         request.domain = domain
-        log.debug('Proxito CNAME: host=%s', host)
+        log.debug('Proxito CNAME.', host=host)
 
         if domain.https and not request.is_secure():
             # Redirect HTTP -> HTTPS (302) for this custom domain
-            log.debug('Proxito CNAME HTTPS Redirect: host=%s', host)
+            log.debug('Proxito CNAME HTTPS Redirect.', host=host)
             request.canonicalize = constants.REDIRECT_HTTPS
 
         # NOTE: consider redirecting non-canonical custom domains to the canonical one
@@ -116,7 +117,7 @@ def map_host_to_project_slug(request):  # pylint: disable=too-many-return-statem
         return project_slug
 
     # Some person is CNAMEing to us without configuring a domain - 404.
-    log.debug('CNAME 404: host=%s', host)
+    log.debug('CNAME 404.', host=host)
     return render(
         request, 'core/dns-404.html', context={'host': host}, status=404
     )
@@ -191,14 +192,14 @@ class ProxitoMiddleware(MiddlewareMixin):
             for http_header in request.domain.http_headers.all():
                 if http_header.name.lower() in response_headers:
                     log.error(
-                        'Overriding an existing response HTTP header. header=%s domain=%s',
-                        http_header.name,
-                        request.domain.domain,
+                        'Overriding an existing response HTTP header.',
+                        http_header=http_header.name,
+                        domain=request.domain.domain,
                     )
                 log.info(
-                    'Adding custom response HTTP header. header=%s domain=%s',
-                    http_header.name,
-                    request.domain.domain,
+                    'Adding custom response HTTP header.',
+                    http_header=http_header.name,
+                    domain=request.domain.domain,
                 )
 
                 if http_header.only_if_secure_request and not request.is_secure():
@@ -294,10 +295,17 @@ class ProxitoMiddleware(MiddlewareMixin):
             #   We make sure there is _always_ a single slash in front to ensure relative redirects,
             #   instead of `//` redirects which are actually alternative domains.
             final_url = '/' + final_url.lstrip('/')
-            log.info('Proxito Slash Redirect: from=%s to=%s', request.get_full_path(), final_url)
+            log.info(
+                'Proxito Slash Redirect.',
+                from_url=request.get_full_path(),
+                to_url=final_url,
+            )
             return redirect(final_url)
 
-        log.debug('Proxito Project: slug=%s', ret)
+        log.debug(
+            'Proxito Project.',
+            project_slug=ret,
+        )
 
         # Otherwise set the slug on the request
         request.host_project_slug = request.slug = ret
@@ -318,8 +326,10 @@ class ProxitoMiddleware(MiddlewareMixin):
             url_key = f'readthedocs.urls.fake.{project.slug}.{project_timestamp}'
 
             log.info(
-                'Setting URLConf: project=%s url_key=%s urlconf=%s',
-                project, url_key, project.urlconf,
+                'Setting URLConf',
+                project_slug=project.slug,
+                url_key=url_key,
+                urlconf=project.urlconf,
             )
             if url_key not in sys.modules:
                 sys.modules[url_key] = project.proxito_urlconf

--- a/readthedocs/proxito/views/decorators.py
+++ b/readthedocs/proxito/views/decorators.py
@@ -1,11 +1,11 @@
-import logging
+import structlog
 from functools import wraps
 
 from django.http import Http404
 
 from readthedocs.projects.models import Project, ProjectRelationship
 
-log = logging.getLogger(__name__)  # noqa
+log = structlog.get_logger(__name__)  # noqa
 
 
 def map_subproject_slug(view_func):
@@ -40,8 +40,9 @@ def map_subproject_slug(view_func):
                     subproject = rel.child
                 else:
                     log.warning(
-                        'The slug is not subproject of project. subproject_slug=%s project_slug=%s',
-                        subproject_slug, kwargs['project'].slug
+                        'The slug is not subproject of project.',
+                        subproject_slug=subproject_slug,
+                        project_slug=kwargs['project'].slug,
                     )
                     raise Http404('Invalid subproject slug')
         return view_func(request, subproject=subproject, *args, **kwargs)
@@ -67,8 +68,8 @@ def map_project_slug(view_func):
             if not project_slug:
                 project_slug = getattr(request, 'host_project_slug', None)
                 log.debug(
-                    'Inserting project slug from request slug=[%s]',
-                    project_slug
+                    'Inserting project slug from request.',
+                    project_slug=project_slug,
                 )
             try:
                 project = Project.objects.get(slug=project_slug)

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -1,7 +1,7 @@
 """Views for doc serving."""
 
 import itertools
-import logging
+import structlog
 from urllib.parse import urlparse
 
 from readthedocs.core.resolver import resolve_path
@@ -26,7 +26,7 @@ from .decorators import map_project_slug
 from .mixins import ServeDocsMixin, ServeRedirectMixin
 from .utils import _get_project_data_from_request
 
-log = logging.getLogger(__name__)  # noqa
+log = structlog.get_logger(__name__)  # noqa
 
 
 class ServePageRedirect(ServeRedirectMixin, ServeDocsMixin, View):
@@ -78,10 +78,14 @@ class ServeDocsBase(ServeRedirectMixin, ServeDocsMixin, View):
             filename=filename,
         )
 
-        log.debug(
-            'Serving docs: project=%s, subproject=%s, lang_slug=%s, version_slug=%s, filename=%s',
-            final_project.slug, subproject_slug, lang_slug, version_slug, filename
+        log.bind(
+            project_slug=final_project.slug,
+            subproject_slug=subproject_slug,
+            lang_slug=lang_slug,
+            version_slug=version_slug,
+            filename=filename,
         )
+        log.debug('Serving docs.')
 
         # Verify if the project is marked as spam and return a 401 in that case
         spam_response = self._spam_response(request, final_project)
@@ -123,8 +127,8 @@ class ServeDocsBase(ServeRedirectMixin, ServeDocsMixin, View):
                 self.version_type != EXTERNAL,
         ]):
             log.warning(
-                'Invalid URL for project with versions. url=%s, project=%s',
-                filename, final_project.slug
+                'Invalid URL for project with versions.',
+                filename=filename,
             )
             raise Http404('Invalid URL for project with versions')
 
@@ -195,7 +199,8 @@ class ServeError404Base(ServeRedirectMixin, ServeDocsMixin, View):
         the Docs default page (Maze Found) is rendered by Django and served.
         """
         # pylint: disable=too-many-locals
-        log.info('Executing 404 handler. proxito_path=%s', proxito_path)
+        log.bind(proxito_path=proxito_path)
+        log.debug('Executing 404 handler.')
 
         # Parse the URL using the normal urlconf, so we get proper subdomain/translation data
         _, __, kwargs = url_resolve(
@@ -214,6 +219,11 @@ class ServeError404Base(ServeRedirectMixin, ServeDocsMixin, View):
             filename=kwargs.get('filename', ''),
         )
 
+        log.bind(
+            project_slug=final_project.slug,
+            version_slug=version_slug,
+        )
+
         storage_root_path = final_project.get_storage_path(
             type_='html',
             version_slug=version_slug,
@@ -227,19 +237,9 @@ class ServeError404Base(ServeRedirectMixin, ServeDocsMixin, View):
                 storage_root_path,
                 f'{filename}/{tryfile}'.lstrip('/'),
             )
-            log.debug(
-                'Trying index filename: project=%s version=%s, file=%s',
-                final_project.slug,
-                version_slug,
-                storage_filename_path,
-            )
+            log.debug('Trying index filename.')
             if build_media_storage.exists(storage_filename_path):
-                log.info(
-                    'Redirecting to index file: project=%s version=%s, storage_path=%s',
-                    final_project.slug,
-                    version_slug,
-                    storage_filename_path,
-                )
+                log.info('Redirecting to index file.')
                 # Use urlparse so that we maintain GET args in our redirect
                 parts = urlparse(proxito_path)
                 if tryfile == 'README.html':
@@ -327,9 +327,9 @@ class ServeError404Base(ServeRedirectMixin, ServeDocsMixin, View):
                 storage_filename_path = build_media_storage.join(storage_root_path, tryfile)
                 if build_media_storage.exists(storage_filename_path):
                     log.info(
-                        'Serving custom 404.html page: [project: %s] [version: %s]',
-                        final_project.slug,
-                        version_slug_404,
+                        'Serving custom 404.html page.',
+                        version_slug_404=version_slug_404,
+                        storage_filename_path=storage_filename_path,
                     )
                     resp = HttpResponse(build_media_storage.open(storage_filename_path).read())
                     resp.status_code = 404

--- a/readthedocs/proxito/views/utils.py
+++ b/readthedocs/proxito/views/utils.py
@@ -1,12 +1,12 @@
 import os
-import logging
+import structlog
 
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, render
 
 from .decorators import map_project_slug, map_subproject_slug
 
-log = logging.getLogger(__name__)  # noqa
+log = structlog.get_logger(__name__)  # noqa
 
 
 def fast_404(request, *args, **kwargs):
@@ -61,8 +61,8 @@ def _get_project_data_from_request(
             filename = os.path.join(lang_slug, version_slug, filename)
             log.warning(
                 'URL looks like versioned on a single version project.'
-                'Changing filename to match. filename=%s',
-                filename
+                'Changing filename to match.',
+                filename=filename,
             )
             lang_slug = version_slug = None
 

--- a/readthedocs/redirects/models.py
+++ b/readthedocs/redirects/models.py
@@ -2,7 +2,7 @@
 
 """Django models for the redirects app."""
 
-import logging
+import structlog
 import re
 
 from django.db import models
@@ -15,7 +15,7 @@ from readthedocs.projects.models import Project
 from .querysets import RedirectQuerySet
 
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 HTTP_STATUS_CHOICES = (
     (301, _('301 - Permanent Redirect')),
@@ -174,7 +174,7 @@ class Redirect(models.Model):
 
     def redirect_prefix(self, path, language=None, version_slug=None):
         if path.startswith(self.from_url):
-            log.debug('Redirecting %s', self)
+            log.debug('Redirecting...', redirect=self)
             cut_path = re.sub('^%s' % self.from_url, '', path)
 
             to = self.get_full_path(
@@ -187,7 +187,7 @@ class Redirect(models.Model):
 
     def redirect_page(self, path, language=None, version_slug=None):
         if path == self.from_url:
-            log.debug('Redirecting %s', self)
+            log.debug('Redirecting...', redirect=self)
             to = self.get_full_path(
                 filename=self.to_url.lstrip('/'),
                 language=language,
@@ -202,7 +202,7 @@ class Redirect(models.Model):
             # reconstruct the full path for an exact redirect
             full_path = self.get_full_path(path, language, version_slug, allow_crossdomain=False)
         if full_path == self.from_url:
-            log.debug('Redirecting %s', self)
+            log.debug('Redirecting...', redirect=self)
             return self.to_url
         # Handle full sub-level redirects
         if '$rest' in self.from_url:
@@ -214,7 +214,7 @@ class Redirect(models.Model):
     def redirect_sphinx_html(self, path, language=None, version_slug=None):
         for ending in ['/', '/index.html']:
             if path.endswith(ending):
-                log.debug('Redirecting %s', self)
+                log.debug('Redirecting...', redirect=self)
                 path = path[1:]  # Strip leading slash.
                 to = re.sub(ending + '$', '.html', path)
                 return self.get_full_path(
@@ -226,7 +226,7 @@ class Redirect(models.Model):
 
     def redirect_sphinx_htmldir(self, path, language=None, version_slug=None):
         if path.endswith('.html'):
-            log.debug('Redirecting %s', self)
+            log.debug('Redirecting...', redirect=self)
             path = path[1:]  # Strip leading slash.
             to = re.sub('.html$', '/', path)
             return self.get_full_path(

--- a/readthedocs/redirects/querysets.py
+++ b/readthedocs/redirects/querysets.py
@@ -1,12 +1,12 @@
 """Queryset for the redirects app."""
-import logging
+import structlog
 
 from django.db import models
 from django.db.models import CharField, F, Q, Value
 
 from readthedocs.core.permissions import AdminPermission
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class RedirectQuerySet(models.QuerySet):

--- a/readthedocs/redirects/utils.py
+++ b/readthedocs/redirects/utils.py
@@ -7,7 +7,7 @@ with it in the database, and generating a redirect response.
 These are not used directly as views; they are instead included into 404
 handlers, so that redirects only take effect if no other view matches.
 """
-import logging
+import structlog
 import re
 from urllib.parse import urlparse, urlunparse
 
@@ -17,7 +17,7 @@ from readthedocs.constants import LANGUAGES_REGEX
 from readthedocs.projects.models import Project
 
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 def project_and_path_from_request(request, path):

--- a/readthedocs/rtd_tests/base.py
+++ b/readthedocs/rtd_tests/base.py
@@ -1,5 +1,5 @@
 """Base classes and mixins for unit tests."""
-import logging
+import structlog
 from collections import OrderedDict
 from unittest.mock import patch
 
@@ -8,7 +8,7 @@ from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.test import RequestFactory, TestCase
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class RequestFactoryTestMixin:

--- a/readthedocs/rtd_tests/tests/test_build_notifications.py
+++ b/readthedocs/rtd_tests/tests/test_build_notifications.py
@@ -43,8 +43,8 @@ class BuildNotificationsTests(TestCase):
             event=WebHookEvent.BUILD_FAILED,
         )
         mock_logger.warning.assert_called_with(
-            'Version not found for given kwargs. %s',
-            {'pk': 345343},
+            'Version not found for given kwargs.',
+            kwargs={'pk': 345343},
         )
 
     def test_send_notification_none(self):

--- a/readthedocs/rtd_tests/tests/test_celery.py
+++ b/readthedocs/rtd_tests/tests/test_celery.py
@@ -343,8 +343,8 @@ class TestCeleryBuilding(TestCase):
             search_ignore=[],
         )
         mock_logger.warning.assert_called_with(
-            'Version not found for given kwargs. %s',
-            {'pk': 345343},
+            'Version not found for given kwargs.',
+            kwargs={'pk': 345343},
         )
 
     @patch('readthedocs.oauth.services.github.GitHubService.send_build_status')

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -192,9 +192,9 @@ class GitHubOAuthTests(TestCase):
 
         self.assertTrue(success)
         mock_logger.info.assert_called_with(
-            "GitHub commit status created for project: %s, commit status: %s",
-            self.project.slug,
-            BUILD_STATUS_SUCCESS
+            "GitHub commit status created for project.",
+            project_slug=self.project.slug,
+            commit_status=BUILD_STATUS_SUCCESS
         )
 
     @mock.patch('readthedocs.oauth.services.github.log')
@@ -209,12 +209,11 @@ class GitHubOAuthTests(TestCase):
 
         self.assertFalse(success)
         mock_logger.info.assert_called_with(
-            'GitHub project does not exist or user does not have '
-            'permissions: project=%s, user=%s, status=%s, url=%s',
-            self.project.slug,
-            self.user.username,
-            404,
-            'https://api.github.com/repos/pypa/pip/statuses/1234'
+            'GitHub project does not exist or user does not have permissions.',
+            project_slug=self.project.slug,
+            user_username=self.user.username,
+            http_status_code=404,
+            statuses_url='https://api.github.com/repos/pypa/pip/statuses/1234'
         )
 
     @mock.patch('readthedocs.oauth.services.github.log')
@@ -227,8 +226,8 @@ class GitHubOAuthTests(TestCase):
 
         self.assertFalse(success)
         mock_logger.exception.assert_called_with(
-            'GitHub commit status creation failed for project: %s',
-            self.project.slug,
+            'GitHub commit status creation failed for project.',
+            project_slug=self.project.slug,
         )
 
     @override_settings(DEFAULT_PRIVACY_LEVEL='private')
@@ -265,8 +264,8 @@ class GitHubOAuthTests(TestCase):
         self.assertTrue(success)
         self.assertIsNotNone(self.integration.secret)
         mock_logger.info.assert_called_with(
-            "GitHub webhook creation successful for project: %s",
-            self.project,
+            "GitHub webhook creation successful for project.",
+            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.github.log')
@@ -282,9 +281,8 @@ class GitHubOAuthTests(TestCase):
         self.assertFalse(success)
         self.assertIsNone(self.integration.secret)
         mock_logger.info.assert_called_with(
-            'GitHub project does not exist or user does not have '
-            'permissions: project=%s',
-            self.project,
+            'GitHub project does not exist or user does not have permissions.',
+            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.github.log')
@@ -300,8 +298,8 @@ class GitHubOAuthTests(TestCase):
 
         self.assertIsNone(self.integration.secret)
         mock_logger.exception.assert_called_with(
-            'GitHub webhook creation failed for project: %s',
-            self.project,
+            'GitHub webhook creation failed for project.',
+            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.github.log')
@@ -319,8 +317,8 @@ class GitHubOAuthTests(TestCase):
         self.assertTrue(success)
         self.assertIsNotNone(self.integration.secret)
         mock_logger.info.assert_called_with(
-            "GitHub webhook update successful for project: %s",
-            self.project,
+            "GitHub webhook update successful for project.",
+            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.github.GitHubService.get_session')
@@ -367,8 +365,8 @@ class GitHubOAuthTests(TestCase):
 
         self.assertIsNone(self.integration.secret)
         mock_logger.exception.assert_called_with(
-            'GitHub webhook update failed for project: %s',
-            self.project,
+            'GitHub webhook update failed for project.',
+            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.github.log')
@@ -402,8 +400,8 @@ class GitHubOAuthTests(TestCase):
 
         self.assertEqual(self.integration.provider_data, webhook_data[0])
         mock_logger.info.assert_called_with(
-            'GitHub integration updated with provider data for project: %s',
-            self.project,
+            'GitHub integration updated with provider data for project.',
+            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.github.log')
@@ -423,9 +421,8 @@ class GitHubOAuthTests(TestCase):
 
         self.assertEqual(self.integration.provider_data, {})
         mock_logger.info.assert_called_with(
-            'GitHub project does not exist or user does not have '
-            'permissions: project=%s',
-            self.project,
+            'GitHub project does not exist or user does not have permissions.',
+            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.github.log')
@@ -445,8 +442,8 @@ class GitHubOAuthTests(TestCase):
 
         self.assertEqual(self.integration.provider_data, {})
         mock_logger.exception.assert_called_with(
-            'GitHub webhook Listing failed for project: %s',
-            self.project,
+            'GitHub webhook Listing failed for project.',
+            project_slug=self.project.slug,
         )
 
 
@@ -700,8 +697,8 @@ class BitbucketOAuthTests(TestCase):
 
         self.assertTrue(success)
         mock_logger.info.assert_called_with(
-            "Bitbucket webhook creation successful for project: %s",
-            self.project,
+            "Bitbucket webhook creation successful for project.",
+            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.bitbucket.log')
@@ -715,9 +712,8 @@ class BitbucketOAuthTests(TestCase):
 
         self.assertFalse(success)
         mock_logger.info.assert_called_with(
-            'Bitbucket project does not exist or user does not have '
-            'permissions: project=%s',
-            self.project,
+            'Bitbucket project does not exist or user does not have permissions.',
+            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.bitbucket.log')
@@ -730,8 +726,8 @@ class BitbucketOAuthTests(TestCase):
         )
 
         mock_logger.exception.assert_called_with(
-            'Bitbucket webhook creation failed for project: %s',
-            self.project,
+            'Bitbucket webhook creation failed for project.',
+            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.bitbucket.log')
@@ -747,8 +743,8 @@ class BitbucketOAuthTests(TestCase):
         self.assertTrue(success)
         self.assertIsNotNone(self.integration.secret)
         mock_logger.info.assert_called_with(
-            "Bitbucket webhook update successful for project: %s",
-            self.project,
+            "Bitbucket webhook update successful for project.",
+            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.bitbucket.BitbucketService.get_session')
@@ -792,8 +788,8 @@ class BitbucketOAuthTests(TestCase):
         )
 
         mock_logger.exception.assert_called_with(
-            'Bitbucket webhook update failed for project: %s',
-            self.project,
+            'Bitbucket webhook update failed for project.',
+            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.bitbucket.log')
@@ -827,8 +823,8 @@ class BitbucketOAuthTests(TestCase):
 
         self.assertEqual(self.integration.provider_data, webhook_data['values'][0])
         mock_logger.info.assert_called_with(
-            'Bitbucket integration updated with provider data for project: %s',
-            self.project,
+            'Bitbucket integration updated with provider data for project.',
+            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.bitbucket.log')
@@ -848,9 +844,8 @@ class BitbucketOAuthTests(TestCase):
 
         self.assertEqual(self.integration.provider_data, {})
         mock_logger.info.assert_called_with(
-            'Bitbucket project does not exist or user does not have '
-            'permissions: project=%s',
-            self.project,
+            'Bitbucket project does not exist or user does not have permissions.',
+            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.bitbucket.log')
@@ -870,8 +865,8 @@ class BitbucketOAuthTests(TestCase):
 
         self.assertEqual(self.integration.provider_data, {})
         mock_logger.exception.assert_called_with(
-            'Bitbucket webhook Listing failed for project: %s',
-            self.project,
+            'Bitbucket webhook Listing failed for project.',
+            project_slug=self.project.slug,
         )
 
 
@@ -1092,9 +1087,9 @@ class GitLabOAuthTests(TestCase):
 
         self.assertTrue(success)
         mock_logger.info.assert_called_with(
-            "GitLab commit status created for project: %s, commit status: %s",
-            self.project.slug,
-            BUILD_STATUS_SUCCESS
+            "GitLab commit status created for project.",
+            project_slug=self.project.slug,
+            commit_status=BUILD_STATUS_SUCCESS
         )
 
     @mock.patch('readthedocs.oauth.services.gitlab.log')
@@ -1112,12 +1107,11 @@ class GitLabOAuthTests(TestCase):
 
         self.assertFalse(success)
         mock_logger.info.assert_called_with(
-            'GitLab project does not exist or user does not have permissions: '
-            'project=%s, user=%s, status=%s, url=%s',
-            self.project.slug,
-            self.user.username,
-            404,
-            'https://gitlab.com/api/v4/projects/9999/statuses/1234',
+            'GitLab project does not exist or user does not have permissions.',
+            project_slug=self.project.slug,
+            user_username=self.user.username,
+            http_status_code=404,
+            statuses_url='https://gitlab.com/api/v4/projects/9999/statuses/1234',
         )
 
     @mock.patch('readthedocs.oauth.services.gitlab.log')
@@ -1133,8 +1127,8 @@ class GitLabOAuthTests(TestCase):
 
         self.assertFalse(success)
         mock_logger.exception.assert_called_with(
-            'GitLab commit status creation failed for project: %s',
-            self.project.slug,
+            'GitLab commit status creation failed for project.',
+            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.gitlab.log')
@@ -1152,8 +1146,8 @@ class GitLabOAuthTests(TestCase):
         self.assertTrue(success)
         self.assertIsNotNone(self.integration.secret)
         mock_logger.info.assert_called_with(
-            "GitLab webhook creation successful for project: %s",
-            self.project,
+            "GitLab webhook creation successful for project.",
+            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.gitlab.log')
@@ -1170,9 +1164,8 @@ class GitLabOAuthTests(TestCase):
         self.assertFalse(success)
         self.assertIsNone(self.integration.secret)
         mock_logger.info.assert_called_with(
-            'Gitlab project does not exist or user does not have '
-            'permissions: project=%s',
-            self.project,
+            'Gitlab project does not exist or user does not have permissions.',
+            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.gitlab.log')
@@ -1188,8 +1181,9 @@ class GitLabOAuthTests(TestCase):
 
         self.assertIsNone(self.integration.secret)
         mock_logger.exception.assert_called_with(
-            'GitLab webhook creation failed for project: %s',
-            self.project,
+            'GitLab webhook creation failed for project.',
+            project_slug=self.project.slug
+            ,
         )
 
     @mock.patch('readthedocs.oauth.services.gitlab.log')
@@ -1209,8 +1203,8 @@ class GitLabOAuthTests(TestCase):
         self.assertTrue(success)
         self.assertIsNotNone(self.integration.secret)
         mock_logger.info.assert_called_with(
-            "GitLab webhook update successful for project: %s",
-            self.project,
+            "GitLab webhook update successful for project.",
+            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.gitlab.GitLabService.get_session')
@@ -1263,8 +1257,8 @@ class GitLabOAuthTests(TestCase):
 
         self.assertIsNone(self.integration.secret)
         mock_logger.exception.assert_called_with(
-            'GitLab webhook update failed for project: %s',
-            self.project,
+            'GitLab webhook update failed for project.',
+            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.gitlab.log')
@@ -1298,8 +1292,8 @@ class GitLabOAuthTests(TestCase):
 
         self.assertEqual(self.integration.provider_data, webhook_data[0])
         mock_logger.info.assert_called_with(
-            'GitLab integration updated with provider data for project: %s',
-            self.project,
+            'GitLab integration updated with provider data for project.',
+            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.gitlab.log')
@@ -1319,9 +1313,8 @@ class GitLabOAuthTests(TestCase):
 
         self.assertEqual(self.integration.provider_data, {})
         mock_logger.info.assert_called_with(
-            'GitLab project does not exist or user does not have '
-            'permissions: project=%s',
-            self.project,
+            'GitLab project does not exist or user does not have permissions.',
+            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.gitlab.log')
@@ -1341,6 +1334,6 @@ class GitLabOAuthTests(TestCase):
 
         self.assertEqual(self.integration.provider_data, {})
         mock_logger.exception.assert_called_with(
-            'GitLab webhook Listing failed for project: %s',
-            self.project,
+            'GitLab webhook Listing failed for project.',
+            project_slug=self.project.slug,
         )

--- a/readthedocs/rtd_tests/tests/test_privacy.py
+++ b/readthedocs/rtd_tests/tests/test_privacy.py
@@ -1,4 +1,4 @@
-import logging
+import structlog
 from unittest import mock
 
 from django.contrib.auth.models import User
@@ -10,7 +10,7 @@ from readthedocs.builds.models import Build, Version
 from readthedocs.projects.forms import UpdateProjectForm
 from readthedocs.projects.models import Project
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 @mock.patch('readthedocs.projects.tasks.clean_build', new=mock.MagicMock)
@@ -32,9 +32,10 @@ class PrivacyTests(TestCase):
     ):
         self.client.login(username='eric', password='test')
         log.info(
-            'Making kong with privacy: %s and version privacy: %s',
-            privacy_level,
-            version_privacy_level,
+            'Changing project privacy level.',
+            project_slug='django-kong',
+            project_privacy_level=privacy_level,
+            version_privacy_level=version_privacy_level,
         )
         # Create project via project form, simulate import wizard without magic
         form = UpdateProjectForm(

--- a/readthedocs/rtd_tests/tests/test_redirects.py
+++ b/readthedocs/rtd_tests/tests/test_redirects.py
@@ -1,5 +1,3 @@
-import logging
-
 from django.http import Http404
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -20,7 +18,6 @@ class RedirectTests(TestCase):
     fixtures = ['eric', 'test_data']
 
     def setUp(self):
-        logging.disable(logging.DEBUG)
         self.client.login(username='eric', password='test')
         pip = Project.objects.get(slug='pip')
         pip.versions.create_latest()

--- a/readthedocs/rtd_tests/utils.py
+++ b/readthedocs/rtd_tests/utils.py
@@ -1,6 +1,6 @@
 """Utility functions for use in tests."""
 
-import logging
+import structlog
 import subprocess
 import textwrap
 from os import chdir, environ, mkdir
@@ -14,7 +14,7 @@ from django_dynamic_fixture import new
 
 from readthedocs.doc_builder.base import restoring_chdir
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 def get_readthedocs_app_path():

--- a/readthedocs/search/api.py
+++ b/readthedocs/search/api.py
@@ -1,4 +1,4 @@
-import logging
+import structlog
 from functools import lru_cache, namedtuple
 from math import ceil
 
@@ -18,7 +18,7 @@ from readthedocs.search.faceted_search import PageSearch
 
 from .serializers import PageSearchSerializer, ProjectData, VersionData
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class PaginatorPage:

--- a/readthedocs/search/documents.py
+++ b/readthedocs/search/documents.py
@@ -1,4 +1,4 @@
-import logging
+import structlog
 
 from django.conf import settings
 from django_elasticsearch_dsl import Document, Index, fields
@@ -14,7 +14,7 @@ page_conf = settings.ES_INDEXES['page']
 page_index = Index(page_conf['name'])
 page_index.settings(**page_conf['settings'])
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class RTDDocTypeMixin:

--- a/readthedocs/search/faceted_search.py
+++ b/readthedocs/search/faceted_search.py
@@ -1,4 +1,4 @@
-import logging
+import structlog
 import re
 
 from django.conf import settings
@@ -18,7 +18,7 @@ from elasticsearch_dsl.query import (
 
 from readthedocs.search.documents import PageDocument, ProjectDocument
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 ALL_FACETS = ['project', 'version', 'role_name', 'language']
 

--- a/readthedocs/search/signals.py
+++ b/readthedocs/search/signals.py
@@ -1,5 +1,5 @@
 """We define custom Django signals to trigger before executing searches."""
-import logging
+import structlog
 
 from django.db.models.signals import post_save, pre_delete
 from django.dispatch import receiver
@@ -9,7 +9,7 @@ from django_elasticsearch_dsl.registries import registry
 from readthedocs.projects.models import Project
 from readthedocs.search.tasks import delete_objects_in_es, index_objects_to_es
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 @receiver(post_save, sender=Project)

--- a/readthedocs/search/tasks.py
+++ b/readthedocs/search/tasks.py
@@ -1,4 +1,4 @@
-import logging
+import structlog
 
 from dateutil.parser import parse
 from django.apps import apps
@@ -12,7 +12,7 @@ from readthedocs.worker import app
 
 from .utils import _get_document, _get_index
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 @app.task(queue='web')
@@ -47,15 +47,23 @@ def index_objects_to_es(
         # Hack the index name temporarily for reindexing tasks
         old_index_name = document._index._name
         document._index._name = index_name
-        log.info('Replacing index name %s with %s', old_index_name, index_name)
+        log.info(
+            'Replacing index name.',
+            old_index_name=old_index_name,
+            new_index_name=index_name,)
 
-    log.info("Indexing model: %s, '%s' objects", model.__name__, queryset.count())
+    log.info(
+        "Indexing model.",
+        model=model.__name__,
+        count=queryset.count(),
+    )
     doc_obj.update(queryset.iterator())
 
     if index_name:
         log.info(
-            'Undoing index replacement, settings %s with %s',
-            document._index._name, old_index_name,
+            'Undoing index replacement.',
+            old_index_name=document._index._name,
+            new_index_name=old_index_name,
         )
         document._index._name = old_index_name
 
@@ -67,7 +75,11 @@ def delete_objects_in_es(app_label, model_name, document_class, objects_id):
     doc_obj = document()
     queryset = doc_obj.get_queryset()
     queryset = queryset.filter(id__in=objects_id)
-    log.info("Deleting model: %s, '%s' objects", model.__name__, queryset.count())
+    log.info(
+        "Deleting model.",
+        model=model.__name__,
+        count=queryset.count(),
+    )
     try:
         # This is a common case that we should be handling a better way
         doc_obj.update(queryset.iterator(), action='delete')
@@ -123,7 +135,7 @@ def index_missing_objects(app_label, model_name, document_class, index_generatio
     queryset = document().get_queryset().exclude(**{query_string: index_generation_time})
     document().update(queryset.iterator())
 
-    log.info("Indexed %s missing objects from model: %s'", queryset.count(), model.__name__)
+    log.info("Indexed missing objects from model.", count=queryset.count(), model=model.__name__)
 
     # TODO: Figure out how to remove the objects from ES index that has been deleted
 
@@ -142,7 +154,7 @@ def delete_old_search_queries_from_db():
     )
 
     if search_queries_qs.exists():
-        log.info('Deleting search queries for last 3 months. Total: %s', search_queries_qs.count())
+        log.info('Deleting search queries for last 3 months.', total=search_queries_qs.count())
         search_queries_qs.delete()
 
 
@@ -151,12 +163,12 @@ def record_search_query(project_slug, version_slug, query, total_results, time_s
     """Record/update a search query for analytics."""
     if not project_slug or not version_slug or not query:
         log.debug(
-            'Not recording the search query. Passed arguments: '
-            'project_slug: %s, version_slug: %s, query: %s, total_results: %s, time: %s',
-            project_slug,
-            version_slug,
-            query, total_results,
-            time_string
+            'Not recording the search query.',
+            project_slug=project_slug,
+            version_slug=version_slug,
+            query=query,
+            total_results=total_results,
+            time=time_string,
         )
         return
 
@@ -186,9 +198,9 @@ def record_search_query(project_slug, version_slug, query, total_results, time_s
     )
     if not version:
         log.debug(
-            'Not recording the search query because project does not exist. '
-            'project=%s version=%s',
-            project_slug, version_slug,
+            'Not recording the search query because project does not exist.',
+            project_slug=project_slug,
+            version_slug=version_slug,
         )
         return
 

--- a/readthedocs/search/views.py
+++ b/readthedocs/search/views.py
@@ -1,6 +1,6 @@
 """Search views."""
 import collections
-import logging
+import structlog
 
 from django.conf import settings
 from django.shortcuts import get_object_or_404, render
@@ -21,8 +21,7 @@ from .serializers import (
     VersionData,
 )
 
-log = logging.getLogger(__name__)
-LOG_TEMPLATE = '(Elastic Search) [%(user)s:%(type)s] [%(project)s:%(version)s:%(language)s] %(msg)s'
+log = structlog.get_logger(__name__)
 
 UserInput = collections.namedtuple(
     'UserInput',

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -855,9 +855,8 @@ class CommunityBaseSettings(Settings):
                 # Always send from the root, handlers can filter levels
                 'level': 'INFO',
             },
-            'django_structlog': {
+            'django_structlog.middlewares.request': {
                 'handlers': ['null'],
-                'level': 'INFO',
                 # Don't double log at the root logger for these.
                 'propagate': False,
             },

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -806,7 +806,17 @@ class CommunityBaseSettings(Settings):
                 "()": structlog.stdlib.ProcessorFormatter,
                 "processors": [
                     structlog.stdlib.ProcessorFormatter.remove_processors_meta,
-                    structlog.dev.ConsoleRenderer(),
+                    structlog.dev.ConsoleRenderer(colors=False),
+                ],
+                # Allows to add extra data to log entries generated via ``logging`` module
+                # See https://www.structlog.org/en/stable/standard-library.html#rendering-using-structlog-based-formatters-within-logging
+                "foreign_pre_chain": shared_processors,
+            },
+            "colored_console": {
+                "()": structlog.stdlib.ProcessorFormatter,
+                "processors": [
+                    structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                    structlog.dev.ConsoleRenderer(colors=True),
                 ],
                 # Allows to add extra data to log entries generated via ``logging`` module
                 # See https://www.structlog.org/en/stable/standard-library.html#rendering-using-structlog-based-formatters-within-logging

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -8,6 +8,7 @@ import structlog
 
 from celery.schedules import crontab
 
+from readthedocs.core.logs import shared_processors
 from readthedocs.core.settings import Settings
 from readthedocs.projects.constants import CELERY_LOW, CELERY_MEDIUM, CELERY_HIGH
 
@@ -803,11 +804,23 @@ class CommunityBaseSettings(Settings):
             # structlog
             "plain_console": {
                 "()": structlog.stdlib.ProcessorFormatter,
-                "processor": structlog.dev.ConsoleRenderer(),
+                "processors": [
+                    structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                    structlog.dev.ConsoleRenderer(),
+                ],
+                # Allows to add extra data to log entries generated via ``logging`` module
+                # See https://www.structlog.org/en/stable/standard-library.html#rendering-using-structlog-based-formatters-within-logging
+                "foreign_pre_chain": shared_processors,
             },
             "key_value": {
                 "()": structlog.stdlib.ProcessorFormatter,
-                "processor": structlog.processors.KeyValueRenderer(key_order=['timestamp', 'level', 'event', 'logger']),
+                "processors": [
+                    structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                    structlog.processors.KeyValueRenderer(key_order=['timestamp', 'level', 'event', 'logger']),
+                ],
+                # Allows to add extra data to log entries generated via ``logging`` module
+                # See https://www.structlog.org/en/stable/standard-library.html#rendering-using-structlog-based-formatters-within-logging
+                "foreign_pre_chain": shared_processors,
             },
         },
         'handlers': {

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring
 
-import logging
 import os
 import subprocess
 import socket
@@ -27,7 +26,7 @@ except ImportError:
 
 
 _ = gettext = lambda s: s
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class CommunityBaseSettings(Settings):
@@ -252,6 +251,7 @@ class CommunityBaseSettings(Settings):
         'django_permissions_policy.PermissionsPolicyMiddleware',
         'simple_history.middleware.HistoryRequestMiddleware',
         'readthedocs.core.logs.ReadTheDocsRequestMiddleware',
+        'django_structlog.middlewares.CeleryMiddleware',
     )
 
     AUTHENTICATION_BACKENDS = (
@@ -621,10 +621,10 @@ class CommunityBaseSettings(Settings):
                     )
                 }
         log.info(
-            'Using dynamic docker limits. hostname=%s memory=%s time=%s',
-            socket.gethostname(),
-            limits['memory'],
-            limits['time'],
+            'Using dynamic docker limits.',
+            hostname=socket.gethostname(),
+            memory=limits['memory'],
+            time=limits['time'],
         )
         return limits
 
@@ -814,7 +814,7 @@ class CommunityBaseSettings(Settings):
             'console': {
                 'level': 'INFO',
                 'class': 'logging.StreamHandler',
-                'formatter': 'default',
+                'formatter': 'plain_console',
             },
             'debug': {
                 'level': 'DEBUG',

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -77,6 +77,7 @@ class DockerBaseSettings(CommunityDevSettings):
     @property
     def LOGGING(self):
         logging = super().LOGGING
+        logging['handlers']['console']['formatter'] = 'colored_console'
         logging['loggers'].update({
             # Disable Django access requests logging (e.g. GET /path/to/url)
             # https://github.com/django/django/blob/ca9872905559026af82000e46cde6f7dedc897b6/django/core/servers/basehttp.py#L24

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -78,6 +78,12 @@ class DockerBaseSettings(CommunityDevSettings):
     def LOGGING(self):
         logging = super().LOGGING
         logging['loggers'].update({
+            # Disable Django access requests logging (e.g. GET /path/to/url)
+            # https://github.com/django/django/blob/ca9872905559026af82000e46cde6f7dedc897b6/django/core/servers/basehttp.py#L24
+            'django.server': {
+                'handlers': ['null'],
+                'propagate': False,
+            },
             # Disable S3 logging
             'boto3': {
                 'handlers': ['null'],

--- a/readthedocs/settings/proxito/base.py
+++ b/readthedocs/settings/proxito/base.py
@@ -5,9 +5,9 @@ Some of these settings will eventually be backported into the main settings file
 but currently we have them to be able to run the site with the old middleware for
 a staged rollout of the proxito code.
 """
-import logging
+import structlog
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class CommunityProxitoSettingsMixin:
@@ -44,6 +44,6 @@ class CommunityProxitoSettingsMixin:
             if mw in classes:
                 classes.remove(mw)
             else:
-                log.warning('Failed to remove middleware: %s', mw)
+                log.warning('Failed to remove middleware.', middleware=mw)
 
         return classes

--- a/readthedocs/sso/admin.py
+++ b/readthedocs/sso/admin.py
@@ -1,5 +1,5 @@
 """Admin interface for SSO models."""
-import logging
+import structlog
 
 from django.contrib import admin, messages
 
@@ -9,7 +9,7 @@ from readthedocs.oauth.tasks import sync_remote_repositories
 from .models import SSODomain, SSOIntegration
 
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class SSOIntegrationAdmin(admin.ModelAdmin):
@@ -31,9 +31,9 @@ class SSOIntegrationAdmin(admin.ModelAdmin):
         for ssointegration in queryset.select_related('organization'):
             members = AdminPermission.members(ssointegration.organization)
             log.info(
-                'Triggering SSO re-sync for organization. organization=%s users=%s',
-                ssointegration.organization.slug,
-                members.count(),
+                'Triggering SSO re-sync for organization.',
+                organization_slug=ssointegration.organization.slug,
+                count=members.count(),
             )
             users_count += members.count()
             for user in members:

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -1,6 +1,6 @@
 """Git-related utilities."""
 
-import logging
+import structlog
 import re
 
 import git
@@ -21,7 +21,7 @@ from readthedocs.projects.validators import validate_submodule_url
 from readthedocs.vcs_support.base import BaseVCS, VCSVersion
 
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class Backend(BaseVCS):
@@ -261,7 +261,7 @@ class Backend(BaseVCS):
                     # blob object - use the `.object` property instead to access it
                     # This is not a real tag for us, so we skip it
                     # https://github.com/rtfd/readthedocs.org/issues/4440
-                    log.warning('Git tag skipped: %s', tag, exc_info=True)
+                    log.warning('Git tag skipped.', tag=tag, exc_info=True)
                     continue
 
             versions.append(VCSVersion(self, hexsha, str(tag)))

--- a/readthedocs/vcs_support/base.py
+++ b/readthedocs/vcs_support/base.py
@@ -1,5 +1,5 @@
 """Base classes for VCS backends."""
-import logging
+import structlog
 import os
 import shutil
 
@@ -7,7 +7,7 @@ from readthedocs.doc_builder.exceptions import BuildEnvironmentWarning
 from readthedocs.projects.exceptions import RepositoryError
 
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class VCSVersion:

--- a/readthedocs/worker.py
+++ b/readthedocs/worker.py
@@ -5,6 +5,8 @@ import os
 from celery import Celery
 from django.conf import settings
 
+from django_structlog.celery.steps import DjangoStructLogInitStep
+
 
 def create_application():
     """Create a Celery application using Django settings."""
@@ -16,6 +18,10 @@ def create_application():
     application = Celery(settings.CELERY_APP_NAME)
     application.config_from_object('django.conf:settings')
     application.autodiscover_tasks(None)
+
+    # A step to initialize django-structlog
+    application.steps['worker'].add(DjangoStructLogInitStep)
+
     return application
 
 


### PR DESCRIPTION
Initial work to migrate our application to structlog for better logging, making
them compatible with New Relic's integration.

There is more work that can be done here to make it better. For example, more
usage of `log.bind` to avoid repetition. Besides, rewriting some log messages and
reducing them to have more Canonical Log
Lines (https://www.structlog.org/en/stable/logging-best-practices.html#canonical-log-lines)
instead.

> **NOTE**: this PR does not really require an extensive review. It's mostly just a search&replace. As far as the tests are passing, it should be fine to merge.

The migration steps followed are described in #8689. Also note that this PR is based on that one.

![Screenshot_2021-11-23_19-01-00](https://user-images.githubusercontent.com/244656/143079312-4062bf47-afa2-46de-b943-84efb143aa60.png)


