### PR TITLE
Middleware: use regular `HttpResponse` and log the suspicious operation

### DIFF
--- a/readthedocs/core/middleware.py
+++ b/readthedocs/core/middleware.py
@@ -9,6 +9,7 @@ from django.core.exceptions import (
     MiddlewareNotUsed,
     SuspiciousOperation,
 )
+from django.http import HttpResponse
 from django.utils.cache import patch_vary_headers
 from django.utils.http import http_date
 
@@ -211,7 +212,14 @@ class NullCharactersMiddleware:
     def __call__(self, request):
         for key, value in request.GET.items():
             if "\x00" in value:
-                raise SuspiciousOperation(
-                    f"There are NULL (0x00) characters in at least one of the parameters ({key}) passed to the request."  # noqa
+                log.info(
+                    "NULL (0x00) characters in GET attributes.",
+                    attribute=key,
+                    value=value,
+                    url=request.build_absolute_uri(),
+                )
+                return HttpResponse(
+                    f"There are NULL (0x00) characters in at least one of the parameters ({key}) passed to the request.",  # noqa
+                    status=400,
                 )
         return self.get_response(request)

--- a/readthedocs/rtd_tests/tests/test_middleware.py
+++ b/readthedocs/rtd_tests/tests/test_middleware.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 from corsheaders.middleware import CorsMiddleware
 from django.conf import settings
-from django.core.exceptions import SuspiciousOperation
 from django.http import HttpResponse
 from django.test import TestCase, override_settings
 from django.test.client import RequestFactory
@@ -272,4 +271,9 @@ class TestNullCharactersMiddleware(TestCase):
 
     def test_request_with_null_chars(self):
         request = self.factory.get("/?language=en\x00es&project_slug=myproject")
-        self.assertRaises(SuspiciousOperation, lambda: self.middleware(request))
+        response = self.middleware(request)
+        self.assertContains(
+            response,
+            "There are NULL (0x00) characters in at least one of the parameters (language) passed to the request.",
+            status_code=400,
+        )


### PR DESCRIPTION
Do not use `raise SuspiciousOperation` here because that ends up into Sentry
marked as an error logged via logger `django.security.SuspiciousOperation`.

I prefer to use regular `log.info` for these situations so they end up in NewRelic
and we can parse them nicely. They are not application errors.