### PR TITLE
Logging: reduce verbosity

### DIFF
--- a/readthedocs/api/v2/views/integrations.py
+++ b/readthedocs/api/v2/views/integrations.py
@@ -405,7 +405,7 @@ class GitHubWebhookView(WebhookMixin, APIView):
 
         # Sync versions when a branch/tag was created/deleted
         if event in (GITHUB_CREATE, GITHUB_DELETE):
-            log.info('Triggered sync_versions.')
+            log.debug('Triggered sync_versions.')
             return self.sync_versions_response(self.project)
 
         # Handle pull request events
@@ -441,7 +441,7 @@ class GitHubWebhookView(WebhookMixin, APIView):
                 # already have the CREATE/DELETE events. So we don't trigger the sync twice.
                 return self.sync_versions_response(self.project, sync=False)
 
-            log.info(
+            log.debug(
                 'Triggered sync_versions.',
                 integration_events=events,
             )
@@ -555,7 +555,7 @@ class GitLabWebhookView(WebhookMixin, APIView):
             after = data.get('after')
             # Tag/branch created/deleted
             if GITLAB_NULL_HASH in (before, after):
-                log.info(
+                log.debug(
                     'Triggered sync_versions.',
                     before=before,
                     after=after,
@@ -657,7 +657,7 @@ class BitbucketWebhookView(WebhookMixin, APIView):
                 # will be triggered with the normal push.
                 if branches:
                     return self.get_response_push(self.project, branches)
-                log.info('Triggered sync_versions.')
+                log.debug('Triggered sync_versions.')
                 return self.sync_versions_response(self.project)
             except KeyError:
                 raise ParseError('Invalid request')

--- a/readthedocs/audit/apps.py
+++ b/readthedocs/audit/apps.py
@@ -11,5 +11,4 @@ class AuditConfig(AppConfig):
     name = 'readthedocs.audit'
 
     def ready(self):
-        log.info("Importing all Signals handlers")
         import readthedocs.audit.signals  # noqa

--- a/readthedocs/builds/apps.py
+++ b/readthedocs/builds/apps.py
@@ -28,4 +28,4 @@ class Config(AppConfig):
             app.tasks.register(Metrics10mTask)
             app.tasks.register(Metrics30mTask)
         except (ModuleNotFoundError, ImportError):
-            log.info('Metrics tasks could not be imported.')
+            log.warning('Metrics tasks could not be imported.')

--- a/readthedocs/core/views/hooks.py
+++ b/readthedocs/core/views/hooks.py
@@ -50,7 +50,7 @@ def build_branches(project, branch_list):
         versions = project.versions_from_branch_name(branch)
 
         for version in versions:
-            log.info(
+            log.debug(
                 'Processing.',
                 project_slug=project.slug,
                 version_slug=version.slug,
@@ -103,7 +103,7 @@ def trigger_sync_versions(project):
             # respect the queue for this project
             options['queue'] = project.build_queue
 
-        log.info(
+        log.debug(
             'Triggering sync repository.',
             project_slug=version.project.slug,
             version_slug=version.slug,

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -355,7 +355,7 @@ class HtmlBuilder(BaseSphinx):
         if os.path.exists(json_path):
             if os.path.exists(json_path_target):
                 shutil.rmtree(json_path_target)
-            log.info('Copying json on the local filesystem')
+            log.debug('Copying json on the local filesystem')
             shutil.copytree(
                 json_path,
                 json_path_target,
@@ -391,7 +391,7 @@ class LocalMediaBuilder(BaseSphinx):
 
     @restoring_chdir
     def move(self, **__):
-        log.info('Creating zip file from path.', path=self.old_artifact_path)
+        log.debug('Creating zip file from path.', path=self.old_artifact_path)
         target_file = os.path.join(
             self.target,
             '{}.zip'.format(self.project.slug),

--- a/readthedocs/doc_builder/base.py
+++ b/readthedocs/doc_builder/base.py
@@ -73,7 +73,7 @@ class BaseBuilder:
         if os.path.exists(self.old_artifact_path):
             if os.path.exists(self.target):
                 shutil.rmtree(self.target)
-            log.info('Copying output type on the local filesystem.', output_type=self.type)
+            log.debug('Copying output type on the local filesystem.', output_type=self.type)
             log.debug('Ignoring patterns.', patterns=self.ignore_patterns)
             shutil.copytree(
                 self.old_artifact_path,

--- a/readthedocs/embed/v3/views.py
+++ b/readthedocs/embed/v3/views.py
@@ -121,17 +121,17 @@ class EmbedAPIBase(CachedResponseMixin, APIView):
     def _find_main_node(self, html):
         main_node = html.css_first('[role=main]')
         if main_node:
-            log.info('Main node found. selector=[role=main]')
+            log.debug('Main node found. selector=[role=main]')
             return main_node
 
         main_node = html.css_first('main')
         if main_node:
-            log.info('Main node found. selector=main')
+            log.debug('Main node found. selector=main')
             return main_node
 
         first_header = html.body.css_first('h1')
         if first_header:
-            log.info('Main node found. selector=h1')
+            log.debug('Main node found. selector=h1')
             return first_header.parent
 
     def _parse_based_on_doctool(self, page_content, fragment, doctool, doctoolversion):

--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -336,7 +336,7 @@ class BitbucketService(Service):
                 recv_data = resp.json()
                 integration.provider_data = recv_data
                 integration.save()
-                log.info(
+                log.debug(
                     'Bitbucket webhook creation successful for project.',
                 )
                 return (True, resp)

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -325,7 +325,7 @@ class GitHubService(Service):
                 recv_data = resp.json()
                 integration.provider_data = recv_data
                 integration.save()
-                log.info('GitHub webhook creation successful for project.')
+                log.debug('GitHub webhook creation successful for project.')
                 return (True, resp)
 
             if resp.status_code in [401, 403, 404]:
@@ -471,7 +471,7 @@ class GitHubService(Service):
             )
             log.bind(http_status_code=resp.status_code)
             if resp.status_code == 201:
-                log.info("GitHub commit status created for project.")
+                log.debug("GitHub commit status created for project.")
                 return True
 
             if resp.status_code in [401, 403, 404]:

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -427,7 +427,7 @@ class GitLabService(Service):
             if resp.status_code == 201:
                 integration.provider_data = resp.json()
                 integration.save()
-                log.info('GitLab webhook creation successful for project.')
+                log.debug('GitLab webhook creation successful for project.')
                 return (True, resp)
 
             if resp.status_code in [401, 403, 404]:
@@ -576,7 +576,7 @@ class GitLabService(Service):
 
             log.bind(http_status_code=resp.status_code)
             if resp.status_code == 201:
-                log.info("GitLab commit status created for project.")
+                log.debug("GitLab commit status created for project.")
                 return True
 
             if resp.status_code in [401, 403, 404]:

--- a/readthedocs/organizations/tasks.py
+++ b/readthedocs/organizations/tasks.py
@@ -15,7 +15,7 @@ def mark_organization_assets_not_cleaned(build_pk):
     try:
         build = Build.objects.get(pk=build_pk)
     except Build.DoesNotExist:
-        log.info("Build does not exist.", build_pk=build_pk)
+        log.debug("Build does not exist.", build_pk=build_pk)
         return
 
     organization = build.project.organizations.first()

--- a/readthedocs/projects/views/mixins.py
+++ b/readthedocs/projects/views/mixins.py
@@ -126,6 +126,7 @@ class ProjectImportMixin:
             'Project imported.',
             project_slug=project.slug,
             user_username=request.user.username,
+            tags=tags,
         )
 
         # TODO: this signal could be removed, or used for sync task

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -192,7 +192,7 @@ class GitHubOAuthTests(TestCase):
 
         self.assertTrue(success)
         mock_logger.bind.assert_called_with(http_status_code=201)
-        mock_logger.info.assert_called_with(
+        mock_logger.debug.assert_called_with(
             "GitHub commit status created for project.",
         )
 
@@ -265,7 +265,7 @@ class GitHubOAuthTests(TestCase):
         self.assertTrue(success)
         self.assertIsNotNone(self.integration.secret)
         mock_logger.bind.assert_called_with(http_status_code=201)
-        mock_logger.info.assert_called_with(
+        mock_logger.debug.assert_called_with(
             "GitHub webhook creation successful for project.",
         )
 
@@ -719,7 +719,7 @@ class BitbucketOAuthTests(TestCase):
             integration_id=self.integration.pk,
             url='https://api.bitbucket.org/2.0/repositories/testuser/testrepo/hooks',
         )
-        mock_logger.info.assert_called_with(
+        mock_logger.debug.assert_called_with(
             "Bitbucket webhook creation successful for project.",
         )
 
@@ -1129,7 +1129,7 @@ class GitLabOAuthTests(TestCase):
 
         self.assertTrue(success)
         mock_logger.bind.assert_called_with(http_status_code=201)
-        mock_logger.info.assert_called_with(
+        mock_logger.debug.assert_called_with(
             "GitLab commit status created for project.",
         )
 
@@ -1192,7 +1192,7 @@ class GitLabOAuthTests(TestCase):
         mock_logger.bind.assert_called_with(
             http_status_code=201,
         )
-        mock_logger.info.assert_called_with(
+        mock_logger.debug.assert_called_with(
             "GitLab webhook creation successful for project.",
         )
 

--- a/readthedocs/subscriptions/utils.py
+++ b/readthedocs/subscriptions/utils.py
@@ -42,7 +42,7 @@ def get_or_create_stripe_customer(organization):
         return create_stripe_customer(organization)
 
     try:
-        log.info('Retrieving existing stripe customer.')
+        log.debug('Retrieving existing stripe customer.')
         stripe_customer = stripe.Customer.retrieve(organization.stripe_id)
         return stripe_customer
     except InvalidRequestError as exc:


### PR DESCRIPTION
Make more usage of `log.debug` for things that are already well tested and we
don't usually require taking a look these logs to reduce the verbosity of them.