### PR TITLE
Disable codecov annotations

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,3 +9,5 @@ coverage:
         informational: true
 codecov:
   require_ci_to_pass: false
+github_checks:
+  annotations: false


### PR DESCRIPTION
Not a fan of these, review is really hard with these enabled. The docs
aren't super clear, but I'm going off an example from:

https://docs.codecov.com/docs/github-checks#disabling-github-checks-patch-annotations-via-yaml

These were enabled in #9119