### PR TITLE
Add a basic djstripe integration

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -175,6 +175,7 @@ class CommunityBaseSettings(Settings):
             'django_filters',
             'polymorphic',
             'simple_history',
+            'djstripe',
 
             # our apps
             'readthedocs.projects',
@@ -741,8 +742,23 @@ class CommunityBaseSettings(Settings):
     TAGGIT_TAGS_FROM_STRING = 'readthedocs.projects.tag_utils.rtd_parse_tags'
 
     # Stripe
+    # Existing values we use
     STRIPE_SECRET = None
     STRIPE_PUBLISHABLE = None
+
+    # DJStripe values
+    STRIPE_LIVE_SECRET_KEY = None
+    STRIPE_TEST_SECRET_KEY = None
+    DJSTRIPE_WEBHOOK_SECRET = None
+
+    STRIPE_LIVE_MODE = False  # Change to True in production
+    DJSTRIPE_USE_NATIVE_JSONFIELD = True  # We recommend setting to True for new installations
+    STRIPE_LIVE_MODE = False  # Set to True in production
+    if not DJSTRIPE_WEBHOOK_SECRET:
+        # This is less optimal than setting the webhook secret
+        # However, the app won't start without the secret
+        # with this setting set to the default
+        DJSTRIPE_WEBHOOK_VALIDATION = "retrieve_event"
 
     # Do Not Track support
     DO_NOT_TRACK_ENABLED = False

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -748,7 +748,7 @@ class CommunityBaseSettings(Settings):
 
     # DJStripe values
     STRIPE_LIVE_SECRET_KEY = None
-    STRIPE_TEST_SECRET_KEY = None
+    STRIPE_TEST_SECRET_KEY = "sk_test_x" # A default so the `checks` don't fail
     DJSTRIPE_WEBHOOK_SECRET = None
 
     STRIPE_LIVE_MODE = False  # Change to True in production

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -752,8 +752,8 @@ class CommunityBaseSettings(Settings):
     DJSTRIPE_WEBHOOK_SECRET = None
 
     STRIPE_LIVE_MODE = False  # Change to True in production
+    DJSTRIPE_FOREIGN_KEY_TO_FIELD = "id"
     DJSTRIPE_USE_NATIVE_JSONFIELD = True  # We recommend setting to True for new installations
-    STRIPE_LIVE_MODE = False  # Set to True in production
     if not DJSTRIPE_WEBHOOK_SECRET:
         # This is less optimal than setting the webhook secret
         # However, the app won't start without the secret

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -746,19 +746,19 @@ class CommunityBaseSettings(Settings):
     STRIPE_SECRET = None
     STRIPE_PUBLISHABLE = None
 
-    # DJStripe values
+    # DJStripe values -- **CHANGE THESE IN PRODUCTION**
     STRIPE_LIVE_SECRET_KEY = None
     STRIPE_TEST_SECRET_KEY = "sk_test_x" # A default so the `checks` don't fail
     DJSTRIPE_WEBHOOK_SECRET = None
-
     STRIPE_LIVE_MODE = False  # Change to True in production
+    # This is less optimal than setting the webhook secret
+    # However, the app won't start without the secret
+    # with this setting set to the default
+    DJSTRIPE_WEBHOOK_VALIDATION = "retrieve_event"
+
+    # These values shouldn't need to change..
     DJSTRIPE_FOREIGN_KEY_TO_FIELD = "id"
     DJSTRIPE_USE_NATIVE_JSONFIELD = True  # We recommend setting to True for new installations
-    if not DJSTRIPE_WEBHOOK_SECRET:
-        # This is less optimal than setting the webhook secret
-        # However, the app won't start without the secret
-        # with this setting set to the default
-        DJSTRIPE_WEBHOOK_VALIDATION = "retrieve_event"
 
     # Do Not Track support
     DO_NOT_TRACK_ENABLED = False

--- a/readthedocs/urls.py
+++ b/readthedocs/urls.py
@@ -9,7 +9,12 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.views.generic.base import RedirectView, TemplateView
 
-from readthedocs.core.views import HomepageView, SupportView, do_not_track, server_error_500
+from readthedocs.core.views import (
+    HomepageView,
+    SupportView,
+    do_not_track,
+    server_error_500,
+)
 from readthedocs.search.api import PageSearchAPIView
 from readthedocs.search.views import GlobalSearchView
 
@@ -51,6 +56,8 @@ rtd_urls = [
     re_path(r'^builds/', include('readthedocs.builds.urls')),
     # For testing the 500's with DEBUG on.
     re_path(r'^500/$', handler500),
+    # Put this as a unique path for the webhook, so we don't clobber existing Stripe URL's
+    re_path(r"^djstripe/", include("djstripe.urls", namespace="djstripe")),
 ]
 
 project_urls = [
@@ -156,6 +163,7 @@ if settings.READ_THE_DOCS_EXTENSIONS:
 
 if settings.ALLOW_ADMIN:
     groups.append(admin_urls)
+
 if settings.DEBUG:
     import debug_toolbar
 

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -70,6 +70,7 @@ django-gravatar2==1.4.4
 pytz==2022.1
 django-kombu==0.9.4
 stripe==2.72.0
+djstripe==2.6.1
 regex==2022.3.15
 markdown==3.3.6
 

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -70,7 +70,7 @@ django-gravatar2==1.4.4
 pytz==2022.1
 django-kombu==0.9.4
 stripe==2.72.0
-djstripe==2.6.1
+dj-stripe==2.6.1
 regex==2022.3.15
 markdown==3.3.6
 


### PR DESCRIPTION
This will allow us to run migrations,
and configure it initially in production.

FIxes https://github.com/readthedocs/readthedocs-corporate/issues/1329

#### Copying from https://github.com/readthedocs/ethical-ad-server/pull/494:

This initial PR only adds the stripe models to our database. 

## How does this work
[DJStripe](https://dj-stripe.readthedocs.io/) is a Stripe sponsored but independent project since Aug 2020. It works by having local database models that mirror the data in Stripe. When Stripe receives changes (say a customer pays an invoice via ACH), Stripe will send a webhook to our djstripe so our local copy stays up to date. In this way, it will be possible for our application to check whether invoices have been paid or are overdue as easily as querying the database.

## Testing locally

* Set the Stripe test key from https://dashboard.stripe.com/test/apikeys into in the `STRIPE_TEST_SECRET_KEY` setting in `docker_compose.py`
* Run the following inside docker:
    ```
    inv docker.manage migrate
    inv docker.manage djstripe_sync_models      # sync data from stripe to the DB
    ```
* This last command will take a *long* time, so go ahead and browse the Stripe data in the Django admin: http://community.dev.readthedocs.io/admin/djstripe/

## Deploying to prod

* We already set the stripe secret key in prod so we don't need to do anything there.
* Create a Stripe webhook in https://dashboard.stripe.com/webhooks that points to `https://readthedocs.org/djstripe/webhook/`
* Set the webhook secret into `DJSTRIPE_WEBHOOK_SECRET`

## Next steps
The next steps are:

* Create FKs from our models to these Stripe models:
* Migrate our existing data from using stripe IDs to use the FKs