### PR TITLE
Proxito: fix URL parsing

### DIFF
--- a/readthedocs/proxito/tests/test_old_redirects.py
+++ b/readthedocs/proxito/tests/test_old_redirects.py
@@ -539,7 +539,12 @@ class UserRedirectTests(MockStorageMixin, BaseDocServing):
 class UserRedirectCrossdomainTest(BaseDocServing):
 
     def test_redirect_prefix_crossdomain(self):
-        """Avoid redirecting to an external site unless the external site is in to_url."""
+        """
+        Avoid redirecting to an external site unless the external site is in to_url.
+
+        We also test by trying to bypass the protocol check with the special chars listed at
+        https://github.com/python/cpython/blob/c3ffbbdf3d5645ee07c22649f2028f9dffc762ba/Lib/urllib/parse.py#L80-L81.
+        """
         fixture.get(
             Redirect,
             project=self.project,
@@ -676,15 +681,6 @@ class UserRedirectCrossdomainTest(BaseDocServing):
             r['Location'], 'http://project.dev.readthedocs.io/en/latest/my.host/path/',
         )
 
-    # (Pdb) proxito_path
-    # '//http://my.host/path/'
-    # (Pdb) urlparse(proxito_path)
-    # ParseResult(scheme='', netloc='http:', path='//my.host/path/', params='', query='', fragment='')
-    # (Pdb)
-    # since there is a netloc inside the path
-    # I'm expecting,
-    # ParseResult(scheme='', netloc='', path='//http://my.host/path/', params='', query='', fragment='')
-    # https://github.com/readthedocs/readthedocs.org/blob/c3001be7a3ef41ebc181c194805f86fed6a009c8/readthedocs/redirects/utils.py#L78
     def test_redirect_sphinx_html_crossdomain_nosubdomain(self):
         """
         Avoid redirecting to an external site unless the external site is in to_url

--- a/readthedocs/proxito/views/mixins.py
+++ b/readthedocs/proxito/views/mixins.py
@@ -1,6 +1,6 @@
 import copy
 import mimetypes
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import urlparse
 
 import structlog
 from django.conf import settings
@@ -17,10 +17,7 @@ from slugify import slugify as unicode_slugify
 from readthedocs.audit.models import AuditLog
 from readthedocs.builds.constants import EXTERNAL, INTERNAL
 from readthedocs.core.resolver import resolve
-from readthedocs.proxito.constants import (
-    REDIRECT_CANONICAL_CNAME,
-    REDIRECT_HTTPS,
-)
+from readthedocs.proxito.constants import REDIRECT_CANONICAL_CNAME, REDIRECT_HTTPS
 from readthedocs.redirects.exceptions import InfiniteRedirectException
 from readthedocs.storage import build_media_storage
 
@@ -284,11 +281,10 @@ class ServeRedirectMixin:
         :returns: redirect response with the correct path
         :rtype: HttpResponseRedirect or HttpResponsePermanentRedirect
         """
-
-        schema, netloc, path, params, query, fragments = urlparse(proxito_path)
         # `proxito_path` doesn't include query params.
         query = urlparse(request.get_full_path()).query
-        new_path = urlunparse((schema, netloc, redirect_path, params, query, fragments))
+        # Pass the query params from the original request to the redirect.
+        new_path = urlparse(redirect_path)._replace(query=query).geturl()
 
         # Re-use the domain and protocol used in the current request.
         # Redirects shouldn't change the domain, version or language.

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -303,14 +303,17 @@ class ServeError404Base(ServeRedirectMixin, ServeDocsMixin, View):
         # ``redirect_filename`` is the path without ``/<lang>/<version>`` and
         # without query, starting with a ``/``. This matches our old logic:
         # https://github.com/readthedocs/readthedocs.org/blob/4b09c7a0ab45cd894c3373f7f07bad7161e4b223/readthedocs/redirects/utils.py#L60
-        # We parse ``filename`` to remove the query from it,
-        # and to remove invalid chars from it.
-        # We don't use ``.path`` to avoid parsing the filename as
-        # a full url.
+        #
+        # We parse ``filename`` to:
+        # - Remove the query params (NOTE: probably it doesn't contain any query params at this point)
+        # - Remove any invalid URL chars (\r, \n, \t).
+        #
+        # We don't use ``.path`` to avoid parsing the filename as a full url.
+        # For example if the filename is ``http://example.com/my-path``, ``.path`` would return ``my-path``.
         parsed = urlparse(filename)
         redirect_filename = parsed._replace(query="").geturl()
 
