### PR TITLE
Note build.jobs required other keys

### DIFF
--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -445,7 +445,7 @@ See :doc:`/build-customization` for more details.
 .. note::
 
    Each key under ``build.jobs`` must be a list of strings.
-   `build.os` and `build.tools` are also required to use `build.jobs`.
+   ``build.os`` and ``build.tools`` are also required to use ``build.jobs``.
 
 
 :Type: ``dict``

--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -445,6 +445,7 @@ See :doc:`/build-customization` for more details.
 .. note::
 
    Each key under ``build.jobs`` must be a list of strings.
+   `build.os` and `build.tools` are also required to use `build.jobs`.
 
 
 :Type: ``dict``


### PR DESCRIPTION
This doesn't have a good error message, we should at least note it.