### PR TITLE
CI: use circle api v2 to trigger builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
       run: |
         curl --request POST \
         --silent --output /dev/null \
-        --url https://circleci.com/api/v1.1/project/github/${{ secrets.CORPORATE_REPO }}/tree/main \
+        --url https://circleci.com/api/v2/project/gh/${{ secrets.CORPORATE_REPO }}/pipeline \
         --user '${{ secrets.CIRCLECI_USER_TOKEN }}:' \
-        --data 'build_parameters[CIRCLE_JOB]=${{ secrets.CIRCLECI_JOB }}'
+        --header 'content-type: application/json' \
+        --data '{"branch": "main", "parameters":{"CIRCLE_JOB": "${{ secrets.CIRCLECI_JOB }}"}}'


### PR DESCRIPTION
Builds triggered with v1 don't have access to the context,
v2 doesn't have this restriction.