### PR TITLE
Move subscription tasks

### DIFF
--- a/readthedocs/subscriptions/apps.py
+++ b/readthedocs/subscriptions/apps.py
@@ -9,3 +9,4 @@ class SubscriptionsConfig(AppConfig):
 
     def ready(self):
         import readthedocs.subscriptions.signals  # noqa
+        import readthedocs.subscriptions.tasks  # noqa

--- a/readthedocs/subscriptions/notifications.py
+++ b/readthedocs/subscriptions/notifications.py
@@ -1,0 +1,117 @@
+"""Organization level notifications."""
+
+from django.urls import reverse
+from messages_extends.constants import WARNING_PERSISTENT
+
+from readthedocs.notifications import Notification, SiteNotification
+from readthedocs.notifications.constants import REQUIREMENT
+from readthedocs.organizations.models import Organization
+from readthedocs.subscriptions.constants import DISABLE_AFTER_DAYS
+
+
+class SubscriptionNotificationMixin:
+
+    """Force to read templates from the subscriptions app."""
+
+    app_templates = 'subscriptions'
+
+
+class TrialEndingNotification(SubscriptionNotificationMixin, Notification):
+
+    """Trial is ending, nudge user towards subscribing."""
+
+    name = 'trial_ending'
+    context_object_name = 'organization'
+    subject = 'Your trial is ending soon'
+    level = REQUIREMENT
+
+    @classmethod
+    def for_organizations(cls):
+        advanced_plan_subscription_trial_ending = (
+            Organization.objects.subscription_trial_ending()
+            .created_days_ago(days=24)
+        )
+        trial_plan_subscription_trial_ending = (
+            Organization.objects.subscription_trial_plan_ending()
+            .created_days_ago(days=24)
+        )
+        return advanced_plan_subscription_trial_ending | trial_plan_subscription_trial_ending
+
+
+class SubscriptionRequiredNotification(SubscriptionNotificationMixin, Notification):
+
+    """Trial has ended, push user into subscribing."""
+
+    name = 'subscription_required'
+    context_object_name = 'organization'
+    subject = 'We hope you enjoyed your trial of Read the Docs!'
+    level = REQUIREMENT
+
+    @classmethod
+    def for_organizations(cls):
+        advanced_plan_subscription_trial_ended = (
+            Organization.objects.subscription_trial_ended()
+            .created_days_ago(days=30)
+        )
+        trial_plan_subscription_ended = (
+            Organization.objects.subscription_trial_plan_ended()
+            .created_days_ago(days=30)
+        )
+        return advanced_plan_subscription_trial_ended | trial_plan_subscription_ended
+
+
+class SubscriptionEndedNotification(SubscriptionNotificationMixin, Notification):
+
+    """
+    Subscription has ended days ago.
+
+    Notify the customer that the Organization will be disabled *soon* if the
+    subscription is not renewed for the organization.
+    """
+
+    name = 'subscription_ended'
+    context_object_name = 'organization'
+    subject = 'Your subscription to Read the Docs has ended'
+    level = REQUIREMENT
+
+    days_after_end = 5
+
+    @classmethod
+    def for_organizations(cls):
+        organizations = Organization.objects.disable_soon(
+            days=cls.days_after_end,
+            exact=True,
+        )
+        return organizations
+
+
+class OrganizationDisabledNotification(SubscriptionEndedNotification):
+
+    """
+    Subscription has ended a month ago.
+
+    Notify the user that the organization will be disabled soon. After this
+    notification is sent, we are safe to disable the organization since the
+    customer was notified twice.
+    """
+
+    name = 'organization_disabled'
+    subject = 'Your Read the Docs organization will be disabled soon'
+
+    days_after_end = DISABLE_AFTER_DAYS
+
+
+class OrganizationDisabledSiteNotification(SubscriptionNotificationMixin, SiteNotification):
+
+    success_message = 'The organization "{{ object.name }}" is currently disabled. You need to <a href="{{ url }}">renew your subscription</a> to keep using Read the Docs.'  # noqa
+    success_level = WARNING_PERSISTENT
+
+    def get_context_data(self):
+        context = super().get_context_data()
+        context.update({
+            'url': reverse(
+                'subscription_detail',
+                args=[self.object.slug],
+            ),
+        })
+        return context

