### PR TITLE
Docs: reduce visibility of Config File V1

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,7 +19,7 @@ search:
   ranking:
     # Deprecated content
     api/v1.html: -1
-    config-file/v1.html: -1
+    config-file/v1.html: -5
 
     # Useful content, but not something we want most users finding
     changelog.html: -6

--- a/docs/user/config-file/index.rst
+++ b/docs/user/config-file/index.rst
@@ -25,4 +25,3 @@ The main advantages of using a configuration file over the web interface are:
     :maxdepth: 3
 
     Version 2 <v2>
-    Version 1 <v1>

--- a/docs/user/config-file/v1.rst
+++ b/docs/user/config-file/v1.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Configuration File V1 (Deprecated)
 ==================================
 
@@ -6,7 +8,7 @@ Read the Docs has support for configuring builds with a YAML file.
 
 .. warning::
 
-   Version 1 shouldn't be used.
+   Version 1 is deprecated and shouldn't be used.
    The version 2 of the configuration file is now available.
    See the :ref:`new features <config-file/v2:New settings>`
    and :ref:`how to migrate from v1 <config-file/v2:Migrating from v1>`.


### PR DESCRIPTION
People is still arriving at Config File V1 and we want to avoid that as much as
possible. However, we can't yet remove this documentation page since it's still
working and there are people already using it.

We should find a way to migrate these projects off from Config File V1 and
finally remove this documentation page. However, that requires a much bigger
amount of work.

Closes #8857