### PR TITLE
Development: remove silent and use long attribute name

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get -y install \
 # If this client should have issues running inside this image, it is also
 # fine to defer it to a separate image.
 # The current minio/mc Docker image could be a lot smaller
-RUN curl -s -q https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2022-06-11T21-10-36Z -o /usr/bin/mc && \
+RUN curl --disable https://dl.min.io/client/mc/release/linux-amd64/archive/mc.RELEASE.2022-06-11T21-10-36Z -o /usr/bin/mc && \
     chmod +x /usr/bin/mc
 
 RUN npm install -g nodemon


### PR DESCRIPTION
- remove `-s` (silent) because it takes some time to download the file and we
  don't know what it's happening; I cancelled the process multiple times due to
  this

- use `--disable` instead `-d` since it's more expressive