### PR TITLE
Subscriptions: handle subscriptions with multiple products/plans/items

### DIFF
--- a/readthedocs/gold/tests/test_webhooks.py
+++ b/readthedocs/gold/tests/test_webhooks.py
@@ -1,6 +1,5 @@
-import requests_mock
 import django_dynamic_fixture as fixture
-
+import requests_mock
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.urls import reverse
@@ -42,8 +41,17 @@ class GoldStripeWebhookTests(TestCase):
                 "id": "sub_a1b2c3",
                 "object": "subscription",
                 "customer": "cus_a1b2c3",
-                "plan": {
-                    "id": "v1-org-15"
+                "items": {
+                    "object": "list",
+                    "data": [
+                        {
+                            "id": "si_DmHJtdglVs7RlD",
+                            "object": "subscription_item",
+                            "price": {
+                                "id": "v1-org-15"
+                            }
+                        }
+                    ]
                 }
             }
         },
@@ -63,8 +71,15 @@ class GoldStripeWebhookTests(TestCase):
             'id': 'sub_a1b2c3',
             'object': 'subscription',
             'customer': 'cus_a1b2c3',
-            'plan': {
-                'id': 'v1-org-15'
+            "items": {
+                "object": "list",
+                "data": [
+                    {
+                        "id": "si_DmHJtdglVs7RlD",
+                        "object": "subscription_item",
+                        "price": {"id": "v1-org-15"},
+                    }
+                ],
             },
         }
         mock_request.get('https://api.stripe.com/v1/subscriptions/sub_a1b2c3', json=payload)

--- a/readthedocs/subscriptions/managers.py
+++ b/readthedocs/subscriptions/managers.py
@@ -87,6 +87,7 @@ class SubscriptionManager(models.Manager):
         # https://stripe.com/docs/api/subscriptions/object?lang=python#subscription_object-current_period_end
         start_date = getattr(stripe_subscription, 'current_period_start', None)
         end_date = getattr(stripe_subscription, 'current_period_end', None)
+        log.bind(stripe_subscription=stripe_subscription.id)
 
         try:
             start_date = timezone.make_aware(
@@ -100,7 +101,6 @@ class SubscriptionManager(models.Manager):
                 'Stripe subscription invalid date.',
                 start_date=start_date,
                 end_date=end_date,
-                stripe_subscription=stripe_subscription.id,
             )
             start_date = None
             end_date = None
@@ -130,31 +130,22 @@ class SubscriptionManager(models.Manager):
                 log.error(
                     'Stripe subscription trial end date invalid. ',
                     trial_end_date=trial_end_date,
-                    stripe_subscription=stripe_subscription.id,
                 )
 
         # Update the plan in case it was changed from the Portal.
-        # Try our best to match a plan that is not custom. This mostly just
-        # updates the UI now that we're using the Stripe Portal. A miss here
-        # just won't update the UI, but this shouldn't happen for most users.
-        from readthedocs.subscriptions.models import Plan
-        try:
-            plan = (
-                Plan.objects
-                # Exclude "custom" here, as we historically reused Stripe plan
-                # id for custom plans. We don't have a better attribute to
-                # filter on here.
-                .exclude(slug__contains='custom')
-                .exclude(name__icontains='Custom')
-                .get(stripe_id=stripe_subscription.plan.id)
-            )
-            rtd_subscription.plan = plan
-        except (Plan.DoesNotExist, Plan.MultipleObjectsReturned):
-            log.error(
-                'Plan lookup failed, skipping plan update.',
-                stripe_subscription=stripe_subscription.id,
-                stripe_plan=stripe_subscription.plan.id,
-            )
+        # This mostly just updates the UI now that we're using the Stripe Portal.
+        # A miss here just won't update the UI, but this shouldn't happen for most users.
+        # NOTE: Previously we were using stripe_subscription.plan,
+        # but that attribute is deprecated, and it's null if the subscription has more than
+        # one item/plan, we have a couple of subscriptions that have more than
+        # one item, so we use the first that is found in our DB.
+        for stripe_item in stripe_subscription["items"].data:
+            plan = self._get_plan(stripe_item.plan)
+            if plan:
+                rtd_subscription.plan = plan
+                break
+        else:
+            log.error("Plan not found, skipping plan update.")
 
         if stripe_subscription.status == 'canceled':
             # Remove ``stripe_id`` when canceled so the customer can
@@ -197,6 +188,27 @@ class SubscriptionManager(models.Manager):
         set_change_reason(rtd_subscription, change_reason)
         rtd_subscription.save()
         return rtd_subscription
