### PR TITLE
add note on setting locale_dirs

### DIFF
--- a/docs/user/guides/manage-translations-sphinx.rst
+++ b/docs/user/guides/manage-translations-sphinx.rst
@@ -187,7 +187,10 @@ Finally, to build our documentation in Spanish(Argentina) we need to tell Sphinx
 
 .. note::
 
-   There is no need to create a new ``conf.py`` to redefine the ``language`` for the Spanish version of this documentation.
+   There is no need to create a new ``conf.py`` to redefine the ``language`` for the Spanish version of this documentation, 
+   but you need to set locale_dirs_ to ``["locale"]`` for Sphinx to find the translated content.
+   
+   .. _locale_dirs: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-locale_dirs
 
 After running this command, the Spanish(Argentina) version of your documentation will be under ``_build/html/es_AR``.
 


### PR DESCRIPTION
locale_dirs defaults to locales but the guide uses locale instead. If only the steps in the guide are followed, sphinx can't find the translations. Let me know if this looks good or you'd rather a different solution