### PR TITLE
Builder: unpin pip

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -471,13 +471,7 @@ class Virtualenv(PythonEnvironment):
             Feature.DONT_INSTALL_LATEST_PIP,
             # 20.3 uses the new resolver by default.
             positive='pip<20.3',
-
-            # We are pinning pip to 21.3.1 because builds are failing when
-            # using a newer version. This is a temporal workaround to avoid
-            # builds failing at this step, but we should come back to this and
-            # unpin pip for this case.
-            # https://github.com/readthedocs/readthedocs.org/issues/8864#issuecomment-1025499598
-            negative='pip<=21.3.1',
+            negative='pip',
         )
         cmd = pip_install_cmd + [pip_version, 'setuptools<58.3.0']
         self.build_env.run(


### PR DESCRIPTION
It seems the problem with pip was solved in
https://github.com/pypa/pip/pull/10867 and 22.0.3 version was released with this
fix.

Revert #8865