--- a/readthedocs/subscriptions/tasks.py
+++ b/readthedocs/subscriptions/tasks.py
@@ -1,0 +1,121 @@
+"""Organization tasks."""
+import datetime
+
+import structlog
+from django.contrib.auth.models import User
+from django.db.models import Count
+from django.http import HttpRequest
+from django.utils import timezone
+
+from readthedocs.builds.models import Build
+from readthedocs.core.utils import send_email
+from readthedocs.organizations.models import Organization
+from readthedocs.projects.models import Domain, Project
+from readthedocs.subscriptions.models import Subscription
+from readthedocs.worker import app
+from readthedocsinc.subscriptions.notifications import (
+    OrganizationDisabledNotification,
+    SubscriptionEndedNotification,
+    SubscriptionRequiredNotification,
+    TrialEndingNotification,
+)
+
+log = structlog.get_logger(__name__)
+
+
+@app.task(queue='web')
+def daily_email():
+    """Daily email beat task for organization notifications."""
+    notifications = (
+        TrialEndingNotification,
+        SubscriptionRequiredNotification,
+        SubscriptionEndedNotification,
+        OrganizationDisabledNotification,
+    )
+
+    orgs_sent = Organization.objects.none()
+
+    for cls in notifications:
+        orgs = cls.for_organizations().exclude(id__in=orgs_sent).distinct()
+        orgs_sent |= orgs
+        for org in orgs:
+            log.info(
+                'Sending notification',
+                notification_name=cls.name,
+                organization_slug=org.slug,
+            )
+            for owner in org.owners.all():
+                notification = cls(
+                    context_object=org,
+                    request=HttpRequest(),
+                    user=owner,
+                )
+                log.info('Notification sent.', recipient=owner)
+                notification.send()
+
+
+@app.task(queue='web')
+def disable_organization_expired_trials():
+    """Daily task to disable organization with expired Trial Plans."""
+    queryset = Organization.objects.subscription_trial_plan_ended()
+
+    for organization in queryset:
+        log.info(
+            'Organization disabled due to trial ended.',
+            organization_slug=organization.slug,
+        )
+        organization.disabled = True
+        organization.save()
+
+
+@app.task(queue='web')
+def weekly_subscription_stats_email(recipients=None):
+    """
+    Weekly email to communicate stats about subscriptions.
+
+    :param list recipients: List of emails to send the stats to.
+    """
+    if not recipients:
+        log.info('No recipients to send stats to.')
+        return
+
+    last_week = timezone.now() - datetime.timedelta(weeks=1)
+    yesterday = timezone.now() - datetime.timedelta(days=1)
+
+    projects = Project.objects.filter(pub_date__gte=last_week).count()
+    builds = Build.objects.filter(date__gte=last_week).count()
+    organizations = Organization.objects.filter(pub_date__gte=last_week).count()
+    domains = Domain.objects.filter(created__gte=last_week).count()
+    organizations_to_disable = Organization.objects.disable_soon(days=30).count()
+    users = User.objects.filter(date_joined__gte=last_week).count()
+    subscriptions = (
+        Subscription.objects
+        .filter(
+            trial_end_date__gte=last_week,
+            trial_end_date__lte=yesterday,
+        )
+        .values('status', 'plan__name')
+        .annotate(total_status=Count('status'))
+        .order_by('status')
+    )
+    context = {
+        'projects': projects,
+        'builds': builds,
+        'organizations': organizations,
+        'domains': domains,
+        'organizations_to_disable': organizations_to_disable,
+        'users': users,
+        'subscriptions': list(subscriptions),
+    }
+
+    log.info('Sending weekly subscription stats email.')
+    send_email(
+        from_email='Read the Docs <no-reply@readthedocs.com>',
+        subject='Weekly subscription stats',
+        recipient=recipients[0],
+        template='subscriptions/notifications/subscription_stats_email.txt',
+        template_html=None,
+        context=context,
+        # Use ``cc`` here because our ``send_email`` does not accept a list of recipients
+        cc=recipients[1:],
+    )

--- a/readthedocs/subscriptions/tasks.py
+++ b/readthedocs/subscriptions/tasks.py
@@ -12,13 +12,14 @@ from readthedocs.core.utils import send_email
 from readthedocs.organizations.models import Organization
 from readthedocs.projects.models import Domain, Project
 from readthedocs.subscriptions.models import Subscription
