### PR TITLE
Remove sphinx-doc.org from external domains

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -881,7 +881,6 @@ class CommunityBaseSettings(Settings):
         r'docs\.python\.org',
         r'docs\.scipy\.org',
         r'docs\.sympy\.org',
-        r'www.sphinx-doc.org',
         r'numpy\.org',
     ]
     RTD_EMBED_API_PAGE_CACHE_TIMEOUT = 5 * 10


### PR DESCRIPTION
Sphinx docs are hosted on RTD.

Low priority change, but came up when talking to @humitos and wanted to send a PR for it already. If I understood correctly, this should have no effect.