### PR TITLE
Add MyST Markdown examples everywhere

### DIFF
--- a/docs/guides/embedding-content.rst
+++ b/docs/guides/embedding-content.rst
@@ -79,17 +79,33 @@ and show a modal when the user clicks in a "Help" link.
     To avoid that, you can manually define Sphinx references above the sections you don't want to break.
     For example,
 
-    .. code-block:: rst
-       :emphasize-lines: 3
+    .. tabs::
 
-       .. in your .rst document file
+       .. tab:: reStructuredText
 
-       .. _unbreakable-section-reference:
+          .. code-block:: rst
+             :emphasize-lines: 3
 
-       Creating an automation rule
-       ---------------------------
+             .. in your .rst document file
 
-       This is the text of the section.
+             .. _unbreakable-section-reference:
+
+             Creating an automation rule
+             ---------------------------
+
+             This is the text of the section.
+
+       .. tab:: MyST (Markdown)
+
+          .. code-block:: md
+             :emphasize-lines: 3
+
+             .. in your .md document file
+
+             (unbreakable-section-reference)=
+             ## Creating an automation rule
+
+             This is the text of the section.
 
     To link to the section "Creating an automation rule" you can send ``section=unbreakable-section-reference``.
     If you change the title it won't break the embedded content because the label for that title will still be ``unbreakable-section-reference``.

--- a/docs/guides/jupyter.rst
+++ b/docs/guides/jupyter.rst
@@ -58,13 +58,29 @@ Next, you will need to enable one of the extensions, as follows:
 Finally, you can include the notebook in any *toctree*.
 For example, add this to your root document:
 
-.. code-block:: rest
+.. tabs::
 
-   .. toctree::
-      :maxdepth: 2
-      :caption: Contents:
+   .. tab:: reStructuredText
 
-      notebooks/Example 1
+      .. code-block:: rst
+
+         .. toctree::
+            :maxdepth: 2
+            :caption: Contents:
+
+            notebooks/Example 1
+
+   .. tab:: MyST (Markdown)
+
+      .. code-block:: md
+
+         ```{toctree}
+         ---
+         maxdepth: 2
+         caption: Contents:
+         ---
+         notebooks/Example 1
+         ```
 
 The notebook will render as any other HTML page in your documentation
 after doing ``make html``.
@@ -255,14 +271,29 @@ For example, this reST markup would create a thumbnail gallery
 with generic images as thumbnails,
 thanks to the Sphinx-Gallery default style:
 
-.. code-block:: rest
+.. tabs::
 
-   Thumbnails gallery
-   ==================
+   .. tab:: reStructuredText
 
-   .. nbgallery::
-      notebooks/Example 1
-      notebooks/Example 2
+      .. code-block:: rst
+
+         Thumbnails gallery
+         ==================
+
+         .. nbgallery::
+            notebooks/Example 1
+            notebooks/Example 2
+
+   .. tab:: MyST (Markdown)
+
+      .. code-block:: md
+
+         # Thumbnails gallery
+
+         ```{nbgallery}
+         notebooks/Example 1
+         notebooks/Example 2
+         ```
 
 .. figure:: /_static/images/guides/thumbnail-gallery.png
    :width: 80%


### PR DESCRIPTION
These were the two last guides that had reStructuredText examples without MyST Markdown examples.