### PR TITLE
Always clear cache after each test

### DIFF
--- a/readthedocs/conftest.py
+++ b/readthedocs/conftest.py
@@ -1,6 +1,6 @@
 import pytest
+from django.core.cache import cache
 from rest_framework.test import APIClient
-
 
 pytest_plugins = (
     'sphinx.testing.fixtures',
@@ -10,3 +10,18 @@ pytest_plugins = (
 @pytest.fixture
 def api_client():
     return APIClient()
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """
+    Clear the cache after each test.
+
+    We don't usually want to share the cache between test cases.
+    We have code that will error, as the cache will
+    reference to things that don't exist in other test case.
+    """
+    # Code run before each test
+    yield
+    # Code run afer each test
+    cache.clear()


### PR DESCRIPTION
There is an error when running tests on .com
due to a cached key somewhere.
Maybe there is missing a tearDown somewhere
or it's the result of a side effect when running these tests
with the settings from .com.

But in any case, I think just making this for each test
is better instead of trying to figureout where to put
a tearDown function.

Hopefully the impact in time isn't big.