### PR TITLE
Adapt scripts and docs to make use of the new github personal tokens

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -24,6 +24,7 @@ services:
   server:
     build:
       args:
+        GITHUB_USER: ${GITHUB_USER:-}
         GITHUB_TOKEN: ${GITHUB_TOKEN:-}
 
   cache:

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04
 
+ARG GITHUB_USER
 ARG GITHUB_TOKEN
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -58,9 +59,9 @@ RUN pip3 install --no-cache-dir -r docker.txt
 WORKDIR /usr/src/app/checkouts/
 RUN if [ -n "$GITHUB_TOKEN" ] ; \
         then \
-        git clone --depth 1 https://${GITHUB_TOKEN}@github.com/readthedocs/readthedocs-ext ; \
+        git clone --depth 1 https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/readthedocs/readthedocs-ext ; \
         pip3 install --no-cache-dir -e readthedocs-ext ; \
-        git clone --depth 1 https://${GITHUB_TOKEN}@github.com/readthedocs/ext-theme ; \
+        git clone --depth 1 https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/readthedocs/ext-theme ; \
         pip3 install --no-cache-dir -e ext-theme ; \
         fi
 

--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -47,7 +47,7 @@ Set up your environment
 
    .. tip::
 
-      If you pass ``GITHUB_TOKEN`` environment variable to this command,
+      If you pass the ``GITHUB_TOKEN`` and ``GITHUB_USER`` environment variables to this command,
       it will add support for readthedocs-ext.
 
 #. pull down Docker images for the builders:

--- a/docs/user/guides/private-python-packages.rst
+++ b/docs/user/guides/private-python-packages.rst
@@ -56,7 +56,7 @@ URI example:
 
 .. code::
 
-   git+https://${GITHUB_TOKEN}@github.com/user/project.git@{version}
+   git+https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/user/project.git@{version}
 
 .. warning::
 


### PR DESCRIPTION
GitHub changed the format of their personal tokens a while ago,
but it also changed the way they are use,
before you'll pass an empty password/user,
now you are required to pass your username with it.

https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#using-a-token-on-the-command-line

If you are using the old tokens, the scripts should continue working (I think, since the GITHUB_USER will be empty)
