### PR TITLE
Disable djstripe

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -176,7 +176,7 @@ class CommunityBaseSettings(Settings):
             'django_filters',
             'polymorphic',
             'simple_history',
-            'djstripe',
+            # 'djstripe',
 
             # our apps
             'readthedocs.projects',

--- a/readthedocs/urls.py
+++ b/readthedocs/urls.py
@@ -57,7 +57,7 @@ rtd_urls = [
     # For testing the 500's with DEBUG on.
     re_path(r'^500/$', handler500),
     # Put this as a unique path for the webhook, so we don't clobber existing Stripe URL's
-    re_path(r"^djstripe/", include("djstripe.urls", namespace="djstripe")),
+    # re_path(r"^djstripe/", include("djstripe.urls", namespace="djstripe")),
 ]
 
 project_urls = [


### PR DESCRIPTION
DJStripe is overriding the api version globally,
our app isn't compatible with that version.