### PR TITLE
Logging: reduce logs in task router

### DIFF
--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -66,17 +66,17 @@ class TaskRouter:
     BUILD_LARGE_QUEUE = 'build:large'
 
     def route_for_task(self, task, args, kwargs, **__):
-        log.info('Executing TaskRouter.', task=task)
+        log.debug('Executing TaskRouter.', task=task)
         if task not in (
             'readthedocs.projects.tasks.update_docs_task',
             'readthedocs.projects.tasks.sync_repository_task',
         ):
-            log.info('Skipping routing non-build task.', task=task)
+            log.debug('Skipping routing non-build task.', task=task)
             return
 
         version = self._get_version(task, args, kwargs)
         if not version:
-            log.info('No Build/Version found. No routing task.', task=task)
+            log.debug('No Build/Version found. No routing task.', task=task)
             return
 
         project = version.project
@@ -138,7 +138,7 @@ class TaskRouter:
             )
             return self.BUILD_LARGE_QUEUE
 
-        log.info(
+        log.debug(
             'No routing task because no conditions were met.',
             project_slug=project.slug,
         )
@@ -155,7 +155,7 @@ class TaskRouter:
             try:
                 version = Version.objects.get(pk=version_pk)
             except Version.DoesNotExist:
-                log.info(
+                log.debug(
                     'Version does not exist. Routing task to default queue.',
                     version_id=version_pk,
                 )


### PR DESCRIPTION
This is well tested already and we haven't find any problem with it. I'm leaving
only the INFO logs when we are changing the routing.