### PR TITLE
API v3: less overrides

### DIFF
--- a/readthedocs/api/v3/permissions.py
+++ b/readthedocs/api/v3/permissions.py
@@ -1,4 +1,4 @@
-from rest_framework.permissions import IsAuthenticated, BasePermission
+from rest_framework.permissions import BasePermission, IsAuthenticated
 
 from readthedocs.core.utils.extend import SettingsOverrideObject
 
@@ -17,7 +17,7 @@ class UserProjectsListing(BasePermission):
             return True
 
 
-class PublicDetailPrivateListing(IsAuthenticated):
+class PublicDetailPrivateListing(BasePermission):
 
     """
     Permission class for our custom use case.

--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -592,25 +592,21 @@ class ProjectSerializer(FlexFieldsModelSerializer):
                 {
                     'many': True,
                 }
-            )
+            ),
+            'organization': (
+                'readthedocs.api.v3.serializers.OrganizationSerializer',
+                # NOTE: we cannot have a Project with multiple organizations.
+                {'source': 'organizations.first'},
+            ),
+            'teams': (
+                serializers.SlugRelatedField,
+                {
+                    'slug_field': 'slug',
+                    'many': True,
+                    'read_only': True,
+                },
+            ),
         }
-
-        if settings.RTD_ALLOW_ORGANIZATIONS:
-            expandable_fields.update({
-                'organization': (
-                    'readthedocs.api.v3.serializers.OrganizationSerializer',
-                    # NOTE: we cannot have a Project with multiple organizations.
-                    {'source': 'organizations.first'},
-                ),
-                'teams': (
-                    serializers.SlugRelatedField,
-                    {
-                        'slug_field': 'slug',
-                        'many': True,
-                        'read_only': True,
-                    },
-                ),
-            })
 
     def get_homepage(self, obj):
         # Overridden only to return ``None`` when the project_url is ``''``

--- a/readthedocs/api/v3/tests/mixins.py
+++ b/readthedocs/api/v3/tests/mixins.py
@@ -43,6 +43,7 @@ class APIEndpointMixin(TestCase):
         # objects (like a Project for translations/subprojects)
         self.project = fixture.get(
             Project,
+            id=1,
             pub_date=self.created,
             modified_date=self.modified,
             description='Project description',

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -120,6 +120,8 @@ class ProjectsViewSetBase(APIv3Settings, NestedViewSetMixin, ProjectQuerySetMixi
         'active_versions',
         'active_versions.last_build',
         'active_versions.last_build.config',
+        'organization',
+        'teams',
     ]
 
     def get_view_name(self):


### PR DESCRIPTION
So, conditionally setting attributes
at the class is good,
but when running tests it doesn't re-evaluate
the class, so we are stuck with the previous values.

Since no project on .org has organizations/teams
it doesn't matter exposing these fields (they return null, empty when
passed to ?expand=).