### PR TITLE
Docs: update sphinx-tabs

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -4,7 +4,7 @@ Sphinx==4.4.0
 Pygments==2.11.2
 
 sphinx_rtd_theme==1.0.0
-sphinx-tabs==3.3.0
+sphinx-tabs==3.3.1
 sphinx-intl==2.0.1
 sphinx-multiproject==1.0.0rc1
 readthedocs-sphinx-search==0.1.1


### PR DESCRIPTION
Dark mode on sphinx-tabs is enabled when it shouldn't, this should fix it.