### PR TITLE
Follow up to dev docs split

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,7 +97,7 @@ intersphinx_mapping = {
     'myst-parser': ('https://myst-parser.readthedocs.io/en/v0.15.1/', None),
     'rst-to-myst': ('https://rst-to-myst.readthedocs.io/en/stable/', None),
     'rtd': ('https://docs.readthedocs.io/en/stable/', None),
-    'rtd-dev': ('https://dev.readthedocs.io/en/stable/', None),
+    'rtd-dev': ('https://dev.readthedocs.io/en/latest/', None),
 }
 myst_enable_extensions = [
     "deflist",


### PR DESCRIPTION
Better to point the dev docs to `latest`. Continuation of #8751.