### PR TITLE
API v3: explicitly test with RTD_ALLOW_ORGANIZATIONS=False

### DIFF
--- a/readthedocs/api/v3/tests/mixins.py
+++ b/readthedocs/api/v3/tests/mixins.py
@@ -22,6 +22,7 @@ from readthedocs.redirects.models import Redirect
     PRODUCTION_DOMAIN='readthedocs.org',
     USE_SUBDOMAIN=True,
     RTD_BUILD_MEDIA_STORAGE='readthedocs.rtd_tests.storage.BuildMediaFileSystemStorageTest',
+    RTD_ALLOW_ORGANIZATIONS=False,
 )
 class APIEndpointMixin(TestCase):
 


### PR DESCRIPTION
This is to fix some tests on .com.
We already have some test for organizations on .com
(we should move them here).