### PR TITLE
Git: fix annotated tags on lsremote

### DIFF
--- a/readthedocs/rtd_tests/utils.py
+++ b/readthedocs/rtd_tests/utils.py
@@ -1,6 +1,5 @@
 """Utility functions for use in tests."""
 
-import structlog
 import subprocess
 import textwrap
 from os import chdir, environ, mkdir
@@ -9,6 +8,7 @@ from os.path import join as pjoin
 from shutil import copytree
 from tempfile import mkdtemp
 
+import structlog
 from django.contrib.auth.models import User
 from django_dynamic_fixture import new
 
@@ -191,6 +191,16 @@ def create_git_submodule(
     check_output(command, env=env)
     check_output(['git', 'add', '.'], env=env)
     check_output(['git', 'commit', '-m', '"{}"'.format(msg)], env=env)
+
+
+@restoring_chdir
+def get_current_commit(directory):
+    env = environ.copy()
+    env["GIT_DIR"] = pjoin(directory, ".git")
+    chdir(directory)
+
+    command = ["git", "rev-parse", "HEAD"]
+    return check_output(command, env=env).decode().strip()
 
 
 @restoring_chdir

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -214,19 +214,28 @@ class Backend(BaseVCS):
         self.check_working_dir()
         code, stdout, stderr = self.run(*cmd)
 
-        tags = []
         branches = []
+        all_tags = {}
+        light_tags = {}
         for line in stdout.splitlines()[1:]:  # skip HEAD
             commit, ref = line.split()
-            if ref.startswith('refs/heads/'):
-                branch = ref.replace('refs/heads/', '')
+            if ref.startswith("refs/heads/"):
+                branch = ref.replace("refs/heads/", "", 1)
                 branches.append(VCSVersion(self, branch, branch))
-            if ref.startswith('refs/tags/'):
-                tag = ref.replace('refs/tags/', '')
+
+            if ref.startswith("refs/tags/"):
+                tag = ref.replace("refs/tags/", "", 1)
+                # If the tag is annotated, then the real commit
+                # will be on the ref ending with ^{}.
                 if tag.endswith('^{}'):
-                    # skip annotated tags since they are duplicated
-                    continue
-                tags.append(VCSVersion(self, commit, tag))
+                    light_tags[tag[:-3]] = commit
+                else:
+                    all_tags[tag] = commit
+
+        # Merge both tags, lightweight tags will have
+        # priority over annotated tags.
+        all_tags.update(light_tags)
+        tags = [VCSVersion(self, commit, tag) for tag, commit in all_tags.items()]
 
         return branches, tags
 

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -215,6 +215,8 @@ class Backend(BaseVCS):
         code, stdout, stderr = self.run(*cmd)
 
         branches = []
+        # Git has two types of tags: lightweight and annotated.
+        # Lightweight tags are the "normal" ones.
         all_tags = {}
         light_tags = {}
         for line in stdout.splitlines()[1:]:  # skip HEAD


### PR DESCRIPTION
When a tag is annotated,
the real commit will be on the ref that ends with `^{}`.

GitPython handles this correctly,
but lsremote was returning the sha of the tag instead of the commit.

We are using GitPython to get the tags when doing a full build,
and lsremote when doing a sync.

This mismatch is causing problems, as rtd will take it as if the tags
were updated.

Fixes https://github.com/readthedocs/readthedocs.org/issues/8992