### PR TITLE
EmbedAPIv3: make usage of CDN

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -25,3 +25,4 @@ filterwarnings =
     ignore:.*:django.utils.deprecation.RemovedInDjango40Warning
     ignore:.*:django.utils.deprecation.RemovedInDjango41Warning
     ignore:.*:elasticsearch.exceptions.ElasticsearchWarning
+    ignore:.*:PendingDeprecationWarning

--- a/readthedocs/api/mixins.py
+++ b/readthedocs/api/mixins.py
@@ -25,7 +25,7 @@ class CDNCacheTagsMixin:
         response = super().dispatch(request, *args, **kwargs)
         cache_tags = self._get_cache_tags()
         if cache_tags:
-            response['Cache-Tag'] = ','.join(cache_tags)
+            response["Cache-Tag"] = ",".join(cache_tags)
         return response
 
     def _get_cache_tags(self):

--- a/readthedocs/api/v2/views/footer_views.py
+++ b/readthedocs/api/v2/views/footer_views.py
@@ -12,7 +12,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_jsonp.renderers import JSONPRenderer
 
-from readthedocs.api.v2.mixins import CDNCacheTagsMixin
+from readthedocs.api.mixins import CDNCacheTagsMixin
 from readthedocs.api.v2.permissions import IsAuthorizedToViewVersion
 from readthedocs.builds.constants import LATEST, TAG
 from readthedocs.builds.models import Version

--- a/readthedocs/embed/v3/tests/test_external_pages.py
+++ b/readthedocs/embed/v3/tests/test_external_pages.py
@@ -1,14 +1,9 @@
 import docutils
-import os
-
 import pytest
 import sphinx
-
-from packaging.version import Version
-
-from django.conf import settings
 from django.core.cache import cache
 from django.urls import reverse
+from packaging.version import Version
 
 from .utils import srcdir
 
@@ -43,7 +38,7 @@ class TestEmbedAPIv3ExternalPages:
         assert response.status_code == 200
 
         # The output is different because docutils is outputting this,
-        # and we're not sanitizing it, but just passing it through. 
+        # and we're not sanitizing it, but just passing it through.
         if Version(docutils.__version__) >= Version('0.17'):
             content = '<div class="body" role="main">\n            \n  <section id="title">\n<h1>Title<a class="headerlink" href="https://docs.project.com#title" title="Permalink to this headline">¶</a></h1>\n<p>This is an example page used to test EmbedAPI parsing features.</p>\n<section id="sub-title">\n<h2>Sub-title<a class="headerlink" href="https://docs.project.com#sub-title" title="Permalink to this headline">¶</a></h2>\n<p>This is a reference to <a class="reference internal" href="https://docs.project.com#sub-title"><span class="std std-ref">Sub-title</span></a>.</p>\n</section>\n</section>\n\n\n          </div>'
         else:
@@ -164,7 +159,13 @@ class TestEmbedAPIv3ExternalPages:
             'external': True,
         }
 
-    @pytest.mark.sphinx('html', srcdir=srcdir, freshenv=True)
+    # TODO: make the test to behave properly with docutils>17. The structure of
+    # the HTML has changed and the ids are not generated as `idX` anymore.
+    @pytest.mark.skipif(
+        Version(docutils.__version__) >= Version("0.18"),
+        reason="docutils>0.18 is not yet supported",
+    )
+    @pytest.mark.sphinx("html", srcdir=srcdir, freshenv=True)
     def test_citation_identifier_doctool_sphinx(self, app, client, requests_mock):
         app.build()
         path = app.outdir / 'bibtex-cite.html'
@@ -241,10 +242,15 @@ class TestEmbedAPIv3ExternalPages:
         response = client.get(self.api_url, params)
         assert response.status_code == 200
 
-        if sphinx.version_info >= (3, 5, 0):
-            content = f'<dl class="glossary simple">\n<dt id="{fragment}">Read the Docs<a class="headerlink" href="https://docs.project.com/glossary.html#{fragment}" title="Permalink to this term">¶</a></dt><dd><p>Best company ever.</p>\n</dd>\n</dl>'
+        if Version(docutils.__version__) >= Version("0.18"):
+            classes = "simple glossary"
         else:
