### PR TITLE
Analytics: Don't use full_path in get_or_create

### DIFF
--- a/readthedocs/analytics/models.py
+++ b/readthedocs/analytics/models.py
@@ -31,10 +31,12 @@ class PageViewManager(models.Manager):
             project=project,
             version=version,
             path=path,
-            full_path=full_path,
             date=timezone.now().date(),
             status=status,
-            defaults={"view_count": 1},
+            defaults={
+                "view_count": 1,
+                "full_path": full_path,
+            },
         )
         if not created:
             page_view.view_count = models.F("view_count") + 1

--- a/readthedocs/analytics/models.py
+++ b/readthedocs/analytics/models.py
@@ -22,6 +22,9 @@ def _last_30_days_iter():
 
 
 class PageViewManager(models.Manager):
+
+    """Manager for PageView model."""
+
     def register_page_view(self, project, version, path, full_path, status):
         # Normalize paths to avoid duplicates.
         path = "/" + path.lstrip("/")


### PR DESCRIPTION
We have old records without `full_path`,
and since `full_path` isn't in the constraints of `unique_together`
Django will try to create a new record with that value
and fail.

This isn't a problem for new page views.