### PR TITLE
Remote repository: Add organization admin action for syncing remote repositories

### DIFF
--- a/readthedocs/organizations/admin.py
+++ b/readthedocs/organizations/admin.py
@@ -1,0 +1,85 @@
+"""Django admin interface for organization models."""
+
+from django.contrib import admin
+from django.contrib.auth.models import User
+from django.db.models import Q
+from django.urls import reverse
+from django.utils.html import format_html
+from django.utils.safestring import mark_safe
+
+from readthedocs.oauth.tasks import sync_remote_repositories
+from readthedocs.organizations.models import Organization
+
+
+class OrganizationAdmin(admin.ModelAdmin):
+
+    """Admin configuration for Organization."""
+
+    readonly_fields = (
+        "pub_date",
+        "modified_date",
+        "slug",
+    )
+    list_display = (
+        "id",
+        "name",
+        "max_concurrent_builds",
+        "disabled",
+        "artifacts_cleaned",
+        "modified_date",
+        "pub_date",
+    )
+    list_filter = (
+        "disabled",
+        "artifacts_cleaned",
+    )
+    raw_id_fields = (
+        "projects",
+        "owners",
+    )
+    search_fields = (
+        "projects__slug",
+        "owners__username",
+        "owners__email",
+        "name",
+        "slug",
+        "email",
+        "url",
+        "stripe_id",
+    )
+    actions = ("sync_remote_repositories_action",)
+
+    def sync_remote_repositories_action(self, request, queryset):
+        """Resync remote repositories for all members of the selected organizations."""
+        formatted_task_urls = []
+
+        users = (
+            User.objects.filter(
+                Q(teams__organization__in=queryset)
+                | Q(owner_organizations__in=queryset),
+            )
+            .values_list("id", "username")
+            .distinct()
+        )
+
+        for user_id, username in users:
+            result = sync_remote_repositories.delay(user_id=user_id)
+            job_status_url = reverse(
+                "api_job_status", kwargs={"task_id": result.task_id}
+            )
+            formatted_task_urls.append(
+                format_html("<a href='{}'>{} task</a>", job_status_url, username)
+            )
+
+        self.message_user(
+            request,
+            mark_safe(
+                "Following sync remote repository tasks were "
+                "triggered: {}".format(", ".join(formatted_task_urls))
+            ),
+        )
+
+    sync_remote_repositories_action.short_description = "Sync remote repositories"
+
+
+admin.site.register(Organization, OrganizationAdmin)

--- a/readthedocs/organizations/tests/test_admin.py
+++ b/readthedocs/organizations/tests/test_admin.py
@@ -1,0 +1,50 @@
+from unittest.mock import call, patch
+
+from django import urls
+from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django_dynamic_fixture import get
+
+from readthedocs.organizations.models import Organization, Team, TeamMember
+
+
+class OrganizationAdminActionsTest(TestCase):
+    """Organization admin action tests."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin = get(User, is_staff=True, is_superuser=True)
+        cls.user = get(User)
+        cls.owner = get(User)
+        cls.organization = get(
+            Organization,
+            owners=[cls.owner],
+        )
+        get(
+            TeamMember,
+            member=cls.user,
+            team=get(Team, organization=cls.organization),
+        )
+
+    def setUp(self):
+        self.client.force_login(self.admin)
+
+    @patch("readthedocs.organizations.admin.sync_remote_repositories")
+    def test_sync_remote_repositories_action(self, mock_sync_remote_repositories):
+        action_data = {
+            ACTION_CHECKBOX_NAME: [self.organization.pk],
+            "action": "sync_remote_repositories_action",
+            "index": 0,
+        }
+        self.client.post(
+            urls.reverse("admin:organizations_organization_changelist"),
+            action_data,
+        )
+        mock_sync_remote_repositories.delay.assert_has_calls(
+            [
+                call(user_id=self.user.pk),
+                call(user_id=self.owner.pk),
+            ],
+            any_order=True,
+        )


### PR DESCRIPTION
This PR implements a Organization Admin Action to run sync_remote_repositories() task for all members of the selected organizations.

Ref: https://github.com/readthedocs/readthedocs.org/pull/9272#pullrequestreview-988932451