### PR TITLE
Don't run spam rules check after ban action

### DIFF
--- a/readthedocs/projects/admin.py
+++ b/readthedocs/projects/admin.py
@@ -319,9 +319,6 @@ class ProjectAdmin(ExtraSimpleHistoryAdmin):
                 'Banned {} user(s)'.format(total),
             )
 
-        # Trigger the spam rules check for these projects
-        self.run_spam_rule_checks(request, queryset)
-
     ban_owner.short_description = 'Ban project owner'
 
     def delete_selected_and_artifacts(self, request, queryset):


### PR DESCRIPTION
Spam rules are run automatically
after the user profile is saved.