### PR TITLE
Mamba: remove CONDA_USES_MAMBA feature flag

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -447,10 +447,6 @@ class Conda(PythonEnvironment):
         """
         Decide whether use ``mamba`` or ``conda`` to create the environment.
 
-        Return ``mamba`` if the project has ``CONDA_USES_MAMBA`` feature and
-        ``conda`` otherwise. This will be the executable name to be used when
-        creating the conda environment.
-
         ``mamba`` is really fast to solve dependencies and download channel
         metadata on startup.
 
@@ -459,10 +455,6 @@ class Conda(PythonEnvironment):
         # Config file using ``build.tools.python``
         if self.config.using_build_tools:
             return self.config.python_interpreter
-
-        # Config file using ``conda``
-        if self.project.has_feature(Feature.CONDA_USES_MAMBA):
-            return 'mamba'
         return 'conda'
 
     def _update_conda_startup(self):
@@ -473,8 +465,6 @@ class Conda(PythonEnvironment):
         independently the version of Miniconda that it has installed.
         """
         self.build_env.run(
-            # TODO: use ``self.conda_bin_name()`` once ``mamba`` is installed in
-            # the Docker image
             'conda',
             'update',
             '--yes',
@@ -482,19 +472,6 @@ class Conda(PythonEnvironment):
             '--name=base',
             '--channel=defaults',
             'conda',
-            cwd=self.checkout_path,
-        )
-
-    def _install_mamba(self):
-        self.build_env.run(
-            'conda',
-            'install',
-            '--yes',
-            '--quiet',
-            '--name=base',
-            '--channel=conda-forge',
-            'python=3.7',
-            'mamba',
             cwd=self.checkout_path,
         )
 
@@ -508,15 +485,6 @@ class Conda(PythonEnvironment):
         if self.project.has_feature(Feature.CONDA_APPEND_CORE_REQUIREMENTS):
             self._append_core_requirements()
             self._show_environment_yaml()
-
-        if all([
-                # The project has CONDA_USES_MAMBA feature enabled and,
-                self.project.has_feature(Feature.CONDA_USES_MAMBA),
-                # the project is not using ``build.tools``,
-                # which has mamba installed via asdf.
-                not self.config.using_build_tools,
-        ]):
-            self._install_mamba()
 
         self.build_env.run(
             self.conda_bin_name(),
@@ -605,9 +573,6 @@ class Conda(PythonEnvironment):
             'mock',
             'pillow',
         ]
-
-        if self.project.has_feature(Feature.CONDA_USES_MAMBA):
-            conda_requirements.append('pip')
 
         # Install pip-only things.
         pip_requirements = [

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1753,7 +1753,6 @@ class Feature(models.Model):
     CLEAN_AFTER_BUILD = "clean_after_build"
     UPDATE_CONDA_STARTUP = "update_conda_startup"
     CONDA_APPEND_CORE_REQUIREMENTS = "conda_append_core_requirements"
-    CONDA_USES_MAMBA = "conda_uses_mamba"
     ALL_VERSIONS_IN_HTML_CONTEXT = "all_versions_in_html_context"
     CACHED_ENVIRONMENT = "cached_environment"
     LIMIT_CONCURRENT_BUILDS = "limit_concurrent_builds"
@@ -1823,10 +1822,6 @@ class Feature(models.Model):
         (
             CONDA_APPEND_CORE_REQUIREMENTS,
             _('Append Read the Docs core requirements to environment.yml file'),
-        ),
-        (
-            CONDA_USES_MAMBA,
-            _('Uses mamba binary instead of conda to create the environment'),
         ),
         (
             ALL_VERSIONS_IN_HTML_CONTEXT,


### PR DESCRIPTION
Mamba can be used via `build.tools.python: mambaforge` now.

This PR removes the `CONDA_USES_MAMBA` feature flag since we already contact
most of the users and opened a PR on their repositories with the config file
required for this change and we also sent an in-site notification to all those
projects still using it.

The message said this feature flag will be removed on May 1st. So, we are all
good to merge and deploy next week (May 3rd).