### PR TITLE
Requirements: downgrade celery

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -32,8 +32,14 @@ Pygments==2.10.0
 
 # Basic tools
 redis==4.1.0
-kombu==5.2.2
-celery==5.2.2
+
+# Pin celery and kombu because it produces an error
+# File "/home/docs/lib/python3.8/site-packages/celery/app/trace.py", line 361, in build_tracer
+#     push_request = request_stack.push
+# AttributeError: 'NoneType' object has no attribute 'push'
+# See https://github.com/celery/celery/discussions/7172
+kombu==5.1.0  # pyup: ignore
+celery==5.1.2  # pyup: ignore
 
 # When upgrading to 0.43.0 we should double check the ``base.html`` change
 # described in the changelog. In previous versions, the allauth app included a


### PR DESCRIPTION
We are getting an error, so we downgrade it to the previous version used until
we figure it out what is happening and how to solve it.