### PR TITLE
Local development: use `nodemon` to watch files instead of `watchmedo`

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -29,7 +29,8 @@ RUN apt-get -y install \
         sqlite \
         netcat \
         telnet \
-        lsb-release
+        lsb-release \
+        npm
 
 # Gets the MinIO mc client used to add buckets upon initialization
 # If this client should have issues running inside this image, it is also
@@ -37,6 +38,8 @@ RUN apt-get -y install \
 # The current minio/mc Docker image could be a lot smaller
 RUN curl -s -q https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2022-06-11T21-10-36Z -o /usr/bin/mc && \
     chmod +x /usr/bin/mc
+
+RUN npm install -g nodemon
 
 # Uncomment en_US.UTF-8 locale and generate it
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -11,11 +11,6 @@ django-redis-cache==3.0.1
 # For resizing images
 pillow==9.1.0
 
-# Local debugging tools
-watchdog==2.1.7
-# watchdog dependency
-argh==0.26.2
-
 # run tests
 tox==3.25.0
 


### PR DESCRIPTION
We have been dealing with a problem with `watchmedo` that restart the process
when it shouldn't be restarted and it doesn't restart it when it should.

I got tired debugging `watchmedo` and I was suggested to give it a try to
`nodemon` because we are already using it in other projects. I'm not super happy
adding a node dependency to the Dockerfile, but I didn't find a better way to do it.

I did some tests with the configuration proposed and it seemed to work pretty
well. I'm sure we will find some edge cases, but we always can tune it a little
more later.

Requires: https://github.com/readthedocs/common/pull/150
Closes https://github.com/readthedocs/readthedocs.org/issues/8802