-        # we can't check for lang and version here to decide if we need to add
+        # We can't check for lang and version here to decide if we need to add
         # the ``/`` or not because ``/install.html`` is a valid path to use as
         # redirect and does not include lang and version on it. It should be
         # fine always adding the ``/`` to the beginning.

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -302,14 +302,15 @@ class ServeError404Base(ServeRedirectMixin, ServeDocsMixin, View):
 
         # ``redirect_filename`` is the path without ``/<lang>/<version>`` and
         # without query, starting with a ``/``. This matches our old logic:
-        # https://github.com/readthedocs/readthedocs.org/blob/4b09c7a0ab45cd894c3373f7f07bad7161e4b223/readthedocs/redirects/utils.py#L60
+        # https://github.com/readthedocs/readthedocs.org/blob/4b09c7a0ab45cd894c3373f7f07bad7161e4b223/readthedocs/redirects/utils.py#L60  # noqa
         #
         # We parse ``filename`` to:
         # - Remove the query params (NOTE: probably it doesn't contain any query params at this point)
         # - Remove any invalid URL chars (\r, \n, \t).
         #
         # We don't use ``.path`` to avoid parsing the filename as a full url.
-        # For example if the filename is ``http://example.com/my-path``, ``.path`` would return ``my-path``.
+        # For example if the filename is ``http://example.com/my-path``,
+        # ``.path`` would return ``my-path``.
         parsed = urlparse(filename)
         redirect_filename = parsed._replace(query="").geturl()
 

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -303,9 +303,12 @@ class ServeError404Base(ServeRedirectMixin, ServeDocsMixin, View):
         # ``redirect_filename`` is the path without ``/<lang>/<version>`` and
         # without query, starting with a ``/``. This matches our old logic:
         # https://github.com/readthedocs/readthedocs.org/blob/4b09c7a0ab45cd894c3373f7f07bad7161e4b223/readthedocs/redirects/utils.py#L60
-        # We parse ``filename`` to remove the query from it
-        schema, netloc, path, params, query, fragments = urlparse(filename)
-        redirect_filename = path
+        # We parse ``filename`` to remove the query from it,
+        # and to remove invalid chars from it.
+        # We don't use ``.path`` to avoid parsing the filename as
+        # a full url.
+        parsed = urlparse(filename)
+        redirect_filename = parsed._replace(query="").geturl()
 
         # we can't check for lang and version here to decide if we need to add
         # the ``/`` or not because ``/install.html`` is a valid path to use as

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -302,10 +302,10 @@ class ServeError404Base(ServeRedirectMixin, ServeDocsMixin, View):
 
         # ``redirect_filename`` is the path without ``/<lang>/<version>`` and
         # without query, starting with a ``/``. This matches our old logic:
-        # https://github.com/readthedocs/readthedocs.org/blob/4b09c7a0ab45cd894c3373f7f07bad7161e4b223/readthedocs/redirects/utils.py#L60  # noqa
+        # https://github.com/readthedocs/readthedocs.org/blob/4b09c7a0ab45cd894c3373f7f07bad7161e4b223/readthedocs/redirects/utils.py#L60   # noqa
         #
         # We parse ``filename`` to:
-        # - Remove the query params (NOTE: probably it doesn't contain any query params at this point)
+        # - Remove the query params (probably it doesn't contain any query params at this point)
         # - Remove any invalid URL chars (\r, \n, \t).
         #
         # We don't use ``.path`` to avoid parsing the filename as a full url.


### PR DESCRIPTION
The "bad" redirect comes from

https://github.com/readthedocs/readthedocs.org/blob/065aa152548017482e0c273697d9d4ad5aa80df4/readthedocs/proxito/views/mixins.py#L296

And that's because we are using the netloc/protocol/etc from the
result of parsing `proxito_path`, which we only need to check for infinite redirects, not to form the final redirect.

This is another place where we are using urlparse and truncating the URL at the wrong path

https://github.com/readthedocs/readthedocs.org/blob/065aa152548017482e0c273697d9d4ad5aa80df4/readthedocs/proxito/views/serve.py#L307-L308

If filename is `https://foo.com/foo`, then path will be `foo`, and that's wrong.

I'm just fixing where the problems are, but we could:

1)  Redirect URLs with those invalid chars (`/%0d/example.com` -> `//example.com` -> `/example.com`) (`/one%0dtwo` -> `/onetwo`)
2) Normalize the path internally and try to serve the file if it exists (not sure if our storage allow to create files with those chars)
3) Directly 404

ref https://github.com/readthedocs/readthedocs.org/issues/9072