### PR TITLE
OAuth: connect `Project` to `RemoteRepository`

### DIFF
--- a/readthedocs/projects/urls/private.py
+++ b/readthedocs/projects/urls/private.py
@@ -20,6 +20,7 @@ from readthedocs.projects.views.private import (
     EnvironmentVariableDelete,
     EnvironmentVariableList,
     ImportView,
+    IntegrationConnectProject,
     IntegrationCreate,
     IntegrationDelete,
     IntegrationDetail,
@@ -199,6 +200,13 @@ integration_urls = [
         ),
         IntegrationWebhookSync.as_view(),
         name='projects_integrations_webhooks_sync',
+    ),
+    re_path(
+        r"^(?P<project_slug>{project_slug})/integrations/connect/$".format(
+            **pattern_opts
+        ),
+        IntegrationConnectProject.as_view(),
+        name="projects_integrations_connect_project",
     ),
     re_path(
         (

--- a/readthedocs/templates/projects/integration_list.html
+++ b/readthedocs/templates/projects/integration_list.html
@@ -14,6 +14,14 @@
 {% block project_edit_content %}
   <div class="button-bar">
     <ul>
+      {% if connect_vcs_repository %}
+      <li>
+        <form style="float: left" method="post" action="{% url 'projects_integrations_connect_project' project_slug=project.slug %}">
+          {% csrf_token %}
+          <input type="submit" value="{% trans "Connect VCS repository" %}">
+        </form>
+      </li>
+      {% endif %}
       <li>
         <a class="button"
            href="{% url 'projects_integrations_create' project_slug=project.slug %}">


### PR DESCRIPTION
There are multiple reasons why a `Project` could be disconnected from a
`RemoteRepository`:

1. it was imported manually
2. the user deleted their account, which also deleted the
   `RemoteRepository` (old behaviour)
3. got disconnected when doing the data migration
4. others?

If any of the previous scenarios happened, the user was not able to (re)connect
their project anymore. The only way was to delete the project and re-import it
using the wizard with a VCS account connected.

This commit adds a button under "Admin" -> "Integrations" page to "Connect VCS
repository" allowing users to perform this action by themselves.

When a `Project` is connected to a `RemoteRepository` permissions can be managed
at VCS level, allowing the organization to be able to use VCS SSO. Besides, this
connection will be used when sending status notifications to the VCS.

Closes #8229 