-            content = f'<dl class="glossary simple">\n<dt id="{fragment}">Read the Docs</dt><dd><p>Best company ever.</p>\n</dd>\n</dl>'
+            classes = "glossary simple"
+
+        if sphinx.version_info >= (3, 5, 0):
+            content = f'<dl class="{classes}">\n<dt id="{fragment}">Read the Docs<a class="headerlink" href="https://docs.project.com/glossary.html#{fragment}" title="Permalink to this term">¶</a></dt><dd><p>Best company ever.</p>\n</dd>\n</dl>'
+        else:
+            content = f'<dl class="{classes}">\n<dt id="{fragment}">Read the Docs</dt><dd><p>Best company ever.</p>\n</dd>\n</dl>'
 
         assert response.json() == {
             'url': url,

--- a/readthedocs/embed/v3/views.py
+++ b/readthedocs/embed/v3/views.py
@@ -16,7 +16,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from selectolax.parser import HTMLParser
 
-from readthedocs.api.v2.mixins import CDNCacheTagsMixin
+from readthedocs.api.mixins import CDNCacheTagsMixin
 from readthedocs.core.unresolver import unresolve
 from readthedocs.core.utils.extend import SettingsOverrideObject
 from readthedocs.embed.utils import clean_links

--- a/readthedocs/embed/v3/views.py
+++ b/readthedocs/embed/v3/views.py
@@ -8,7 +8,6 @@ import structlog
 from django.conf import settings
 from django.core.cache import cache
 from django.shortcuts import get_object_or_404
-from django.utils.functional import cached_property
 from rest_framework import status
 from rest_framework.permissions import AllowAny
 from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
@@ -16,8 +15,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from selectolax.parser import HTMLParser
 
-from readthedocs.api.mixins import CDNCacheTagsMixin
-from readthedocs.core.unresolver import unresolve
+from readthedocs.api.mixins import CDNCacheTagsMixin, EmbedAPIMixin
 from readthedocs.core.utils.extend import SettingsOverrideObject
 from readthedocs.embed.utils import clean_links
 from readthedocs.projects.constants import PUBLIC
@@ -26,7 +24,7 @@ from readthedocs.storage import build_media_storage
 log = structlog.get_logger(__name__)
 
 
-class EmbedAPIBase(CDNCacheTagsMixin, APIView):
+class EmbedAPIBase(EmbedAPIMixin, CDNCacheTagsMixin, APIView):
 
     # pylint: disable=line-too-long
     # pylint: disable=no-self-use
@@ -48,13 +46,6 @@ class EmbedAPIBase(CDNCacheTagsMixin, APIView):
 
     permission_classes = [AllowAny]
     renderer_classes = [JSONRenderer, BrowsableAPIRenderer]
-
-    @cached_property
-    def unresolved_url(self):
-        url = self.request.GET.get('url')
-        if not url:
-            return None
-        return unresolve(url)
 
     def _download_page_content(self, url):
         # Sanitize the URL before requesting it

--- a/readthedocs/embed/views.py
+++ b/readthedocs/embed/views.py
@@ -15,7 +15,7 @@ from rest_framework.renderers import BrowsableAPIRenderer, JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from readthedocs.api.v2.mixins import CDNCacheTagsMixin
+from readthedocs.api.mixins import CDNCacheTagsMixin
 from readthedocs.api.v2.permissions import IsAuthorizedToViewVersion
 from readthedocs.builds.constants import EXTERNAL
 from readthedocs.core.resolver import resolve

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -12,7 +12,7 @@ from django.views import View
 from django.views.decorators.cache import cache_page
 
 from readthedocs.analytics.models import PageView
-from readthedocs.api.v2.mixins import CDNCacheTagsMixin
+from readthedocs.api.mixins import CDNCacheTagsMixin
 from readthedocs.builds.constants import EXTERNAL, LATEST, STABLE
 from readthedocs.builds.models import Version
 from readthedocs.core.mixins import CDNCacheControlMixin

--- a/readthedocs/search/api.py
+++ b/readthedocs/search/api.py
@@ -9,7 +9,7 @@ from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.generics import GenericAPIView
 from rest_framework.pagination import PageNumberPagination
 
-from readthedocs.api.v2.mixins import CDNCacheTagsMixin
+from readthedocs.api.mixins import CDNCacheTagsMixin
 from readthedocs.api.v2.permissions import IsAuthorizedToViewVersion
 from readthedocs.builds.models import Version
 from readthedocs.projects.models import Feature, Project

--- a/tox.embedapi.ini
+++ b/tox.embedapi.ini
@@ -1,6 +1,9 @@
 [tox]
 # NOTE: Sphinx 3.5 and 4.x < 4.2 fails with Python 3.10 because of a typing issue
-envlist = sphinx-{18,20,21,22,23,24,30,31,32,33,34,42,43,44,45,latest}
+#
+# NOTE: Sphinx 1.8 and 2.0 are not tested anymore because of some
+# incompatibilities with Python 3.10 and sphinxcontrib-bibtex
+envlist = sphinx-{21,22,23,24,30,31,32,33,34,42,43,44,45,50,latest}
 
 [testenv]
 description = run test suite for the EmbedAPIv3
@@ -11,11 +14,8 @@ install_command =
         cat {toxinidir}/requirements/pip.txt | grep -v "Sphinx" > {toxinidir}/requirements/embedapi.txt; \
         sed {toxinidir}/requirements/testing.txt -e "s|pip.txt|embedapi.txt|g" > {toxinidir}/requirements/testing.embedapi.txt; \
         pip install -r {toxinidir}/requirements/testing.embedapi.txt; \
-        pip install sphinxcontrib-bibtex; \
         pip install $*;' -- {opts} {packages}
 deps =
-    sphinx-18: Sphinx~=1.8.0
-    sphinx-20: Sphinx~=2.0.0
     sphinx-21: Sphinx~=2.1.0
     sphinx-22: Sphinx~=2.2.0
     sphinx-23: Sphinx~=2.3.0
@@ -29,7 +29,9 @@ deps =
     sphinx-43: Sphinx~=4.3.0
     sphinx-44: Sphinx~=4.4.0
     sphinx-45: Sphinx~=4.5.0
+    sphinx-50: Sphinx~=5.0.0
     sphinx-latest: Sphinx
+    sphinxcontrib-bibtex~=2.3.0
     jinja2<3.1.0
 setenv =
     DJANGO_SETTINGS_MODULE=readthedocs.settings.test


### PR DESCRIPTION
* Move `CDNCacheTagsMixin` one level up in the directories, since it's shared between API v2 and v3
* Do not CDN cache requests that hit external pages because we can purge them properly (we don't have control over the external page)
* Refactor EmbedAPI v2 and v3 to share some code via a new mixin class
* Update tests:
  * Do not run tests on Sphinx 1.8 and 2.0 anymore
  * Skip a bibtex that's failing because the HTML changed on docutils 0.18
  * Fix a glossary test to work on docutils 0.17 and 0.18