-from readthedocs.worker import app
-from readthedocsinc.subscriptions.notifications import (
+from readthedocs.subscriptions.notifications import (
     OrganizationDisabledNotification,
     SubscriptionEndedNotification,
     SubscriptionRequiredNotification,
     TrialEndingNotification,
 )
+from readthedocs.worker import app
+
 
 log = structlog.get_logger(__name__)
 

--- a/readthedocs/subscriptions/templates/subscriptions/notifications/organization_disabled_email.html
+++ b/readthedocs/subscriptions/templates/subscriptions/notifications/organization_disabled_email.html
@@ -1,0 +1,15 @@
+<p>Your subscription period for <b>{{ organization.name }}<b> has ended and you haven't yet renewed. If
+you'd like to continue using Read the Docs to manage your
+documentation, please renew the subscription for your organization now.</p>
+
+<p>You can renew it here:</p>
+
+<p><a href="{{ production_uri }}{% url 'subscription_detail' organization.slug %}">{{ production_uri }}{% url 'subscription_detail' organization.slug %}</a></p>
+
+<p><b>Your builds will soon be disabled and access to your documentation will be removed.</b></p>
+
+<p>
+    If you need more help with Read the Docs for Business, we'd love to help you!
+    <a href="{{ production_uri }}{% url 'support' %}">Get in touch with us</a>
+    and let us know what problems you're having.
+</p>

--- a/readthedocs/subscriptions/templates/subscriptions/notifications/organization_disabled_site.html
+++ b/readthedocs/subscriptions/templates/subscriptions/notifications/organization_disabled_site.html
@@ -1,0 +1,3 @@
+Your organization <b>{{ organization.name }}<b> will soon be disabled.
+To continue using Read the Docs,
+please <a href="{% url 'subscription_detail' organization.slug %}">renew your subscription</a>.

--- a/readthedocs/subscriptions/templates/subscriptions/notifications/subscription_ended_email.html
+++ b/readthedocs/subscriptions/templates/subscriptions/notifications/subscription_ended_email.html
@@ -1,0 +1,16 @@
+<p>The subscription period for <b>{{ organization.name }}<b> has ended. If
+you'd like to continue using Read the Docs to manage your
+documentation, please renew the subscription for your organization soon.</p>
+
+<p>You can renew it here:</p>
+
+<p><a href="{{ production_uri }}{% url 'subscription_detail' organization.slug %}">{{ production_uri }}{% url 'subscription_detail' organization.slug %}</a></p>
+
+<p><b>If you don't upgrade your account, your builds will soon be disabled
+    and access to your documentation will be removed.</b></p>
+
+<p>
+    If you need more help with Read the Docs, we'd love to help you!
+    <a href="{{ production_uri }}{% url 'support' %}">Get in touch with us</a>
+    and let us know what problems you're having.
+</p>

--- a/readthedocs/subscriptions/templates/subscriptions/notifications/subscription_ended_site.html
+++ b/readthedocs/subscriptions/templates/subscriptions/notifications/subscription_ended_site.html
@@ -1,0 +1,3 @@
+The subscription for {{ organization.name }} has ended.
+To continue using Read the Docs,
+please <a href="{% url 'subscription_detail' organization.slug %}">renew your subscription</a>.

--- a/readthedocs/subscriptions/templates/subscriptions/notifications/subscription_required_email.html
+++ b/readthedocs/subscriptions/templates/subscriptions/notifications/subscription_required_email.html
@@ -1,0 +1,24 @@
+<p>The trial period for <b>{{ organization.name }}<b> has ended. If
+you'd like to continue using Read the Docs to host and manage your
+documentation, please sign up for a subscription soon.
+</p>
+
+<p>You can sign up here:</p>
+
+<p><a href="{{ production_uri }}{% url 'subscription_detail' organization.slug %}">{{ production_uri }}{% url 'subscription_detail' organization.slug %}</a></p>
+
+<p><b>If you don't upgrade your account, your builds will be disabled,
+and access to your documentation will be removed.</b></p>
+
+<p>
+  If you need more information on the various plan options available to you,
+  see <a href="{{ production_uri }}{% url 'pricing' %}">our pricing page</a>
+  or always feel free to <a href="{{ production_uri }}{% url 'support' %}">get in touch with us</a>.
+</p>
+
+
+<p>
+    If you need more help with Read the Docs, we'd love to help you!
+    <a href="{{ production_uri }}{% url 'support' %}">Get in touch with us</a>
+    and let us know what problems you're having.
+</p>

--- a/readthedocs/subscriptions/templates/subscriptions/notifications/subscription_required_site.html
+++ b/readthedocs/subscriptions/templates/subscriptions/notifications/subscription_required_site.html
@@ -1,0 +1,3 @@
+The trial period for {{ organization.name }} has ended.
+To continue using Read the Docs,
+please <a href="{% url 'subscription_detail' organization.slug %}">add a subscription to your organization</a>.

--- a/readthedocs/subscriptions/templates/subscriptions/notifications/subscription_stats_email.txt
+++ b/readthedocs/subscriptions/templates/subscriptions/notifications/subscription_stats_email.txt
@@ -1,0 +1,18 @@
+Hi Read the Docs team,
+
+These are the stats of the past week:
+
+* Projects: {{ projects }}
+* Builds: {{ builds }}
+* Organizations: {{ organizations }}
+* Domains: {{ domains }}
+* Orgnizations to disable: {{ organizations_to_disable }}
+* Users: {{ users }}
+* Subscriptions:
+{% for subscription in subscriptions %}
+  * {{ subscription.plan__name }}/{{ subscription.status}}: {{ subscription.total_status }}
+{% endfor %}
+
+
+Regards,
+Read the Docs Team

--- a/readthedocs/subscriptions/templates/subscriptions/notifications/trial_ending_email.html
+++ b/readthedocs/subscriptions/templates/subscriptions/notifications/trial_ending_email.html
@@ -1,0 +1,19 @@
+<p>This is just a reminder that the trial period for <b>{{ organization.name }}</b>
+will end in under 7 days. We hope your trial has gone smoothly!</p>
+
+<p>Be sure to add a subscription to your organization before your trial period
+is over if you wish to continue using Read the Docs. If you don't upgrade your account,
+your builds will be disabled, and documentation serving will be disabled.</p>
+
+<p>You can add a subscription to your organization here:</p>
+
+<p><a href="{{ production_uri }}{% url 'subscription_detail' organization.slug %}">{{ production_uri }}{% url 'subscription_detail' organization.slug %}</a></p>
+
+<p>
+  If you'd like more information on the various plan options available to you,
+  see <a href="{{ production_uri }}{% url 'pricing' %}">our pricing page</a>
+    or always feel free to <a href="{{ production_uri }}{% url 'support' %}">get in touch with us</a>.
+</p>
+
+<p>We hope you've enjoyed Read the Docs so far! If you have any questions, don't
+hesitate to contact us!</p>

--- a/readthedocs/subscriptions/templates/subscriptions/notifications/trial_ending_site.html
+++ b/readthedocs/subscriptions/templates/subscriptions/notifications/trial_ending_site.html
@@ -1,0 +1,1 @@
+The trial period for {{ organization.name }} is almost over. Please <a href="{% url 'subscription_detail' organization.slug %}">add a subscription to your organization</a> to continue using Read the Docs.

--- a/readthedocs/subscriptions/tests/test_daily_email.py
+++ b/readthedocs/subscriptions/tests/test_daily_email.py
@@ -1,0 +1,209 @@
+from datetime import timedelta
+from unittest import mock
+
+import django_dynamic_fixture as fixture
+from django.test import TestCase
+from django.utils import timezone
+
+from readthedocs.organizations.models import Organization, OrganizationOwner
+from readthedocs.subscriptions.models import Subscription
+from readthedocsinc.subscriptions.tasks import daily_email
+
+
+@mock.patch('readthedocs.notifications.backends.send_email')
+@mock.patch('readthedocs.notifications.storages.FallbackUniqueStorage')
+class DailyEmailTests(TestCase):
+
+    def test_trial_ending(self, mock_storage_class, mock_send_email):
+        """Trial ending daily email."""
+        org1 = fixture.get(
+            Organization,
+            pub_date=timezone.now() - timedelta(days=24),
+            subscription=None,
+        )
+        owner1 = fixture.get(
+            OrganizationOwner,
+            organization=org1,
+        )
+        org2 = fixture.get(
+            Organization,
+            pub_date=timezone.now() - timedelta(days=25),
+            subscription=None,
+        )
+        owner2 = fixture.get(
+            OrganizationOwner,
+            organization=org2,
+        )
+
+        mock_storage = mock.Mock()
+        mock_storage_class.return_value = mock_storage
+
+        daily_email()
+
+        self.assertEqual(mock_storage.add.call_count, 1)
+        mock_storage.add.assert_has_calls([
+            mock.call(
+                message=mock.ANY,
+                extra_tags='',
+                level=31,
+                user=owner1.owner,
+            ),
+        ])
+        self.assertEqual(mock_send_email.call_count, 1)
+        mock_send_email.assert_has_calls([
+            mock.call(
+                request=mock.ANY,
+                subject='Your trial is ending soon',
+                recipient=owner1.owner.email,
+                template=mock.ANY,
+                template_html=mock.ANY,
+                context=mock.ANY,
+            ),
+        ])
+
+    def test_trial_ended(self, mock_storage_class, mock_send_email):
+        """Trial ended daily email."""
+        org1 = fixture.get(
+            Organization,
+            pub_date=timezone.now() - timedelta(days=30),
+            subscription=None,
+        )
+        owner1 = fixture.get(
+            OrganizationOwner,
+            organization=org1,
+        )
+        org2 = fixture.get(
+            Organization,
+            pub_date=timezone.now() - timedelta(days=31),
+            subscription=None,
+        )
+        owner2 = fixture.get(
+            OrganizationOwner,
+            organization=org2,
+        )
+
+        mock_storage = mock.Mock()
+        mock_storage_class.return_value = mock_storage
+
+        daily_email()
+
+        self.assertEqual(mock_storage.add.call_count, 1)
+        mock_storage.add.assert_has_calls([
+            mock.call(
+                message=mock.ANY,
+                extra_tags='',
+                level=31,
+                user=owner1.owner,
+            ),
+        ])
+        self.assertEqual(mock_send_email.call_count, 1)
+        mock_send_email.assert_has_calls([
+            mock.call(
+                request=mock.ANY,
+                subject='We hope you enjoyed your trial of Read the Docs!',
+                recipient=owner1.owner.email,
+                template=mock.ANY,
+                template_html=mock.ANY,
+                context=mock.ANY,
+            ),
+        ])
+
+    def test_subscription_ended_days_ago(
+            self,
+            mock_storage_class,
+            mock_send_email,
+    ):
+        """Subscription ended some days ago daily email."""
+        sub1 = fixture.get(
+            Subscription,
+            status='past_due',
+            end_date=timezone.now() - timedelta(days=5),
+        )
+        owner1 = fixture.get(
+            OrganizationOwner,
+            organization=sub1.organization,
+        )
+
+        sub2 = fixture.get(
+            Subscription,
+            status='past_due',
+            end_date=timezone.now() - timedelta(days=3),
+        )
+        owner2 = fixture.get(
+            OrganizationOwner,
+            organization=sub2.organization,
+        )
+
+        mock_storage = mock.Mock()
+        mock_storage_class.return_value = mock_storage
+
+        daily_email()
+
+        self.assertEqual(mock_storage.add.call_count, 1)
+        mock_storage.add.assert_has_calls([
+            mock.call(
+                message=mock.ANY,
+                extra_tags='',
+                level=31,
+                user=owner1.owner,
+            ),
+        ])
+        self.assertEqual(mock_send_email.call_count, 1)
+        mock_send_email.assert_has_calls([
+            mock.call(
+                request=mock.ANY,
+                subject='Your subscription to Read the Docs has ended',
+                recipient=owner1.owner.email,
+                template=mock.ANY,
+                template_html=mock.ANY,
+                context=mock.ANY,
+            ),
+        ])
+
+    def test_organization_disabled(self, mock_storage_class, mock_send_email):
+        """Subscription ended ``DISABLE_AFTER_DAYS`` days ago daily email."""
+        sub1 = fixture.get(
+            Subscription,
+            status='past_due',
+            end_date=timezone.now() - timedelta(days=30),
+        )
+        owner1 = fixture.get(
+            OrganizationOwner,
+            organization=sub1.organization,
+        )
+
+        sub2 = fixture.get(
+            Subscription,
+            status='past_due',
+            end_date=timezone.now() - timedelta(days=35),
+        )
+        owner2 = fixture.get(
+            OrganizationOwner,
+            organization=sub2.organization,
+        )
+
+        mock_storage = mock.Mock()
+        mock_storage_class.return_value = mock_storage
+
+        daily_email()
+
+        self.assertEqual(mock_storage.add.call_count, 1)
+        mock_storage.add.assert_has_calls([
+            mock.call(
+                message=mock.ANY,
+                extra_tags='',
+                level=31,
+                user=owner1.owner,
+            ),
+        ])
+        self.assertEqual(mock_send_email.call_count, 1)
+        mock_send_email.assert_has_calls([
+            mock.call(
+                request=mock.ANY,
+                subject='Your Read the Docs organization will be disabled soon',
+                recipient=owner1.owner.email,
+                template=mock.ANY,
+                template_html=mock.ANY,
+                context=mock.ANY,
+            ),
+        ])

--- a/readthedocs/subscriptions/tests/test_daily_email.py
+++ b/readthedocs/subscriptions/tests/test_daily_email.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 
 from readthedocs.organizations.models import Organization, OrganizationOwner
 from readthedocs.subscriptions.models import Subscription
-from readthedocsinc.subscriptions.tasks import daily_email
+from readthedocs.subscriptions.tasks import daily_email
 
 
 @mock.patch('readthedocs.notifications.backends.send_email')


### PR DESCRIPTION
This code was moved from .com, we don't make use of these tasks on .org, but we run them in celery beat on .com.