### PR TITLE
Docs: remove old FAQ entry

### DIFF
--- a/docs/user/faq.rst
+++ b/docs/user/faq.rst
@@ -101,27 +101,6 @@ environment, and will be set to ``True`` when building on RTD::
 
 
 
-`Client Error 401` when building documentation
-----------------------------------------------
-
-If you did not install the `test_data` fixture during the installation
-instructions, you will get the following error::
-
-    slumber.exceptions.HttpClientError: Client Error 401: http://localhost:8000/api/v1/version/
-
-This is because the API admin user does not exist, and so cannot authenticate.
-You can fix this by loading the test_data::
-
-    ./manage.py loaddata test_data
-
-If you'd prefer not to install the test data, you'll need to provide a database
-account for the builder to use. You can provide these credentials by editing the
-following settings::
-
-    SLUMBER_USERNAME = 'test'
-    SLUMBER_PASSWORD = 'test'
-
-
 How do I host multiple projects on one custom domain?
 -----------------------------------------------------
 


### PR DESCRIPTION
We changed how we are installing Read the Docs for development and this is not
valid anymore.