### PR TITLE
Avoid jQuery in rtd-data.js

### DIFF
--- a/readthedocs/core/static-src/core/js/doc-embed/rtd-data.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/rtd-data.js
@@ -9,7 +9,7 @@ var constants = require('./constants');
 var configMethods = {
     is_rtd_like_theme: function () {
         // Returns true for the Read the Docs theme on both sphinx and mkdocs
-        if ($('div.rst-other-versions').length === 1) {
+        if (document.querySelectorAll('div.rst-other-versions').length === 1) {
             // Crappy heuristic, but people change the theme name
             // So we have to do some duck typing.
             return true;
@@ -60,7 +60,7 @@ function get() {
         ad_free: false,
     };
 
-    $.extend(config, defaults, window.READTHEDOCS_DATA);
+    Object.assign(config, defaults, window.READTHEDOCS_DATA);
 
     if (!("proxied_api_host" in config)) {
         // Use direct proxied API host

--- a/readthedocs/core/static-src/core/js/doc-embed/sphinx.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/sphinx.js
@@ -11,7 +11,7 @@ function init() {
     var rtd = rtddata.get();
 
     /// Click tracking on flyout
-    $(document).on('click', "[data-toggle='rst-current-version']", function () {
+    document.addEventListener('click', "[data-toggle='rst-current-version']", function () {
         var flyout_state = $("[data-toggle='rst-versions']").hasClass('shift-up') ? 'was_open' : 'was_closed';
 
         // Only report back if analytics is enabled

--- a/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
@@ -71,7 +71,7 @@ function create_ad_placement() {
         // Assumes the ad would be ~200px high
         element = $("<div />").appendTo(selector);
         offset = element.offset();
-        if (!offset || (offset.top - window.scrollTop + 200) > window.offsetHeight) {
+        if (!offset || (offset.top - window.scrollY + 200) > window.innerHeight) {
             if (rtd.is_rtd_like_theme()) {
                 selector = $('<div />').insertAfter('footer hr');
                 class_name = 'ethical-rtd';

--- a/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
@@ -71,7 +71,7 @@ function create_ad_placement() {
         // Assumes the ad would be ~200px high
         element = $("<div />").appendTo(selector);
         offset = element.offset();
-        if (!offset || (offset.top - $(window).scrollTop() + 200) > $(window).height()) {
+        if (!offset || (offset.top - window.scrollTop + 200) > window.offsetHeight) {
             if (rtd.is_rtd_like_theme()) {
                 selector = $('<div />').insertAfter('footer hr');
                 class_name = 'ethical-rtd';
@@ -199,7 +199,7 @@ function init() {
             } else {
                 // The ad client hasn't loaded yet which could happen due to a variety of issues
                 // Add an event listener for it to load
-                $("#ethicaladsjs").on("load", function () {
+                document.getElementById("ethicaladsjs").addEventListener("load", function () {
                     if (typeof ethicalads !== "undefined") {
                         ethicalads.load();
                     }


### PR DESCRIPTION
WARNING: This is totally untested! But with a bit of luck, it might just work ...

Sphinx 6 will drop jQuery, so we should get rid of it also in the JavaScript that's injected by RTD.