### PR TITLE
Build: access valid arguments

### DIFF
--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -150,10 +150,11 @@ class BuildRequest(Request):
 
     def on_timeout(self, soft, timeout):
         super().on_timeout(soft, timeout)
+
         log.bind(
             task_name=self.task.name,
-            project_slug=self.task.args.project_slug,
-            build_id=self.task.args.build_id,
+            project_slug=self.task.data.project.slug,
+            build_id=self.task.data.build['id'],
             timeout=timeout,
             soft=soft,
         )


### PR DESCRIPTION
`self.task.args` does not exists.

Solves some Sentry issues found after deploy.

We could do something else here maybe. However, I'd like to know what are the
projects hitting the timeout regularly so we have more data about this problem.