### PR TITLE
Analytics: skip requests from bots on 404s

### DIFF
--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -1002,7 +1002,7 @@ class TestAdditionalDocViews(BaseDocServing):
 
         # Only requests with threat score below 10 are recorded.
         self.assertEqual(
-            {'/en/latest/one', '/en/latest/two'},
+            {"/en/latest/one", "/en/latest/two"},
             {pageview.full_path for pageview in PageView.objects.all()},
         )
 

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -878,6 +878,7 @@ class TestAdditionalDocViews(BaseDocServing):
 
     @mock.patch.object(BuildMediaFileSystemStorageTest, "exists")
     def test_track_broken_link(self, storage_exists):
+        storage_exists.return_value = False
         get(
             Feature,
             feature_id=Feature.RECORD_404_PAGE_VIEWS,
@@ -892,8 +893,6 @@ class TestAdditionalDocViews(BaseDocServing):
             "/en/not-found/",
         ]
         for path in paths:
-            storage_exists.reset_mock()
-            storage_exists.return_value = False
             resp = self.client.get(
                 reverse(
                     "proxito_404_handler",
@@ -973,6 +972,39 @@ class TestAdditionalDocViews(BaseDocServing):
         self.assertEqual(pageview.full_path, "/en/latest/not-found/")
         self.assertEqual(pageview.view_count, 1)
         self.assertEqual(pageview.status, 404)
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "exists")
+    def test_track_broken_link_threat_score(self, storage_exists):
+        storage_exists.return_value = False
+        get(
+            Feature,
+            feature_id=Feature.RECORD_404_PAGE_VIEWS,
+            projects=[self.project],
+        )
+        self.assertEqual(PageView.objects.all().count(), 0)
+
+        paths = [
+            ("/en/latest/one", 1),
+            ("/en/latest/two", 7),
+            ("/en/latest/three", 13),
+            ("/en/latest/four", 57),
+        ]
+        for path, score in paths:
+            resp = self.client.get(
+                reverse(
+                    "proxito_404_handler",
+                    kwargs={"proxito_path": path},
+                ),
+                HTTP_HOST="project.readthedocs.io",
+                HTTP_X_CLOUDFLARE_THREAT_SCORE=score,
+            )
+            self.assertEqual(resp.status_code, 404)
+
+        # Only requests with threat score below 10 are recorded.
+        self.assertEqual(
+            {'/en/latest/one', '/en/latest/two'},
+            {pageview.full_path for pageview in PageView.objects.all()},
+        )
 
     def test_sitemap_xml(self):
         self.project.versions.update(active=True)

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -410,10 +410,10 @@ class ServeError404Base(ServeRedirectMixin, ServeDocsMixin, View):
             # it goes from 0 to 100, 0 being low risk,
             # and values above 10 are bots/spammers.
             # https://developers.cloudflare.com/ruleset-engine/rules-language/fields/#dynamic-fields.
-            threat_score = int(self.request.headers.get('X-Cloudflare-Threat-Score', 0))
+            threat_score = int(self.request.headers.get("X-Cloudflare-Threat-Score", 0))
             if threat_score > 10:
                 log.info(
-                    'Suspicious threat score, not recording 404.',
+                    "Suspicious threat score, not recording 404.",
                     threat_score=threat_score,
                 )
                 return

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -406,6 +406,18 @@ class ServeError404Base(ServeRedirectMixin, ServeDocsMixin, View):
             if not project.has_feature(Feature.RECORD_404_PAGE_VIEWS):
                 return
 
+            # This header is set from Cloudflare,
+            # it goes from 0 to 100, 0 being low risk,
+            # and values above 10 are bots/spammers.
+            # https://developers.cloudflare.com/ruleset-engine/rules-language/fields/#dynamic-fields.
+            threat_score = int(self.request.headers.get('X-Cloudflare-Threat-Score', 0))
+            if threat_score > 10:
+                log.info(
+                    'Suspicious threat score, not recording 404.',
+                    threat_score=threat_score,
+                )
+                return
+
             # If the path isn't attached to a version
             # it should be the same as the full_path,
             # otherwise it would be empty.


### PR DESCRIPTION
We need to create a transform rule on cloudflare with this dynamic header on the request. I have already created that rule for a test domain.

Closes https://github.com/readthedocs/readthedocs.org/issues/9116