### PR TITLE
Tune build config migration

### DIFF
--- a/readthedocs/builds/migrations/0039_migrate_config_data.py
+++ b/readthedocs/builds/migrations/0039_migrate_config_data.py
@@ -1,16 +1,27 @@
-from django.db import migrations, models
-from django.db.models import F
+from django.db import migrations
+from django.db.models import F, JSONField, Max, Min
 from django.db.models.functions import Cast
 
 
 def forwards_func(apps, schema_editor):
+    """Copy build config to JSONField."""
+    # Do migration in chunks, because prod Build table is a big boi.
+    # We don't use `iterator()` here because `update()` will be quicker.
     Build = apps.get_model('builds', 'Build')
-    (
-        Build.objects
-        .annotate(_config_in_json=Cast('_config', output_field=models.JSONField()))
-        # Copy `_config` JSONField (text) into `_config_json` (jsonb)
-        .update(_config_json=F('_config_in_json'))
-    )
+    step = 10000
+    build_pks = Build.objects.aggregate(min_pk=Min('id'), max_pk=Max('id'))
+    for first_pk in range(build_pks['min_pk'], build_pks['max_pk'], step):
+        last_pk = first_pk + step
+        build_update = (
+            Build.objects.filter(
+                pk__gte=first_pk,
+                pk__lt=last_pk,
+                _config_json__isnull=True,
+            ).annotate(
+                _config_in_json=Cast('_config', output_field=JSONField()),
+            ).update(_config_json=F('_config_in_json'))
+        )
+        print(f'Migrated builds: first_pk={first_pk} last_pk={last_pk} updated={build_update}')
 
 
 class Migration(migrations.Migration):
@@ -20,5 +31,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(forwards_func)
+        migrations.RunPython(forwards_func),
     ]

--- a/readthedocs/builds/migrations/0039_migrate_config_data.py
+++ b/readthedocs/builds/migrations/0039_migrate_config_data.py
@@ -10,7 +10,11 @@ def forwards_func(apps, schema_editor):
     Build = apps.get_model('builds', 'Build')
     step = 10000
     build_pks = Build.objects.aggregate(min_pk=Min('id'), max_pk=Max('id'))
-    for first_pk in range(build_pks['min_pk'], build_pks['max_pk'], step):
+    build_min_pk, build_max_pk = (build_pks['min_pk'], build_pks['max_pk'])
+    # Protection for tests, which have no build instances
+    if not build_min_pk and build_max_pk:
+        return
+    for first_pk in range(build_min_pk, build_max_pk, step):
         last_pk = first_pk + step
         build_update = (
             Build.objects.filter(

--- a/readthedocs/builds/migrations/0039_migrate_config_data.py
+++ b/readthedocs/builds/migrations/0039_migrate_config_data.py
@@ -12,7 +12,7 @@ def forwards_func(apps, schema_editor):
     build_pks = Build.objects.aggregate(min_pk=Min('id'), max_pk=Max('id'))
     build_min_pk, build_max_pk = (build_pks['min_pk'], build_pks['max_pk'])
     # Protection for tests, which have no build instances
-    if not build_min_pk and build_max_pk:
+    if not all([build_min_pk, build_max_pk]):
         return
     for first_pk in range(build_min_pk, build_max_pk, step):
         last_pk = first_pk + step


### PR DESCRIPTION
Use the hacked up script that we ran in place of the migration. We hit
issues with a simple `.update()` backing up queries in production, so
ended up running this script instead. Mostly just archiving this logic
in case we ever want to come back to this.