### PR TITLE
Search: fix parsing of footnotes

### DIFF
--- a/readthedocs/search/tests/data/sphinx/in/page.html
+++ b/readthedocs/search/tests/data/sphinx/in/page.html
@@ -100,4 +100,61 @@
     </div>
   </div>
   <!--End code blocks-->
+
+  <div class="section" id="footnotes-and-domains">
+    <h2>Footnotes and domains<a class="headerlink" href="#footnotes-and-domains" title="Permalink to this headline">¶</a></h2>
+    <!-- This is a sphinx domain, won't be parsed. -->
+    <dl class="py class">
+      <dt class="sig sig-object py" id="test_py_module.test.Foo">
+        <em class="property"><span class="pre">class</span><span class="w"> </span></em><span class="sig-prename descclassname"><span class="pre">test_py_module.test.</span></span><span class="sig-name descname"><span class="pre">Foo</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="n"><span class="pre">qux</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">spam</span></span><span class="o"><span class="pre">=</span></span><span class="default_value"><span class="pre">False</span></span></em><span class="sig-paren">)</span><a class="reference internal" href="../_modules/test_py_module/test.html#Foo"><span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#test_py_module.test.Foo" title="Permalink to this definition"></a>
+      </dt>
+      <dd>
+        <p>Docstring for class Foo.</p>
+        <p>This text tests for the formatting of docstrings generated from output
+          <code class="docutils literal notranslate"><span class="pre">sphinx.ext.autodoc</span></code>.
+        </p>
+        <dl class="py method">
+          <dt class="sig sig-object py" id="test_py_module.test.Foo.__init__">
+            <span class="sig-name descname"><span class="pre">__init__</span></span><span class="sig-paren">(</span>
+            <em class="sig-param"><span class="n"><span class="pre">qux</span></span></em>, <em class="sig-param"><span class="n"><span class="pre">spam</span></span><span class="o"><span class="pre">=</span></span>
+              <span class="default_value"><span class="pre">False</span></span></em><span class="sig-paren">)</span>
+            <a class="reference internal" href="../_modules/test_py_module/test.html#Foo.__init__">
+              <span class="viewcode-link"><span class="pre">[source]</span></span></a><a class="headerlink" href="#test_py_module.test.Foo.__init__" title="Permalink to this definition"></a>
+          </dt>
+          <dd>
+            <p>Start the Foo.</p>
+            <dl class="field-list simple">
+              <dt class="field-odd">Parameters<span class="colon">:</span></dt>
+              <dd class="field-odd">
+                <ul class="simple">
+                  <li>
+                    <p><strong>qux</strong> (<em>string</em>) – The first argument to initialize class.</p>
+                  </li>
+                  <li>
+                    <p><strong>spam</strong> (<em>bool</em>) – Spam me yes or no…</p>
+                  </li>
+                </ul>
+              </dd>
+            </dl>
+          </dd>
+        </dl>
+      </dd>
+    </dl>
+    <!-- End of sphinx domain -->
+
+    <!-- These are footnotes, shouldn't be confused wiht a sphinx domain. -->
+    <dl class="footnote brackets">
+      <dt class="label" id="id6"><span class="brackets">1</span><span class="fn-backref">(<a href="#id1">1</a>,<a href="#id7">2</a>)</span></dt>
+      <dd>
+        <p>A <span class="highlighted">footnote</span> contains body elements, consistently indented by at least 3 spaces.</p>
+        <p>This is the <span class="highlighted">footnote</span>’s second paragraph.</p>
+      </dd>
+      <dt class="label" id="id9"><span class="brackets"><a class="fn-backref" href="#id2">3</a></span></dt>
+      <dd>
+        <p>This <span class="highlighted">footnote</span> is numbered automatically and anonymously using a label of “#” only.</p>
+      </dd>
+    </dl>
+  </div>
+  <!-- End of footnote -->
+
 </div>

--- a/readthedocs/search/tests/data/sphinx/out/page.json
+++ b/readthedocs/search/tests/data/sphinx/out/page.json
@@ -28,10 +28,18 @@
       "content": "Sphinx configuration file used to build this docs: # -*- coding: utf-8 -*- # Default settings project = 'Test Builds' extensions = [ 'sphinx_autorun', ] latex_engine = 'xelatex' # allow us to build Unicode chars # Include all your settings here html_theme = 'sphinx_rtd_theme' >>> # Build at >>> import datetime >>> datetime.datetime.utcnow() # UTC datetime.datetime(2020, 5, 3, 16, 38, 11, 137311)"
     },
     {
+      "id": "footnotes-and-domains",
+      "title": "Footnotes and domains",
+      "content": "1(1,2) A footnote contains body elements, consistently indented by at least 3 spaces. This is the footnote’s second paragraph. 3 This footnote is numbered automatically and anonymously using a label of “#” only."
+    },
+    {
       "content": "This is a H3 title. Fig. 4 I'm a figure!",
       "id": "subsub-title",
       "title": "Subsub title"
     }
   ],
-  "domain_data": {}
+  "domain_data": {
+    "test_py_module.test.Foo": "Docstring for class Foo. This text tests for the formatting of docstrings generated from output sphinx.ext.autodoc.",
+    "test_py_module.test.Foo.__init__": "Start the Foo."
+  }
 }


### PR DESCRIPTION
Our code to detect sphinx domains is a little naive,
sphinx also doesn't make it easy to detect these.
We were removing footnotes in the process of removing domains.

Also de code that extracts domains had a bug,
but looks like we aren't using that as the source of domains, so our domains search wasn't affected by it,
we are using the ones we have in our DB.. so not really sure about why we are parsing them at all :D (maybe this was before we stored the domains in our db?)

found this while testing docutils 18.1