### PR TITLE
Fix bumpver issue

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = readthedocs
-version = 7.4.2
+version = 8.0.1
 license = MIT
 description = Read the Docs builds and hosts documentation
 author = Read the Docs, Inc
@@ -38,7 +38,7 @@ push = False
 
 [bumpver:file_patterns]
 setup.cfg =
-    version = "{version}"
+    version = {version}
 package.json =
     "version": "{version}",
 docs/conf.py =


### PR DESCRIPTION
The setup.cfg pattern wasn't matching with the additional quotes
on the pattern. Bump to current 8.0.1 version as well.

A similar fix was hotfixed on main for readthedocs-corproate.