### PR TITLE
Fix broken link in edit-source-links-sphinx.rst

### DIFF
--- a/docs/user/guides/edit-source-links-sphinx.rst
+++ b/docs/user/guides/edit-source-links-sphinx.rst
@@ -8,7 +8,7 @@ You can use these variables in your own Sphinx theme as well.
 More information can be found on `Sphinx documentation`_.
 
 .. _`our Sphinx theme`: https://sphinx-rtd-theme.readthedocs.io/
-.. _`Sphinx documentation`: http://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_context
+.. _`Sphinx documentation`: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_context
 
 GitHub
 ------

--- a/docs/user/guides/edit-source-links-sphinx.rst
+++ b/docs/user/guides/edit-source-links-sphinx.rst
@@ -8,7 +8,7 @@ You can use these variables in your own Sphinx theme as well.
 More information can be found on `Sphinx documentation`_.
 
 .. _`our Sphinx theme`: https://sphinx-rtd-theme.readthedocs.io/
-.. _`Sphinx documentation`: http://www.sphinx-doc.org/en/master/configuration.html#confval-html_context
+.. _`Sphinx documentation`: http://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_context
 
 GitHub
 ------


### PR DESCRIPTION
The link to the relevant section in the Sphinx documentation was changed.