### PR TITLE
Fix codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 *       @readthedocs/backend
 
-docs/*  @readthedocs/advocacy
+/docs/  @readthedocs/advocacy


### PR DESCRIPTION
`docs/*` only includes top-level files.

See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax