### PR TITLE
Pin storages with boto3

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -100,7 +100,7 @@ django-cors-middleware==1.4.0  # pyup: ignore
 # User agent parsing - used for analytics purposes
 user-agents==2.2.0
 
-django-storages==1.12.3
+django-storages[boto3]==1.12.3
 
 
 # Required only in development and linting


### PR DESCRIPTION
PR #8853 changed the specifier from `django-storages[boto3]` to just
`django-storages`, and I believe this caused a bug with local
environments.

I tried to rebuild my local image, but then noticed an import error as
django storages was trying to load the missing module `boto3`. It seems
prior to #8853, we were installing the `boto3` depenedency using the
extras install format for django-storage.