### PR TITLE
Config file: system_site_packages overwritten from project's setting

### DIFF
--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -938,13 +938,9 @@ class BuildConfigV2(BuildConfigBase):
         ]
 
         with self.catch_validation_error('python.system_packages'):
-            system_packages = self.defaults.get(
-                'use_system_packages',
-                False,
-            )
             system_packages = self.pop_config(
                 'python.system_packages',
-                system_packages,
+                False,
             )
             python['use_system_site_packages'] = validate_bool(system_packages)
 

--- a/readthedocs/config/tests/test_config.py
+++ b/readthedocs/config/tests/test_config.py
@@ -1604,25 +1604,23 @@ class TestBuildConfigV2:
         build.validate()
         assert build.python.use_system_site_packages is False
 
-    def test_python_system_packages_respects_default(self):
+    def test_python_system_packages_dont_respects_default(self):
         build = self.get_build_config(
             {},
             {'defaults': {'use_system_packages': True}},
         )
         build.validate()
-        assert build.python.use_system_site_packages is True
+        assert build.python.use_system_site_packages is False
 
     def test_python_system_packages_priority_over_default(self):
         build = self.get_build_config(
             {'python': {'system_packages': False}},
-            {'defaults': {'use_system_packages': True}},
         )
         build.validate()
         assert build.python.use_system_site_packages is False
 
         build = self.get_build_config(
             {'python': {'system_packages': True}},
-            {'defaults': {'use_system_packages': False}},
         )
         build.validate()
         assert build.python.use_system_site_packages is True


### PR DESCRIPTION
I created a test case to demostrate what was reported in the issue. Summarizing,
if the project uses a config file and does not define `python.system_packages`
but has `Project.use_system_packages=True` the config option is `True` which is
wrong. When a config file is used, settings at Project level should be ignored
as this messages from "Advanced settings" states:

> These settings can be configured using a configuration file. That's the
recommended way to set up your project. Settings listed here are ignored when
using a configuration file.

Reference #8782