### PR TITLE
Feature overview hotfix

### DIFF
--- a/docs/user/features.rst
+++ b/docs/user/features.rst
@@ -1,5 +1,5 @@
-Feature Overview
-================
+Main Features
+=============
 
 Read the Docs offers a number of platform features that are possible because we both build and host documentation for you.
 

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -64,7 +64,6 @@ to help you create fantastic documentation for your project.
    /intro/getting-started-with-mkdocs
 
    /intro/import-guide
-   /features
    /choosing-a-site
    /glossary
 
@@ -105,8 +104,9 @@ and some of the core features of Read the Docs.
 .. toctree::
    :maxdepth: 1
    :hidden:
-   :caption: Feature Overview
+   :caption: Features
 
+   /features
    /config-file/index
    /integrations
    /custom-domains


### PR DESCRIPTION
Quickfix for currently displaying "Feature Overview" twice

Before:
![image](https://user-images.githubusercontent.com/374612/174819103-762e4308-cf74-4e0d-8aac-55387f5398c2.png)

After:
![image](https://user-images.githubusercontent.com/374612/174819427-0dde3efc-8e65-40c8-af14-2d39d38c49bd.png)

