### PR TITLE
django-storages: upgrade

### DIFF
--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -62,15 +62,6 @@ Set up your environment
 
       inv docker.up  --init  # --init is only needed the first time
 
-#. add read permissions to the storage backend:
-
-   * go to http://localhost:9000/ (MinIO S3 storage backend)
-   * login as ``admin`` / ``password``
-   * click "..." next to the ``static`` bucket name and then "Edit Policy"
-   * leave "prefix" empty and click "Add" to give "Read Only" access on the ``static`` bucket
-   * click on the "+" icon on the bottom-right corner, then "Create bucket" with the name ``media``,
-     hit Enter on the keyboard, and repeat the operation above to give "Read Only" access to it
-
 #. go to http://community.dev.readthedocs.io to access your local instance of Read the Docs.
 
 

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -167,9 +167,6 @@ class DockerBaseSettings(CommunityDevSettings):
     S3_STATIC_STORAGE_OVERRIDE_HOSTNAME = 'community.dev.readthedocs.io'
     S3_MEDIA_STORAGE_OVERRIDE_HOSTNAME = 'community.dev.readthedocs.io'
 
-    AWS_AUTO_CREATE_BUCKET = True
-    AWS_DEFAULT_ACL = 'public-read'
-    AWS_BUCKET_ACL = 'public-read'
     AWS_S3_ENCRYPTION = False
     AWS_S3_SECURE_URLS = False
     AWS_S3_USE_SSL = False

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -101,18 +101,7 @@ django-cors-middleware==1.4.0  # pyup: ignore
 # User agent parsing - used for analytics purposes
 user-agents==2.2.0
 
-
-# Utilities used to upload build media to cloud storage
-# django-storages is pinned to this particular commit because it
-# supports generating URLs with other method than GET when using
-# private buckets.
-#
-# Besides, support for the corresponding AWS_BUCKET_ACL and
-# AWS_AUTO_CREATE_BUCKET settings have been removed in 1.10. We depend on this
-# in our Docker setup. We can upgrade it but we need to add a
-# `create_buckets.sh` to be called on `--init` as we used to do for Azurite
-# https://github.com/jschneier/django-storages/pull/636
-git+https://github.com/jschneier/django-storages@d0f027c98a877f75615cfc42b4d51c038fa41bf6#egg=django-storages[boto3]==1.9.1
+django-storages==1.12.3
 
 
 # Required only in development and linting


### PR DESCRIPTION
Currently, the development environment is broken. We haven't noticed this
because it fails on creating the `staticfiles.json` file on `--init` and without
that the whole environment is broken.

By deleting my local volumes I was able to reproduce it. Now, my environment is
broken and it does not work without this patch.

Note that this commit requires a change in `common/` repository to auto-create
the buckets on S3 (MinIO) when called with `--init`. This is required because
newer version of django-storages removed support for auto-creation.

Closes #8812
Requires https://github.com/readthedocs/common/pull/101