### PR TITLE
Build: bugfix `RepositoryError.CLONE_ERROR` message

### DIFF
--- a/readthedocs/projects/exceptions.py
+++ b/readthedocs/projects/exceptions.py
@@ -51,11 +51,16 @@ class RepositoryError(BuildUserError):
         "Please check the command output for more information.",
     )
 
-    @property
-    def CLONE_ERROR(self):  # noqa: N802
+    # NOTE: we are not using `@property` here because Python 3.8 does not
+    # suport `@property` together with `@classmethod`. On Python >= 3.9, we
+    # could call `RepositoryError.CLONE_ERROR` without parenthesis and it will
+    # work. However, for now, we are just using a class method and calling it
+    # as a function/method.
+    @classmethod
+    def CLONE_ERROR(cls):  # noqa: N802
         if settings.ALLOW_PRIVATE_REPOS:
-            return self.PRIVATE_ALLOWED
-        return self.PRIVATE_NOT_ALLOWED
+            return cls.PRIVATE_ALLOWED
+        return cls.PRIVATE_NOT_ALLOWED
 
     def get_default_message(self):
         return self.GENERIC_ERROR

--- a/readthedocs/vcs_support/backends/bzr.py
+++ b/readthedocs/vcs_support/backends/bzr.py
@@ -38,7 +38,7 @@ class Backend(BaseVCS):
         try:
             self.run("bzr", "checkout", self.repo_url, ".")
         except RepositoryError:
-            raise RepositoryError(RepositoryError.CLONE_ERROR)
+            raise RepositoryError(RepositoryError.CLONE_ERROR())
 
     @property
     def tags(self):

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -200,7 +200,7 @@ class Backend(BaseVCS):
             code, stdout, stderr = self.run(*cmd)
             return code, stdout, stderr
         except RepositoryError:
-            raise RepositoryError(RepositoryError.CLONE_ERROR)
+            raise RepositoryError(RepositoryError.CLONE_ERROR())
 
     @property
     def lsremote(self):

--- a/readthedocs/vcs_support/backends/hg.py
+++ b/readthedocs/vcs_support/backends/hg.py
@@ -43,7 +43,7 @@ class Backend(BaseVCS):
             )
             return output
         except RepositoryError:
-            raise RepositoryError(RepositoryError.CLONE_ERROR)
+            raise RepositoryError(RepositoryError.CLONE_ERROR())
 
     @property
     def branches(self):

--- a/readthedocs/vcs_support/backends/svn.py
+++ b/readthedocs/vcs_support/backends/svn.py
@@ -62,7 +62,7 @@ class Backend(BaseVCS):
             url = self.repo_url
         retcode, out, err = self.run('svn', 'checkout', url, '.')
         if retcode != 0:
-            raise RepositoryError(RepositoryError.CLONE_ERROR)
+            raise RepositoryError(RepositoryError.CLONE_ERROR())
         return retcode, out, err
 
     @property


### PR DESCRIPTION
This commit converts the `@property` used to select the correct message
depending on the platform (.org or .com) by a `@classmethod` to make it simpler
to realize that we need to call it as a regular method.

In Python 3.9, we will be able to combine these two decorators and we won't need
parenthesis anymore. For now, we need to add parenthesis to make the call of the
method.