### PR TITLE
API v3: improve message when using the API on the browser

### DIFF
--- a/readthedocs/api/v3/routers.py
+++ b/readthedocs/api/v3/routers.py
@@ -6,16 +6,16 @@ class DocsAPIRootView(APIRootView):
 
     # Overridden only to add documentation for BrowsableAPIRenderer.
 
+    # noqa
     """
-    Read the Docs APIv3 root endpoint.
+    Each request requires an `Authorization` HTTP header with `Token <your-token>`,
+    find the token in [your account](/accounts/tokens/).
 
-    The API is browsable by sending the header ``Authorization: Token <token>`` on each request. You can find your Token at [https://readthedocs.org/accounts/tokens/](https://readthedocs.org/accounts/tokens/).
-
-    Read its full documentation at [https://docs.readthedocs.io/page/api/v3.html](https://docs.readthedocs.io/page/api/v3.html).
-    """  # noqa
+    Read the full documentation at <https://docs.readthedocs.io/page/api/v3.html>.
+    """
 
     def get_view_name(self):
-        return 'Read the Docs APIv3'
+        return 'Read the Docs API v3'
 
 
 class DefaultRouterWithNesting(NestedRouterMixin, DefaultRouter):

--- a/readthedocs/templates/rest_framework/api.html
+++ b/readthedocs/templates/rest_framework/api.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block branding %}
-  <a class='navbar-brand' rel="nofollow" href='https://readthedocs.org'>
+<a class='navbar-brand' rel="nofollow" href='https://{{ PRODUCTION_DOMAIN }}'>
     Read the Docs
   </a>
 {% endblock %}

--- a/readthedocs/templates/rest_framework/api.html
+++ b/readthedocs/templates/rest_framework/api.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block branding %}
-<a class="navbar-brand" rel="nofollow" href="https://{{ PRODUCTION_DOMAIN }}">
+  <a class="navbar-brand" rel="nofollow" href="https://{{ PRODUCTION_DOMAIN }}">
     Read the Docs
   </a>
 {% endblock %}

--- a/readthedocs/templates/rest_framework/api.html
+++ b/readthedocs/templates/rest_framework/api.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block branding %}
-<a class='navbar-brand' rel="nofollow" href='https://{{ PRODUCTION_DOMAIN }}'>
+<a class="navbar-brand" rel="nofollow" href="https://{{ PRODUCTION_DOMAIN }}">
     Read the Docs
   </a>
 {% endblock %}


### PR DESCRIPTION
To use the api on the browser, there is no need to pass the auth token,
we use the user session.

Also, the token link was redirecting always to .org,
use a relative link instead.

And remove the duplication in the title.

![Screenshot from 2021-12-15 15-46-47](https://user-images.githubusercontent.com/4975310/146262565-717267bb-86a2-4cf2-a776-51f076e7ca39.png)
