### PR TITLE
Build: reset build error before start building

### DIFF
--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -329,6 +329,9 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         # Save the builder instance's name into the build object
         self.data.build['builder'] = socket.gethostname()
 
+        # Reset any previous build error reported to the user
+        self.data.build['error'] = ''
+
         # Also note there are builds that are triggered without a commit
         # because they just build the latest commit for that version
         self.data.build_commit = kwargs.get('build_commit')

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -283,6 +283,7 @@ class TestBuildTask(BuildEnvironmentBase):
             'id': 1,
             'state': 'cloning',
             'commit': 'a1b2c3',
+            'error': '',
             'builder': mock.ANY,
         }
 
@@ -331,6 +332,7 @@ class TestBuildTask(BuildEnvironmentBase):
             'commit': 'a1b2c3',
             'config': mock.ANY,
             'builder': mock.ANY,
+            'error': '',
         }
         # Update build state: building
         assert self.requests_mock.request_history[6].json() == {
@@ -339,6 +341,7 @@ class TestBuildTask(BuildEnvironmentBase):
             'commit': 'a1b2c3',
             'config': mock.ANY,
             'builder': mock.ANY,
+            'error': '',
         }
         # Update build state: uploading
         assert self.requests_mock.request_history[7].json() == {
@@ -347,6 +350,7 @@ class TestBuildTask(BuildEnvironmentBase):
             'commit': 'a1b2c3',
             'config': mock.ANY,
             'builder': mock.ANY,
+            'error': '',
         }
         # Update version state
         assert self.requests_mock.request_history[8]._request.method == 'PATCH'
@@ -371,6 +375,7 @@ class TestBuildTask(BuildEnvironmentBase):
             'builder': mock.ANY,
             'length': mock.ANY,
             'success': True,
+            'error': '',
         }
 
         self.mocker.mocks['build_media_storage'].sync_directory.assert_has_calls([


### PR DESCRIPTION
We need to clean up the build error previously shown to the user once the build
is retried for any reason. For example, this avoids the case that the build was
concurrency limited and shows "Concurrency limit reached (2), retrying in 5
minutes."

Then, in the next retry, even after the build is finished, the error is not
removed and we ended up with a successful build showing an error in the build's
detail page. Example: https://readthedocs.org/projects/test-builds/builds/16118772/