### PR TITLE
Build: log when a build is reset

### DIFF
--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -345,8 +345,9 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
 
     def _reset_build(self):
         # Reset build only if it has some commands already.
-        if self.data.build.get('commands'):
-            api_v2.build(self.data.build['id']).reset.post()
+        if self.data.build.get("commands"):
+            log.info("Reseting build.")
+            api_v2.build(self.data.build["id"]).reset.post()
 
     def on_failure(self, exc, task_id, args, kwargs, einfo):
         if not hasattr(self.data, 'build'):


### PR DESCRIPTION
If the build worker is killed for any reason, as we are using `ACKS_LATE`, the
build task will be picked by another worker and re-executed.

When that happens, we detect that the `Build` object already has some commands
saved on it and we delete those commands to start again from scratch.

This commit just adds a log line to be aware how often this situation happens in
production and be able to make other decisions.