### PR TITLE
Spam: deny dashboard on spammy projects

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -9,8 +9,6 @@ markers =
 python_files = tests.py test_*.py *_tests.py
 filterwarnings =
     # Ignore external dependencies warning deprecations
-    # textclassifier
-    ignore:The 'warn' method is deprecated, use 'warning' instead:DeprecationWarning
     # django-rest-framework
     ignore:Pagination may yield inconsistent results with an unordered object_list.*:django.core.paginator.UnorderedObjectListWarning
     # docutils

--- a/readthedocs/projects/exceptions.py
+++ b/readthedocs/projects/exceptions.py
@@ -51,13 +51,3 @@ class RepositoryError(BuildEnvironmentError):
         if settings.ALLOW_PRIVATE_REPOS:
             return self.PRIVATE_ALLOWED
         return self.PRIVATE_NOT_ALLOWED
-
-
-class ProjectSpamError(Exception):
-
-    """
-    Error raised when a project field has detected spam.
-
-    This error is not raised to users, we use this for banning users in the
-    background.
-    """

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -11,7 +11,6 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
-from textclassifier.validators import ClassifierValidator
 
 from readthedocs.builds.constants import INTERNAL
 from readthedocs.core.history import SimpleHistoryModelForm
@@ -19,7 +18,6 @@ from readthedocs.core.utils import slugify, trigger_build
 from readthedocs.core.utils.extend import SettingsOverrideObject
 from readthedocs.integrations.models import Integration
 from readthedocs.oauth.models import RemoteRepository
-from readthedocs.projects.exceptions import ProjectSpamError
 from readthedocs.projects.models import (
     Domain,
     EmailHook,
@@ -173,7 +171,6 @@ class ProjectExtraForm(ProjectForm):
         )
 
     description = forms.CharField(
-        validators=[ClassifierValidator(raises=ProjectSpamError)],
         required=False,
         max_length=150,
         widget=forms.Textarea,

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -40,7 +40,7 @@ from readthedocs.proxito.views.utils import _get_project_data_from_request
 from readthedocs.storage import build_media_storage
 
 from ..constants import PRIVATE
-from .base import ProjectOnboardMixin
+from .base import ProjectOnboardMixin, ProjectSpamMixin
 
 log = structlog.get_logger(__name__)
 search_log = structlog.get_logger(__name__ + '.search')
@@ -87,8 +87,13 @@ def project_redirect(request, invalid_project_slug):
     ))
 
 
-class ProjectDetailViewBase(ProjectRelationListMixin, BuildTriggerMixin,
-                            ProjectOnboardMixin, DetailView):
+class ProjectDetailViewBase(
+        ProjectSpamMixin,
+        ProjectRelationListMixin,
+        BuildTriggerMixin,
+        ProjectOnboardMixin,
+        DetailView,
+):
 
     """Display project onboard steps."""
 

--- a/readthedocs/rtd_tests/tests/test_project_forms.py
+++ b/readthedocs/rtd_tests/tests/test_project_forms.py
@@ -5,7 +5,6 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils.translation import ugettext_lazy as _
 from django_dynamic_fixture import get
-from textclassifier.validators import ClassifierValidator
 
 from readthedocs.builds.constants import EXTERNAL, LATEST, STABLE
 from readthedocs.builds.models import Version
@@ -16,7 +15,6 @@ from readthedocs.projects.constants import (
     REPO_TYPE_HG,
     SPHINX,
 )
-from readthedocs.projects.exceptions import ProjectSpamError
 from readthedocs.projects.forms import (
     EmailHookForm,
     EnvironmentVariableForm,
@@ -35,20 +33,6 @@ from readthedocs.projects.models import (
 
 
 class TestProjectForms(TestCase):
-
-    @mock.patch.object(ClassifierValidator, '__call__')
-    def test_form_spam(self, mocked_validator):
-        """Form description field fails spam validation."""
-        mocked_validator.side_effect = ProjectSpamError
-
-        data = {
-            'description': 'foo',
-            'documentation_type': 'sphinx',
-            'language': 'en',
-        }
-        form = ProjectExtraForm(data)
-        with self.assertRaises(ProjectSpamError):
-            form.is_valid()
 
     def test_import_repo_url(self):
         """Validate different type of repository URLs on importing a Project."""

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -16,7 +16,6 @@ from readthedocs.integrations.models import GenericAPIWebhook, GitHubWebhook
 from readthedocs.oauth.models import RemoteRepository, RemoteRepositoryRelation
 from readthedocs.organizations.models import Organization
 from readthedocs.projects.constants import PUBLIC
-from readthedocs.projects.exceptions import ProjectSpamError
 from readthedocs.projects.models import Domain, Project, WebHook, WebHookEvent
 from readthedocs.projects.views.mixins import ProjectRelationMixin
 from readthedocs.projects.views.private import ImportWizardView
@@ -25,7 +24,7 @@ from readthedocs.rtd_tests.base import RequestFactoryTestMixin, WizardTestCase
 
 
 @mock.patch('readthedocs.projects.tasks.update_docs_task', mock.MagicMock())
-class TestProfileMiddleware(RequestFactoryTestMixin, TestCase):
+class TestImportProjectBannedUser(RequestFactoryTestMixin, TestCase):
 
     wizard_class_slug = 'import_wizard_view'
     url = '/dashboard/import/manual/'
@@ -50,7 +49,7 @@ class TestProfileMiddleware(RequestFactoryTestMixin, TestCase):
                               for (k, v) in list(data[key].items())})
         self.data['{}-current_step'.format(self.wizard_class_slug)] = 'extra'
 
