### PR TITLE
Github: use probot auto-assign bot

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,3 @@
+# https://github.com/kentaro-m/auto-assign#assign-author-as-assignee
+# Set to author to set pr creator as assignee
+addAssignees: author


### PR DESCRIPTION
This bot will auto-assign any PR created to it's own author. It will help us to
manage our new Roadmap using GitHub Beta Projects in a better way.

> We can easily disable if we find it does not work as we expected.