### PR TITLE
BuildCommand: add option to merge or not stderr with stdout

### DIFF
--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -220,7 +220,7 @@ class Backend(BaseVCS):
         cmd = ["git", "ls-remote", *extra_args, self.repo_url]
 
         self.check_working_dir()
-        _, stdout, _ = self.run(*cmd)
+        _, stdout, _ = self.run(*cmd, demux=True, record=False)
 
         branches = []
         # Git has two types of tags: lightweight and annotated.


### PR DESCRIPTION
This is mainly for our internal commands,
specifically for ls-remote, where a warning was getting in the
output that we parse.

We should use this option in more of our internal commands where we
parse the output.

Ref https://sentry.io/organizations/read-the-docs/issues/3227717706/?project=148442&query=is%3Aunresolved