### PR TITLE
Proxito: do not serve non-existent versions

### DIFF
--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -198,6 +198,25 @@ class TestFullDocServing(BaseDocServing):
 
     # Invalid tests
 
+    def test_non_existent_version(self):
+        url = "/en/non-existent-version/"
+        host = "project.dev.readthedocs.io"
+        resp = self.client.get(url, HTTP_HOST=host)
+        self.assertEqual(resp.status_code, 404)
+
+    def test_inactive_version(self):
+        url = "/en/inactive/"
+        host = "project.dev.readthedocs.io"
+        fixture.get(
+            Version,
+            verbose_name="inactive",
+            slug="inactive",
+            active=False,
+            project=self.project,
+        )
+        resp = self.client.get(url, HTTP_HOST=host)
+        self.assertEqual(resp.status_code, 404)
+
     @override_settings(
         RTD_EXTERNAL_VERSION_DOMAIN='dev.readthedocs.build',
     )

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -204,6 +204,12 @@ class TestFullDocServing(BaseDocServing):
         resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(resp.status_code, 404)
 
+    def test_non_existent_version_with_filename(self):
+        url = "/en/non-existent-version/doesnt-exist.html"
+        host = "project.dev.readthedocs.io"
+        resp = self.client.get(url, HTTP_HOST=host)
+        self.assertEqual(resp.status_code, 404)
+
     def test_inactive_version(self):
         url = "/en/inactive/"
         host = "project.dev.readthedocs.io"

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -108,10 +108,7 @@ class ServeDocsBase(CachedView, ServeRedirectMixin, ServeDocsMixin, View):
             log.warning("Version does not exist or is not active.")
             raise Http404("Version does not exist or is not active.")
 
-        if (
-            self._is_cache_enabled(final_project)
-            and version and not version.is_private
-        ):
+        if self._is_cache_enabled(final_project) and version and not version.is_private:
             # All public versions can be cached.
             self.cache_request = True
 

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -104,7 +104,7 @@ class ServeDocsBase(CachedView, ServeRedirectMixin, ServeDocsMixin, View):
         #
         # However, if there is a `version_slug` in the URL but there is no
         # version on the database we want to return 404.
-        if version and not version.active or (not version and version_slug):
+        if (version and not version.active) or (version_slug and not version):
             log.warning("Version does not exist or is not active.")
             raise Http404("Version does not exist or is not active.")
 


### PR DESCRIPTION
Avoid serving files that are still in the storage (S3) for some reason but its
associated version was deleted or de-activated.

Closes https://github.com/readthedocs/readthedocs-ops/issues/1139