### PR TITLE
Build: handle Celery timeout events

### DIFF
--- a/readthedocs/builds/views.py
+++ b/readthedocs/builds/views.py
@@ -193,7 +193,7 @@ class BuildDetail(BuildBase, DetailView):
             build_task_id=build.task_id,
             terminate=terminate,
         )
-        app.control.revoke(build.task_id, signal=signal.SIGINT, terminate=terminate)
+        app.control.revoke(build.task_id, signal=signal.SIGUSR1, terminate=terminate)
 
         return HttpResponseRedirect(
             reverse('builds_detail', args=[project.slug, build.pk]),

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -791,12 +791,12 @@ class DockerBuildEnvironment(BuildEnvironment):
         if state is not None and state.get('Running') is False:
             if state.get('ExitCode') == DOCKER_TIMEOUT_EXIT_CODE:
                 raise BuildUserError(
-                    _('Build exited due to time out'),
+                    BuildUserError.TIMEOUT,
                 )
 
             if state.get('OOMKilled', False):
                 raise BuildUserError(
-                    _('Build exited due to excessive memory consumption'),
+                    BuildUserError.EXCESSIVE_MEMORY_CONSUMPTION,
                 )
 
             if state.get('Error'):

--- a/readthedocs/doc_builder/exceptions.py
+++ b/readthedocs/doc_builder/exceptions.py
@@ -40,6 +40,10 @@ class BuildUserError(BuildBaseException):
     BUILD_COMMANDS_WITHOUT_OUTPUT = gettext_noop(
         f'No "{BUILD_COMMANDS_OUTPUT_PATH_HTML}" folder was created during this build.'
     )
+    TIMEOUT = gettext_noop("Build exited due to time out")
+    EXCESSIVE_MEMORY_CONSUMPTION = gettext_noop(
+        "Build exited due to excessive memory consumption"
+    )
 
 
 class ProjectBuildsSkippedError(BuildUserError):

--- a/readthedocs/doc_builder/exceptions.py
+++ b/readthedocs/doc_builder/exceptions.py
@@ -72,6 +72,11 @@ class BuildCancelled(BuildUserError):
     state = BUILD_STATE_CANCELLED
 
 
+class BuildTimeoutCancelled(BuildUserError):
+    message = gettext_noop("Build cancelled due timeout.")
+    state = BUILD_STATE_CANCELLED
+
+
 class MkDocsYAMLParseError(BuildUserError):
     GENERIC_WITH_PARSE_EXCEPTION = gettext_noop(
         'Problem parsing MkDocs YAML configuration. {exception}',

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -271,17 +271,10 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
 
     Request = BuildRequest
 
-    def _setup_sigterm(self):
-        def sigterm_received(*args, **kwargs):
-            log.warning('SIGTERM received. Waiting for build to stop gracefully after it finishes.')
-
+    def _setup_signals(self):
         def sigint_received(*args, **kwargs):
             log.warning('SIGINT received. Canceling the build running.')
             raise BuildCancelled
-
-        # Do not send the SIGTERM signal to children (pip is automatically killed when
-        # receives SIGTERM and make the build to fail one command and stop build)
-        signal.signal(signal.SIGTERM, sigterm_received)
 
         signal.signal(signal.SIGINT, sigint_received)
 
@@ -371,10 +364,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         # (e.g. cleanup task failed for some reason)
         clean_build(self.data.version)
 
-        # NOTE: this is never called. I didn't find anything in the logs, so we
-        # can probably remove it
-        self._setup_sigterm()
-
+        self._setup_signals()
         self._check_project_disabled()
         self._check_duplicated_build()
         self._check_concurrency_limit()

--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -153,11 +153,26 @@ class BuildRequest(Request):
 
         log.bind(
             task_name=self.task.name,
-            project_slug=self.task.data.project.slug,
-            build_id=self.task.data.build['id'],
             timeout=timeout,
             soft=soft,
         )
+
+        # NOTE: we don't have access to ``self.task.data`` because it's not the
+        # same instance. However, we can get the attributes which it was called
+        # to log them.
+        if self.task.name.endswith("update_docs_task"):
+            version_id, build_id = self.args
+            log.bind(
+                version_id=version_id,
+                build_id=build_id,
+                build_commit=self.kwargs.get("build_commit"),
+            )
+        elif self.task.name.endswith("sync_repository_task"):
+            (version_id,) = self.args
+            log.bind(
+                version_id=version_id,
+            )
+
         if soft:
             log.warning('Build is taking too much time. Risk to be killed soon.')
         else:

--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 import shutil
+import signal
 
 import structlog
 from celery.worker.request import Request
@@ -174,6 +175,9 @@ class BuildRequest(Request):
             )
 
         if soft:
-            log.warning('Build is taking too much time. Risk to be killed soon.')
+            log.warning("Canceling build due to soft timeout.")
+            self.app.control.revoke(
+                self.task_id, signal=signal.SIGUSR2, terminate=False
+            )
         else:
             log.warning('A timeout was enforced for task.')


### PR DESCRIPTION
Solve the problem reported by Sentry when the Celery task times out: https://sentry.io/organizations/read-the-docs/issues/3038754375/

> Each commit has a detailed explanation of the changes

Note to myself: the latest commit tries to handle soft timeout cancelled properly. It's close but it needs a little more of QA because for some reason `SIGUSR1` is triggered/catched as well.