### PR TITLE
CI: fix codecov again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,7 @@ jobs:
       - run: git submodule update --init
       - run: pip install --user tox
       - run: tox -e py38
-      - codecov/upload:
-          file: .coverage
+      - codecov/upload
 
   tests-embedapi:
     docker:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,5 +4,8 @@ coverage:
     project: off
     patch: off
 
+# Our tests are located in the readthedocs directory,
+# not in the root directory, so this is needed.
+# https://docs.codecov.com/docs/fixing-paths
 fixes:
-   - "/home/circleci/readthedocs::"
+  - "/home/circleci/project/::"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,3 +3,6 @@ coverage:
   status:
     project: off
     patch: off
+
+fixes:
+   - "/home/circleci/::"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,9 +3,3 @@ coverage:
   status:
     project: off
     patch: off
-
-# Our tests are located in the readthedocs directory,
-# not in the root directory, so this is needed.
-# https://docs.codecov.com/docs/fixing-paths
-fixes:
-  - "/home/circleci/project/readthedocs/::"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,4 +8,4 @@ coverage:
 # not in the root directory, so this is needed.
 # https://docs.codecov.com/docs/fixing-paths
 fixes:
-  - "/home/circleci/project/readthedocs::"
+  - "/home/circleci/project/readthedocs/::"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,4 +8,4 @@ coverage:
 # not in the root directory, so this is needed.
 # https://docs.codecov.com/docs/fixing-paths
 fixes:
-  - "/home/circleci/project/::"
+  - "/home/circleci/project/readthedocs::"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,4 +5,4 @@ coverage:
     patch: off
 
 fixes:
-   - "/home/circleci/::"
+   - "/home/circleci/readthedocs::"

--- a/tox.ini
+++ b/tox.ini
@@ -20,11 +20,11 @@ basepython =
 commands =
     /bin/sh -c '\
         export DJANGO_SETTINGS_MODULE=readthedocs.settings.test; \
-        pytest --cov-report= --cov-config .coveragerc --cov=. --pyargs readthedocs --suppress-no-test-exit-code -m "not proxito and not embed_api" {posargs:{env:TOX_POSARGS:-m "not search and not proxito and not embed_api"}}'
+        pytest --cov-report=xml --cov-config .coveragerc --cov=. --pyargs readthedocs --suppress-no-test-exit-code -m "not proxito and not embed_api" {posargs:{env:TOX_POSARGS:-m "not search and not proxito and not embed_api"}}'
 
     /bin/sh -c '\
         export DJANGO_SETTINGS_MODULE=readthedocs.settings.proxito.test; \
-        pytest --cov-report= --cov-config .coveragerc --cov=. --cov-append --pyargs readthedocs -m proxito --suppress-no-test-exit-code {posargs}'
+        pytest --cov-report=xml --cov-config .coveragerc --cov=. --cov-append --pyargs readthedocs -m proxito --suppress-no-test-exit-code {posargs}'
 
 [testenv:docs]
 description = Build readthedocs user documentation


### PR DESCRIPTION
Finally, the xml format was required (the sqlite format did work on the other PR for some reason :man_shrugging:, but xml  is the recommended). Found this in their example at https://github.com/codecov/example-python/blob/master/.circleci/config.yml