### PR TITLE
Sentry and Celery: do not log `RepositoryError` in Sentry

### DIFF
--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -117,6 +117,9 @@ class SyncRepositoryTask(SyncRepositoryMixin, Task):
     name = __name__ + '.sync_repository_task'
     max_retries = 5
     default_retry_delay = 7 * 60
+    throws = (
+        RepositoryError,
+    )
 
     def before_start(self, task_id, args, kwargs):
         log.info('Running task.', name=self.name)


### PR DESCRIPTION
This usually happens because there is a problem with the user's repository (e.g.
the repository is private and requires a password) which is something we cannot
solve from our side. So, we ignore this exceptions from being logged in Sentry.