### PR TITLE
Build: implement `build.jobs` config file key

### DIFF
--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -802,9 +802,6 @@ class BuildConfigV2(BuildConfigBase):
             )
 
         build["jobs"] = {}
-        for job in BuildJobs.__slots__:
-            build["jobs"][job] = []
-
         for job, commands in jobs.items():
             with self.catch_validation_error(f"build.jobs.{job}"):
                 build["jobs"][job] = [

--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -1294,9 +1294,7 @@ class BuildConfigV2(BuildConfigBase):
             return BuildWithTools(
                 os=build['os'],
                 tools=tools,
-                jobs=BuildJobs(
-                    **{job: commands for job, commands in build["jobs"].items()}
-                ),
+                jobs=BuildJobs(**build["jobs"]),
                 apt_packages=build["apt_packages"],
             )
         return Build(**build)

--- a/readthedocs/config/models.py
+++ b/readthedocs/config/models.py
@@ -37,7 +37,7 @@ class Build(Base):
 
 class BuildWithTools(Base):
 
-    __slots__ = ('os', 'tools', 'apt_packages')
+    __slots__ = ("os", "tools", "jobs", "apt_packages")
 
     def __init__(self, **kwargs):
         kwargs.setdefault('apt_packages', [])
@@ -47,6 +47,22 @@ class BuildWithTools(Base):
 class BuildTool(Base):
 
     __slots__ = ('version', 'full_version')
+
+
+class BuildJobs(Base):
+
+    __slots__ = (
+        "pre_checkout",
+        "post_checkout",
+        "pre_system_dependencies",
+        "post_system_dependencies",
+        "pre_create_environment",
+        "post_create_environment",
+        "pre_install",
+        "post_install",
+        "pre_build",
+        "post_build",
+    )
 
 
 class Python(Base):

--- a/readthedocs/config/models.py
+++ b/readthedocs/config/models.py
@@ -65,12 +65,12 @@ class BuildJobs(Base):
     )
 
     def __init__(self, **kwargs):
-    """
-    Create an empty list as a default for all possible builds.jobs configs.
-    
-    This is necessary because it makes the code cleaner when we add items to these lists,
-    without having to check for a dict to be created first. 
-    """
+        """
+        Create an empty list as a default for all possible builds.jobs configs.
+
+        This is necessary because it makes the code cleaner when we add items to these lists,
+        without having to check for a dict to be created first.
+        """
         for step in self.__slots__:
             kwargs.setdefault(step, [])
         super().__init__(**kwargs)

--- a/readthedocs/config/models.py
+++ b/readthedocs/config/models.py
@@ -65,6 +65,12 @@ class BuildJobs(Base):
     )
 
     def __init__(self, **kwargs):
+    """
+    Create an empty list as a default for all possible builds.jobs configs.
+    
+    This is necessary because it makes the code cleaner when we add items to these lists,
+    without having to check for a dict to be created first. 
+    """
         for step in self.__slots__:
             kwargs.setdefault(step, [])
         super().__init__(**kwargs)

--- a/readthedocs/config/models.py
+++ b/readthedocs/config/models.py
@@ -51,6 +51,8 @@ class BuildTool(Base):
 
 class BuildJobs(Base):
 
+    """Object used for `build.jobs` key."""
+
     __slots__ = (
         "pre_checkout",
         "post_checkout",

--- a/readthedocs/config/models.py
+++ b/readthedocs/config/models.py
@@ -64,6 +64,11 @@ class BuildJobs(Base):
         "post_build",
     )
 
+    def __init__(self, **kwargs):
+        for step in self.__slots__:
+            kwargs.setdefault(step, [])
+        super().__init__(**kwargs)
+
 
 class Python(Base):
 

--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -291,6 +291,33 @@ class BuildDirector:
         return False
 
     def run_build_job(self, job):
