### PR TITLE
Test explicitly with/out organizations

### DIFF
--- a/readthedocs/projects/tests/test_views.py
+++ b/readthedocs/projects/tests/test_views.py
@@ -1,12 +1,14 @@
 from django.contrib.auth.models import User
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import reverse
 from django_dynamic_fixture import get
 
 from readthedocs.integrations.models import Integration
+from readthedocs.organizations.models import Organization
 from readthedocs.projects.models import Project
 
 
+@override_settings(RTD_ALLOW_ORGANIZATIONS=False)
 class TestExternalBuildOption(TestCase):
     def setUp(self):
         self.user = get(User)
@@ -97,4 +99,15 @@ class TestExternalBuildOption(TestCase):
             field.help_text.startswith(
                 "To build from pull requests your repository's webhook needs to send pull request events."
             )
+        )
+
+
+@override_settings(RTD_ALLOW_ORGANIZATIONS=True)
+class TestExternalBuildOptionWithOrganizations(TestExternalBuildOption):
+    def setUp(self):
+        super().setUp()
+        self.organization = get(
+            Organization,
+            projects=[self.project],
+            owners=[self.user],
         )


### PR DESCRIPTION
So tests pass on .com