### PR TITLE
CDN: avoid cache tags collision

### DIFF
--- a/readthedocs/api/v2/mixins.py
+++ b/readthedocs/api/v2/mixins.py
@@ -37,10 +37,10 @@ class CachedResponseMixin:
             version = self._get_version()
             tags = [
                 project.slug,
-                f'{project.slug}-{version.slug}',
+                f'{project.slug}:{version.slug}',
             ]
             if self.project_cache_tag:
-                tags.append(f'{project.slug}-{self.project_cache_tag}')
+                tags.append(f'{project.slug}:{self.project_cache_tag}')
             return tags
         except Exception as e:
             log.debug('Error while retrieving project and version for this view.')

--- a/readthedocs/api/v2/mixins.py
+++ b/readthedocs/api/v2/mixins.py
@@ -3,6 +3,19 @@ import structlog
 log = structlog.get_logger(__name__)
 
 
+def get_cache_tag(*args):
+    """
+    Generate a cache tag from the given args.
+
+    The final tag is composed of several parts
+    that form a unique tag (like project and version slug).
+
+    All parts are separated using a character that isn't
+    allowed in slugs to avoid collitions.
+    """
+    return ':'.join(args)
+
+
 class CachedResponseMixin:
 
     """
@@ -37,10 +50,10 @@ class CachedResponseMixin:
             version = self._get_version()
             tags = [
                 project.slug,
-                f'{project.slug}:{version.slug}',
+                get_cache_tag(project.slug, version.slug),
             ]
             if self.project_cache_tag:
-                tags.append(f'{project.slug}:{self.project_cache_tag}')
+                tags.append(get_cache_tag(project.slug, self.project_cache_tag))
             return tags
         except Exception as e:
             log.debug('Error while retrieving project and version for this view.')

--- a/readthedocs/api/v2/mixins.py
+++ b/readthedocs/api/v2/mixins.py
@@ -1,19 +1,8 @@
 import structlog
 
+from readthedocs.core.utils import get_cache_tag
+
 log = structlog.get_logger(__name__)
-
-
-def get_cache_tag(*args):
-    """
-    Generate a cache tag from the given args.
-
-    The final tag is composed of several parts
-    that form a unique tag (like project and version slug).
-
-    All parts are separated using a character that isn't
-    allowed in slugs to avoid collitions.
-    """
-    return ':'.join(args)
 
 
 class CachedResponseMixin:

--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -4,6 +4,7 @@ import datetime
 import re
 
 import structlog
+from django.conf import settings
 from django.utils import timezone
 from django.utils.functional import keep_lazy
 from django.utils.safestring import SafeText, mark_safe

--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -1,12 +1,9 @@
 """Common utility functions."""
 
 import datetime
-import errno
-import structlog
-import os
 import re
 
-from django.conf import settings
+import structlog
 from django.utils import timezone
 from django.utils.functional import keep_lazy
 from django.utils.safestring import SafeText, mark_safe
@@ -274,3 +271,16 @@ def slugify(value, *args, **kwargs):
         # DNS doesn't allow - at the beginning or end of subdomains
         value = mark_safe(value.strip('-'))
     return value
+
+
+def get_cache_tag(*args):
+    """
+    Generate a cache tag from the given args.
+
+    The final tag is composed of several parts
+    that form a unique tag (like project and version slug).
+
+    All parts are separated using a character that isn't
+    allowed in slugs to avoid collisions.
+    """
+    return ':'.join(args)

--- a/readthedocs/embed/tests/test_api.py
+++ b/readthedocs/embed/tests/test_api.py
@@ -265,7 +265,7 @@ class BaseTestEmbedAPI:
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data == expected
-        assert response['Cache-tag'] == 'project,project-latest'
+        assert response['Cache-tag'] == 'project,project:latest'
 
     @mock.patch('readthedocs.embed.views.build_media_storage')
     def test_embed_mkdocs(self, storage_mock, client):

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -159,7 +159,7 @@ class ProxitoMiddleware(MiddlewareMixin):
         if project_slug:
             cache_tags.append(project_slug)
         if version_slug:
-            cache_tags.append(f'{project_slug}-{version_slug}')
+            cache_tags.append(f'{project_slug}:{version_slug}')
 
         if cache_tags:
             response['Cache-Tag'] = ','.join(cache_tags)

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -15,7 +15,7 @@ from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.deprecation import MiddlewareMixin
 
-from readthedocs.api.v2.mixins import get_cache_tag
+from readthedocs.core.utils import get_cache_tag
 from readthedocs.projects.models import Domain, Project, ProjectRelationship
 from readthedocs.proxito import constants
 

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -15,6 +15,7 @@ from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.deprecation import MiddlewareMixin
 
+from readthedocs.api.v2.mixins import get_cache_tag
 from readthedocs.projects.models import Domain, Project, ProjectRelationship
 from readthedocs.proxito import constants
 
@@ -159,7 +160,7 @@ class ProxitoMiddleware(MiddlewareMixin):
         if project_slug:
             cache_tags.append(project_slug)
         if version_slug:
-            cache_tags.append(f'{project_slug}:{version_slug}')
+            cache_tags.append(get_cache_tag(project_slug, version_slug))
 
         if cache_tags:
             response['Cache-Tag'] = ','.join(cache_tags)

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -1013,7 +1013,7 @@ class TestCDNCache(BaseDocServing):
         for url in urls:
             resp = self.client.get(url, secure=True, HTTP_HOST=host)
             self.assertEqual(resp.headers['CDN-Cache-Control'], expected_value, url)
-            self.assertEqual(resp.headers['Cache-Tag'], 'project,project-latest', url)
+            self.assertEqual(resp.headers['Cache-Tag'], 'project,project:latest', url)
 
         # Page & system redirects are always cached.
         # Authz is done on the redirected URL.
@@ -1055,7 +1055,7 @@ class TestCDNCache(BaseDocServing):
         for url in urls:
             resp = self.client.get(url, secure=True, HTTP_HOST=host)
             self.assertEqual(resp.headers['CDN-Cache-Control'], expected_value, url)
-            self.assertEqual(resp.headers['Cache-Tag'], 'subproject,subproject-latest', url)
+            self.assertEqual(resp.headers['Cache-Tag'], 'subproject,subproject:latest', url)
 
         # Page & system redirects are always cached.
         # Authz is done on the redirected URL.
@@ -1093,7 +1093,7 @@ class TestCDNCache(BaseDocServing):
         resp = self.client.get('/en/latest/', secure=False, HTTP_HOST=self.domain.domain)
         self.assertEqual(resp['Location'], f'https://{self.domain.domain}/en/latest/')
         self.assertEqual(resp.headers['CDN-Cache-Control'], 'private')
-        self.assertEqual(resp.headers['Cache-Tag'], 'project,project-latest')
+        self.assertEqual(resp.headers['Cache-Tag'], 'project,project:latest')
 
     def test_cache_public_versions(self):
         self.project.versions.update(privacy_level=PUBLIC)
@@ -1109,7 +1109,7 @@ class TestCDNCache(BaseDocServing):
         resp = self.client.get('/en/latest/', secure=False, HTTP_HOST=self.domain.domain)
         self.assertEqual(resp['Location'], f'https://{self.domain.domain}/en/latest/')
         self.assertEqual(resp.headers['CDN-Cache-Control'], 'public')
-        self.assertEqual(resp.headers['Cache-Tag'], 'project,project-latest')
+        self.assertEqual(resp.headers['Cache-Tag'], 'project,project:latest')
 
     def test_cache_on_private_versions_subproject(self):
         self.subproject.versions.update(privacy_level=PRIVATE)
@@ -1129,7 +1129,7 @@ class TestCDNCache(BaseDocServing):
         )
         self.assertEqual(resp['Location'], f'https://{self.domain.domain}/projects/subproject/en/latest/')
         self.assertEqual(resp.headers['CDN-Cache-Control'], 'private')
-        self.assertEqual(resp.headers['Cache-Tag'], 'subproject,subproject-latest')
+        self.assertEqual(resp.headers['Cache-Tag'], 'subproject,subproject:latest')
 
     def test_cache_public_versions_subproject(self):
         self.subproject.versions.update(privacy_level=PUBLIC)
@@ -1149,4 +1149,4 @@ class TestCDNCache(BaseDocServing):
         )
         self.assertEqual(resp['Location'], f'https://{self.domain.domain}/projects/subproject/en/latest/')
         self.assertEqual(resp.headers['CDN-Cache-Control'], 'public')
-        self.assertEqual(resp.headers['Cache-Tag'], 'subproject,subproject-latest')
+        self.assertEqual(resp.headers['Cache-Tag'], 'subproject,subproject:latest')

--- a/readthedocs/proxito/tests/test_headers.py
+++ b/readthedocs/proxito/tests/test_headers.py
@@ -31,7 +31,7 @@ class ProxitoHeaderTests(BaseDocServing):
     def test_serve_headers(self):
         r = self.client.get('/en/latest/', HTTP_HOST='project.dev.readthedocs.io')
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r['Cache-Tag'], 'project,project-latest')
+        self.assertEqual(r['Cache-Tag'], 'project,project:latest')
         self.assertEqual(r['X-RTD-Domain'], 'project.dev.readthedocs.io')
         self.assertEqual(r['X-RTD-Project'], 'project')
         self.assertEqual(r['X-RTD-Project-Method'], 'subdomain')
@@ -42,7 +42,7 @@ class ProxitoHeaderTests(BaseDocServing):
     def test_subproject_serve_headers(self):
         r = self.client.get('/projects/subproject/en/latest/', HTTP_HOST='project.dev.readthedocs.io')
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r['Cache-Tag'], 'subproject,subproject-latest')
+        self.assertEqual(r['Cache-Tag'], 'subproject,subproject:latest')
         self.assertEqual(r['X-RTD-Domain'], 'project.dev.readthedocs.io')
         self.assertEqual(r['X-RTD-Project'], 'subproject')
 
@@ -75,7 +75,7 @@ class ProxitoHeaderTests(BaseDocServing):
         )
         r = self.client.get("/en/latest/", HTTP_HOST=hostname)
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r['Cache-Tag'], 'project,project-latest')
+        self.assertEqual(r['Cache-Tag'], 'project,project:latest')
         self.assertEqual(r['X-RTD-Domain'], self.domain.domain)
         self.assertEqual(r['X-RTD-Project'], self.project.slug)
         self.assertEqual(r['X-RTD-Project-Method'], 'cname')
@@ -91,7 +91,7 @@ class ProxitoHeaderTests(BaseDocServing):
         )
         r = self.client.get(url, HTTP_HOST='project.dev.readthedocs.io')
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r['Cache-Tag'], 'project,project-latest,project-rtd-footer')
+        self.assertEqual(r['Cache-Tag'], 'project,project:latest,project:rtd-footer')
 
     def test_user_domain_headers(self):
         hostname = 'docs.domain.com'

--- a/readthedocs/search/tests/test_proxied_api.py
+++ b/readthedocs/search/tests/test_proxied_api.py
@@ -22,5 +22,5 @@ class TestProxiedSearchAPI(BaseTestDocumentSearch):
         }
         resp = self.get_search(api_client, search_params)
         assert resp.status_code == 200
-        cache_tags = f'{project.slug},{project.slug}-{version.slug},{project.slug}-rtd-search'
+        cache_tags = f'{project.slug},{project.slug}:{version.slug},{project.slug}:rtd-search'
         assert resp['Cache-Tag'] == cache_tags


### PR DESCRIPTION
We are using `-` as separator
between the project and version slug.
Is easy to generate a collision to generate the same
tag for two or more projects.

For example:

- Project: my-project
  Version: latest
  Tag: my-project-latest

- Project: my
  Version: project-latest
  Tag: my-project-latest

A collision can happen on .org if the final tag has 3 or more `-`,
and on .com if the final tag has 4 or more `-` (since we concatenate the
org slug to each project).

This isn't a security issue,
since the cache tag is used only to purge
the cache, not as a key to cache the content.

I've solved this issue by using a character that isn't
allowed on slugs as separator (`:`).

We will need to purge the cache after deploygin this change.