### PR TITLE
CSP header: enforce mode

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -105,7 +105,7 @@ class CommunityBaseSettings(Settings):
     CSP_FRAME_ANCESTORS = ("'none'",)
     CSP_OBJECT_SRC = ("'none'",)
     CSP_REPORT_URI = None
-    CSP_REPORT_ONLY = True  # Set to false to enable CSP in blocking mode
+    CSP_REPORT_ONLY = False
     CSP_EXCLUDE_URL_PREFIXES = (
         "/admin/",
     )


### PR DESCRIPTION
We have been in report mode for some time (years?) already and we haven't
detected any issues with our application. Most of the reports we received in
Sentry are valid and should be blocked.

Because of that, we are making `Content-Security-Policy` HTTP header to be
enfoced instead of keep in report only mode.

Related: https://github.com/readthedocs/readthedocs-ops/pull/1204