### PR TITLE
Celery: use AppUserError exception to handle user errors properly

### DIFF
--- a/readthedocs/core/exceptions.py
+++ b/readthedocs/core/exceptions.py
@@ -1,0 +1,24 @@
+from django.utils.translation import gettext_noop
+
+
+class ReadTheDocsBaseException(Exception):
+    message = None
+    status_code = None
+
+    def __init__(self, message=None, **kwargs):
+        self.status_code = kwargs.pop(
+            'status_code',
+            None,
+        ) or self.status_code or 1
+        self.message = message or self.message or self.get_default_message()
+        super().__init__(message, **kwargs)
+
+    def get_default_message(self):
+        return self.message
+
+
+class AppUserError(ReadTheDocsBaseException):
+    SOCIAL_CONNECTION_REVOKED = gettext_noop(
+        'Our access to your following accounts was revoked: {providers}. '
+        'Please, reconnect them from your social account connections.'
+    )

--- a/readthedocs/core/utils/tasks/public.py
+++ b/readthedocs/core/utils/tasks/public.py
@@ -67,6 +67,9 @@ class PublicTask(Task):
 
     def __call__(self, *args, **kwargs):
         # We override __call__ to let tasks use the run method.
+        #
+        # TODO: this should probably be replaced by `on_failure` instead of
+        # overriding `__call__` here.
         error = False
         exception_raised = None
         self.set_permission_context(kwargs)

--- a/readthedocs/doc_builder/exceptions.py
+++ b/readthedocs/doc_builder/exceptions.py
@@ -3,26 +3,11 @@
 """Exceptions raised when building documentation."""
 
 from django.utils.translation import gettext_noop
+from readthedocs.core.exceptions import ReadTheDocsBaseException
 from readthedocs.builds.constants import BUILD_STATUS_DUPLICATED
 
 
-class BuildBaseException(Exception):
-    message = None
-    status_code = None
-
-    def __init__(self, message=None, **kwargs):
-        self.status_code = kwargs.pop(
-            'status_code',
-            None,
-        ) or self.status_code or 1
-        self.message = message or self.message or self.get_default_message()
-        super().__init__(message, **kwargs)
-
-    def get_default_message(self):
-        return self.message
-
-
-class BuildAppError(BuildBaseException):
+class BuildAppError(ReadTheDocsBaseException):
     GENERIC_WITH_BUILD_ID = gettext_noop(
         'There was a problem with Read the Docs while building your documentation. '
         'Please try again later. '
@@ -31,7 +16,7 @@ class BuildAppError(BuildBaseException):
     )
 
 
-class BuildUserError(BuildBaseException):
+class BuildUserError(ReadTheDocsBaseException):
     GENERIC = gettext_noop(
         "We encountered a problem with a command while building your project. "
         "To resolve this error, double check your project configuration and installed "


### PR DESCRIPTION
- raise `AppUserError` on known exceptions that we want to communicate to users
- do not log these exceptions on Sentry
- re-use a base `ReadTheDocsBaseException` for all our own exceptions
- add note to refactor the usage of `__call__` to use `on_failure` instead