### PR TITLE
Celery: increase timeout limit for `sync_remote_repositories` task

### DIFF
--- a/readthedocs/oauth/tasks.py
+++ b/readthedocs/oauth/tasks.py
@@ -26,7 +26,15 @@ log = structlog.get_logger(__name__)
 
 
 @PublicTask.permission_check(user_id_matches)
-@app.task(queue='web', base=PublicTask)
+@app.task(
+    queue='web',
+    base=PublicTask,
+    # We have experienced timeout problems on users having a lot of
+    # repositories to sync. This is usually due to users belonging to big
+    # organizations (e.g. conda-forge).
+    time_limit=900,
+    soft_time_limit=600,
+)
 def sync_remote_repositories(user_id):
     user = User.objects.filter(pk=user_id).first()
     if not user:


### PR DESCRIPTION
Users belonging to huge GH organizations, like `conda-forge`, were never syncing
their repositories because the task timed out and none of the relationships were
created.