### PR TITLE
director.py: restore READTHEDOCS_VERSION_[TYPE|NAME]

### DIFF
--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -401,6 +401,8 @@ class BuildDirector:
         env = {
             "READTHEDOCS": "True",
             "READTHEDOCS_VERSION": self.data.version.slug,
+            "READTHEDOCS_VERSION_TYPE": self.data.version.type,
+            "READTHEDOCS_VERSION_NAME": self.data.version.verbose_name,
             "READTHEDOCS_PROJECT": self.data.project.slug,
             "READTHEDOCS_LANGUAGE": self.data.project.language,
         }


### PR DESCRIPTION
These env vars were accidentally removed in #9002.  This commit naively restores the 2 missing env variables in the new `get_rtd_env_vars()` location.

Signed-off-by: Jeff Squyres <jeff@squyres.com>

This commit is a potential naïve fix for #9051.  I have no good way to test this, but it does restore the 2 env vars that were removed in #9002.