### PR TITLE
Test: remove verbose warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -17,5 +17,11 @@ filterwarnings =
     ignore:Using 'method_whitelist' with Retry is deprecated and will be removed in v2.0.*:DeprecationWarning
     # kombu
     ignore:SelectableGroups dict interface is deprecated.*:DeprecationWarning
-    ignore:RemovedInDjango40Warning
-    ignore:RemovedInDjango41Warning
+
+    # builtins
+    ignore:DateTimeField .* received a naive datetime .* while time zone support is active:RuntimeWarning
+    ignore:.*:DeprecationWarning
+
+    ignore:.*:django.utils.deprecation.RemovedInDjango40Warning
+    ignore:.*:django.utils.deprecation.RemovedInDjango41Warning
+    ignore:.*:elasticsearch.exceptions.ElasticsearchWarning


### PR DESCRIPTION
Most of them are warnings we don't have control because they are from third
party applications.