### PR TITLE
Build: allow NULL when updating the config

### DIFF
--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -145,7 +145,7 @@ class BuildSerializer(serializers.ModelSerializer):
     commit_url = serializers.ReadOnlyField(source='get_commit_url')
     # Jsonfield needs an explicit serializer
     # https://github.com/dmkoch/django-jsonfield/issues/188#issuecomment-300439829
-    config = serializers.JSONField(required=False)
+    config = serializers.JSONField(required=False, allow_null=True)
 
     class Meta:
         model = Build


### PR DESCRIPTION
When the Build object is updated via PATCH initially, it fails because the
`config` field does not accept `None`. This commit makes the `None` to work.