### PR TITLE
Docs: mention `ubuntu-22.04` as a valid option

### DIFF
--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -331,7 +331,7 @@ Image names refer to the operating system Read the Docs uses to build them.
    Arbitrary Docker images are not supported.
 
 :Type: ``string``
-:Options: ``ubuntu-20.04``
+:Options: ``ubuntu-20.04``, ``ubuntu-22.04``
 :Required: ``true``
 
 build.tools

--- a/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
+++ b/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
@@ -85,7 +85,8 @@
               "title": "Operating System",
               "description": "Operating system to be used in the build.",
               "enum": [
-                "ubuntu-20.04"
+                "ubuntu-20.04",
+                "ubuntu-22.04"
               ]
             },
             "tools": {


### PR DESCRIPTION
Add `ubuntu-22.04` as a valid option when describing `build.os` in the
documentation reference.