### PR TITLE
Build: comment `record=False` usage

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -483,6 +483,10 @@ class BuildEnvironment(BaseEnvironment):
     :param version: Project version that is being built
     :param build: Build instance
     :param environment: shell environment variables
+    :param record: whether or not record a build commands in the databse via
+    the API. The only case where we want this to be `False` is when
+    instantiating this class from `sync_repository_task` because it's a
+    background task that does not expose commands to the user.
     """
 
     def __init__(


### PR DESCRIPTION
Just add a comment after merging the hotfix PR in
https://github.com/readthedocs/readthedocs.org/pull/8899