### PR TITLE
Build: pin pip as workaround

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -471,7 +471,13 @@ class Virtualenv(PythonEnvironment):
             Feature.DONT_INSTALL_LATEST_PIP,
             # 20.3 uses the new resolver by default.
             positive='pip<20.3',
-            negative='pip',
+
+            # We are pinning pip to 21.3.1 because builds are failing when
+            # using a newer version. This is a temporal workaround to avoid
+            # builds failing at this step, but we should come back to this and
+            # unpin pip for this case.
+            # https://github.com/readthedocs/readthedocs.org/issues/8864#issuecomment-1025499598
+            negative='pip==21.3.1',
         )
         cmd = pip_install_cmd + [pip_version, 'setuptools<58.3.0']
         self.build_env.run(

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -477,7 +477,7 @@ class Virtualenv(PythonEnvironment):
             # builds failing at this step, but we should come back to this and
             # unpin pip for this case.
             # https://github.com/readthedocs/readthedocs.org/issues/8864#issuecomment-1025499598
-            negative='pip==21.3.1',
+            negative='pip<=21.3.1',
         )
         cmd = pip_install_cmd + [pip_version, 'setuptools<58.3.0']
         self.build_env.run(


### PR DESCRIPTION
Latest pip version is failing wit

```
ERROR: Exception:
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/qtile/envs/3274/lib/python3.7/site-packages/pip/_internal/cli/base_command.py", line 165, in exc_logging_wrapper
    status = run_func(*args)
  File "/home/docs/checkouts/readthedocs.org/user_builds/qtile/envs/3274/lib/python3.7/site-packages/pip/_internal/cli/req_command.py", line 205, in wrapper
    return func(self, options, args)
  File "/home/docs/checkouts/readthedocs.org/user_builds/qtile/envs/3274/lib/python3.7/site-packages/pip/_internal/commands/install.py", line 389, in run
    to_install = resolver.get_installation_order(requirement_set)
  File "/home/docs/checkouts/readthedocs.org/user_builds/qtile/envs/3274/lib/python3.7/site-packages/pip/_internal/resolution/resolvelib/resolver.py", line 190, in get_installation_order
    expected_node_count=len(self._result.mapping) + 1,
  File "/home/docs/checkouts/readthedocs.org/user_builds/qtile/envs/3274/lib/python3.7/site-packages/pip/_internal/resolution/resolvelib/resolver.py", line 276, in get_topological_weights
    assert len(weights) == expected_node_count
AssertionError
```

By pining it to the previous version we can make builds to workaround this issue
and keep building docs successfully.

See https://github.com/readthedocs/readthedocs.org/issues/8864