### PR TITLE
Project: use `RemoteRepository` to define `default_branch`

### DIFF
--- a/docs/user/versions.rst
+++ b/docs/user/versions.rst
@@ -4,7 +4,8 @@ Versioned Documentation
 Read the Docs supports multiple versions of your repository.
 On initial import,
 we will create a ``latest`` version.
-This will point at the default branch for your VCS control: ``master``, ``default``, or ``trunk``.
+This will point at the default branch defined in your VCS control
+(by default, ``main`` on Git and ``default`` in Mercurial).
 
 If your project has any tags or branches with a name following `semantic versioning <https://semver.org/>`_,
 we also create a ``stable`` version, tracking your most recent release.
@@ -120,7 +121,7 @@ When you log in to a documentation site, you will be logged in until close your 
 To log out, click on the :guilabel:`Log out` link in your documentation's flyout menu.
 This is usually located in the bottom right or bottom left, depending on the theme design.
 This will log you out from the current domain,
-but not end any other session that you have active. 
+but not end any other session that you have active.
 
 .. figure:: /_static/images/logout-button.png
    :align: center

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1168,6 +1168,10 @@ class Project(models.Model):
         """Get the version representing 'latest'."""
         if self.default_branch:
             return self.default_branch
+
+        if self.remote_repository and self.remote_repository.default_branch:
+            return self.remote_repository.default_branch
+
         return self.vcs_class().fallback_branch
 
     def add_subproject(self, child, alias=None):

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 from unittest import mock
 
 from allauth.socialaccount.models import SocialAccount
@@ -6,7 +5,6 @@ from django.contrib.auth.models import User
 from django.http.response import HttpResponseRedirect
 from django.test import TestCase, override_settings
 from django.urls import reverse
-from django.utils import timezone
 from django.views.generic.base import ContextMixin
 from django_dynamic_fixture import get, new
 
@@ -127,7 +125,7 @@ class TestBasicsForm(WizardTestCase):
         self.assertEqual(proj.documentation_type, 'sphinx')
 
     def test_remote_repository_is_added(self):
-        remote_repo = get(RemoteRepository)
+        remote_repo = get(RemoteRepository, default_branch="default-branch")
         socialaccount = get(SocialAccount, user=self.user)
         get(
             RemoteRepositoryRelation,
@@ -144,6 +142,7 @@ class TestBasicsForm(WizardTestCase):
         proj = Project.objects.get(name='foobar')
         self.assertIsNotNone(proj)
         self.assertEqual(proj.remote_repository, remote_repo)
+        self.assertEqual(proj.get_default_branch(), remote_repo.default_branch)
 
     def test_remote_repository_invalid_type(self):
         self.step_data['basics']['remote_repository'] = 'Invalid id'
@@ -264,7 +263,7 @@ class TestAdvancedForm(TestBasicsForm):
         self.assertWizardFailure(resp, 'documentation_type')
 
     def test_remote_repository_is_added(self):
-        remote_repo = get(RemoteRepository)
+        remote_repo = get(RemoteRepository, default_branch="default-branch")
         socialaccount = get(SocialAccount, user=self.user)
         get(
             RemoteRepositoryRelation,
@@ -283,6 +282,7 @@ class TestAdvancedForm(TestBasicsForm):
         proj = Project.objects.get(name='foobar')
         self.assertIsNotNone(proj)
         self.assertEqual(proj.remote_repository, remote_repo)
+        self.assertEqual(proj.get_default_branch(), remote_repo.default_branch)
 
 
 @mock.patch('readthedocs.core.utils.trigger_build', mock.MagicMock())


### PR DESCRIPTION
Currently, we are using `Project.default_branch` when it's defined and falling
back to VCS's default branch. However, with the massive rename from `master` to
`main` in GitHub, a lot of project are pointing to the wrong default branch.

Since we are storing the default branch of the GitHub repository under
`RemoteRepository.default_branch` and we are refreshing this list more
frequently now, we can use it before using VCS's default branch as fallback.

Closes #7907