### PR TITLE
GitHub OAuth: use bigger pages to make fewer requests

### DIFF
--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -1,8 +1,8 @@
 """OAuth utility functions."""
 
-import structlog
 from datetime import datetime
 
+import structlog
 from allauth.socialaccount.models import SocialAccount
 from allauth.socialaccount.providers import registry
 from django.conf import settings
@@ -16,7 +16,6 @@ from readthedocs.oauth.models import (
     RemoteRepositoryRelation,
 )
 
-
 log = structlog.get_logger(__name__)
 
 
@@ -24,7 +23,6 @@ class SyncServiceError(Exception):
 
     """Error raised when a service failed to sync."""
 
-    pass
 
 
 class Service:
@@ -149,7 +147,7 @@ class Service:
         """
         resp = None
         try:
-            resp = self.get_session().get(url, data=kwargs)
+            resp = self.get_session().get(url, params=kwargs)
 
             # TODO: this check of the status_code would be better in the
             # ``create_session`` method since it could be used from outside, but

--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -11,18 +11,12 @@ from oauthlib.oauth2.rfc6749.errors import InvalidClientIdError
 from requests.exceptions import RequestException
 from requests_oauthlib import OAuth2Session
 
-from readthedocs.oauth.models import (
-    RemoteOrganizationRelation,
-    RemoteRepositoryRelation,
-)
-
 log = structlog.get_logger(__name__)
 
 
 class SyncServiceError(Exception):
 
     """Error raised when a service failed to sync."""
-
 
 
 class Service:

--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -1,9 +1,9 @@
 """OAuth utility functions."""
 
 import json
-import structlog
 import re
 
+import structlog
 from allauth.socialaccount.providers.bitbucket_oauth2.views import (
     BitbucketOAuth2Adapter,
 )
@@ -15,13 +15,8 @@ from readthedocs.builds import utils as build_utils
 from readthedocs.integrations.models import Integration
 
 from ..constants import BITBUCKET
-from ..models import (
-    RemoteOrganization,
-    RemoteRepository,
-    RemoteRepositoryRelation,
-)
+from ..models import RemoteOrganization, RemoteRepository, RemoteRepositoryRelation
 from .base import Service, SyncServiceError
-
 
 log = structlog.get_logger(__name__)
 
@@ -43,7 +38,8 @@ class BitbucketService(Service):
         # Get user repos
         try:
             repos = self.paginate(
-                'https://bitbucket.org/api/2.0/repositories/?role=member',
+                "https://bitbucket.org/api/2.0/repositories/",
+                role="member",
             )
             for repo in repos:
                 remote_repository = self.create_repository(repo)
@@ -61,7 +57,8 @@ class BitbucketService(Service):
         # existing repositories.
         try:
             resp = self.paginate(
-                'https://bitbucket.org/api/2.0/repositories/?role=admin',
+                "https://bitbucket.org/api/2.0/repositories/",
+                role="admin",
             )
             admin_repo_relations = (
                 RemoteRepositoryRelation.objects.filter(
@@ -88,7 +85,8 @@ class BitbucketService(Service):
 
         try:
             workspaces = self.paginate(
-                'https://api.bitbucket.org/2.0/workspaces/?role=member',
+                "https://api.bitbucket.org/2.0/workspaces/",
+                role="member",
             )
             for workspace in workspaces:
                 remote_organization = self.create_organization(workspace)

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -1,9 +1,9 @@
 """OAuth utility functions."""
 
 import json
-import structlog
 import re
 
+import structlog
 from allauth.socialaccount.models import SocialToken
 from allauth.socialaccount.providers.github.views import GitHubOAuth2Adapter
 from django.conf import settings
@@ -12,10 +12,7 @@ from requests.exceptions import RequestException
 
 from readthedocs.api.v2.client import api
 from readthedocs.builds import utils as build_utils
-from readthedocs.builds.constants import (
-    BUILD_STATUS_SUCCESS,
-    SELECT_BUILD_STATUS,
-)
+from readthedocs.builds.constants import BUILD_STATUS_SUCCESS, SELECT_BUILD_STATUS
 from readthedocs.core.permissions import AdminPermission
 from readthedocs.integrations.models import Integration
 
@@ -40,7 +37,7 @@ class GitHubService(Service):
         remote_repositories = []
 
         try:
-            repos = self.paginate('https://api.github.com/user/repos?per_page=100')
+            repos = self.paginate("https://api.github.com/user/repos", per_page=100)
             for repo in repos:
                 remote_repository = self.create_repository(repo)
                 remote_repositories.append(remote_repository)
@@ -58,14 +55,14 @@ class GitHubService(Service):
         remote_repositories = []
 
         try:
-            orgs = self.paginate('https://api.github.com/user/orgs')
+            orgs = self.paginate("https://api.github.com/user/orgs", per_page=100)
             for org in orgs:
                 org_details = self.get_session().get(org['url']).json()
                 remote_organization = self.create_organization(org_details)
-                # Add repos
-                # TODO ?per_page=100
+                org_url = org["url"]
                 org_repos = self.paginate(
-                    '{org_url}/repos'.format(org_url=org['url']),
+                    f"{org_url}/repos",
+                    per_page=100,
                 )
 
                 remote_organizations.append(remote_organization)

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -74,7 +74,6 @@ class GitLabService(Service):
         try:
             repos = self.paginate(
                 "{url}/api/v4/projects".format(url=self.adapter.provider_base_url),
-                pagination="keyset",
                 per_page=100,
                 archived=False,
                 order_by='path',
@@ -101,7 +100,6 @@ class GitLabService(Service):
         try:
             orgs = self.paginate(
                 "{url}/api/v4/groups".format(url=self.adapter.provider_base_url),
-                pagination="keyset",
                 per_page=100,
                 all_available=False,
                 order_by='path',
@@ -114,7 +112,6 @@ class GitLabService(Service):
                         url=self.adapter.provider_base_url,
                         id=org['id'],
                     ),
-                    pagination="keyset",
                     per_page=100,
                     archived=False,
                     order_by='path',

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -1,20 +1,17 @@
 """OAuth utility functions."""
 
 import json
-import structlog
 import re
 from urllib.parse import quote_plus, urlparse
 
+import structlog
 from allauth.socialaccount.providers.gitlab.views import GitLabOAuth2Adapter
 from django.conf import settings
 from django.urls import reverse
 from requests.exceptions import RequestException
 
 from readthedocs.builds import utils as build_utils
-from readthedocs.builds.constants import (
-    BUILD_STATUS_SUCCESS,
-    SELECT_BUILD_STATUS,
-)
+from readthedocs.builds.constants import BUILD_STATUS_SUCCESS, SELECT_BUILD_STATUS
 from readthedocs.integrations.models import Integration
 
 from ..constants import GITLAB
@@ -76,7 +73,8 @@ class GitLabService(Service):
         remote_repositories = []
         try:
             repos = self.paginate(
-                '{url}/api/v4/projects'.format(url=self.adapter.provider_base_url),
+                "{url}/api/v4/projects".format(url=self.adapter.provider_base_url),
+                pagination="keyset",
                 per_page=100,
                 archived=False,
                 order_by='path',
@@ -102,7 +100,8 @@ class GitLabService(Service):
 
         try:
             orgs = self.paginate(
-                '{url}/api/v4/groups'.format(url=self.adapter.provider_base_url),
+                "{url}/api/v4/groups".format(url=self.adapter.provider_base_url),
+                pagination="keyset",
                 per_page=100,
                 all_available=False,
                 order_by='path',
@@ -115,6 +114,7 @@ class GitLabService(Service):
                         url=self.adapter.provider_base_url,
                         id=org['id'],
                     ),
+                    pagination="keyset",
                     per_page=100,
                     archived=False,
                     order_by='path',


### PR DESCRIPTION
Currently, we are using the default pagination that GitHub offers, which is 30.
This commit increases the page size to 100 when fetching organization for a user
and repositories for each organizations.

Note we are already using 100 page size when fetching repositories for a user.

Related to #8979