### PR TITLE
Archive builds: avoid filtering by commands__isnull

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -427,7 +427,7 @@ class CommunityBaseSettings(Settings):
             'options': {'queue': 'web'},
         },
         'quarter-archive-builds': {
-            'task': 'readthedocs.builds.tasks.archive_builds',
+            'task': 'readthedocs.builds.tasks.archive_builds_task',
             'schedule': crontab(minute='*/15'),
             'options': {'queue': 'web'},
             'kwargs': {


### PR DESCRIPTION
That filter doesn't makes much sense since we are always using
`include_cold=False`.
Yes, this avoids iterating over builds that don't have commands,
but it makes the query really slow.

```python
max_date = timezone.now() - timezone.timedelta(days=1)
limit = 2000
queryset2 = (
    Build.objects
    .exclude(cold_storage=True)
    .exclude(commands__isnull=True)
    .filter(date__lt=max_date)
    .prefetch_related('commands')
    .only('date', 'cold_storage')
    [:limit]
)
queryset = (
    Build.objects
    .exclude(cold_storage=True)
    .filter(date__lt=max_date)
    .prefetch_related('commands')
    .only('date', 'cold_storage')
    [:limit]
)

In [51]: queryset.explain()
Out[51]: "Limit  (cost=0.43..2989.01 rows=2000 width=13)\n  ->  Index Scan Backward using date_index on builds_build  (c
ost=0.43..1931896.14 rows=1292853 width=13)\n        Index Cond: (date < '2022-02-28 23:39:08.918053+00'::timestamp with
 time zone)\n        Filter: ((NOT cold_storage) OR (cold_storage IS NULL))"

In [52]: queryset2.explain()
Out[52]: "Limit  (cost=1001.32..5654.86 rows=2000 width=13)\n  ->  Gather Merge  (cost=1001.32..3009174.57 rows=1292853
width=13)\n        Workers Planned: 2\n        ->  Nested Loop Anti Join  (cost=1.29..2858947.23 rows=538689 width=13)\n
              ->  Parallel Index Scan Backward using date_index on builds_build  (cost=0.43..1866041.17 rows=538689 widt
h=13)\n                    Index Cond: (date < '2022-02-28 23:39:08.918053+00'::timestamp with time zone)\n
       Filter: ((NOT cold_storage) OR (cold_storage IS NULL))\n              ->  Nested Loop Left Join  (cost=0.86..1.83
 rows=1 width=4)\n                    Filter: (u1.id IS NULL)\n                    ->  Index Only Scan using builds_buil
d_pkey on builds_build u0  (cost=0.43..0.99 rows=1 width=4)\n                          Index Cond: (id = builds_build.id
)\n                    ->  Index Scan using builds_buildcommandresult_9b69b72a on builds_buildcommandresult u1  (cost=0.
42..0.70 rows=14 width=8)\n                          Index Cond: (build_id = u0.id)"
```

We aren't saving the empty file,
but we check if the file exists on
https://github.com/readthedocs/readthedocs.org/blob/b74079d9ed26da7569151775b144867903f862b9/readthedocs/api/v2/views/model_views.py#L266-L266,
so all good.