### PR TITLE
Fix issue with build task routing and config argument

### DIFF
--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -115,7 +115,7 @@ class TaskRouter:
         last_builds = version.builds.order_by('-date')[:self.N_LAST_BUILDS]
         # Version has used conda in previous builds
         for build in last_builds.iterator():
-            build_tools_python = build.config.get('build', {}).get('tools', {}).get('python', '')
+            build_tools_python = build.config.get('build', {}).get('tools', {}).get('python', {}).get('version', '')
             conda = build.config.get('conda', None)
 
             uses_conda = any([


### PR DESCRIPTION
Our config doesn't pass through a string, it passes through a dict that
matches:

```{"version": "1.2.3", "full_version": "1.2.3"}```