### PR TITLE
ci: add informational Codecov status checks

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,6 +2,8 @@ comment: off
 coverage:
   status:
     project:
-      informational: true
+      default:
+        informational: true
     patch:
-      informational: true
+      default:
+        informational: true

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,7 @@
 comment: off
 coverage:
   status:
-    project: off
-    patch: off
+    project:
+      informational: true
+    patch:
+      informational: true

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,3 +7,5 @@ coverage:
     patch:
       default:
         informational: true
+codecov:
+  require_ci_to_pass: false


### PR DESCRIPTION
Hi, Tom from Codecov here. I noticed that you were using Codecov but weren't actually getting any notifications on pull requests. I figured it would be useful to get some idea if code being changed is being tested, but also not blocking CI/merging. Let me know if this makes sense or if we can do something that would be helpful.