-    def test_profile_middleware_no_profile(self):
+    def test_not_banned_user(self):
         """User without profile and isn't banned."""
         req = self.request(method='post', path='/projects/import', data=self.data)
         req.user = get(User, profile=None)
@@ -58,18 +57,7 @@ class TestProfileMiddleware(RequestFactoryTestMixin, TestCase):
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp['location'], '/projects/foobar/')
 
-    @mock.patch('readthedocs.projects.views.private.ProjectBasicsForm.clean')
-    def test_profile_middleware_spam(self, form):
-        """User will be banned."""
-        form.side_effect = ProjectSpamError
-        req = self.request(method='post', path='/projects/import', data=self.data)
-        req.user = get(User)
-        resp = ImportWizardView.as_view()(req)
-        self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp['location'], '/')
-        self.assertTrue(req.user.profile.banned)
-
-    def test_profile_middleware_banned(self):
+    def test_banned_user(self):
         """User is banned."""
         req = self.request(method='post', path='/projects/import', data=self.data)
         req.user = get(User)
@@ -295,54 +283,6 @@ class TestAdvancedForm(TestBasicsForm):
         proj = Project.objects.get(name='foobar')
         self.assertIsNotNone(proj)
         self.assertEqual(proj.remote_repository, remote_repo)
-
-    @mock.patch(
-        'readthedocs.projects.views.private.ProjectExtraForm.clean_description',
-        create=True,
-    )
-    def test_form_spam(self, mocked_validator):
-        """Don't add project on a spammy description."""
-        self.user.date_joined = timezone.now() - timedelta(days=365)
-        self.user.save()
-        mocked_validator.side_effect = ProjectSpamError
-
-        with self.assertRaises(Project.DoesNotExist):
-            proj = Project.objects.get(name='foobar')
-
-        resp = self.post_step('basics')
-        self.assertWizardResponse(resp, 'extra')
-        resp = self.post_step('extra', session=list(resp._request.session.items()))
-        self.assertIsInstance(resp, HttpResponseRedirect)
-        self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp['location'], '/')
-
-        with self.assertRaises(Project.DoesNotExist):
-            proj = Project.objects.get(name='foobar')
-        self.assertFalse(self.user.profile.banned)
-
-    @mock.patch(
-        'readthedocs.projects.views.private.ProjectExtraForm.clean_description',
-        create=True,
-    )
-    def test_form_spam_ban_user(self, mocked_validator):
-        """Don't add spam and ban new user."""
-        self.user.date_joined = timezone.now()
-        self.user.save()
-        mocked_validator.side_effect = ProjectSpamError
-
-        with self.assertRaises(Project.DoesNotExist):
-            proj = Project.objects.get(name='foobar')
-
-        resp = self.post_step('basics')
-        self.assertWizardResponse(resp, 'extra')
-        resp = self.post_step('extra', session=list(resp._request.session.items()))
-        self.assertIsInstance(resp, HttpResponseRedirect)
-        self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp['location'], '/')
-
-        with self.assertRaises(Project.DoesNotExist):
-            proj = Project.objects.get(name='foobar')
-        self.assertTrue(self.user.profile.banned)
 
 
 @mock.patch('readthedocs.core.utils.trigger_build', mock.MagicMock())

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -170,7 +170,6 @@ class CommunityBaseSettings(Settings):
             'rest_framework',
             'rest_framework.authtoken',
             'corsheaders',
-            'textclassifier',
             'annoying',
             'django_extensions',
             'crispy_forms',

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -78,12 +78,6 @@ django-crispy-forms==1.13.0
 
 docker==5.0.3
 
-django-textclassifier==1.0
-# django-textclassifier doesn't have pinned versions
-# if there is an update they could break our code
-nltk==3.6.6
-textblob==0.17.1
-
 django-annoying==0.10.6
 django-messages-extends==0.6.2
 djangorestframework-jsonp==1.0.2


### PR DESCRIPTION
Quick/Initial implementation to deny showing a project's dashboard if spam score
is above the threshold.

- the old and non-used `ProjectSpamError` that checked for an invalid
  description was removed together with all its logic
- the mixin `ProjectSpamMixin` was re-purposed to check the spam score and deny
  serving the dashboard
- move "disable banned user to import projects" inside the `ImportWizardView`


Note that currently we are only denying the dashboard for the project's
detail ("Overview" in our UI) view. If we want to deny other pages like
"Downloads", "Search", "Builds", "Versions" and "Admin" we need to adapt other
views as well (e.g. migrate them from function-based view to class-based view to
be able to re-use the mixin). This can be implemented in a future version.
Together with this, we could only deny the dashboard to non-maintainers of the
project itself, allowing them to make some changes in case of a mistake.