### PR TITLE
Redirects: avoid using re.sub

### DIFF
--- a/readthedocs/redirects/models.py
+++ b/readthedocs/redirects/models.py
@@ -172,7 +172,8 @@ class Redirect(models.Model):
     def redirect_prefix(self, path, language=None, version_slug=None):
         if path.startswith(self.from_url):
             log.debug("Redirecting...", redirect=self)
-            cut_path = path[len(self.from_url) :]
+            # pep8 and blank don't agree on having a space before :.
+            cut_path = path[len(self.from_url) :]  # noqa
 
             to = self.get_full_path(
                 filename=cut_path,

--- a/readthedocs/redirects/models.py
+++ b/readthedocs/redirects/models.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
-
 """Django models for the redirects app."""
 
-import structlog
 import re
 
+import structlog
 from django.db import models
 from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
@@ -13,7 +11,6 @@ from readthedocs.core.resolver import resolve_path
 from readthedocs.projects.models import Project
 
 from .querysets import RedirectQuerySet
-
 
 log = structlog.get_logger(__name__)
 
@@ -174,8 +171,8 @@ class Redirect(models.Model):
 
     def redirect_prefix(self, path, language=None, version_slug=None):
         if path.startswith(self.from_url):
-            log.debug('Redirecting...', redirect=self)
-            cut_path = re.sub('^%s' % self.from_url, '', path)
+            log.debug("Redirecting...", redirect=self)
+            cut_path = path[len(self.from_url) :]
 
             to = self.get_full_path(
                 filename=cut_path,
@@ -208,7 +205,7 @@ class Redirect(models.Model):
         if '$rest' in self.from_url:
             match = self.from_url.split('$rest')[0]
             if full_path.startswith(match):
-                cut_path = re.sub('^%s' % match, self.to_url, full_path)
+                cut_path = full_path.replace(match, self.to_url, 1)
                 return cut_path
 
     def redirect_sphinx_html(self, path, language=None, version_slug=None):


### PR DESCRIPTION
We are using `re.sub` just for a simple substitution, and aren't escaping the part that is generated from the user, instead of escaping that part I'm just removing the prefix and using str.replace