### PR TITLE
Requirements: downgrade redis to 3.5.3

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -31,7 +31,11 @@ pyyaml==5.4.1  # pyup: ignore
 Pygments==2.10.0
 
 # Basic tools
-redis==4.1.0
+
+# Downgrade redis to 3.5.3 (latest 3.x release) because pip raises this error:
+# django-redis-cache 2.1.3 depends on redis<4.0
+redis==3.5.3
+
 kombu==5.2.2
 celery==5.2.2
 

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -34,7 +34,7 @@ Pygments==2.10.0
 
 # Downgrade redis to 3.5.3 (latest 3.x release) because pip raises this error:
 # django-redis-cache 2.1.3 depends on redis<4.0
-redis==3.5.3
+redis==3.5.3  # pyup: ignore
 
 kombu==5.2.2
 celery==5.2.2


### PR DESCRIPTION
It seems that new pip version complains about this error now and breaks the
installation process. We are pinning to the latest 3.x version of redis for now.

I think we can upgrade the django-redis-cache version once we are on Django 3.2.x

Closes #8786 