### PR TITLE
Throw an exception from Celery retry()

### DIFF
--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -276,7 +276,6 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
             })
             self.retry(
                 exc=BuildMaxConcurrencyError,
-                throw=False,
                 # We want to retry this build more times
                 max_retries=25,
             )


### PR DESCRIPTION
Without an exception here, or handling the return from
`_check_concurrency_limit`, a build that hits a concurrency limit in
this method will both set a retry on the task, but will also continue
processing the current task like normal. This results in two identical
builds, then three, then four, and so on.

Untested what this does to the UI though. Edit: the UI reports the retry as I'd expect :+1: 