### PR TITLE
Build: Mercurial (`hg`) compatibility with old versions

### DIFF
--- a/readthedocs/vcs_support/backends/hg.py
+++ b/readthedocs/vcs_support/backends/hg.py
@@ -33,7 +33,14 @@ class Backend(BaseVCS):
     def clone(self):
         self.make_clean_working_dir()
         try:
-            output = self.run("hg", "clone", self.repo_url, ".")
+            # Disable sparse-revlog extension when cloning because it's not
+            # included in older versions of Mercurial and producess an error
+            # when using an old version. See
+            # https://github.com/readthedocs/readthedocs.org/pull/9042/
+
+            output = self.run(
+                "hg", "clone", "--config", "format.sparse-revlog=no", self.repo_url, "."
+            )
             return output
         except RepositoryError:
             raise RepositoryError(RepositoryError.CLONE_ERROR)


### PR DESCRIPTION
We are using Ubuntu 20.04 LTS to perform the clone
step (`readthedocs/build:ubuntu-20.04`) which comes with Mercurial v5.3.1 and
install by default the `sparse-revlog` requirement.

However, if the build is using `readthedocs/build:latest`, which comes with
Mercurial v4.5.3 and does not contain that requirement it fails:

```
hg identify --id
abort: repository requires features unknown to this Mercurial: sparserevlog!
(see https://mercurial-scm.org/wiki/MissingRequirement for more information)
```

This commit disables that requirements to make the clone compatible with the
older version of Mercurial.

Closes https://github.com/readthedocs/readthedocs.org/issues/8995