### PR TITLE
Build: allow users to use Ubuntu 22.04 LTS

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -537,6 +537,7 @@ class CommunityBaseSettings(Settings):
         # Mapping of build.os options to docker image.
         'os': {
             'ubuntu-20.04': f'{DOCKER_DEFAULT_IMAGE}:ubuntu-20.04',
+            'ubuntu-22.04': f'{DOCKER_DEFAULT_IMAGE}:ubuntu-22.04',
         },
         # Mapping of build.tools options to specific versions.
         'tools': {

--- a/scripts/compile_version_upload_s3.sh
+++ b/scripts/compile_version_upload_s3.sh
@@ -89,7 +89,7 @@ set -x # Echo commands
 
 # Define variables
 SLEEP=350 # Container timeout
-OS="ubuntu-20.04" # Docker image name
+OS="${OS:-ubuntu-22.04}" # Docker image name
 TOOL=$1
 VERSION=$2
 


### PR DESCRIPTION
Ubuntu 22.04 LTS is not yet released, but it's already available to use. We can
start allowing people to use this image for their builds.

To make usage of this image in production, we need to:

- `docker build` and push to Docker Hub: https://github.com/readthedocs/readthedocs-docker-images/pull/178
- update the hash for this image on https://github.com/readthedocs/readthedocs-ops/pull/1144
- run `./scripts/compile_version_upload_s3.sh` for the new image with all the `build.tools` supported