### PR TITLE
Add bumpver configuration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,6 @@ use f'{docset}/setting' as value on the setting, for example::
 
 import os
 import sys
-from configparser import RawConfigParser
 
 import sphinx_rtd_theme
 
@@ -45,13 +44,6 @@ for k, v in docsets[docset].items():
     locals()[k] = v
 
 
-def get_version():
-    """Return package version from setup.cfg."""
-    config = RawConfigParser()
-    config.read(os.path.join('..', 'setup.cfg'))
-    return config.get('metadata', 'version')
-
-
 sys.path.append(os.path.abspath('_ext'))
 extensions = [
     'sphinx.ext.autosectionlabel',
@@ -75,7 +67,7 @@ master_doc = 'index'
 copyright = '2010-{}, Read the Docs, Inc & contributors'.format(
     timezone.now().year
 )
-version = get_version()
+version = "7.4.2"
 release = version
 exclude_patterns = ['_build']
 default_role = 'obj'

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "readthedocs",
-  "version": "7.4.1",
+  "version": "7.4.2",
   "description": "Read the Docs build dependencies",
-  "author": "Anthony Johnson <anthony@readthedocs.com>",
+  "author": "Read the Docs, Inc <support@readthedocs.com>",
   "scripts": {
     "build": "gulp build",
     "dev": "gulp dev",

--- a/readthedocs/__init__.py
+++ b/readthedocs/__init__.py
@@ -2,18 +2,4 @@
 
 import os.path
 
-from configparser import RawConfigParser
-
-
-def get_version(setupcfg_path):
-    """Return package version from setup.cfg."""
-    config = RawConfigParser()
-    config.read(setupcfg_path)
-    return config.get('metadata', 'version')
-
-
-__version__ = get_version(
-    os.path.abspath(
-        os.path.join(os.path.dirname(__file__), '..', 'setup.cfg'),
-    ),
-)
+__version__ = "7.4.2"

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,3 +28,20 @@ zip_safe = False
 github_owner = readthedocs
 github_repo = readthedocs.org
 
+[bumpver]
+current_version = "7.4.2"
+version_pattern = "MAJOR.MINOR.PATCH[TAGNUM]"
+commit_message = "Bump version {old_version} -> {new_version}"
+commit = False
+tag = False
+push = False
+
+[bumpver:file_patterns]
+setup.cfg =
+    version = "{version}"
+package.json =
+    "version": "{version}",
+docs/conf.py =
+    version = "{version}"
+readthedocs/__init__.py =
+    __version__ = "{version}"


### PR DESCRIPTION
This is directly called from ops/deploy, so usage of this tool is
abstracted and not super important.

It's easy to use however, and has a string input method, instead of
incrementing each part individually, a la bump2version.

```
% bumpver update --dry --set-version "8.0.0"
INFO    - fetching tags from remote (to turn off use: -n / --no-fetch)
INFO    - Old Version: 7.4.2
INFO    - New Version: 8.0.0
--- docs/conf.py
+++ docs/conf.py
@@ -67,7 +67,7 @@
 copyright = '2010-{}, Read the Docs, Inc & contributors'.format(
     timezone.now().year
 )
-version = "7.4.2"
+version = "8.0.0"
 release = version
 exclude_patterns = ['_build']
 default_role = 'obj'
--- package.json
+++ package.json
@@ -1,6 +1,6 @@
 {
   "name": "readthedocs",
-  "version": "7.4.2",
+  "version": "8.0.0",
   "description": "Read the Docs build dependencies",
   "author": "Read the Docs, Inc <support@readthedocs.com>",
   "scripts": {
--- readthedocs/__init__.py
+++ readthedocs/__init__.py
@@ -2,5 +2,5 @@

 import os.path

-__version__ = "7.4.2"
+__version__ = "8.0.0"

--- setup.cfg
+++ setup.cfg
@@ -29,7 +29,7 @@
 github_repo = readthedocs.org

 [bumpver]
-current_version = "7.4.2"
+current_version = "8.0.0"
 version_pattern = "MAJOR.MINOR.PATCH[TAGNUM]"
 commit_message = "Bump version {old_version} -> {new_version}"
 commit = False
```