### PR TITLE
AuditLog: always fill organization id & slug

### DIFF
--- a/readthedocs/audit/models.py
+++ b/readthedocs/audit/models.py
@@ -193,8 +193,9 @@ class AuditLog(TimeStampedModel):
             organization = self.project.organizations.first()
             if organization:
                 self.organization = organization
-                self.log_organization_id = organization.id
-                self.log_organization_slug = organization.slug
+        if self.organization:
+            self.log_organization_id = self.organization.id
+            self.log_organization_slug = self.organization.slug
         super().save(**kwargs)
 
     def auth_backend_display(self):

--- a/readthedocs/audit/tests/test_models.py
+++ b/readthedocs/audit/tests/test_models.py
@@ -47,3 +47,33 @@ class TestAuditModels(TestCase):
         self.assertIsNone(self.auditlog.organization)
         self.assertEqual(self.auditlog.log_organization_id, id)
         self.assertEqual(self.auditlog.log_organization_slug, slug)
+
+    def test_log_attached_to_user_only(self):
+        log = get(
+            AuditLog,
+            user=self.user,
+        )
+        self.assertEqual(log.user, self.user)
+        self.assertEqual(log.log_user_id, self.user.id)
+        self.assertEqual(log.log_user_username, self.user.username)
+
+    def test_log_attached_to_project_with_organization_only(self):
+        log = get(
+            AuditLog,
+            project=self.project,
+        )
+        self.assertEqual(log.project, self.project)
+        self.assertEqual(log.log_project_id, self.project.id)
+        self.assertEqual(log.log_project_slug, self.project.slug)
+        self.assertEqual(log.organization, self.organization)
+        self.assertEqual(log.log_organization_id, self.organization.id)
+        self.assertEqual(log.log_organization_slug, self.organization.slug)
+
+    def test_log_attached_to_organization_only(self):
+        log = get(
+            AuditLog,
+            organization=self.organization,
+        )
+        self.assertEqual(log.organization, self.organization)
+        self.assertEqual(log.log_organization_id, self.organization.id)
+        self.assertEqual(log.log_organization_slug, self.organization.slug)


### PR DESCRIPTION
Currently we don't have logs attached to an organization only,
so we don't need to do any type of migration.