### PR TITLE
Spam: contact link on template

### DIFF
--- a/readthedocs/templates/spam.html
+++ b/readthedocs/templates/spam.html
@@ -25,7 +25,7 @@
             <h1>Project marked as spam</h1>
             <p>Read the Docs has marked this content as spam and is not serving it anymore.</p>
             {# We can't use url templatetag here because the URL is not defined in El Proxito #}
-            <p>Please <a href="https://{{ PUBLIC_DOMAIN }}/support/">contact us</a> if you think this is a mistake.</p>
+            <p>Please <a href="https://{{ PRODUCTION_DOMAIN }}/support/">contact us</a> if you think this is a mistake.</p>
             <p style="color: #666;">410 - Gone</p>
         </main>
     </body>


### PR DESCRIPTION
It was pointing to readthedocs.io instead of readthedocs.org