### PR TITLE
Logging: reduce noise on working features

### DIFF
--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -295,7 +295,7 @@ class ProxitoMiddleware(MiddlewareMixin):
             #   We make sure there is _always_ a single slash in front to ensure relative redirects,
             #   instead of `//` redirects which are actually alternative domains.
             final_url = '/' + final_url.lstrip('/')
-            log.info(
+            log.debug(
                 'Proxito Slash Redirect.',
                 from_url=request.get_full_path(),
                 to_url=final_url,
@@ -321,7 +321,7 @@ class ProxitoMiddleware(MiddlewareMixin):
         if project.urlconf:
 
             # Stop Django from caching URLs
-            # https://github.com/django/django/blob/stable/2.2.x/django/urls/resolvers.py#L65-L69  # noqa
+            # https://github.com/django/django/blob/7cf7d74/django/urls/resolvers.py#L65-L69  # noqa
             project_timestamp = project.modified_date.strftime("%Y%m%d.%H%M%S%f")
             url_key = f'readthedocs.urls.fake.{project.slug}.{project_timestamp}'
 

--- a/readthedocs/proxito/views/mixins.py
+++ b/readthedocs/proxito/views/mixins.py
@@ -203,7 +203,9 @@ class ServeRedirectMixin:
             query_params=urlparse_result.query,
             external=hasattr(request, 'external_domain'),
         )
-        log.info('System Redirect.', host=request.get_host(), from_url=filename, to_url=to)
+        log.debug(
+            "System Redirect.", host=request.get_host(), from_url=filename, to_url=to
+        )
         resp = HttpResponseRedirect(to)
         resp['X-RTD-Redirect'] = 'system'
         return resp

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -170,7 +170,7 @@ class ServeDocsBase(CDNCacheControlMixin, ServeRedirectMixin, ServeDocsMixin, Vi
                 not final_project.single_version,
                 self.version_type != EXTERNAL,
         ]):
-            log.warning(
+            log.debug(
                 'Invalid URL for project with versions.',
                 filename=filename,
             )


### PR DESCRIPTION
Based on New Relic stats these logs cover 50% of the total data logged.
As we know these features are working fine, we can reduce these logs now and
send them to debug in case we need them again while debugging.

![Screenshot_2022-05-23_10-02-30](https://user-images.githubusercontent.com/244656/169772447-1fbe5144-100d-42ef-b967-08aa182d5754.png)

(from New Relic dashboard)