### PR TITLE
requirements: use django-cors-headers instead

### DIFF
--- a/readthedocs/settings/dev.py
+++ b/readthedocs/settings/dev.py
@@ -44,7 +44,7 @@ class CommunityDevSettings(CommunityBaseSettings):
     # 127.0.0.1 test
     # and navigate to http://test:8000
     CORS_ORIGIN_WHITELIST = (
-        'test:8000',
+        'http://test:8000',
     )
 
     # Disable auto syncing elasticsearch documents in development

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -90,9 +90,7 @@ dj-pagination==2.5.0
 # Version comparison stuff
 packaging==21.3
 
-# django-cors-middleware==1.5.0 fails with
-# AttributeError: 'dict' object has no attribute 'has_header'
-django-cors-middleware==1.4.0  # pyup: ignore
+django-cors-headers==3.10.0
 
 # User agent parsing - used for analytics purposes
 user-agents==2.2.0

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -90,7 +90,7 @@ dj-pagination==2.5.0
 # Version comparison stuff
 packaging==21.3
 
-django-cors-headers==3.10.0
+django-cors-headers==2.0.0
 
 # User agent parsing - used for analytics purposes
 user-agents==2.2.0

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -90,10 +90,7 @@ dj-pagination==2.5.0
 # Version comparison stuff
 packaging==21.3
 
-# django-cors-middleware was replaced by django-cors-headers
-# django-cors-headers==3.10.0 is failing with:
-# AttributeError: 'dict' object has no attribute 'has_header'
-django-cors-headers==2.0.0  # pyup: ignore
+django-cors-headers==3.11.0
 
 # User agent parsing - used for analytics purposes
 user-agents==2.2.0

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -90,7 +90,10 @@ dj-pagination==2.5.0
 # Version comparison stuff
 packaging==21.3
 
-django-cors-headers==2.0.0
+# django-cors-middleware was replaced by django-cors-headers
+# django-cors-headers==3.10.0 is failing with:
+# AttributeError: 'dict' object has no attribute 'has_header'
+django-cors-headers==2.0.0  # pyup: ignore
 
 # User agent parsing - used for analytics purposes
 user-agents==2.2.0


### PR DESCRIPTION
Note that `django-cors-middleware` is deprecated (see note in
https://github.com/zestedesavoir/django-cors-middleware) and they recommend
using `django-cors-headers` instead.

Related to #8692 