### PR TITLE
Build: do not send VCS build status on specific exceptions

### DIFF
--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -231,6 +231,9 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         ProjectBuildsSkippedError,
     )
 
+    # Do not send external build status on failure builds for these exceptions.
+    exceptions_without_external_build_status = (DuplicatedBuildError,)
+
     acks_late = True
     track_started = True
 
@@ -407,7 +410,9 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         # Oh, I think this is to differentiate a task triggered with
         # `Build.commit` than a one triggered just with the `Version` to build
         # the _latest_ commit of it
-        if self.data.build_commit:
+        if self.data.build_commit and not isinstance(
+            exc, self.exceptions_without_external_build_status
+        ):
             send_external_build_status(
                 version_type=self.data.version.type,
                 build_pk=self.data.build['id'],


### PR DESCRIPTION
When the exception is an exception we know it does not require communicating the
VCS service about its state, we avoid sending the build status to the VCS
service.

This is currently used to avoid sending a "failure" (red cross) notification
when the build is marked as duplicated. In the future, it could also be used
when the build is auto-cancelled because a new commit on the same branch was
done (see https://github.com/readthedocs/readthedocs.org/issues/8961)

Closes #9040