### PR TITLE
Logs: typo on keyname

### DIFF
--- a/readthedocs/embed/views.py
+++ b/readthedocs/embed/views.py
@@ -147,7 +147,7 @@ class EmbedAPIBase(CachedResponseMixin, APIView):
             'EmbedAPI successful response.',
             project_slug=project.slug,
             version_slug=version.slug,
-            doct=doc,
+            doc=doc,
             section=section,
             path=path,
             url=url,


### PR DESCRIPTION
Note that we were mixing `doct=` and `doc=`. This change will make all of them behave properly.

cc @astrojuanlu to upgrade the NR dashboard. 