### PR TITLE
Build: use same build environment for setup and build

### DIFF
--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -548,13 +548,19 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         # objects in the database
         self.sync_versions(self.data.build_director.vcs_repository)
 
-        # Installing
-        self.update_build(state=BUILD_STATE_INSTALLING)
-        self.data.build_director.setup_environment()
+        # TODO: remove the ``create_build_environment`` hack. Ideally, this should be
+        # handled inside the ``BuildDirector`` but we can't use ``with
+        # self.build_environment`` twice because it kills the container on
+        # ``__exit__``
+        self.data.build_director.create_build_environment()
+        with self.data.build_director.build_environment:
+            # Installing
+            self.update_build(state=BUILD_STATE_INSTALLING)
+            self.data.build_director.setup_environment()
 
-        # Building
-        self.update_build(state=BUILD_STATE_BUILDING)
-        self.data.build_director.build()
+            # Building
+            self.update_build(state=BUILD_STATE_BUILDING)
+            self.data.build_director.build()
 
     @staticmethod
     def get_project(project_pk):


### PR DESCRIPTION
We can't do `with self.build_environment:` twice because the context manager
kills the Docker container on `__exit__`. So, the second time we call the `with`
it will create a new container which won't have all the work done in the
previous steps.

We could avoid this by using shared volumes instead, but that's a bigger
refactor. For now, I'm moving the part that creates the build environment back
to the Celery task and executing `setup_environment` _and_ `build` steps from
there, which is not ideally, but solves the problem for now.

This problem was introduced in #9002 