+        """
+        Run a command specified by the user under `build.jobs.` config key.
+
+        It uses the "VCS environment" for pre_/post_ checkout jobs and "build
+        environment" for the rest of them.
+
+        Note that user's commands:
+
+        - are not escaped
+        - are run with under the path where the repository was cloned
+        - are run as RTD_DOCKER_USER user
+        - users can't run commands as `root` user
+        - all the user's commands receive environment variables
+
+        Example:
+
+          build:
+            jobs:
+              pre_install:
+                - echo `date`
+                - python path/to/myscript.py
+              pre_build:
+                - sed -i **/*.rst -e "s|{version}|v3.5.1|g"
+
+        In this case, `self.data.config.build.jobs.pre_build` will contains
+        `sed` command.
+        """
         if (
             getattr(self.data.config.build, "jobs", None) is None
             or getattr(self.data.config.build.jobs, job, None) is None

--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -298,11 +298,12 @@ class BuildDirector:
             return
 
         cwd = self.data.project.checkout_path(self.data.version.slug)
+        environment = self.vcs_environment
+        if job not in ("pre_checkout", "post_checkout"):
+            environment = self.build_environment
+
         commands = getattr(self.data.config.build.jobs, job, [])
         for command in commands:
-            environment = self.vcs_environment
-            if job not in ("pre_checkout", "post_checkout"):
-                environment = self.build_environment
             environment.run(*command.split(), escape_command=False, cwd=cwd)
 
     # Helpers

--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -303,7 +303,7 @@ class BuildDirector:
         - are run with under the path where the repository was cloned
         - are run as RTD_DOCKER_USER user
         - users can't run commands as `root` user
-        - all the user's commands receive environment variables
+        - all the user's commands receive same environment variables as regular commands
 
         Example:
 

--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -169,12 +169,17 @@ class BuildDirector:
         3. build PDF
         4. build ePub
         """
+
+        self.pre_build()
+
         self.data.outcomes = defaultdict(lambda: False)
         self.data.outcomes["html"] = self.build_html()
         self.data.outcomes["search"] = self.is_type_sphinx()
         self.data.outcomes["localmedia"] = self.build_htmlzip()
         self.data.outcomes["pdf"] = self.build_pdf()
         self.data.outcomes["epub"] = self.build_epub()
+
+        self.post_build()
 
         after_build.send(
             sender=self.data.version,

--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -343,6 +343,8 @@ class BuildDirector:
         env = {
             "READTHEDOCS": "True",
             "READTHEDOCS_VERSION": self.data.version.slug,
+            "READTHEDOCS_VERSION_TYPE": self.data.version.type,
+            "READTHEDOCS_VERSION_NAME": self.data.version.verbose_name,
             "READTHEDOCS_PROJECT": self.data.project.slug,
             "READTHEDOCS_LANGUAGE": self.data.project.language,
         }

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -732,6 +732,46 @@ class TestBuildTask(BuildEnvironmentBase):
             ]
         )
 
+    @mock.patch("readthedocs.doc_builder.director.load_yaml_config")
+    def test_build_jobs(self, load_yaml_config):
+        config = BuildConfigV2(
+            {},
+            {
+                "version": 2,
+                "build": {
+                    "os": "ubuntu-20.04",
+                    "tools": {"python": "3.7"},
+                    "jobs": {
+                        "post_checkout": ["git fetch --unshallow"],
+                        "pre_build": ["echo `date`"],
+                    },
+                },
+            },
+            source_file="readthedocs.yml",
+        )
+        config.validate()
+        load_yaml_config.return_value = config
+
+        self._trigger_update_docs_task()
+
+        self.mocker.mocks["environment.run"].assert_has_calls(
+            [
+                mock.call(
+                    "git", "fetch", "--unshallow", escape_command=False, cwd=mock.ANY
+                ),
+                # Don't care about the intermediate commands. They are checked
+                # in other tests
+                mock.ANY,
+                mock.ANY,
+                mock.ANY,
+                mock.ANY,
+                mock.ANY,
+                mock.ANY,
+                mock.ANY,
+                mock.call("echo", "`date`", escape_command=False, cwd=mock.ANY),
+            ]
+        )
+
     @mock.patch("readthedocs.doc_builder.python_environments.tarfile")
     @mock.patch("readthedocs.doc_builder.python_environments.build_tools_storage")
     @mock.patch("readthedocs.doc_builder.director.load_yaml_config")


### PR DESCRIPTION
Allow people to use `build.jobs` to execute pre/post steps.

```yaml
build:
  jobs:
    pre_install:
      - echo `date`
      - python path/to/myscript.py
    pre_build:
      - sed -i **/*.rst -e "s|{version}|v3.5.1|g"
```

> See a full example of a working config file: https://github.com/readthedocs/test-builds/blob/build-jobs/.readthedocs.yaml

### Decisions made

* `build.jobs` can't be used without `build.os` / `build.tools`. This is done on purpose to avoid maintaining old/deprecated features (config file v1 and v2 with `build.image`)
* CWD path is the path where the repository was cloned
* _none_ of the "internal jobs" (`checkout`, `install`, `build`, etc) can be overwritten in this initial version. We will need a defined contract (e.g. `metadata.yaml`) to allow this
* we are not escaping the commands the user wrote in the YAML. They are run as-is without modification
* all user's commands are executed via the default Docker user (e.g. `docs`)
* users can't execute commands as `root`
* one, many or _all_ the pre/post jobs can be defined
* all user's commands receive environment variables

Closes #8201
Closes #5989 