### PR TITLE
Custom Domain: make cname_target configurable

### DIFF
--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -780,6 +780,16 @@ class DomainCreateBase(DomainMixin, CreateView):
             return super().post(request, *args, **kwargs)
         return HttpResponse('Action not allowed', status=401)
 
+    def get_success_url(self):
+        """Redirect to the edit view so users can follow the next steps."""
+        return reverse(
+            'projects_domains_edit',
+            args=[
+                self.get_project().slug,
+                self.object.pk,
+            ],
+        )
+
 
 class DomainCreate(SettingsOverrideObject):
 

--- a/readthedocs/templates/projects/domain_form.html
+++ b/readthedocs/templates/projects/domain_form.html
@@ -27,14 +27,19 @@
   {% endif %}
 
   {% if domain.domainssl %}
-    {# This references optional code to get the SSL certificate status #}
+   {# This references optional code that handles certificates for custom domains. #}
+
+    <p class="helptext">
+      {% blocktrans trimmed with cname_target=domain.domainssl.cname_target %}
+        To configure this domain add a CNAME record in your DNS pointing
+        your custom domain to <code>{{ cname_target }}</code>.
+      {% endblocktrans %}
+    </p>
+
     <p>
       <strong>{% trans 'SSL certificate status' %}: </strong>
       <span>{{ domain.domainssl.status }}</span>
     </p>
-    {% if domain.domainssl.status == 'pending_validation' %}
-      <p class="help_text"><small>{% trans 'Did you setup a CNAME record in DNS pointing at "readthedocs.io"?' %}</small></p>
-    {% endif %}
   {% endif %}
 
   {% if domain %}


### PR DESCRIPTION
This is so we can share the same view with .com
when switching to CF.

The steps will require to only create a CNAME record,
the value of this record will be unique per-domain on .com,
and it will continue to be static on .org.

The are PRs on .com and -ext