### PR TITLE
Notification: don't send it on build retry

### DIFF
--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -245,12 +245,16 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
     # Do not send notifications on failure builds for these exceptions.
     exceptions_without_notifications = (
         BuildCancelled,
+        BuildMaxConcurrencyError,
         DuplicatedBuildError,
         ProjectBuildsSkippedError,
     )
 
     # Do not send external build status on failure builds for these exceptions.
-    exceptions_without_external_build_status = (DuplicatedBuildError,)
+    exceptions_without_external_build_status = (
+        BuildMaxConcurrencyError,
+        DuplicatedBuildError,
+    )
 
     acks_late = True
     track_started = True


### PR DESCRIPTION
Do not send notifications (email/webhook and VCS commit status) when a build
"fails" because it it's retried.

> While testing https://github.com/readthedocs/readthedocs.org/issues/9014#issuecomment-1091913936 I receive two notifications that I shouldn't have received and I noticed that we are not skipping this exception.