### PR TITLE
Build: `RepositoryError` message

### DIFF
--- a/readthedocs/projects/exceptions.py
+++ b/readthedocs/projects/exceptions.py
@@ -52,7 +52,7 @@ class RepositoryError(BuildUserError):
     )
 
     @property
-    def CLONE_ERROR(self):
+    def CLONE_ERROR(self):  # noqa: N802
         if settings.ALLOW_PRIVATE_REPOS:
             return self.PRIVATE_ALLOWED
         return self.PRIVATE_NOT_ALLOWED

--- a/readthedocs/projects/exceptions.py
+++ b/readthedocs/projects/exceptions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 
 """Project exceptions."""
 
@@ -47,7 +46,16 @@ class RepositoryError(BuildUserError):
 
     FAILED_TO_CHECKOUT = _('Failed to checkout revision: {}')
 
-    def get_default_message(self):
+    GENERIC_ERROR = _(
+        "There was a problem with your repository. "
+        "Please, take a look at the commands' output to find out the reason.",
+    )
+
+    @property
+    def CLONE_ERROR(self):
         if settings.ALLOW_PRIVATE_REPOS:
             return self.PRIVATE_ALLOWED
         return self.PRIVATE_NOT_ALLOWED
+
+    def get_default_message(self):
+        return self.GENERIC_ERROR

--- a/readthedocs/projects/exceptions.py
+++ b/readthedocs/projects/exceptions.py
@@ -47,8 +47,8 @@ class RepositoryError(BuildUserError):
     FAILED_TO_CHECKOUT = _('Failed to checkout revision: {}')
 
     GENERIC_ERROR = _(
-        "There was a problem with your repository. "
-        "Please, take a look at the commands' output to find out the reason.",
+        "There was a problem cloning your repository. "
+        "Please check the command output for more information.",
     )
 
     @property

--- a/readthedocs/vcs_support/backends/bzr.py
+++ b/readthedocs/vcs_support/backends/bzr.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 
 """Bazaar-related utilities."""
 
@@ -36,7 +35,10 @@ class Backend(BaseVCS):
 
     def clone(self):
         self.make_clean_working_dir()
-        self.run('bzr', 'checkout', self.repo_url, '.')
+        try:
+            self.run("bzr", "checkout", self.repo_url, ".")
+        except RepositoryError:
+            raise RepositoryError(RepositoryError.CLONE_ERROR)
 
     @property
     def tags(self):

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -1,12 +1,12 @@
 """Git-related utilities."""
 
-import structlog
 import re
 
 import git
-from gitdb.util import hex_to_bin
+import structlog
 from django.core.exceptions import ValidationError
 from git.exc import BadName, InvalidGitRepositoryError, NoSuchPathError
+from gitdb.util import hex_to_bin
 
 from readthedocs.builds.constants import EXTERNAL
 from readthedocs.config import ALL
@@ -19,7 +19,6 @@ from readthedocs.projects.constants import (
 from readthedocs.projects.exceptions import RepositoryError
 from readthedocs.projects.validators import validate_submodule_url
 from readthedocs.vcs_support.base import BaseVCS, VCSVersion
-
 
 log = structlog.get_logger(__name__)
 
@@ -197,8 +196,11 @@ class Backend(BaseVCS):
 
         cmd.extend([self.repo_url, '.'])
 
-        code, stdout, stderr = self.run(*cmd)
-        return code, stdout, stderr
+        try:
+            code, stdout, stderr = self.run(*cmd)
+            return code, stdout, stderr
+        except RepositoryError:
+            raise RepositoryError(RepositoryError.CLONE_ERROR)
 
     @property
     def lsremote(self):

--- a/readthedocs/vcs_support/backends/hg.py
+++ b/readthedocs/vcs_support/backends/hg.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 
 """Mercurial-related utilities."""
 from readthedocs.projects.exceptions import RepositoryError
@@ -33,8 +32,11 @@ class Backend(BaseVCS):
 
     def clone(self):
         self.make_clean_working_dir()
-        output = self.run('hg', 'clone', self.repo_url, '.')
-        return output
+        try:
+            output = self.run("hg", "clone", self.repo_url, ".")
+            return output
+        except RepositoryError:
+            raise RepositoryError(RepositoryError.CLONE_ERROR)
 
     @property
     def branches(self):

--- a/readthedocs/vcs_support/backends/svn.py
+++ b/readthedocs/vcs_support/backends/svn.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 
 """Subversion-related utilities."""
 
@@ -63,7 +62,7 @@ class Backend(BaseVCS):
             url = self.repo_url
         retcode, out, err = self.run('svn', 'checkout', url, '.')
         if retcode != 0:
-            raise RepositoryError
+            raise RepositoryError(RepositoryError.CLONE_ERROR)
         return retcode, out, err
 
     @property

--- a/readthedocs/vcs_support/base.py
+++ b/readthedocs/vcs_support/base.py
@@ -1,11 +1,11 @@
 """Base classes for VCS backends."""
-import structlog
 import os
 import shutil
 
-from readthedocs.doc_builder.exceptions import BuildUserError, BuildCancelled
-from readthedocs.projects.exceptions import RepositoryError
+import structlog
 
+from readthedocs.doc_builder.exceptions import BuildCancelled, BuildUserError
+from readthedocs.projects.exceptions import RepositoryError
 
 log = structlog.get_logger(__name__)
 
@@ -108,7 +108,9 @@ class BaseVCS:
             raise BuildCancelled
         except BuildUserError as e:
             # Re raise as RepositoryError to handle it properly from outside
-            raise RepositoryError(str(e))
+            if hasattr(e, "message"):
+                raise RepositoryError(e.message)
+            raise RepositoryError
 
         # Return a tuple to keep compatibility
         return (build_cmd.exit_code, build_cmd.output, build_cmd.error)


### PR DESCRIPTION
When a `RepositoryError` _without_ a message was raised we were setting the
message as `"None"` and reporting this to the user :(

This commit first checks if the exception already contains a message and use
it in that case. If the exception does not contains a message, it raises it
without a message so the generic one is added by the Celery
handler (`on_failure`).

Also, it improves the messages reported to the user to communicate a more
detailed error depending the case.

Related to the error reported in https://github.com/readthedocs/readthedocs.org/issues/8995