### PR TITLE
oauth: sync remote repositories fix

### DIFF
--- a/readthedocs/oauth/tasks.py
+++ b/readthedocs/oauth/tasks.py
@@ -72,11 +72,12 @@ def sync_remote_repositories_organizations(organization_slugs=None):
             query.count(),
         )
     else:
-        query = (
+        organization_ids = (
             SSOIntegration.objects
             .filter(provider=SSOIntegration.PROVIDER_ALLAUTH)
             .values_list('organization', flat=True)
         )
+        query = Organization.objects.filter(id__in=organization_ids)
         log.info(
             'Triggering SSO re-sync for all organizations. count=%s',
             query.count(),

--- a/readthedocs/rtd_tests/tests/test_oauth_tasks.py
+++ b/readthedocs/rtd_tests/tests/test_oauth_tasks.py
@@ -7,12 +7,15 @@ from allauth.socialaccount.providers.gitlab.views import GitLabOAuth2Adapter
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django_dynamic_fixture import get
+from unittest import mock
 from unittest.mock import patch
 
 from readthedocs.builds.models import Version
 from readthedocs.oauth.services.base import SyncServiceError
-from readthedocs.oauth.tasks import sync_remote_repositories
+from readthedocs.oauth.tasks import sync_remote_repositories, sync_remote_repositories_organizations
+from readthedocs.organizations.models import Organization, OrganizationOwner
 from readthedocs.projects.models import Project
+from readthedocs.sso.models import SSOIntegration
 
 
 class SyncRemoteRepositoriesTests(TestCase):
@@ -73,3 +76,37 @@ class SyncRemoteRepositoriesTests(TestCase):
         sync_bb.assert_called_once()
         sync_gl.assert_called_once()
         sync_gh.assert_called_once()
+
+    @patch('readthedocs.oauth.tasks.sync_remote_repositories')
+    def test_sync_remote_repository_organizations_slugs(self, mock_sync_remote_repositories):
+        organization = get(Organization)
+        get(
+            OrganizationOwner,
+            owner=self.user,
+            organization=organization,
+        )
+        sync_remote_repositories_organizations(organization_slugs=[organization.slug])
+        mock_sync_remote_repositories.delay.assert_called_once()
+        mock_sync_remote_repositories.delay.assert_has_calls(
+            [mock.call(self.user.pk, countdown=0)],
+        )
+
+    @patch('readthedocs.oauth.tasks.sync_remote_repositories')
+    def test_sync_remote_repository_organizations_without_slugs(self, mock_sync_remote_repositories):
+        organization = get(Organization)
+        get(
+            SSOIntegration,
+            provider=SSOIntegration.PROVIDER_ALLAUTH,
+            organization=organization,
+        )
+        get(
+            OrganizationOwner,
+            owner=self.user,
+            organization=organization,
+        )
+
+        sync_remote_repositories_organizations()
+        mock_sync_remote_repositories.delay.assert_called_once()
+        mock_sync_remote_repositories.delay.assert_has_calls(
+            [mock.call(self.user.pk, countdown=0)],
+        )


### PR DESCRIPTION
`.values_list` returns a list of id when accessing the related object. We use
that list of ids to query `Organization` model and get real organization objects instead.

Solves: https://sentry.io/organizations/read-the-docs/issues/2747536252/