+
+    def _get_plan(self, stripe_plan):
+        from readthedocs.subscriptions.models import Plan
+
+        try:
+            plan = (
+                Plan.objects
+                # Exclude "custom" here, as we historically reused Stripe plan
+                # id for custom plans. We don't have a better attribute to
+                # filter on here.
+                .exclude(slug__contains="custom")
+                .exclude(name__icontains="Custom")
+                .get(stripe_id=stripe_plan.id)
+            )
+            return plan
+        except (Plan.DoesNotExist, Plan.MultipleObjectsReturned):
+            log.info(
+                "Plan lookup failed.",
+                stripe_plan=stripe_plan.id,
+            )
+        return None
 
 
 class PlanFeatureManager(models.Manager):

--- a/readthedocs/subscriptions/managers.py
+++ b/readthedocs/subscriptions/managers.py
@@ -189,6 +189,7 @@ class SubscriptionManager(models.Manager):
         rtd_subscription.save()
         return rtd_subscription
 
+    # pylint: disable=no-self-use
     def _get_plan(self, stripe_plan):
         from readthedocs.subscriptions.models import Plan
 

--- a/readthedocs/subscriptions/tests/test_models.py
+++ b/readthedocs/subscriptions/tests/test_models.py
@@ -57,14 +57,13 @@ class SubscriptionTests(TestCase):
                 'current_period_start': 120778389,
                 'current_period_end': 123456789,
                 'trial_end': 1475437877,
-                "plan": None,
                 "items": {
                     "object": "list",
                     "data": [
                         {
                             "id": "si_KOcEsHCktPUedU",
                             "object": "subscription_item",
-                            "plan": {
+                            "price": {
                                 "id": "advanced",
                             },
                         },
@@ -98,14 +97,13 @@ class SubscriptionTests(TestCase):
             {
                 'id': 'sub_foo',
                 'status': 'unpaid',
-                "plan": None,
                 "items": {
                     "object": "list",
                     "data": [
                         {
                             "id": "si_KOcEsHCktPUedU",
                             "object": "subscription_item",
-                            "plan": {
+                            "price": {
                                 "id": "advanced",
                             },
                         },
@@ -131,14 +129,13 @@ class SubscriptionTests(TestCase):
             {
                 'id': 'sub_bar',
                 'status': 'active',
-                "plan": None,
                 "items": {
                     "object": "list",
                     "data": [
                         {
                             "id": "si_KOcEsHCktPUedU",
                             "object": "subscription_item",
-                            "plan": {
+                            "price": {
                                 "id": "advanced",
                             },
                         },

--- a/readthedocs/subscriptions/tests/test_models.py
+++ b/readthedocs/subscriptions/tests/test_models.py
@@ -57,9 +57,19 @@ class SubscriptionTests(TestCase):
                 'current_period_start': 120778389,
                 'current_period_end': 123456789,
                 'trial_end': 1475437877,
-                'plan': {
-                    'id': 'advanced',
-                }
+                "plan": None,
+                "items": {
+                    "object": "list",
+                    "data": [
+                        {
+                            "id": "si_KOcEsHCktPUedU",
+                            "object": "subscription_item",
+                            "plan": {
+                                "id": "advanced",
+                            },
+                        },
+                    ],
+                },
             },
             None,
         )
@@ -88,9 +98,19 @@ class SubscriptionTests(TestCase):
             {
                 'id': 'sub_foo',
                 'status': 'unpaid',
-                'plan': {
-                    'id': 'advanced',
-                }
+                "plan": None,
+                "items": {
+                    "object": "list",
+                    "data": [
+                        {
+                            "id": "si_KOcEsHCktPUedU",
+                            "object": "subscription_item",
+                            "plan": {
+                                "id": "advanced",
+                            },
+                        },
+                    ],
+                },
             },
             None,
         )
@@ -111,9 +131,19 @@ class SubscriptionTests(TestCase):
             {
                 'id': 'sub_bar',
                 'status': 'active',
-                'plan': {
-                    'id': 'advanced',
-                }
+                "plan": None,
+                "items": {
+                    "object": "list",
+                    "data": [
+                        {
+                            "id": "si_KOcEsHCktPUedU",
+                            "object": "subscription_item",
+                            "plan": {
+                                "id": "advanced",
+                            },
+                        },
+                    ],
+                },
             },
             None,
         )


### PR DESCRIPTION
subcription.plan is deprecated in favor of subscription.items,
this is only a problem for subscriptions that have more than one product
(subscriptions.plan will be null for those cases).

On .com have only a couple of subscriptions with multiple plans/products,
the features they provide are being added manually at the moment,
so we don't need to track those in our DB yet.

Also, the whole Plan object is deprecated in favor of the Price object.

Ref https://sentry.io/organizations/read-the-docs/issues/3048896842/?environment=production&project=161479&query=stripe&statsPeriod=14d