### PR TITLE
Build: truncate command output

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -458,9 +458,9 @@ class BaseEnvironment:
                 msg = "Command failed"
                 build_output = ""
                 if build_cmd.output:
-                    build_output += "\n".join(build_cmd.output.split("\n")[10:])
-                    build_output += "\n ..Output Truncated.."
                     build_output += "\n".join(build_cmd.output.split("\n")[:10])
+                    build_output += "\n ..Output Truncated.. \n"
+                    build_output += "\n".join(build_cmd.output.split("\n")[-10:])
                 log.warning(
                     msg,
                     command=build_cmd.get_command(),


### PR DESCRIPTION
The logic wrote in #9286 was incorrect. The logs keeps showing a lot of the
command's output.

We want to take the first 10 lines and the last 10 lines.