### PR TITLE
Properly log build exceptions in Celery

### DIFF
--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -425,9 +425,9 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         else:
             # We don't know what happened in the build. Log the exception and
             # report a generic message to the user.
-            log.exception('Build failed with unhandled exception.')
-            self.data.build['error'] = BuildAppError.GENERIC_WITH_BUILD_ID.format(
-                build_id=self.data.build['id'],
+            log.exception("Build failed with unhandled exception.", exc_info=exc)
+            self.data.build["error"] = BuildAppError.GENERIC_WITH_BUILD_ID.format(
+                build_id=self.data.build["id"],
             )
 
         # Send notifications for unhandled errors

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -146,7 +146,7 @@ class SyncRepositoryTask(SyncRepositoryMixin, Task):
             )
         else:
             # Catch unhandled errors when syncing
-            # Note we are using `log.error(exc_info=...)` instead of `log.exception` 
+            # Note we are using `log.error(exc_info=...)` instead of `log.exception`
             # because this is not executed inside a try/except block.
             log.error(
                 "An unhandled exception was raised during VCS syncing.", exc_info=exc
@@ -429,7 +429,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         else:
             # We don't know what happened in the build. Log the exception and
             # report a generic message to the user.
-            # Note we are using `log.error(exc_info=...)` instead of `log.exception` 
+            # Note we are using `log.error(exc_info=...)` instead of `log.exception`
             # because this is not executed inside a try/except block.
             log.error("Build failed with unhandled exception.", exc_info=exc)
             self.data.build["error"] = BuildAppError.GENERIC_WITH_BUILD_ID.format(

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -146,7 +146,9 @@ class SyncRepositoryTask(SyncRepositoryMixin, Task):
             )
         else:
             # Catch unhandled errors when syncing
-            log.exception('An unhandled exception was raised during VCS syncing.')
+            log.exception(
+                "An unhandled exception was raised during VCS syncing.", exc_info=exc
+            )
 
     def after_return(self, status, retval, task_id, args, kwargs, einfo):
         clean_build(self.data.version)

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -146,7 +146,9 @@ class SyncRepositoryTask(SyncRepositoryMixin, Task):
             )
         else:
             # Catch unhandled errors when syncing
-            log.exception(
+            # Note we are using `log.error(exc_info=...)` instead of `log.exception` 
+            # because this is not executed inside a try/except block.
+            log.error(
                 "An unhandled exception was raised during VCS syncing.", exc_info=exc
             )
 
@@ -427,7 +429,9 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         else:
             # We don't know what happened in the build. Log the exception and
             # report a generic message to the user.
-            log.exception("Build failed with unhandled exception.", exc_info=exc)
+            # Note we are using `log.error(exc_info=...)` instead of `log.exception` 
+            # because this is not executed inside a try/except block.
+            log.error("Build failed with unhandled exception.", exc_info=exc)
             self.data.build["error"] = BuildAppError.GENERIC_WITH_BUILD_ID.format(
                 build_id=self.data.build["id"],
             )


### PR DESCRIPTION
This code wasn't in an exception,
so we have to pass the exc_info explicitly.