### PR TITLE
Translations: integrate Transifex into our Docker tasks

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,9 +1,7 @@
-[readthedocs.readthedocs]
+[main]
+host = https://www.transifex.com
+
+[o:readthedocs:p:readthedocs:r:readthedocs]
 file_filter = readthedocs/locale/<lang>/LC_MESSAGES/django.po
 source_file = readthedocs/locale/en/LC_MESSAGES/django.po
 source_lang = en
-
-[main]
-host = https://www.transifex.com
-type = PO
-

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -y update
 RUN apt-get -y install \
         curl \
         g++ \
+        gettext \
         git-core \
         libevent-dev \
         libpq-dev \

--- a/tasks.py
+++ b/tasks.py
@@ -2,11 +2,10 @@
 
 import os
 
-from invoke import task, Collection
+from invoke import Collection, task
 
-import common.tasks
 import common.dockerfiles.tasks
-
+import common.tasks
 
 ROOT_PATH = os.path.dirname(__file__)
 
@@ -30,25 +29,6 @@ namespace.add_collection(
     name='docker',
 )
 
-# Localization tasks
-@task
-def push(ctx):
-    """Rebuild and push the source language to Transifex"""
-    with ctx.cd(os.path.join(ROOT_PATH, 'readthedocs')):
-        ctx.run('django-admin makemessages -l en')
-        ctx.run('tx push -s')
-        ctx.run('django-admin compilemessages -l en')
-
-
-@task
-def pull(ctx):
-    """Pull the updated translations from Transifex"""
-    with ctx.cd(os.path.join(ROOT_PATH, 'readthedocs')):
-        ctx.run('tx pull -f ')
-        ctx.run('django-admin makemessages --all')
-        ctx.run('django-admin compilemessages')
-
-
 @task
 def docs(ctx, regenerate_config=False, push=False):
     """Pull and push translations to Transifex for our docs"""
@@ -70,8 +50,6 @@ def docs(ctx, regenerate_config=False, push=False):
 
 namespace.add_collection(
     Collection(
-        push,
-        pull,
         docs,
     ),
     name='l10n',


### PR DESCRIPTION
I tried to integrate these commands into the release/deploy process but it was complicated. The main problem is that we need to install all the Python dependencies since we need to run `django-admin` commands as part of the process. So, instead of dealing with a new Python environment for the release process, we could use the Docker image where all the other Django commands are executed to update the translations.

Once this PR is merged, the process will be:

```
inv docker.translations --pull
inv docker.translations --push
```

I'm going to update the release/deploy script to call these commands _before_ running the other commands.

Requires: https://github.com/readthedocs/common/pull/147
Reference: https://github.com/readthedocs/readthedocs-ops/issues/1195
Reference: https://github.com/readthedocs/readthedocs.org/issues/4463
