### PR TITLE
Development: avoid path collision when running multiple builders

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -730,8 +730,8 @@ class DockerBuildEnvironment(BuildEnvironment):
             from pathlib import Path
             binds = {
                 settings.RTD_DOCKER_COMPOSE_VOLUME: {
-                    'bind': str(Path(self.project.doc_path).parent),
-                    'mode': 'rw',
+                    "bind": str(Path(settings.DOCROOT).parent),
+                    "mode": "rw",
                 },
             }
         else:

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -48,6 +48,13 @@ class DockerBaseSettings(CommunityDevSettings):
     ADSERVER_API_KEY = None
     ADSERVER_API_TIMEOUT = 2  # seconds - Docker for Mac is very slow
 
+    @property
+    def DOCROOT(self):
+        # Add an extra directory level using the container's hostname.
+        # This allows us to run development environment with multiple builders (`--scale-build=2` or more),
+        # and avoid the builders overwritting each others when building the same project/version
+        return os.path.join(self.SITE_ROOT, 'user_builds', socket.gethostname())
+
     # New templates
     @property
     def RTD_EXT_THEME_DEV_SERVER_ENABLED(self):

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -53,7 +53,7 @@ class DockerBaseSettings(CommunityDevSettings):
         # Add an extra directory level using the container's hostname.
         # This allows us to run development environment with multiple builders (`--scale-build=2` or more),
         # and avoid the builders overwritting each others when building the same project/version
-        return os.path.join(self.SITE_ROOT, 'user_builds', socket.gethostname())
+        return os.path.join(super().DOCROOT, socket.gethostname())
 
     # New templates
     @property


### PR DESCRIPTION
When starting up the local development with multiple builders (e.g. `inv
docker.up --scale-build=2`, or more) it's possible to find them collisioning on
the `user_builds/` path when building the same version on each builder.

This happens locally but not on production, because we are running all of them
on the same host machine using the same disk/volume for all of them.

To avoid this collision, this commit adds an extra directory with the `hostname`
of the container to the `DOCROOT` to avoid this collision.