### PR TITLE
Optimize archive_builds task

### DIFF
--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -1,16 +1,16 @@
 import json
-import structlog
-from datetime import datetime, timedelta
 from io import BytesIO
 
 import requests
+import structlog
 from celery import Task
 from django.conf import settings
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from readthedocs import __version__
-from readthedocs.api.v2.serializers import BuildSerializer
+from readthedocs.api.v2.serializers import BuildCommandSerializer
 from readthedocs.api.v2.utils import (
     delete_versions_from_db,
     get_deleted_active_versions,
@@ -187,7 +187,7 @@ class ArchiveBuilds(Task):
 
         lock_id = '{0}-lock'.format(self.name)
         days = kwargs.get('days', 14)
-        limit = kwargs.get('limit', 5000)
+        limit = kwargs.get('limit', 2000)
         delete = kwargs.get('delete', True)
 
         with memcache_lock(lock_id, self.app.oid) as acquired:
@@ -205,23 +205,28 @@ def archive_builds_task(days=14, limit=200, include_cold=False, delete=False):
     :arg include_cold: If True, include builds that are already in cold storage
     :arg delete: If True, deletes BuildCommand objects after archiving them
     """
-    max_date = datetime.now() - timedelta(days=days)
+    max_date = timezone.now() - timezone.timedelta(days=days)
     queryset = Build.objects.exclude(commands__isnull=True)
     if not include_cold:
         queryset = queryset.exclude(cold_storage=True)
-    queryset = queryset.filter(date__lt=max_date)[:limit]
+
+    queryset = (
+        queryset
+        .filter(date__lt=max_date)
+        .prefetch_related('commands')
+        .only('date', 'cold_storage')
+        [:limit]
+    )
 
     for build in queryset:
-        data = BuildSerializer(build).data['commands']
-        if data:
-            for cmd in data:
+        commands = BuildCommandSerializer(build.commands, many=True).data
+        if commands:
+            for cmd in commands:
                 if len(cmd['output']) > MAX_BUILD_COMMAND_SIZE:
                     cmd['output'] = cmd['output'][-MAX_BUILD_COMMAND_SIZE:]
                     cmd['output'] = "... (truncated) ...\n\nCommand output too long. Truncated to last 1MB.\n\n" + cmd['output']  # noqa
                     log.warning('Truncating build command for build.', build_id=build.id)
-            output = BytesIO()
-            output.write(json.dumps(data).encode('utf8'))
-            output.seek(0)
+            output = BytesIO(json.dumps(commands).encode('utf8'))
             filename = '{date}/{id}.json'.format(date=str(build.date.date()), id=build.id)
             try:
                 build_commands_storage.save(name=filename, content=output)
@@ -240,7 +245,7 @@ def delete_inactive_external_versions(limit=200, days=30 * 3):
 
     The commit status is updated to link to the build page, as the docs are removed.
     """
-    days_ago = datetime.now() - timedelta(days=days)
+    days_ago = timezone.now() - timezone.timedelta(days=days)
     queryset = Version.external.filter(
         active=False,
         modified__lte=days_ago,

--- a/readthedocs/builds/tests/test_tasks.py
+++ b/readthedocs/builds/tests/test_tasks.py
@@ -1,11 +1,16 @@
 from datetime import datetime, timedelta
+from unittest import mock
 
 from django.test import TestCase
+from django.utils import timezone
 from django_dynamic_fixture import get
 
 from readthedocs.builds.constants import BRANCH, EXTERNAL, TAG
-from readthedocs.builds.models import Version
-from readthedocs.builds.tasks import delete_inactive_external_versions
+from readthedocs.builds.models import Build, BuildCommandResult, Version
+from readthedocs.builds.tasks import (
+    archive_builds_task,
+    delete_inactive_external_versions,
+)
 from readthedocs.projects.models import Project
 
 
@@ -68,3 +73,34 @@ class TestTasks(TestCase):
         self.assertEqual(Version.objects.all().count(), 4)
         self.assertEqual(Version.external.all().count(), 2)
         self.assertFalse(Version.objects.filter(slug='external-inactive-old').exists())
+
+    @mock.patch('readthedocs.builds.tasks.build_commands_storage')
+    def test_archive_builds(self, build_commands_storage):
+        project = get(Project)
+        version = get(Version, project=project)
+        for i in range(10):
+            date = timezone.now() - timezone.timedelta(days=i)
+            build = get(
+                Build,
+                project=project,
+                version=version,
+                date=date,
+                cold_storage=False,
+            )
+            for _ in range(10):
+                get(
+                    BuildCommandResult,
+                    build=build,
+                    command='ls',
+                    output='docs',
+                )
+
+        self.assertEqual(Build.objects.count(), 10)
+        self.assertEqual(BuildCommandResult.objects.count(), 100)
+
+        archive_builds_task(days=5, delete=True)
+
+        self.assertEqual(len(build_commands_storage.save.mock_calls), 5)
+        self.assertEqual(Build.objects.count(), 10)
+        self.assertEqual(Build.objects.filter(cold_storage=True).count(), 5)
+        self.assertEqual(BuildCommandResult.objects.count(), 50)


### PR DESCRIPTION
A couple of things I noticed:

- We were doing an extra query for each build
  to retrieve the `commands` relationship.
  I have used prefetch_related to fix this.
- We were serializing the whole object,
  but only using the `commands` part.
  I have fixed this by serializing only the commands
  instead, and using `only` in the qs.

Also, now that we are using prefetch_related,
we can't use `iterator()` since that will
ignore prefetch_related.

And since we can't use iterator,
now the whole thing will be loaded into memory,
so I have reduced the limit from 5K to 2K,
I have tested this query on web extra and with 2K the
process isn't killed.

Currently, we have `285648` builds that aren't on storage