### PR TITLE
CI: Don't install debug tools when running tests

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -50,6 +50,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 WORKDIR /tmp
 
 COPY requirements/pip.txt pip.txt
+COPY requirements/debug.txt debug.txt
 COPY requirements/docker.txt docker.txt
 RUN pip3 install --no-cache-dir -r docker.txt
 

--- a/docs/dev/tests.rst
+++ b/docs/dev/tests.rst
@@ -13,7 +13,7 @@ paths. Before testing, make sure you have Tox installed:
 
 .. prompt:: bash
 
-    pip install tox
+   pip install tox
 
 To run the full test and lint suite against your changes, simply run Tox. Tox
 should return without any errors. You can run Tox against all of our
@@ -21,7 +21,7 @@ environments by running:
 
 .. prompt:: bash
 
-    tox
+   tox
 
 By default, tox won't run tests from search,
 in order to run all test including the search tests,
@@ -31,7 +31,7 @@ you can also set the ``TOX_POSARGS`` environment variable to an empty string:
 
 .. prompt:: bash
 
-    TOX_POSARGS='' tox
+   TOX_POSARGS='' tox
 
 .. note::
 
@@ -40,19 +40,22 @@ you can also set the ``TOX_POSARGS`` environment variable to an empty string:
 
 .. prompt:: bash
 
-       tox -- -m 'not search' -x
+   tox -- -m 'not search' -x
 
 To target a specific environment:
 
 .. prompt:: bash
 
-    tox -e py38
+   tox -e py38
 
 The ``tox`` configuration has the following environments configured. You can
 target a single environment to limit the test suite:
 
 py38
     Run our test suite using Python 3.8
+
+py38-debug
+    Same as ``py38``, but there are some useful debugging tools available in the environment.
 
 lint
     Run code linting using `Prospector`_. This currently runs `pylint`_,

--- a/readthedocs/api/v3/tests/mixins.py
+++ b/readthedocs/api/v3/tests/mixins.py
@@ -167,5 +167,10 @@ class APIEndpointMixin(TestCase):
 
         It's just a helper for debugging API responses.
         """
-        import datadiff
-        return super().assertDictEqual(d1, d2, datadiff.diff(d1, d2))
+        message = ''
+        try:
+            import datadiff
+            message = datadiff.diff(d1, d2)
+        except ImportError:
+            pass
+        return super().assertDictEqual(d1, d2, message)

--- a/requirements/debug.txt
+++ b/requirements/debug.txt
@@ -1,0 +1,4 @@
+# Useful tools during a debug session.
+datadiff==2.0.0
+ipdb==0.13.9
+pdbpp==0.10.3

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,6 +1,8 @@
 # Requirements for our local docker development
 
 -r pip.txt
+-r debug.txt
+
 # https://www.psycopg.org/docs/install.html#psycopg-vs-psycopg-binary
 psycopg2-binary==2.9.2  # pyup: ignore
 
@@ -9,16 +11,8 @@ django-redis-cache==3.0.0
 # For resizing images
 pillow==9.0.0
 
-# local debugging tools
+# Local debugging tools
 watchdog==2.1.6
-datadiff==2.0.0
-ipdb==0.13.9
-pdbpp==0.10.3
-
-# jedi 0.18 is incompatible with ipython
-# https://github.com/ipython/ipython/issues/12740
-jedi>0.17,<0.18  # pyup: ignore
-
 # watchdog dependency
 argh==0.26.2
 

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -16,8 +16,4 @@ Mercurial==6.0.1
 yamale==2.2.0  # pyup: <3.0
 pytest-mock==3.6.1
 
-# local debugging tools
-datadiff==2.0.0
-ipdb==0.13.9
-
 requests-mock==1.9.3

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,9 @@ setenv =
     LC_ALL=en_US.UTF-8
     DJANGO_SETTINGS_SKIP_LOCAL=True
 passenv = CI TRAVIS TRAVIS_* HOME
-deps = -r{toxinidir}/requirements/testing.txt
+deps =
+  -r{toxinidir}/requirements/testing.txt
+  debug: -r{toxinidir}/requirements/debug.txt
 changedir = {toxinidir}/readthedocs
 basepython =
     python3.8


### PR DESCRIPTION
pip is freezing when installing ipdb,
but we also shouldn't install these in our CI.

Installing them from a separate file fixes the issues
with pip's dependency resolver.