### PR TITLE
Sync versions: filter by type on update

### DIFF
--- a/readthedocs/api/v2/utils.py
+++ b/readthedocs/api/v2/utils.py
@@ -1,8 +1,8 @@
 """Utility functions that are used by both views and celery tasks."""
 
 import itertools
-import structlog
 
+import structlog
 from rest_framework.pagination import PageNumberPagination
 
 from readthedocs.builds.constants import (
@@ -79,6 +79,8 @@ def sync_versions_to_db(project, versions, type):  # pylint: disable=redefined-b
             Version.objects.filter(
                 project=project,
                 verbose_name=version_name,
+                # Always filter by type, a tag and a branch
+                # can share the same verbose_name.
                 type=type,
             ).update(
                 identifier=version_id,

--- a/readthedocs/api/v2/utils.py
+++ b/readthedocs/api/v2/utils.py
@@ -79,9 +79,9 @@ def sync_versions_to_db(project, versions, type):  # pylint: disable=redefined-b
             Version.objects.filter(
                 project=project,
                 verbose_name=version_name,
+                type=type,
             ).update(
                 identifier=version_id,
-                type=type,
                 machine=False,
             )
 

--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -75,8 +75,8 @@ class TestGitBackend(TestCase):
         repo_branches, repo_tags = repo.lsremote
 
         self.assertEqual(
-            set(branches + default_branches),
-            {branch.verbose_name for branch in repo_branches},
+            {branch: branch for branch in default_branches + branches},
+            {branch.verbose_name: branch.identifier for branch in repo_branches},
         )
 
         self.assertEqual(
@@ -111,8 +111,8 @@ class TestGitBackend(TestCase):
         repo.clone()
 
         self.assertEqual(
-            set(branches + default_branches),
-            {branch.verbose_name for branch in repo.branches},
+            {branch: branch for branch in default_branches + branches},
+            {branch.verbose_name: branch.identifier for branch in repo.branches},
         )
 
     @patch('readthedocs.projects.models.Project.checkout_path')

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -287,11 +287,17 @@ class Backend(BaseVCS):
 
         for branch in branches:
             verbose_name = branch.name
-            if verbose_name.startswith('origin/'):
-                verbose_name = verbose_name.replace('origin/', '')
-            if verbose_name == 'HEAD':
+            if verbose_name.startswith("origin/"):
+                verbose_name = verbose_name.replace("origin/", "", 1)
+            if verbose_name == "HEAD":
                 continue
-            versions.append(VCSVersion(self, str(branch), verbose_name))
+            versions.append(
+                VCSVersion(
+                    repository=self,
+                    identifier=verbose_name,
+                    verbose_name=verbose_name,
+                )
+            )
         return versions
 
     @property


### PR DESCRIPTION
If two versions share the same verbose name
(a branch named 2.0 and a tag named 2.0),
then we will be updating both,
instead of just one and changing its type from branch to tag.
Later when running this same code,
it will see the branch as new, since isn't included in our queryset that
filters by type=branch.

This wasn't happening before because this check was true
https://github.com/readthedocs/readthedocs.org/blob/2e3f208c4906de649a9b5b9e33afee6cc20b86bc/readthedocs/api/v2/utils.py#L74-L74

Since a branch would never change its identifier
(origin/name), but once lsremote was enabled,
the identifier didn't included the 'origin/' part.

So, when doing a full build the branches would be changed
to (origin/name) and when doing a syn they would be changed
to (name), and so on.

Ref https://github.com/readthedocs/readthedocs.org/issues/8992#issuecomment-1062466017