### PR TITLE
Celery: trigger `archive_builds` frequently with a lower limit

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -426,13 +426,13 @@ class CommunityBaseSettings(Settings):
             'schedule': crontab(minute=0, hour=4),
             'options': {'queue': 'web'},
         },
-        'hourly-archive-builds': {
+        'quarter-archive-builds': {
             'task': 'readthedocs.builds.tasks.archive_builds',
-            'schedule': crontab(minute=30),
+            'schedule': crontab(minute='*/15'),
             'options': {'queue': 'web'},
             'kwargs': {
                 'days': 1,
-                'limit': 2000,
+                'limit': 500,
                 'delete': True,
             },
         },


### PR DESCRIPTION
Using `LIMIT 5000` and also `LIMIT 2000` has been causing our database to use
too much CPU. This commit changes this limit to reduce it to 500.

Quickly checking CloudWatch logs, I see that we have around 10k builds per day.
Triggering the task every 15 minutes with a limit of 500 gives us 48k builds
archived per day. If my math is correct, I think we are fine.