### PR TITLE
Development: allow to pass `--ngrok` when starting up

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -34,6 +34,9 @@ services:
     networks:
       readthedocs:
         ipv4_address: 10.10.0.100
+    environment:
+      - NGINX_WEB_SERVER_NAME=${NGINX_WEB_SERVER_NAME:-community.dev.readthedocs.io}
+      - NGINX_PROXITO_SERVER_NAME=${NGINX_PROXITO_SERVER_NAME:-*.community.dev.readthedocs.io *.org.dev.readthedocs.build}
 
   proxito:
     image: community_server:latest
@@ -53,6 +56,7 @@ services:
       - HOSTIP=${HOSTIP:-}
     extra_hosts:
       - "community.dev.readthedocs.io:10.10.0.100"
+      - "readthedocs.ngrok.io:10.5.0.100"
 
   celery:
     image: community_server:latest

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -56,7 +56,7 @@ services:
       - HOSTIP=${HOSTIP:-}
     extra_hosts:
       - "community.dev.readthedocs.io:10.10.0.100"
-      - "readthedocs.ngrok.io:10.5.0.100"
+      - "${NGINX_WEB_SERVER_NAME}:10.5.0.100"
 
   celery:
     image: community_server:latest

--- a/dockerfiles/nginx/proxito.conf.template
+++ b/dockerfiles/nginx/proxito.conf.template
@@ -1,7 +1,7 @@
 # Proxito
 server {
     listen 80 default_server;
-    server_name *.community.dev.readthedocs.io *.org.dev.readthedocs.build;
+    server_name $NGINX_PROXITO_SEVER_NAME;
 
     # TODO: serve the favicon.ico from the project/version itself instead
     location /favicon.ico {

--- a/dockerfiles/nginx/proxito.conf.template
+++ b/dockerfiles/nginx/proxito.conf.template
@@ -1,7 +1,7 @@
 # Proxito
 server {
     listen 80 default_server;
-    server_name $NGINX_PROXITO_SEVER_NAME;
+    server_name $NGINX_PROXITO_SERVER_NAME;
 
     # TODO: serve the favicon.ico from the project/version itself instead
     location /favicon.ico {

--- a/dockerfiles/nginx/web.conf.template
+++ b/dockerfiles/nginx/web.conf.template
@@ -2,7 +2,7 @@ server {
     listen 80;
 
     # This should match settings.PRODUCTION_DOMAIN
-    server_name community.dev.readthedocs.io;
+    server_name $NGINX_WEB_SERVER_NAME;
 
     location /favicon.ico {
         proxy_pass http://storage:9000/static/images/favicon.ico;

--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -95,6 +95,7 @@ save some work while typing docker compose commands. This section explains these
     * ``--init`` is used the first time this command is ran to run initial migrations, create an admin user, etc
     * ``--no-reload`` makes all celery processes and django runserver
       to use no reload and do not watch for files changes
+    * ``--ngrok`` is useful when it's required to access the local instance from outside (e.g. GitHub webhook)
 
 ``inv docker.shell``
     Opens a shell in a container (web by default).

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -15,8 +15,8 @@ class DockerBaseSettings(CommunityDevSettings):
     DOCKER_LIMITS = {'memory': '1g', 'time': 900}
     USE_SUBDOMAIN = True
 
-    PRODUCTION_DOMAIN = 'community.dev.readthedocs.io'
-    PUBLIC_DOMAIN = 'community.dev.readthedocs.io'
+    PRODUCTION_DOMAIN = os.environ.get('RTD_PRODUCTION_DOMAIN', 'community.dev.readthedocs.io')
+    PUBLIC_DOMAIN = PRODUCTION_DOMAIN
     PUBLIC_API_URL = f'http://{PRODUCTION_DOMAIN}'
 
     SLUMBER_API_HOST = 'http://web:8000'
@@ -173,8 +173,8 @@ class DockerBaseSettings(CommunityDevSettings):
     S3_BUILD_ENVIRONMENT_STORAGE_BUCKET = 'envs'
     S3_BUILD_TOOLS_STORAGE_BUCKET = 'build-tools'
     S3_STATIC_STORAGE_BUCKET = 'static'
-    S3_STATIC_STORAGE_OVERRIDE_HOSTNAME = 'community.dev.readthedocs.io'
-    S3_MEDIA_STORAGE_OVERRIDE_HOSTNAME = 'community.dev.readthedocs.io'
+    S3_STATIC_STORAGE_OVERRIDE_HOSTNAME = PRODUCTION_DOMAIN
+    S3_MEDIA_STORAGE_OVERRIDE_HOSTNAME = PRODUCTION_DOMAIN
 
     AWS_S3_ENCRYPTION = False
     AWS_S3_SECURE_URLS = False


### PR DESCRIPTION
`inv docker.up --ngrok readthedocs.ngrok.io` will allow you to access http://readthedocs.ngrok.io after executing:

```
ngrok http --subdomain=readthedocs --subdomain=test-builds.readthedocs --scheme=http 80
```

This commit renames NGINX config files to convert them into templates, so they
are replaced with the environment variables. See https://github.com/docker-library/docs/tree/master/nginx#using-environment-variables-in-nginx-configuration-new-in-119



Closes #9030 
Closes #7982 
Requires https://github.com/readthedocs/common/pull/151