### PR TITLE
Remove explicit username from tutorial

### DIFF
--- a/docs/user/tutorial/index.rst
+++ b/docs/user/tutorial/index.rst
@@ -143,7 +143,7 @@ The next page will ask you to fill some details about your Read the Docs project
 Name
   The name of the project. It has to be unique across all the service,
   so it is better if you prepend your username,
-  for example ``astrojuanlu-rtd-tutorial``.
+  for example ``{username}-rtd-tutorial``.
 
 Repository URL
   The URL that contains the sources. Leave the automatically filled value.


### PR DESCRIPTION
It turns out that lots of people following the tutorial
do not even want to think about the name of the project,
and they copy-paste whatever is in there.
I do not blame them!
But to avoid lots of tutorials with _my_ username,
let us write something generic.