### PR TITLE
Proxied static files: use its own storage class

### DIFF
--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -1139,7 +1139,7 @@ class TestAdditionalDocViews(BaseDocServing):
         self.assertEqual(response.status_code, 404)
 
     @override_settings(
-        STATICFILES_STORAGE="readthedocs.rtd_tests.storage.BuildMediaFileSystemStorageTest"
+        RTD_STATICFILES_STORAGE="readthedocs.rtd_tests.storage.BuildMediaFileSystemStorageTest"
     )
     def test_serve_static_files(self):
         resp = self.client.get(

--- a/readthedocs/proxito/views/mixins.py
+++ b/readthedocs/proxito/views/mixins.py
@@ -4,7 +4,6 @@ from urllib.parse import urlparse
 
 import structlog
 from django.conf import settings
-from django.contrib.staticfiles.storage import staticfiles_storage
 from django.http import (
     HttpResponse,
     HttpResponsePermanentRedirect,
@@ -20,7 +19,7 @@ from readthedocs.builds.constants import EXTERNAL, INTERNAL
 from readthedocs.core.resolver import resolve
 from readthedocs.proxito.constants import REDIRECT_CANONICAL_CNAME, REDIRECT_HTTPS
 from readthedocs.redirects.exceptions import InfiniteRedirectException
-from readthedocs.storage import build_media_storage
+from readthedocs.storage import build_media_storage, staticfiles_storage
 
 log = structlog.get_logger(__name__)  # noqa
 

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -4,7 +4,6 @@ from urllib.parse import urlparse
 
 import structlog
 from django.conf import settings
-from django.contrib.staticfiles.storage import staticfiles_storage
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import resolve as url_resolve
@@ -24,7 +23,7 @@ from readthedocs.projects.constants import SPHINX_HTMLDIR
 from readthedocs.projects.models import Feature
 from readthedocs.projects.templatetags.projects_tags import sort_version_aware
 from readthedocs.redirects.exceptions import InfiniteRedirectException
-from readthedocs.storage import build_media_storage
+from readthedocs.storage import build_media_storage, staticfiles_storage
 
 from .decorators import map_project_slug
 from .mixins import ServeDocsMixin, ServeRedirectMixin

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -314,6 +314,7 @@ class CommunityBaseSettings(Settings):
     RTD_BUILD_ENVIRONMENT_STORAGE = 'readthedocs.builds.storage.BuildMediaFileSystemStorage'
     RTD_BUILD_TOOLS_STORAGE = 'readthedocs.builds.storage.BuildMediaFileSystemStorage'
     RTD_BUILD_COMMANDS_STORAGE = 'readthedocs.builds.storage.BuildMediaFileSystemStorage'
+    RTD_STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 
     @property
     def TEMPLATES(self):

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -156,6 +156,7 @@ class DockerBaseSettings(CommunityDevSettings):
     RTD_BUILD_TOOLS_STORAGE = 'readthedocs.storage.s3_storage.S3BuildToolsStorage'
     # Storage for static files (those collected with `collectstatic`)
     STATICFILES_STORAGE = 'readthedocs.storage.s3_storage.S3StaticStorage'
+    RTD_STATICFILES_STORAGE = 'readthedocs.storage.s3_storage.RTDS3StaticStorage'
 
     AWS_ACCESS_KEY_ID = 'admin'
     AWS_SECRET_ACCESS_KEY = 'password'

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -156,7 +156,7 @@ class DockerBaseSettings(CommunityDevSettings):
     RTD_BUILD_TOOLS_STORAGE = 'readthedocs.storage.s3_storage.S3BuildToolsStorage'
     # Storage for static files (those collected with `collectstatic`)
     STATICFILES_STORAGE = 'readthedocs.storage.s3_storage.S3StaticStorage'
-    RTD_STATICFILES_STORAGE = 'readthedocs.storage.s3_storage.RTDS3StaticStorage'
+    RTD_STATICFILES_STORAGE = 'readthedocs.storage.s3_storage.NoManifestS3StaticStorage'
 
     AWS_ACCESS_KEY_ID = 'admin'
     AWS_SECRET_ACCESS_KEY = 'password'

--- a/readthedocs/storage/__init__.py
+++ b/readthedocs/storage/__init__.py
@@ -6,7 +6,6 @@ Some storage backends (notably S3) have a slow instantiation time
 so doing those upfront improves performance.
 """
 from django.conf import settings
-
 from django.core.files.storage import get_storage_class
 from django.utils.functional import LazyObject
 
@@ -31,7 +30,13 @@ class ConfiguredBuildToolsStorage(LazyObject):
         self._wrapped = get_storage_class(settings.RTD_BUILD_TOOLS_STORAGE)()
 
 
+class ConfiguredStaticStorage(LazyObject):
+    def _setup(self):
+        self._wrapped = get_storage_class(settings.RTD_STATICFILES_STORAGE)()
+
+
 build_media_storage = ConfiguredBuildMediaStorage()
 build_environment_storage = ConfiguredBuildEnvironmentStorage()
 build_commands_storage = ConfiguredBuildCommandsStorage()
 build_tools_storage = ConfiguredBuildToolsStorage()
+staticfiles_storage = ConfiguredStaticStorage()

--- a/readthedocs/storage/s3_storage.py
+++ b/readthedocs/storage/s3_storage.py
@@ -50,18 +50,7 @@ class S3BuildCommandsStorage(S3PrivateBucketMixin, S3Boto3Storage):
                 'Ensure S3_BUILD_COMMANDS_STORAGE_BUCKET is defined.',
             )
 
-
-class S3StaticStorage(
-    OverrideHostnameMixin,
-    S3ManifestStaticStorage,
-    S3Boto3Storage
-):  # pylint: disable=too-many-ancestors
-
-    """
-    An AWS S3 Storage backend for static media.
-
-    * Uses Django's ManifestFilesMixin to have unique file paths (eg. core.a6f5e2c.css)
-    """
+class S3StaticStorageMixin:
 
     bucket_name = getattr(settings, 'S3_STATIC_STORAGE_BUCKET', None)
     override_hostname = getattr(settings, 'S3_STATIC_STORAGE_OVERRIDE_HOSTNAME', None)
@@ -78,6 +67,28 @@ class S3StaticStorage(
         self.bucket_acl = 'public-read'
         self.default_acl = 'public-read'
         self.querystring_auth = False
+
+
+class S3StaticStorage(
+    S3StaticStorageMixin, OverrideHostnameMixin, S3ManifestStaticStorage, S3Boto3Storage
+):  # pylint: disable=too-many-ancestors
+
+    """
+    An AWS S3 Storage backend for static media.
+
+    * Uses Django's ManifestFilesMixin to have unique file paths (eg. core.a6f5e2c.css)
+    """
+
+
+class RTDS3StaticStorage(
+    S3StaticStorageMixin, OverrideHostnameMixin, S3Boto3Storage
+):  # pylint: disable=too-many-ancestors
+
+    """
+    Storage backend for static files used outside Django's static files.
+
+    This is the same as S3StaticStorage, but without inheriting from S3ManifestStaticStorage.
+    """
 
 
 class S3BuildEnvironmentStorage(S3PrivateBucketMixin, BuildMediaStorageMixin, S3Boto3Storage):

--- a/readthedocs/storage/s3_storage.py
+++ b/readthedocs/storage/s3_storage.py
@@ -50,6 +50,7 @@ class S3BuildCommandsStorage(S3PrivateBucketMixin, S3Boto3Storage):
                 'Ensure S3_BUILD_COMMANDS_STORAGE_BUCKET is defined.',
             )
 
+
 class S3StaticStorageMixin:
 
     bucket_name = getattr(settings, 'S3_STATIC_STORAGE_BUCKET', None)
@@ -69,9 +70,10 @@ class S3StaticStorageMixin:
         self.querystring_auth = False
 
 
+# pylint: disable=too-many-ancestors
 class S3StaticStorage(
     S3StaticStorageMixin, OverrideHostnameMixin, S3ManifestStaticStorage, S3Boto3Storage
-):  # pylint: disable=too-many-ancestors
+):
 
     """
     An AWS S3 Storage backend for static media.
@@ -80,14 +82,15 @@ class S3StaticStorage(
     """
 
 
-class RTDS3StaticStorage(
+class NoManifestS3StaticStorage(
     S3StaticStorageMixin, OverrideHostnameMixin, S3Boto3Storage
-):  # pylint: disable=too-many-ancestors
+):
 
     """
     Storage backend for static files used outside Django's static files.
 
-    This is the same as S3StaticStorage, but without inheriting from S3ManifestStaticStorage.
+    This is the same as S3StaticStorage, but without inheriting from S3ManifestStaticStorage,
+    this way we can get the URL of any file in that bucket, even hashed ones.
     """
 
 


### PR DESCRIPTION
The class from Django's static files inherits from ManifestFilesMixin,
which doesn't allow serving hashed static files.

We need to add this new setting to our ops repos