### PR TITLE
Requirements: remove `django-permissions-policy`

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -110,12 +110,6 @@ class CommunityBaseSettings(Settings):
         "/admin/",
     )
 
-    # Permissions Policy
-    # https://github.com/adamchainz/django-permissions-policy
-    PERMISSIONS_POLICY = {
-        "interest-cohort": [],
-    }
-
     # Read the Docs
     READ_THE_DOCS_EXTENSIONS = ext
     RTD_LATEST = 'latest'
@@ -251,7 +245,6 @@ class CommunityBaseSettings(Settings):
         'corsheaders.middleware.CorsMiddleware',
         'csp.middleware.CSPMiddleware',
         'readthedocs.core.middleware.ReferrerPolicyMiddleware',
-        'django_permissions_policy.PermissionsPolicyMiddleware',
         'simple_history.middleware.HistoryRequestMiddleware',
         'readthedocs.core.logs.ReadTheDocsRequestMiddleware',
         'django_structlog.middlewares.CeleryMiddleware',

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -105,9 +105,6 @@ django-debug-toolbar==3.2.4
 
 # For enabling content-security-policy
 django-csp==3.7
-# For setting the permissions-policy security header
-# We can not upgrade to 4.8.0 because it removes `interest-cohort` feature and we are still using it.
-django-permissions-policy==4.7.0  # pyup: ignore
 
 django-structlog==2.2.0
 structlog==21.5.0


### PR DESCRIPTION
`interest-cohort` is not a thing anymore. See
https://github.com/readthedocs/readthedocs.org/pull/8954#discussion_r816962542