### PR TITLE
CI: fix codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  codecov: codecov/codecov@3.1.1
+
 jobs:
   tests:
     docker:
@@ -16,7 +19,8 @@ jobs:
       - run: git submodule sync
       - run: git submodule update --init
       - run: pip install --user tox
-      - run: tox -e py38,codecov
+      - run: tox -e py38
+      - codecov/upload
 
   tests-embedapi:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,8 @@ jobs:
       - run: git submodule update --init
       - run: pip install --user tox
       - run: tox -e py38
-      - codecov/upload
+      - codecov/upload:
+          file: .coverage
 
   tests-embedapi:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@3.1.1
+  codecov: codecov/codecov@3.2.2
 
 jobs:
   tests:
@@ -20,8 +20,7 @@ jobs:
       - run: git submodule update --init
       - run: pip install --user tox
       - run: tox -e py38
-      - codecov/upload:
-          file: readthedocs/.coverage
+      - codecov/upload
 
   tests-embedapi:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,8 @@ jobs:
       - run: git submodule update --init
       - run: pip install --user tox
       - run: tox -e py38
-      - codecov/upload
+      - codecov/upload:
+          file: readthedocs/.coverage
 
   tests-embedapi:
     docker:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,3 +3,6 @@ coverage:
   status:
     project: off
     patch: off
+
+fixes:
+   - "/home/circleci/project/::"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,6 +3,3 @@ coverage:
   status:
     project: off
     patch: off
-
-fixes:
-   - "/home/circleci/project/::"

--- a/tox.ini
+++ b/tox.ini
@@ -13,19 +13,18 @@ setenv =
     DJANGO_SETTINGS_SKIP_LOCAL=True
 passenv = CI TRAVIS TRAVIS_* HOME
 deps =
-  -r{toxinidir}/requirements/testing.txt
-  debug: -r{toxinidir}/requirements/debug.txt
-changedir = {toxinidir}/readthedocs
+  -r requirements/testing.txt
+  debug: -r requirements/debug.txt
 basepython =
     python3.8
 commands =
     /bin/sh -c '\
         export DJANGO_SETTINGS_MODULE=readthedocs.settings.test; \
-        pytest --cov-report= --cov-config {toxinidir}/.coveragerc --cov=. --suppress-no-test-exit-code -m "not proxito and not embed_api" {posargs:{env:TOX_POSARGS:-m "not search and not proxito and not embed_api"}}'
+        pytest --cov-report= --cov-config .coveragerc --cov=. --pyargs readthedocs --suppress-no-test-exit-code -m "not proxito and not embed_api" {posargs:{env:TOX_POSARGS:-m "not search and not proxito and not embed_api"}}'
 
     /bin/sh -c '\
         export DJANGO_SETTINGS_MODULE=readthedocs.settings.proxito.test; \
-        pytest --cov-report= --cov-config {toxinidir}/.coveragerc --cov=. --cov-append -m proxito --suppress-no-test-exit-code {posargs}'
+        pytest --cov-report= --cov-config .coveragerc --cov=. --cov-append --pyargs readthedocs -m proxito --suppress-no-test-exit-code {posargs}'
 
 [testenv:docs]
 description = Build readthedocs user documentation
@@ -69,7 +68,6 @@ commands =
 
 [testenv:migrations]
 description = check for missing migrations
-changedir = {toxinidir}
 commands =
     ./manage.py makemigrations --check --dry-run
 
@@ -115,4 +113,4 @@ whitelist_externals = echo
 commands =
     coverage report --show-missing
     coverage html
-    echo Annotated HTML coverage report is in {toxinidir}/readthedocs/htmlcov/index.html
+    echo Annotated HTML coverage report is in {toxinidir}/htmlcov/index.html

--- a/tox.ini
+++ b/tox.ini
@@ -81,6 +81,7 @@ commands =
 [testenv:lint]
 description = run linter (prospector) to ensure the source code corresponds to our coding standards
 deps = -r{toxinidir}/requirements/lint.txt
+changedir = {toxinidir}/readthedocs
 commands =
     prospector \
     --profile-path={toxinidir} \

--- a/tox.ini
+++ b/tox.ini
@@ -116,8 +116,3 @@ commands =
     coverage report --show-missing
     coverage html
     echo Annotated HTML coverage report is in {toxinidir}/readthedocs/htmlcov/index.html
-
-[testenv:codecov]
-description = upload coverage report
-deps = codecov
-commands = codecov


### PR DESCRIPTION
https://docs.codecov.com/docs/codecov-uploader doesn't mention anything about the pip package... but it suggest using this an orb for circle.

After that, codecov was able to run, it wasn't able to find the files it needed to upload, this was because we are running pytest inside the readthedocs dir instead of the root dir of the repo, we could have fixed this with

https://github.com/readthedocs/readthedocs.org/pull/9006/commits/ecb84dd0706fb3dd5046f8c3d391de0869396ab2
https://github.com/readthedocs/readthedocs.org/pull/9006/commits/dc364ab85c4d6f8e10afb864edd89a5287c6360e

but I went and just changed our tox setup to run pytest from the root of the repo as they suggest in their docs.