### PR TITLE
Celery: upgrade to latest version

### DIFF
--- a/readthedocs/builds/apps.py
+++ b/readthedocs/builds/apps.py
@@ -10,20 +10,3 @@ class Config(AppConfig):
     name = 'readthedocs.builds'
     label = 'builds'
     verbose_name = _("Builds")
-
-    def ready(self):
-        from readthedocs.worker import app
-
-        try:
-            from readthedocsext.monitoring.metrics.tasks import (
-                Metrics1mTask,
-                Metrics5mTask,
-                Metrics10mTask,
-                Metrics30mTask,
-            )
-            app.tasks.register(Metrics1mTask)
-            app.tasks.register(Metrics5mTask)
-            app.tasks.register(Metrics10mTask)
-            app.tasks.register(Metrics30mTask)
-        except (ModuleNotFoundError, ImportError):
-            log.warning('Metrics tasks could not be imported.')

--- a/readthedocs/builds/apps.py
+++ b/readthedocs/builds/apps.py
@@ -12,9 +12,7 @@ class Config(AppConfig):
     verbose_name = _("Builds")
 
     def ready(self):
-        from readthedocs.builds.tasks import ArchiveBuilds
         from readthedocs.worker import app
-        app.tasks.register(ArchiveBuilds)
 
         try:
             from readthedocsext.monitoring.metrics.tasks import (

--- a/readthedocs/builds/apps.py
+++ b/readthedocs/builds/apps.py
@@ -10,3 +10,6 @@ class Config(AppConfig):
     name = 'readthedocs.builds'
     label = 'builds'
     verbose_name = _("Builds")
+
+    def ready(self):
+        import readthedocs.builds.tasks

--- a/readthedocs/builds/tests/test_tasks.py
+++ b/readthedocs/builds/tests/test_tasks.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from unittest import mock
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 from django_dynamic_fixture import get
 
@@ -74,6 +74,7 @@ class TestTasks(TestCase):
         self.assertEqual(Version.external.all().count(), 2)
         self.assertFalse(Version.objects.filter(slug='external-inactive-old').exists())
 
+    @override_settings(RTD_SAVE_BUILD_COMMANDS_TO_STORAGE=True)
     @mock.patch('readthedocs.builds.tasks.build_commands_storage')
     def test_archive_builds(self, build_commands_storage):
         project = get(Project)

--- a/readthedocs/builds/tests/test_tasks.py
+++ b/readthedocs/builds/tests/test_tasks.py
@@ -98,7 +98,7 @@ class TestTasks(TestCase):
         self.assertEqual(Build.objects.count(), 10)
         self.assertEqual(BuildCommandResult.objects.count(), 100)
 
-        archive_builds_task(days=5, delete=True)
+        archive_builds_task.delay(days=5, delete=True)
 
         self.assertEqual(len(build_commands_storage.save.mock_calls), 5)
         self.assertEqual(Build.objects.count(), 10)

--- a/readthedocs/builds/utils.py
+++ b/readthedocs/builds/utils.py
@@ -94,8 +94,9 @@ def memcache_lock(lock_id, oid):
     finally:
         # memcache delete is very slow, but we have to use it to take
         # advantage of using add() for atomic locking
-        if monotonic() < timeout_at:
+        if monotonic() < timeout_at and status:
             # don't release the lock if we exceeded the timeout
             # to lessen the chance of releasing an expired lock
-            # owned by someone else.
+            # owned by someone else
+            # also don't release the lock if we didn't acquire it
             cache.delete(lock_id)

--- a/readthedocs/core/apps.py
+++ b/readthedocs/core/apps.py
@@ -14,3 +14,8 @@ class CoreAppConfig(AppConfig):
 
         # Import `readthedocs.core.logs` to set up structlog
         import readthedocs.core.logs  # noqa
+
+        try:
+            import readthedocsext.monitoring.metrics.tasks
+        except (ModuleNotFoundError, ImportError):
+            log.info('Metrics tasks could not be imported.')

--- a/readthedocs/core/apps.py
+++ b/readthedocs/core/apps.py
@@ -1,8 +1,10 @@
-# -*- coding: utf-8 -*-
-
 """App configurations for core app."""
 
+import structlog
+
 from django.apps import AppConfig
+
+log = structlog.get_logger(__name__)
 
 
 class CoreAppConfig(AppConfig):

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -205,9 +205,6 @@ class SyncRepositoryTask(SyncRepositoryMixin, Task):
     bind=True,
 )
 def sync_repository_task(self, version_id):
-    # NOTE: `before_start` is new on Celery 5.2.x, but we are using 5.1.x currently.
-    self.before_start(self.request.id, self.request.args, self.request.kwargs)
-
     self.execute()
 
 
@@ -993,7 +990,4 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
     bind=True,
 )
 def update_docs_task(self, version_id, build_id, build_commit=None):
-    # NOTE: `before_start` is new on Celery 5.2.x, but we are using 5.1.x currently.
-    self.before_start(self.request.id, self.request.args, self.request.kwargs)
-
     self.execute()

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -426,7 +426,7 @@ class CommunityBaseSettings(Settings):
             'schedule': crontab(minute=0, hour=4),
             'options': {'queue': 'web'},
         },
-        'half-hourly-archive-builds': {
+        'hourly-archive-builds': {
             'task': 'readthedocs.builds.tasks.archive_builds',
             'schedule': crontab(minute=30),
             'options': {'queue': 'web'},

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -426,12 +426,14 @@ class CommunityBaseSettings(Settings):
             'schedule': crontab(minute=0, hour=4),
             'options': {'queue': 'web'},
         },
-        'hourly-archive-builds': {
+        'half-hourly-archive-builds': {
             'task': 'readthedocs.builds.tasks.archive_builds',
             'schedule': crontab(minute=30),
             'options': {'queue': 'web'},
             'kwargs': {
                 'days': 1,
+                'limit': 2000,
+                'delete': True,
             },
         },
         'every-day-delete-inactive-external-versions': {

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -38,13 +38,7 @@ Pygments==2.11.2
 # django-redis-cache 2.1.3 depends on redis<4.0
 redis==3.5.3  # pyup: ignore
 
-# Pin celery and kombu because it produces an error
-# File "/home/docs/lib/python3.8/site-packages/celery/app/trace.py", line 361, in build_tracer
-#     push_request = request_stack.push
-# AttributeError: 'NoneType' object has no attribute 'push'
-# See https://github.com/celery/celery/discussions/7172
-kombu==5.1.0  # pyup: ignore
-celery==5.1.2  # pyup: ignore
+celery==5.2.3
 
 # When upgrading to 0.43.0 we should double check the ``base.html`` change
 # described in the changelog. In previous versions, the allauth app included a


### PR DESCRIPTION
- upgrade celery to 5.2.3
- `before_start` is now a method recognized by this version
- migrate some class-based tasks to function-based tasks to avoid bug when registering them

See https://github.com/celery/celery/discussions/7172#discussioncomment-1827682