### PR TITLE
requirements: add requests-oauthlib

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -42,6 +42,7 @@ celery==5.1.2
 # ``account/base.html`` -- you will need to check your templates and likely
 # override ``account/base.html`` within your project.
 django-allauth==0.42.0  # pyup: ignore
+requests-oauthlib==1.3.0
 
 # GitPython >3.1.18 drops support for python 3.6.
 GitPython==3.1.18  # pyup: ignore


### PR DESCRIPTION
We are installing requests-oauthlib as a transitive dependency of
django-allauth. However, we are importing it directly, so we should declare it
as our own dependency.

Closes #8692 