### PR TITLE
Logging: tweaks and minor improvements

### DIFF
--- a/readthedocs/api/v2/views/integrations.py
+++ b/readthedocs/api/v2/views/integrations.py
@@ -68,6 +68,12 @@ class WebhookMixin:
     def post(self, request, project_slug):
         """Set up webhook post view with request and project objects."""
         self.request = request
+
+        log.bind(
+            project_slug=project_slug,
+            integration_type=self.integration_type,
+        )
+
         # WARNING: this is a hack to allow us access to `request.body` later.
         # Due to a limitation of DRF, we can't access `request.body`
         # after accessing `request.data`.
@@ -85,11 +91,7 @@ class WebhookMixin:
         except Project.DoesNotExist:
             raise NotFound('Project not found')
         if not self.is_payload_valid():
-            log.warning(
-                'Invalid payload for project and integration.',
-                project_slug=project_slug,
-                integration_type=self.integration_type,
-            )
+            log.warning('Invalid payload for project and integration.')
             return Response(
                 {'detail': self.invalid_payload_msg},
                 status=HTTP_400_BAD_REQUEST,
@@ -186,7 +188,6 @@ class WebhookMixin:
         if not_building:
             log.info(
                 'Skipping project branches.',
-                project_slug=project.slug,
                 branches=branches,
             )
         triggered = bool(to_build)
@@ -338,10 +339,7 @@ class GitHubWebhookView(WebhookMixin, APIView):
         signature = self.request.META.get(GITHUB_SIGNATURE_HEADER)
         secret = self.get_integration().secret
         if not secret:
-            log.info(
-                'Skipping payload signature validation.',
-                project_slug=self.project.slug,
-            )
+            log.debug('Skipping payload signature validation.')
             return True
         if not signature:
             return False
@@ -397,6 +395,7 @@ class GitHubWebhookView(WebhookMixin, APIView):
         created = self.data.get('created', False)
         deleted = self.data.get('deleted', False)
         event = self.request.META.get(GITHUB_EVENT_HEADER, GITHUB_PUSH)
+        log.bind(webhook_event=event)
         webhook_github.send(
             Project,
             project=self.project,
@@ -406,11 +405,7 @@ class GitHubWebhookView(WebhookMixin, APIView):
 
         # Sync versions when a branch/tag was created/deleted
         if event in (GITHUB_CREATE, GITHUB_DELETE):
-            log.info(
-                'Triggered sync_versions.',
-                project_slug=self.project.slug,
-                webhook_event=event,
-            )
+            log.info('Triggered sync_versions.')
             return self.sync_versions_response(self.project)
 
         # Handle pull request events
@@ -446,7 +441,10 @@ class GitHubWebhookView(WebhookMixin, APIView):
                 # already have the CREATE/DELETE events. So we don't trigger the sync twice.
                 return self.sync_versions_response(self.project, sync=False)
 
-            log.info('Triggered sync_versions.', project_slug=self.project.slug, events=events)
+            log.info(
+                'Triggered sync_versions.',
+                integration_events=events,
+            )
             return self.sync_versions_response(self.project)
 
         # Trigger a build for all branches in the push
@@ -516,10 +514,7 @@ class GitLabWebhookView(WebhookMixin, APIView):
         token = self.request.META.get(GITLAB_TOKEN_HEADER)
         secret = self.get_integration().secret
         if not secret:
-            log.info(
-                'Skipping payload signature validation.',
-                project_slug=self.project.slug,
-            )
+            log.debug('Skipping payload signature validation.')
             return True
         if not token:
             return False
@@ -546,6 +541,7 @@ class GitLabWebhookView(WebhookMixin, APIView):
         """
         event = self.request.data.get('object_kind', GITLAB_PUSH)
         action = self.data.get('object_attributes', {}).get('action', None)
+        log.bind(webhook_event=event)
         webhook_gitlab.send(
             Project,
             project=self.project,
@@ -561,7 +557,6 @@ class GitLabWebhookView(WebhookMixin, APIView):
             if GITLAB_NULL_HASH in (before, after):
                 log.info(
                     'Triggered sync_versions.',
-                    project_slug=self.project.slug,
                     before=before,
                     after=after,
                 )
@@ -638,6 +633,7 @@ class BitbucketWebhookView(WebhookMixin, APIView):
         attribute (null if it is a creation).
         """
         event = self.request.META.get(BITBUCKET_EVENT_HEADER, BITBUCKET_PUSH)
+        log.bind(webhook_event=event)
         webhook_bitbucket.send(
             Project,
             project=self.project,
@@ -661,11 +657,7 @@ class BitbucketWebhookView(WebhookMixin, APIView):
                 # will be triggered with the normal push.
                 if branches:
                     return self.get_response_push(self.project, branches)
-                log.info(
-                    'Triggered sync_versions.',
-                    project_slug=self.project.slug,
-                    webhook_event=event,
-                )
+                log.info('Triggered sync_versions.')
                 return self.sync_versions_response(self.project)
             except KeyError:
                 raise ParseError('Invalid request')

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -546,8 +546,12 @@ class BuildEnvironment(BaseEnvironment):
         self.update_build(BUILD_STATE_FINISHED)
         log.info(
             'Build finished',
+            # TODO: move all of these attributes to ``log.bind`` if possible
             project_slug=self.project.slug if self.project else '',
             version_slug=self.version.slug if self.version else '',
+            # TODO: add organization_slug here
+            success=self.build.get('success'),
+            length=self.build.get('length'),
         )
         return ret
 

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -550,8 +550,8 @@ class BuildEnvironment(BaseEnvironment):
             project_slug=self.project.slug if self.project else '',
             version_slug=self.version.slug if self.version else '',
             # TODO: add organization_slug here
-            success=self.build.get('success'),
-            length=self.build.get('length'),
+            success=self.build.get('success') if self.build else '',
+            length=self.build.get('length') if self.build else '',
         )
         return ret
 

--- a/readthedocs/embed/v3/views.py
+++ b/readthedocs/embed/v3/views.py
@@ -346,6 +346,8 @@ class EmbedAPIBase(CachedResponseMixin, APIView):
             'EmbedAPI successful response.',
             project_slug=self.unresolved_url.project.slug if not external else None,
             domain=domain if external else None,
+            doctool=doctool,
+            doctoolversion=doctoolversion,
             url=url,
             referer=request.META.get('HTTP_REFERER'),
             external=external,

--- a/readthedocs/gold/views.py
+++ b/readthedocs/gold/views.py
@@ -239,7 +239,7 @@ class StripeEventView(APIView):
                     user = User.objects.get(username=username)
                     subscription = stripe.Subscription.retrieve(event.data.object.subscription)
                     log.bind(stripe_plan=subscription.plan.id)
-                    log.info('Gold Membership subscrpition.')
+                    log.info('Gold Membership subscription.')
                     gold, _ = GoldUser.objects.get_or_create(
                         user=user,
                         stripe_id=stripe_customer,

--- a/readthedocs/gold/views.py
+++ b/readthedocs/gold/views.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """Gold subscription views."""
 
 import json
@@ -16,17 +14,16 @@ from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
 from vanilla import DetailView, FormView, GenericView
-from rest_framework.exceptions import APIException
 from rest_framework.views import APIView
 from rest_framework import permissions
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 
 from readthedocs.core.mixins import PrivateViewMixin
-from readthedocs.projects.models import Domain, Project
+from readthedocs.projects.models import Project
 
 from .forms import GoldProjectForm, GoldSubscriptionForm
-from .models import GoldUser, LEVEL_CHOICES
+from .models import GoldUser
 
 
 log = structlog.get_logger(__name__)
@@ -222,6 +219,7 @@ class StripeEventView(APIView):
     def post(self, request, format=None):
         try:
             event = stripe.Event.construct_from(request.data, settings.STRIPE_SECRET)
+            log.bind(event=event.type)
             if event.type not in self.EVENTS:
                 log.warning('Unhandled Stripe event.', event_type=event.type)
                 return Response({
@@ -230,14 +228,18 @@ class StripeEventView(APIView):
                 })
 
             stripe_customer = event.data.object.customer
+            log.bind(stripe_customer=stripe_customer)
 
             if event.type == self.EVENT_CHECKOUT_COMPLETED:
                 username = event.data.object.client_reference_id
+                log.bind(user_username=username)
                 mode = event.data.object.mode
                 if mode == 'subscription':
                     # Gold Membership
                     user = User.objects.get(username=username)
                     subscription = stripe.Subscription.retrieve(event.data.object.subscription)
+                    log.bind(gold_level=subscription.plan.id)
+                    log.info('Gold Membership subscrpition.')
                     gold, _ = GoldUser.objects.get_or_create(
                         user=user,
                         stripe_id=stripe_customer,
@@ -252,6 +254,10 @@ class StripeEventView(APIView):
                         from readthedocsext.donate.utils import handle_payment_webhook
                         stripe_session = event.data.object.id
                         price_in_cents = event.data.object.amount_total
+                        log.info(
+                            'Gold Membership one-time donation.',
+                            price_in_cents=price_in_cents,
+                        )
                         handle_payment_webhook(
                             username,
                             stripe_customer,
@@ -266,20 +272,16 @@ class StripeEventView(APIView):
 
             elif event.type == self.EVENT_CHECKOUT_PAYMENT_FAILED:
                 username = event.data.object.client_reference_id
+                log.bind(user_username=username)
                 # TODO: add user notification saying it failed
-                log.exception(
-                    'Gold User payment failed.',
-                    user_username=username,
-                    stripe_customer=stripe_customer,
-                )
+                log.exception('Gold User payment failed.')
 
             elif event.type == self.EVENT_CUSTOMER_SUBSCRIPTION_UPDATED:
                 subscription = event.data.object
                 level = subscription.plan.id
                 log.info(
                     'Gold User subscription updated.',
-                    stripe_customer=stripe_customer,
-                    level=level,
+                    gold_level=level,
                 )
                 (
                     GoldUser.objects
@@ -291,11 +293,8 @@ class StripeEventView(APIView):
                 )
 
                 if subscription.status != 'active':
-                    # TODO: check if the subscription was canceled, past due, etc
-                    # and take the according action. Only acummulate errors on Sentry for now.
-                    log.error(
+                    log.warning(
                         'GoldUser is not active anymore.',
-                        stripe_customer=stripe_customer,
                     )
         except Exception:
             log.exception('Unexpected data in Stripe Event object')

--- a/readthedocs/gold/views.py
+++ b/readthedocs/gold/views.py
@@ -238,7 +238,7 @@ class StripeEventView(APIView):
                     # Gold Membership
                     user = User.objects.get(username=username)
                     subscription = stripe.Subscription.retrieve(event.data.object.subscription)
-                    log.bind(gold_level=subscription.plan.id)
+                    log.bind(stripe_plan=subscription.plan.id)
                     log.info('Gold Membership subscrpition.')
                     gold, _ = GoldUser.objects.get_or_create(
                         user=user,
@@ -281,7 +281,7 @@ class StripeEventView(APIView):
                 level = subscription.plan.id
                 log.info(
                     'Gold User subscription updated.',
-                    gold_level=level,
+                    stripe_plan=level,
                 )
                 (
                     GoldUser.objects

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -367,9 +367,7 @@ class GitHubService(Service):
         resp = None
 
         provider_data = self.get_provider_data(project, integration)
-        url = provider_data.get('url')
         log.bind(
-            url=url,
             project_slug=project.slug,
             integration_id=integration.pk,
         )
@@ -380,12 +378,16 @@ class GitHubService(Service):
             return self.setup_webhook(project, integration)
 
         try:
+            url = provider_data.get('url')
             resp = session.patch(
                 url,
                 data=data,
                 headers={'content-type': 'application/json'},
             )
-            log.bind(http_status_code=resp.status_code)
+            log.bind(
+                http_status_code=resp.status_code,
+                url=url,
+            )
 
             # GitHub will return 200 if already synced
             if resp.status_code in [200, 201]:

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -314,7 +314,7 @@ class GitHubService(Service):
         resp = None
         try:
             resp = session.post(
-                url
+                url,
                 data=data,
                 headers={'content-type': 'application/json'},
             )

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -330,17 +330,17 @@ class GitHubService(Service):
 
             if resp.status_code in [401, 403, 404]:
                 log.warning('GitHub project does not exist or user does not have permissions.')
-                return (False, resp)
+            else:
+                # Unknown response from GitHub
+                try:
+                    debug_data = resp.json()
+                except ValueError:
+                    debug_data = resp.content
+                log.warning(
+                    'GitHub webhook creation failed for project. Unknown response from GitHub.',
+                    debug_data=debug_data,
+                )
 
-            # Unknown response from GitHub
-            try:
-                debug_data = resp.json()
-            except ValueError:
-                debug_data = resp.content
-            log.warning(
-                'GitHub webhook creation failed for project. Unknown response from GitHub.',
-                debug_data=debug_data,
-            )
         # Catch exceptions with request or deserializing JSON
         except (RequestException, ValueError):
             log.exception('GitHub webhook creation failed for project.')

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -509,6 +509,8 @@ class GitLabService(Service):
                 debug_data = resp.json()
             except ValueError:
                 debug_data = resp.content
+            except Exception:
+                debug_data = None
             log.exception(
                 'GitLab webhook update failed.',
                 debug_data=debug_data,

--- a/readthedocs/oauth/tasks.py
+++ b/readthedocs/oauth/tasks.py
@@ -32,9 +32,6 @@ def sync_remote_repositories(user_id):
     if not user:
         return
 
-    # TODO: remove this log once we find out what's causing OOM
-    log.info('Running readthedocs.oauth.tasks.sync_remote_repositories.', locals=locals())
-
     failed_services = set()
     for service_cls in registry:
         for service in service_cls.for_user(user):

--- a/readthedocs/projects/tasks.py
+++ b/readthedocs/projects/tasks.py
@@ -1326,9 +1326,6 @@ def fileify(version_pk, commit, build, search_ranking, search_ignore):
         return
     project = version.project
 
-    # TODO: remove this log once we find out what's causing OOM
-    log.info('Running readthedocs.projects.tasks.fileify.', locals=locals())
-
     if not commit:
         log.warning(
             'Search index not being built because no commit information',

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -389,9 +389,14 @@ class ServeRobotsTXTBase(ServeDocsMixin, View):
         )
         path = build_media_storage.join(storage_path, 'robots.txt')
 
+        log.bind(
+            project_slug=project.slug,
+            version_slug=version.slug,
+        )
         if build_media_storage.exists(path):
             url = build_media_storage.url(path)
             url = urlparse(url)._replace(scheme='', netloc='').geturl()
+            log.info('Serving custom robots.txt file.')
             return self._serve_docs(
                 request,
                 final_project=project,

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -191,10 +191,12 @@ class GitHubOAuthTests(TestCase):
         )
 
         self.assertTrue(success)
+        mock_logger.bind.assert_called_with(
+            project_slug=self.project.slug,
+            commit_status=BUILD_STATUS_SUCCESS,
+        )
         mock_logger.info.assert_called_with(
             "GitHub commit status created for project.",
-            project_slug=self.project.slug,
-            commit_status=BUILD_STATUS_SUCCESS
         )
 
     @mock.patch('readthedocs.oauth.services.github.log')
@@ -208,12 +210,14 @@ class GitHubOAuthTests(TestCase):
         )
 
         self.assertFalse(success)
-        mock_logger.info.assert_called_with(
-            'GitHub project does not exist or user does not have permissions.',
+        mock_logger.bind.assert_called_with(
             project_slug=self.project.slug,
             user_username=self.user.username,
             http_status_code=404,
             statuses_url='https://api.github.com/repos/pypa/pip/statuses/1234'
+        )
+        mock_logger.info.assert_called_with(
+            'GitHub project does not exist or user does not have permissions.',
         )
 
     @mock.patch('readthedocs.oauth.services.github.log')
@@ -225,9 +229,9 @@ class GitHubOAuthTests(TestCase):
         )
 
         self.assertFalse(success)
+        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
         mock_logger.exception.assert_called_with(
             'GitHub commit status creation failed for project.',
-            project_slug=self.project.slug,
         )
 
     @override_settings(DEFAULT_PRIVACY_LEVEL='private')
@@ -263,9 +267,9 @@ class GitHubOAuthTests(TestCase):
 
         self.assertTrue(success)
         self.assertIsNotNone(self.integration.secret)
+        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
         mock_logger.info.assert_called_with(
             "GitHub webhook creation successful for project.",
-            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.github.log')
@@ -280,9 +284,9 @@ class GitHubOAuthTests(TestCase):
 
         self.assertFalse(success)
         self.assertIsNone(self.integration.secret)
-        mock_logger.info.assert_called_with(
+        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
+        mock_logger.warning.assert_called_with(
             'GitHub project does not exist or user does not have permissions.',
-            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.github.log')
@@ -297,9 +301,9 @@ class GitHubOAuthTests(TestCase):
         self.integration.refresh_from_db()
 
         self.assertIsNone(self.integration.secret)
+        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
         mock_logger.exception.assert_called_with(
             'GitHub webhook creation failed for project.',
-            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.github.log')
@@ -316,9 +320,9 @@ class GitHubOAuthTests(TestCase):
 
         self.assertTrue(success)
         self.assertIsNotNone(self.integration.secret)
+        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
         mock_logger.info.assert_called_with(
             "GitHub webhook update successful for project.",
-            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.github.GitHubService.get_session')
@@ -399,9 +403,9 @@ class GitHubOAuthTests(TestCase):
         self.integration.refresh_from_db()
 
         self.assertEqual(self.integration.provider_data, webhook_data[0])
+        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
         mock_logger.info.assert_called_with(
             'GitHub integration updated with provider data for project.',
-            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.github.log')
@@ -420,9 +424,9 @@ class GitHubOAuthTests(TestCase):
         self.integration.refresh_from_db()
 
         self.assertEqual(self.integration.provider_data, {})
-        mock_logger.info.assert_called_with(
+        mock_logger.warning.assert_called_with(
             'GitHub project does not exist or user does not have permissions.',
-            project_slug=self.project.slug,
+            https_status_code=404,
         )
 
     @mock.patch('readthedocs.oauth.services.github.log')
@@ -441,9 +445,9 @@ class GitHubOAuthTests(TestCase):
         self.integration.refresh_from_db()
 
         self.assertEqual(self.integration.provider_data, {})
+        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
         mock_logger.exception.assert_called_with(
             'GitHub webhook Listing failed for project.',
-            project_slug=self.project.slug,
         )
 
 
@@ -696,9 +700,9 @@ class BitbucketOAuthTests(TestCase):
         )
 
         self.assertTrue(success)
+        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
         mock_logger.info.assert_called_with(
             "Bitbucket webhook creation successful for project.",
-            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.bitbucket.log')
@@ -711,9 +715,9 @@ class BitbucketOAuthTests(TestCase):
         )
 
         self.assertFalse(success)
+        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
         mock_logger.info.assert_called_with(
             'Bitbucket project does not exist or user does not have permissions.',
-            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.bitbucket.log')
@@ -725,9 +729,9 @@ class BitbucketOAuthTests(TestCase):
             self.integration
         )
 
+        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
         mock_logger.exception.assert_called_with(
             'Bitbucket webhook creation failed for project.',
-            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.bitbucket.log')
@@ -742,9 +746,9 @@ class BitbucketOAuthTests(TestCase):
 
         self.assertTrue(success)
         self.assertIsNotNone(self.integration.secret)
+        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
         mock_logger.info.assert_called_with(
             "Bitbucket webhook update successful for project.",
-            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.bitbucket.BitbucketService.get_session')
@@ -787,9 +791,9 @@ class BitbucketOAuthTests(TestCase):
             self.integration
         )
 
+        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
         mock_logger.exception.assert_called_with(
             'Bitbucket webhook update failed for project.',
-            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.bitbucket.log')
@@ -822,9 +826,9 @@ class BitbucketOAuthTests(TestCase):
         self.integration.refresh_from_db()
 
         self.assertEqual(self.integration.provider_data, webhook_data['values'][0])
+        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
         mock_logger.info.assert_called_with(
             'Bitbucket integration updated with provider data for project.',
-            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.bitbucket.log')
@@ -843,9 +847,9 @@ class BitbucketOAuthTests(TestCase):
         self.integration.refresh_from_db()
 
         self.assertEqual(self.integration.provider_data, {})
+        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
         mock_logger.info.assert_called_with(
             'Bitbucket project does not exist or user does not have permissions.',
-            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.bitbucket.log')
@@ -864,9 +868,9 @@ class BitbucketOAuthTests(TestCase):
         self.integration.refresh_from_db()
 
         self.assertEqual(self.integration.provider_data, {})
+        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
         mock_logger.exception.assert_called_with(
             'Bitbucket webhook Listing failed for project.',
-            project_slug=self.project.slug,
         )
 
 
@@ -1086,10 +1090,12 @@ class GitLabOAuthTests(TestCase):
         )
 
         self.assertTrue(success)
-        mock_logger.info.assert_called_with(
-            "GitLab commit status created for project.",
+        mock_logger.bind.assert_called_with(
             project_slug=self.project.slug,
             commit_status=BUILD_STATUS_SUCCESS
+        )
+        mock_logger.info.assert_called_with(
+            "GitLab commit status created for project.",
         )
 
     @mock.patch('readthedocs.oauth.services.gitlab.log')
@@ -1106,12 +1112,15 @@ class GitLabOAuthTests(TestCase):
         )
 
         self.assertFalse(success)
-        mock_logger.info.assert_called_with(
-            'GitLab project does not exist or user does not have permissions.',
+        mock_logger.bind.assert_called_with(
             project_slug=self.project.slug,
             user_username=self.user.username,
             http_status_code=404,
             statuses_url='https://gitlab.com/api/v4/projects/9999/statuses/1234',
+        )
+
+        mock_logger.info.assert_called_with(
+            'GitLab project does not exist or user does not have permissions.',
         )
 
     @mock.patch('readthedocs.oauth.services.gitlab.log')
@@ -1126,9 +1135,11 @@ class GitLabOAuthTests(TestCase):
         )
 
         self.assertFalse(success)
+        mock_logger.bind.assert_called_with(
+            project_slug=self.project.slug,
+        )
         mock_logger.exception.assert_called_with(
             'GitLab commit status creation failed for project.',
-            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.gitlab.log')
@@ -1145,9 +1156,9 @@ class GitLabOAuthTests(TestCase):
 
         self.assertTrue(success)
         self.assertIsNotNone(self.integration.secret)
+        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
         mock_logger.info.assert_called_with(
             "GitLab webhook creation successful for project.",
-            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.gitlab.log')
@@ -1163,9 +1174,9 @@ class GitLabOAuthTests(TestCase):
 
         self.assertFalse(success)
         self.assertIsNone(self.integration.secret)
+        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
         mock_logger.info.assert_called_with(
             'Gitlab project does not exist or user does not have permissions.',
-            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.gitlab.log')
@@ -1180,10 +1191,9 @@ class GitLabOAuthTests(TestCase):
         self.integration.refresh_from_db()
 
         self.assertIsNone(self.integration.secret)
+        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
         mock_logger.exception.assert_called_with(
             'GitLab webhook creation failed for project.',
-            project_slug=self.project.slug
-            ,
         )
 
     @mock.patch('readthedocs.oauth.services.gitlab.log')
@@ -1202,9 +1212,9 @@ class GitLabOAuthTests(TestCase):
 
         self.assertTrue(success)
         self.assertIsNotNone(self.integration.secret)
+        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
         mock_logger.info.assert_called_with(
             "GitLab webhook update successful for project.",
-            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.gitlab.GitLabService.get_session')
@@ -1256,9 +1266,9 @@ class GitLabOAuthTests(TestCase):
         self.integration.refresh_from_db()
 
         self.assertIsNone(self.integration.secret)
+        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
         mock_logger.exception.assert_called_with(
             'GitLab webhook update failed for project.',
-            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.gitlab.log')
@@ -1291,9 +1301,9 @@ class GitLabOAuthTests(TestCase):
         self.integration.refresh_from_db()
 
         self.assertEqual(self.integration.provider_data, webhook_data[0])
+        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
         mock_logger.info.assert_called_with(
             'GitLab integration updated with provider data for project.',
-            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.gitlab.log')
@@ -1312,9 +1322,9 @@ class GitLabOAuthTests(TestCase):
         self.integration.refresh_from_db()
 
         self.assertEqual(self.integration.provider_data, {})
+        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
         mock_logger.info.assert_called_with(
             'GitLab project does not exist or user does not have permissions.',
-            project_slug=self.project.slug,
         )
 
     @mock.patch('readthedocs.oauth.services.gitlab.log')
@@ -1333,7 +1343,7 @@ class GitLabOAuthTests(TestCase):
         self.integration.refresh_from_db()
 
         self.assertEqual(self.integration.provider_data, {})
+        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
         mock_logger.exception.assert_called_with(
             'GitLab webhook Listing failed for project.',
-            project_slug=self.project.slug,
         )

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -191,10 +191,7 @@ class GitHubOAuthTests(TestCase):
         )
 
         self.assertTrue(success)
-        mock_logger.bind.assert_called_with(
-            project_slug=self.project.slug,
-            commit_status=BUILD_STATUS_SUCCESS,
-        )
+        mock_logger.bind.assert_called_with(http_status_code=201)
         mock_logger.info.assert_called_with(
             "GitHub commit status created for project.",
         )
@@ -210,12 +207,7 @@ class GitHubOAuthTests(TestCase):
         )
 
         self.assertFalse(success)
-        mock_logger.bind.assert_called_with(
-            project_slug=self.project.slug,
-            user_username=self.user.username,
-            http_status_code=404,
-            statuses_url='https://api.github.com/repos/pypa/pip/statuses/1234'
-        )
+        mock_logger.bind.assert_called_with(http_status_code=404)
         mock_logger.info.assert_called_with(
             'GitHub project does not exist or user does not have permissions.',
         )
@@ -229,7 +221,12 @@ class GitHubOAuthTests(TestCase):
         )
 
         self.assertFalse(success)
-        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
+        mock_logger.bind.assert_called_with(
+            project_slug=self.project.slug,
+            commit_status='success',
+            user_username=self.user.username,
+            statuses_url='https://api.github.com/repos/pypa/pip/statuses/1234',
+        )
         mock_logger.exception.assert_called_with(
             'GitHub commit status creation failed for project.',
         )
@@ -267,7 +264,7 @@ class GitHubOAuthTests(TestCase):
 
         self.assertTrue(success)
         self.assertIsNotNone(self.integration.secret)
-        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
+        mock_logger.bind.assert_called_with(http_status_code=201)
         mock_logger.info.assert_called_with(
             "GitHub webhook creation successful for project.",
         )
@@ -284,7 +281,7 @@ class GitHubOAuthTests(TestCase):
 
         self.assertFalse(success)
         self.assertIsNone(self.integration.secret)
-        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
+        mock_logger.bind.assert_called_with(http_status_code=404)
         mock_logger.warning.assert_called_with(
             'GitHub project does not exist or user does not have permissions.',
         )
@@ -301,7 +298,11 @@ class GitHubOAuthTests(TestCase):
         self.integration.refresh_from_db()
 
         self.assertIsNone(self.integration.secret)
-        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
+        mock_logger.bind.assert_called_with(
+            project_slug=self.project.slug,
+            integration_id=self.integration.pk,
+            url='https://api.github.com/repos/pypa/pip/hooks',
+        )
         mock_logger.exception.assert_called_with(
             'GitHub webhook creation failed for project.',
         )
@@ -320,7 +321,10 @@ class GitHubOAuthTests(TestCase):
 
         self.assertTrue(success)
         self.assertIsNotNone(self.integration.secret)
-        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
+        mock_logger.bind.assert_called_with(
+            http_status_code=201,
+            url='https://github.com/',
+        )
         mock_logger.info.assert_called_with(
             "GitHub webhook update successful for project.",
         )
@@ -368,10 +372,7 @@ class GitHubOAuthTests(TestCase):
         self.integration.refresh_from_db()
 
         self.assertIsNone(self.integration.secret)
-        mock_logger.exception.assert_called_with(
-            'GitHub webhook update failed for project.',
-            project_slug=self.project.slug,
-        )
+        mock_logger.exception.assert_called_with('GitHub webhook update failed for project.')
 
     @mock.patch('readthedocs.oauth.services.github.log')
     @mock.patch('readthedocs.oauth.services.github.GitHubService.get_session')
@@ -403,7 +404,11 @@ class GitHubOAuthTests(TestCase):
         self.integration.refresh_from_db()
 
         self.assertEqual(self.integration.provider_data, webhook_data[0])
-        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
+        mock_logger.bind.assert_called_with(
+            project_slug=self.project.slug,
+            integration_id=self.integration.pk,
+            url='https://api.github.com/repos/pypa/pip/hooks',
+        )
         mock_logger.info.assert_called_with(
             'GitHub integration updated with provider data for project.',
         )
@@ -445,7 +450,11 @@ class GitHubOAuthTests(TestCase):
         self.integration.refresh_from_db()
 
         self.assertEqual(self.integration.provider_data, {})
-        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
+        mock_logger.bind.assert_called_with(
+            project_slug=self.project.slug,
+            integration_id=self.integration.pk,
+            url='https://api.github.com/repos/pypa/pip/hooks',
+        )
         mock_logger.exception.assert_called_with(
             'GitHub webhook Listing failed for project.',
         )
@@ -700,7 +709,11 @@ class BitbucketOAuthTests(TestCase):
         )
 
         self.assertTrue(success)
-        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
+        mock_logger.bind.assert_called_with(
+            project_slug=self.project.slug,
+            integration_id=self.integration.pk,
+            url='https://api.bitbucket.org/2.0/repositories/testuser/testrepo/hooks',
+        )
         mock_logger.info.assert_called_with(
             "Bitbucket webhook creation successful for project.",
         )
@@ -715,7 +728,11 @@ class BitbucketOAuthTests(TestCase):
         )
 
         self.assertFalse(success)
-        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
+        mock_logger.bind.assert_called_with(
+            project_slug=self.project.slug,
+            integration_id=self.integration.pk,
+            url='https://api.bitbucket.org/2.0/repositories/testuser/testrepo/hooks',
+        )
         mock_logger.info.assert_called_with(
             'Bitbucket project does not exist or user does not have permissions.',
         )
@@ -729,7 +746,11 @@ class BitbucketOAuthTests(TestCase):
             self.integration
         )
 
-        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
+        mock_logger.bind.assert_called_with(
+            project_slug=self.project.slug,
+            integration_id=self.integration.pk,
+            url='https://api.bitbucket.org/2.0/repositories/testuser/testrepo/hooks',
+        )
         mock_logger.exception.assert_called_with(
             'Bitbucket webhook creation failed for project.',
         )
@@ -826,7 +847,11 @@ class BitbucketOAuthTests(TestCase):
         self.integration.refresh_from_db()
 
         self.assertEqual(self.integration.provider_data, webhook_data['values'][0])
-        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
+        mock_logger.bind.assert_called_with(
+            project_slug=self.project.slug,
+            integration_id=self.integration.pk,
+            url='https://api.bitbucket.org/2.0/repositories/testuser/testrepo/hooks',
+        )
         mock_logger.info.assert_called_with(
             'Bitbucket integration updated with provider data for project.',
         )
@@ -847,7 +872,11 @@ class BitbucketOAuthTests(TestCase):
         self.integration.refresh_from_db()
 
         self.assertEqual(self.integration.provider_data, {})
-        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
+        mock_logger.bind.assert_called_with(
+            project_slug=self.project.slug,
+            integration_id=self.integration.pk,
+            url='https://api.bitbucket.org/2.0/repositories/testuser/testrepo/hooks',
+        )
         mock_logger.info.assert_called_with(
             'Bitbucket project does not exist or user does not have permissions.',
         )
@@ -868,7 +897,11 @@ class BitbucketOAuthTests(TestCase):
         self.integration.refresh_from_db()
 
         self.assertEqual(self.integration.provider_data, {})
-        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
+        mock_logger.bind.assert_called_with(
+            project_slug=self.project.slug,
+            integration_id=self.integration.pk,
+            url='https://api.bitbucket.org/2.0/repositories/testuser/testrepo/hooks',
+        )
         mock_logger.exception.assert_called_with(
             'Bitbucket webhook Listing failed for project.',
         )
@@ -1090,10 +1123,7 @@ class GitLabOAuthTests(TestCase):
         )
 
         self.assertTrue(success)
-        mock_logger.bind.assert_called_with(
-            project_slug=self.project.slug,
-            commit_status=BUILD_STATUS_SUCCESS
-        )
+        mock_logger.bind.assert_called_with(http_status_code=201)
         mock_logger.info.assert_called_with(
             "GitLab commit status created for project.",
         )
@@ -1112,13 +1142,7 @@ class GitLabOAuthTests(TestCase):
         )
 
         self.assertFalse(success)
-        mock_logger.bind.assert_called_with(
-            project_slug=self.project.slug,
-            user_username=self.user.username,
-            http_status_code=404,
-            statuses_url='https://gitlab.com/api/v4/projects/9999/statuses/1234',
-        )
-
+        mock_logger.bind.assert_called_with(http_status_code=404)
         mock_logger.info.assert_called_with(
             'GitLab project does not exist or user does not have permissions.',
         )
@@ -1137,9 +1161,13 @@ class GitLabOAuthTests(TestCase):
         self.assertFalse(success)
         mock_logger.bind.assert_called_with(
             project_slug=self.project.slug,
+            commit_status='success',
+            user_username=self.user.username,
+            url=mock.ANY,
         )
         mock_logger.exception.assert_called_with(
-            'GitLab commit status creation failed for project.',
+            'GitLab commit status creation failed.',
+            debug_data=None,
         )
 
     @mock.patch('readthedocs.oauth.services.gitlab.log')
@@ -1156,7 +1184,9 @@ class GitLabOAuthTests(TestCase):
 
         self.assertTrue(success)
         self.assertIsNotNone(self.integration.secret)
-        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
+        mock_logger.bind.assert_called_with(
+            http_status_code=201,
+        )
         mock_logger.info.assert_called_with(
             "GitLab webhook creation successful for project.",
         )
@@ -1174,7 +1204,7 @@ class GitLabOAuthTests(TestCase):
 
         self.assertFalse(success)
         self.assertIsNone(self.integration.secret)
-        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
+        mock_logger.bind.assert_called_with(http_status_code=404)
         mock_logger.info.assert_called_with(
             'Gitlab project does not exist or user does not have permissions.',
         )
@@ -1191,9 +1221,13 @@ class GitLabOAuthTests(TestCase):
         self.integration.refresh_from_db()
 
         self.assertIsNone(self.integration.secret)
-        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
+        mock_logger.bind.assert_called_with(
+            project_slug=self.project.slug,
+            integration_id=self.integration.pk,
+            url='https://gitlab.com/api/v4/projects/testorga%2Ftestrepo/hooks',
+        )
         mock_logger.exception.assert_called_with(
-            'GitLab webhook creation failed for project.',
+            'GitLab webhook creation failed.',
         )
 
     @mock.patch('readthedocs.oauth.services.gitlab.log')
@@ -1212,7 +1246,10 @@ class GitLabOAuthTests(TestCase):
 
         self.assertTrue(success)
         self.assertIsNotNone(self.integration.secret)
-        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
+        mock_logger.bind.assert_called_with(
+            project_slug=self.project.slug,
+            integration_id=self.integration.pk,
+        )
         mock_logger.info.assert_called_with(
             "GitLab webhook update successful for project.",
         )
@@ -1266,9 +1303,13 @@ class GitLabOAuthTests(TestCase):
         self.integration.refresh_from_db()
 
         self.assertIsNone(self.integration.secret)
-        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
+        mock_logger.bind.assert_called_with(
+            project_slug=self.project.slug,
+            integration_id=self.integration.pk,
+        )
         mock_logger.exception.assert_called_with(
-            'GitLab webhook update failed for project.',
+            'GitLab webhook update failed.',
+            debug_data=None,
         )
 
     @mock.patch('readthedocs.oauth.services.gitlab.log')
@@ -1301,7 +1342,10 @@ class GitLabOAuthTests(TestCase):
         self.integration.refresh_from_db()
 
         self.assertEqual(self.integration.provider_data, webhook_data[0])
-        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
+        mock_logger.bind.assert_called_with(
+            project_slug=self.project.slug,
+            integration_id=self.integration.pk,
+        )
         mock_logger.info.assert_called_with(
             'GitLab integration updated with provider data for project.',
         )
@@ -1322,7 +1366,10 @@ class GitLabOAuthTests(TestCase):
         self.integration.refresh_from_db()
 
         self.assertEqual(self.integration.provider_data, {})
-        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
+        mock_logger.bind.assert_called_with(
+            project_slug=self.project.slug,
+            integration_id=self.integration.pk,
+        )
         mock_logger.info.assert_called_with(
             'GitLab project does not exist or user does not have permissions.',
         )
@@ -1343,7 +1390,10 @@ class GitLabOAuthTests(TestCase):
         self.integration.refresh_from_db()
 
         self.assertEqual(self.integration.provider_data, {})
-        mock_logger.bind.assert_called_with(project_slug=self.project.slug)
+        mock_logger.bind.assert_called_with(
+            project_slug=self.project.slug,
+            integration_id=self.integration.pk,
+        )
         mock_logger.exception.assert_called_with(
             'GitLab webhook Listing failed for project.',
         )

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -825,6 +825,7 @@ class CommunityBaseSettings(Settings):
             "key_value": {
                 "()": structlog.stdlib.ProcessorFormatter,
                 "processors": [
+                    structlog.processors.TimeStamper(fmt='iso'),
                     structlog.stdlib.ProcessorFormatter.remove_processors_meta,
                     structlog.processors.KeyValueRenderer(key_order=['timestamp', 'level', 'event', 'logger']),
                 ],


### PR DESCRIPTION
The main purpose of this PR is to reduce the log entries sent to Sentry unless they are errors that we can fix only. We were sending "GitHub webhook creating failed", and the reason was the repository was deleted for example --which is not an error on our side.

Besides, there are some tweaks and improvements to have more structured logs where we can get analytics from. 