### PR TITLE
API v3: don't include subproject_of on subprojects

### DIFF
--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -524,7 +524,7 @@ class ProjectUpdateSerializer(SettingsOverrideObject):
     _default_class = ProjectUpdateSerializerBase
 
 
-class ProjectSerializerBase(FlexFieldsModelSerializer):
+class ProjectSerializer(FlexFieldsModelSerializer):
 
     """
     Project serializer.
@@ -625,13 +625,6 @@ class ProjectSerializerBase(FlexFieldsModelSerializer):
             return self.__class__(obj.superprojects.first().parent).data
         except Exception:
             return None
-
-
-# FIXME: this override isn't needed, but tests will fail if removed.
-# We may have been relying on a weird behavior of using this class
-# as a base class of another.
-class ProjectSerializer(SettingsOverrideObject):
-    _default_class = ProjectSerializerBase
 
 
 class SubprojectCreateSerializer(FlexFieldsModelSerializer):

--- a/readthedocs/api/v3/tests/responses/projects-subprojects-detail.json
+++ b/readthedocs/api/v3/tests/responses/projects-subprojects-detail.json
@@ -35,55 +35,6 @@
             "url": "https://github.com/rtfd/subproject"
         },
         "slug": "subproject",
-        "subproject_of": {
-            "_links": {
-                "_self": "https://readthedocs.org/api/v3/projects/project/",
-                "builds": "https://readthedocs.org/api/v3/projects/project/builds/",
-                "environmentvariables": "https://readthedocs.org/api/v3/projects/project/environmentvariables/",
-                "redirects": "https://readthedocs.org/api/v3/projects/project/redirects/",
-                "subprojects": "https://readthedocs.org/api/v3/projects/project/subprojects/",
-                "superproject": "https://readthedocs.org/api/v3/projects/project/superproject/",
-                "translations": "https://readthedocs.org/api/v3/projects/project/translations/",
-                "versions": "https://readthedocs.org/api/v3/projects/project/versions/"
-            },
-            "created": "2019-04-29T10:00:00Z",
-            "default_branch": "master",
-            "default_version": "latest",
-            "homepage": "http://project.com",
-            "id": 1,
-            "language": {
-                "code": "en",
-                "name": "English"
-            },
-            "modified": "2019-04-29T12:00:00Z",
-            "name": "project",
-            "programming_language": {
-                "code": "words",
-                "name": "Only Words"
-            },
-            "repository": {
-                "type": "git",
-                "url": "https://github.com/rtfd/project"
-            }, "slug": "project",
-            "subproject_of": null,
-            "tags": [
-                "tag",
-                "project",
-                "test"
-            ],
-            "translation_of": null,
-            "urls": {
-                "builds": "https://readthedocs.org/projects/project/builds/",
-                "documentation": "http://project.readthedocs.io/en/latest/",
-                "home": "https://readthedocs.org/projects/project/",
-                "versions": "https://readthedocs.org/projects/project/versions/"
-            },
-            "users": [
-                {
-                    "username": "testuser"
-                }
-            ]
-        },
         "tags": [],
         "translation_of": null,
         "urls": {

--- a/readthedocs/api/v3/tests/responses/projects-subprojects-list.json
+++ b/readthedocs/api/v3/tests/responses/projects-subprojects-list.json
@@ -40,55 +40,6 @@
                     "url": "https://github.com/rtfd/subproject"
                 },
                 "slug": "subproject",
-                "subproject_of": {
-                    "_links": {
-                        "_self": "https://readthedocs.org/api/v3/projects/project/",
-                        "builds": "https://readthedocs.org/api/v3/projects/project/builds/",
-                        "environmentvariables": "https://readthedocs.org/api/v3/projects/project/environmentvariables/",
-                        "redirects": "https://readthedocs.org/api/v3/projects/project/redirects/",
-                        "subprojects": "https://readthedocs.org/api/v3/projects/project/subprojects/",
-                        "superproject": "https://readthedocs.org/api/v3/projects/project/superproject/",
-                        "translations": "https://readthedocs.org/api/v3/projects/project/translations/",
-                        "versions": "https://readthedocs.org/api/v3/projects/project/versions/"
-                    },
-                    "created": "2019-04-29T10:00:00Z",
-                    "default_branch": "master",
-                    "default_version": "latest",
-                    "homepage": "http://project.com",
-                    "id": 1,
-                    "language": {
-                        "code": "en",
-                        "name": "English"
-                    },
-                    "modified": "2019-04-29T12:00:00Z",
-                    "name": "project",
-                    "programming_language": {
-                        "code": "words",
-                        "name": "Only Words"
-                    },
-                    "repository": {
-                        "type": "git",
-                        "url": "https://github.com/rtfd/project"
-                    }, "slug": "project",
-                    "subproject_of": null,
-                    "tags": [
-                        "tag",
-                        "project",
-                        "test"
-                    ],
-                    "translation_of": null,
-                    "urls": {
-                        "builds": "https://readthedocs.org/projects/project/builds/",
-                        "documentation": "http://project.readthedocs.io/en/latest/",
-                        "home": "https://readthedocs.org/projects/project/",
-                        "versions": "https://readthedocs.org/projects/project/versions/"
-                    },
-                    "users": [
-                        {
-                            "username": "testuser"
-                        }
-                    ]
-                },
                 "tags": [],
                 "translation_of": null,
                 "urls": {

--- a/readthedocs/api/v3/tests/responses/projects-subprojects-list_POST.json
+++ b/readthedocs/api/v3/tests/responses/projects-subprojects-list_POST.json
@@ -35,55 +35,6 @@
             "url": "https://github.com/rtfd/project"
         },
         "slug": "new-project",
-        "subproject_of": {
-            "_links": {
-                "_self": "https://readthedocs.org/api/v3/projects/project/",
-                "builds": "https://readthedocs.org/api/v3/projects/project/builds/",
-                "environmentvariables": "https://readthedocs.org/api/v3/projects/project/environmentvariables/",
-                "redirects": "https://readthedocs.org/api/v3/projects/project/redirects/",
-                "subprojects": "https://readthedocs.org/api/v3/projects/project/subprojects/",
-                "superproject": "https://readthedocs.org/api/v3/projects/project/superproject/",
-                "translations": "https://readthedocs.org/api/v3/projects/project/translations/",
-                "versions": "https://readthedocs.org/api/v3/projects/project/versions/"
-            },
-            "created": "2019-04-29T10:00:00Z",
-            "default_branch": "master",
-            "default_version": "latest",
-            "homepage": "http://project.com",
-            "id": 1,
-            "language": {
-                "code": "en",
-                "name": "English"
-            },
-            "modified": "2019-04-29T12:00:00Z",
-            "name": "project",
-            "programming_language": {
-                "code": "words",
-                "name": "Only Words"
-            },
-            "repository": {
-                "type": "git",
-                "url": "https://github.com/rtfd/project"
-            }, "slug": "project",
-            "subproject_of": null,
-            "tags": [
-                "tag",
-                "project",
-                "test"
-            ],
-            "translation_of": null,
-            "urls": {
-                "builds": "https://readthedocs.org/projects/project/builds/",
-                "documentation": "http://project.readthedocs.io/en/latest/",
-                "home": "https://readthedocs.org/projects/project/",
-                "versions": "https://readthedocs.org/projects/project/versions/"
-            },
-            "users": [
-                {
-                    "username": "testuser"
-                }
-            ]
-        },
         "tags": [],
         "translation_of": null,
         "urls": {


### PR DESCRIPTION
As explained and confirmed in
https://github.com/readthedocs/readthedocs.org/issues/8394,
subproject_of was never meant to be included,
there is a bug when using the SettingsOverrideObject instead
of using the base class, and the tests were wrong.

Closes https://github.com/readthedocs/readthedocs.org/issues/8394