### PR TITLE
Initial test of adding plan to CDN

### DIFF
--- a/docs/user/hosting.rst
+++ b/docs/user/hosting.rst
@@ -19,7 +19,7 @@ We support CDN's on both of our sites,
 as we talk about below.
 
 .. tabs::
-   
+
    .. tab:: |org_brand|
 
       On |org_brand|,
@@ -36,7 +36,7 @@ as we talk about below.
    .. tab:: |com_brand|
 
       On |com_brand|,
-      we offer a CDN as part of our Enterprise plan.
+      we offer a CDN as part of our **Pro plan** and above.
       Please contact support@readthedocs.com to discuss how we can enable this for you.
 
 .. _CloudFlare: https://www.cloudflare.com/

--- a/readthedocs/core/mixins.py
+++ b/readthedocs/core/mixins.py
@@ -66,10 +66,9 @@ class CachedView:
     @lru_cache(maxsize=1)
     def _is_cache_enabled(self, project):
         """Helper function to check if CDN is enabled for a project."""
-        plan_has_cdn = PlanFeature.objects.filter(
-            feature_type=PlanFeature.TYPE_CDN,
-            plan__subscriptions__organization__in=project.organizations.all(),
-        ).exists()
+        plan_has_cdn = PlanFeature.objects.get_feature(
+            obj=project, type=PlanFeature.TYPE_CDN
+        )
         return settings.ALLOW_PRIVATE_REPOS and (
             plan_has_cdn or project.has_feature(Feature.CDN_ENABLED)
         )

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -14,6 +14,7 @@ from readthedocs.analytics.models import PageView
 from readthedocs.audit.models import AuditLog
 from readthedocs.builds.constants import EXTERNAL, INTERNAL, LATEST
 from readthedocs.builds.models import Version
+from readthedocs.organizations.models import Organization
 from readthedocs.projects import constants
 from readthedocs.projects.constants import (
     MKDOCS,
@@ -26,6 +27,7 @@ from readthedocs.projects.constants import (
 from readthedocs.projects.models import Domain, Feature, Project
 from readthedocs.proxito.views.mixins import ServeDocsMixin
 from readthedocs.rtd_tests.storage import BuildMediaFileSystemStorageTest
+from readthedocs.subscriptions.models import Plan, PlanFeature, Subscription
 
 from .base import BaseDocServing
 
@@ -1306,3 +1308,27 @@ class TestCDNCache(BaseDocServing):
         self.assertEqual(resp['Location'], f'https://{self.domain.domain}/projects/subproject/en/latest/')
         self.assertEqual(resp.headers['CDN-Cache-Control'], 'public')
         self.assertEqual(resp.headers['Cache-Tag'], 'subproject,subproject:latest')
+
+    def test_cache_on_plan(self):
+        self.organization = get(Organization)
+        self.plan = get(
+            Plan,
+            published=True,
+        )
+        self.subscription = get(
+            Subscription,
+            plan=self.plan,
+            organization=self.organization,
+        )
+        self.feature = get(
+            PlanFeature,
+            plan=self.plan,
+            feature_type=PlanFeature.TYPE_CDN,
+        )
+
+        # Delete feature plan, so we aren't using that logic
+        Feature.objects.filter(feature_id=Feature.CDN_ENABLED).delete()
+
+        # Add project to plan, so we're using that to enable CDN
+        self.organization.projects.add(self.project)
+        self._test_cache_control_header_project(expected_value="public")


### PR DESCRIPTION
This uses the TYPE_CDN to enable the CDN for a user.
We'll need to update this to the DB Plans where we want it.

Fixes https://github.com/readthedocs/readthedocs-corporate/issues/1410