### PR TITLE
Docs: jsdoc example using `build.jobs` and `build.tools`

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -196,3 +196,22 @@ It's possible to use ``post_checkout`` user-defined job for this.
          - ./git-lfs fetch
          # Make local files to have the real content on them
          - ./git-lfs checkout
+
+
+Document your code with ``jsdoc``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It's possible to make usage of ``jsdoc`` to document your Javascript code directly from your source code.
+To setup it, you need to first define the version of ``nodejs`` you want to use and also install ``jsdoc`` as shown below:
+
+.. code:: yaml
+
+   version: 2
+   build:
+     os: "ubuntu-22.04"
+     tools:
+       python: "3.9"
+       nodejs: "16"
+     jobs:
+       post_install:
+         - npm install -g jsdoc

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -198,11 +198,11 @@ It's possible to use ``post_checkout`` user-defined job for this.
          - ./git-lfs checkout
 
 
-Document your code with ``jsdoc``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Install Node.js dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-It's possible to make usage of ``jsdoc`` to document your Javascript code directly from your source code.
-To setup it, you need to first define the version of ``nodejs`` you want to use and also install ``jsdoc`` as shown below:
+It's possible to install Node.js together with the required dependencies by using :term:`user-defined build jobs`.
+To setup it, you need to define the version of Node.js to use and install the dependencies by using ``build.jobs.post_install``:
 
 .. code:: yaml
 
@@ -214,4 +214,7 @@ To setup it, you need to first define the version of ``nodejs`` you want to use 
        nodejs: "16"
      jobs:
        post_install:
+         # Install dependencies defined in your ``package.json``
+         - npm ci
+         # Install any other extra dependencies to build the docs
          - npm install -g jsdoc


### PR DESCRIPTION
Expand our build customization page with an example for jsdoc.

See https://test-builds.readthedocs.io/en/jsdoc/ as example of usage.