### PR TITLE
Tests: make `tests-embedapi` require regular `tests` first

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ workflows:
     jobs:
       - checks
       - tests
-      - tests-embedapi
+      - tests-embedapi:
         requires:
           - checks
           - tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,6 @@ workflows:
       - checks
       - tests
       - tests-embedapi:
-        requires:
-          - checks
-          - tests
+          requires:
+            - checks
+            - tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,3 +63,6 @@ workflows:
       - checks
       - tests
       - tests-embedapi
+        requires:
+          - checks
+          - tests


### PR DESCRIPTION
I'm adding this requirement so we don't trigger all the tests concurrently and
also avoid running EmbedAPI tests if there is a failure on any of the other two.
This way we will be saving some resources here.

EmbedAPI tests are _not required_ to merge a PR, so I think it's fine if they
are not always run.