### PR TITLE
SyncRepositoryTask: rate limit to 1 per minute per project

### DIFF
--- a/readthedocs/builds/constants.py
+++ b/readthedocs/builds/constants.py
@@ -3,7 +3,6 @@
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
-
 BUILD_STATE_TRIGGERED = 'triggered'
 BUILD_STATE_CLONING = 'cloning'
 BUILD_STATE_INSTALLING = 'installing'
@@ -136,3 +135,5 @@ BUILD_STATUS_CHOICES = (
 
 
 MAX_BUILD_COMMAND_SIZE = 1000000  # This keeps us under Azure's upload limit
+
+LOCK_EXPIRE = 60 * 180  # Lock expires in 3 hours

--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -22,6 +22,7 @@ from readthedocs.builds.constants import (
     BUILD_STATUS_PENDING,
     BUILD_STATUS_SUCCESS,
     EXTERNAL,
+    LOCK_EXPIRE,
     MAX_BUILD_COMMAND_SIZE,
     TAG,
 )
@@ -189,7 +190,7 @@ def archive_builds_task(self, days=14, limit=200, delete=False):
         return
 
     lock_id = '{0}-lock'.format(self.name)
-    with memcache_lock(lock_id, self.app.oid) as acquired:
+    with memcache_lock(lock_id, LOCK_EXPIRE, self.app.oid) as acquired:
         if not acquired:
             log.warning('Archive Builds Task still locked')
             return False

--- a/readthedocs/builds/utils.py
+++ b/readthedocs/builds/utils.py
@@ -103,15 +103,15 @@ def external_version_name(build_or_version):
 
 
 @contextmanager
-def memcache_lock(lock_id, oid):
+def memcache_lock(lock_id, lock_expire, oid):
     """
     Create a lock using django's cache for running a celery task.
 
     From http://docs.celeryproject.org/en/latest/tutorials/task-cookbook.html#cookbook-task-serial
     """
-    timeout_at = monotonic() + LOCK_EXPIRE - 3
+    timeout_at = monotonic() + lock_expire - 3
     # cache.add fails if the key already exists
-    status = cache.add(lock_id, oid, LOCK_EXPIRE)
+    status = cache.add(lock_id, oid, lock_expire)
     try:
         yield status
     finally:

--- a/readthedocs/builds/utils.py
+++ b/readthedocs/builds/utils.py
@@ -20,8 +20,6 @@ from readthedocs.projects.constants import (
     GITLAB_REGEXS,
 )
 
-LOCK_EXPIRE = 60 * 180  # Lock expires in 3 hours
-
 
 def get_github_username_repo(url):
     if 'github' in url:
@@ -103,7 +101,7 @@ def external_version_name(build_or_version):
 
 
 @contextmanager
-def memcache_lock(lock_id, lock_expire, oid):
+def memcache_lock(lock_id, lock_expire, app_identifier):
     """
     Create a lock using django's cache for running a celery task.
 
@@ -111,7 +109,7 @@ def memcache_lock(lock_id, lock_expire, oid):
     """
     timeout_at = monotonic() + lock_expire - 3
     # cache.add fails if the key already exists
-    status = cache.add(lock_id, oid, lock_expire)
+    status = cache.add(lock_id, app_identifier, lock_expire)
     try:
         yield status
     finally:

--- a/readthedocs/projects/exceptions.py
+++ b/readthedocs/projects/exceptions.py
@@ -4,7 +4,7 @@
 from django.conf import settings
 from django.utils.translation import gettext_noop as _
 
-from readthedocs.doc_builder.exceptions import BuildUserError
+from readthedocs.doc_builder.exceptions import BuildAppError, BuildUserError
 
 
 class ProjectConfigurationError(BuildUserError):
@@ -59,3 +59,8 @@ class RepositoryError(BuildUserError):
 
     def get_default_message(self):
         return self.GENERIC_ERROR
+
+
+class SyncRepositoryLocked(BuildAppError):
+
+    """Error risen when there is another sync_repository_task already running."""

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -159,7 +159,7 @@ class SyncRepositoryTask(SyncRepositoryMixin, Task):
         Allow to execute 1 task per minute.
         """
         lock_id = f"{self.name}-lock-{self.data.project.slug}"
-        locked = not cache.add(lock_id, oid, 60)
+        locked = not cache.add(lock_id, self.app.oid, 60)
         if locked:
             raise SyncRepositoryLocked
 

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -193,8 +193,10 @@ class SyncRepositoryTask(SyncRepositoryMixin, Task):
 )
 def sync_repository_task(self, version_id):
     lock_id = f"{self.name}-lock-{self.data.project.slug}"
-    with memcache_lock(lock_id, 60, self.app.oid) as lock_acquired:
-        # Run `sync_repository_task` one at a time. If the task exceedes the 60
+    with memcache_lock(
+        lock_id=lock_id, lock_expire=60, app_identifier=self.app.oid
+    ) as lock_acquired:
+        # Run `sync_repository_task` one at a time. If the task exceeds the 60
         # seconds, the lock is released and another task can be run in parallel
         # by a different worker.
         # See https://github.com/readthedocs/readthedocs.org/pull/9021/files#r828509016

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -132,6 +132,8 @@ class SyncRepositoryTask(SyncRepositoryMixin, Task):
             version_slug=self.data.version.slug,
         )
 
+        self._check_rate_limit()
+
     def on_failure(self, exc, task_id, args, kwargs, einfo):
         # Do not log as error handled exceptions
         if isinstance(exc, RepositoryError):
@@ -150,7 +152,7 @@ class SyncRepositoryTask(SyncRepositoryMixin, Task):
     def after_return(self, status, retval, task_id, args, kwargs, einfo):
         clean_build(self.data.version)
 
-    def _rate_limit(self):
+    def _check_rate_limit(self):
         """
         Rate limit the task per-project.
 
@@ -162,8 +164,6 @@ class SyncRepositoryTask(SyncRepositoryMixin, Task):
             raise SyncRepositoryLocked
 
     def execute(self):
-        self._rate_limit()
-
         environment = self.data.environment_class(
             project=self.data.project,
             version=self.data.version,


### PR DESCRIPTION
Different reasons (e.g. multiple push) makes our platform to trigger
`SyncRepositoryTask` multiple times one next to the other for the same project.
This consumes a lot of resources (clone the repository, query the databse,
update the database's versions, etc) but in the end it's is useless because
there is nothing has changed so quickly in the repository to require re-syncing
the versions.

We've found projects triggernig more than 1.5k of this task in a single day or
even in less time. This has made our database's CPU to spike and reduce the
availability of our workers to execute `UpdateDocsTask`, blocking our users and
producing a worse UX to them.

This commit makes usage of a lock (based on Celery's `memcache_lock`) to execute
up to 1 task per minute per project, and discard the rest of them.

Closes https://github.com/readthedocs/readthedocs.org/issues/8922