### PR TITLE
Requirements: upgrade gitpython because of security issue

### DIFF
--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -51,8 +51,7 @@ celery==5.1.2  # pyup: ignore
 django-allauth==0.42.0  # pyup: ignore
 requests-oauthlib==1.3.1
 
-# GitPython >3.1.18 drops support for python 3.6.
-GitPython==3.1.18  # pyup: ignore
+GitPython==3.1.27
 
 # Search
 elasticsearch==7.17.0  # pyup: <8.0.0


### PR DESCRIPTION
- we are using py3.8 so we don't need to ignore gitpython anymore
- upgrade to latest version because it fixes a security issue reported at
  https://github.com/gitpython-developers/GitPython/issues/1409