### PR TITLE
Skip slug check when editing an organization

### DIFF
--- a/readthedocs/organizations/forms.py
+++ b/readthedocs/organizations/forms.py
@@ -59,9 +59,11 @@ class OrganizationForm(SimpleHistoryModelForm):
         super().__init__(*args, **kwargs)
 
     def clean_name(self):
-        """Raise exception on duplicate organization."""
+        """Raise exception on duplicate organization slug."""
         name = self.cleaned_data['name']
-        if self.instance and self.instance.name and name == self.instance.name:
+
+        # Skip slug validation on already created organizations.
+        if self.instance.pk:
             return name
 
         potential_slug = slugify(name)


### PR DESCRIPTION
This is the same behavior we have for projects

https://github.com/readthedocs/readthedocs.org/blob/b70be9f3abb1ad4f1608496de353f86701aef8e0/readthedocs/projects/forms.py#L118-L130