### PR TITLE
Sessions: do not save on each request

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -75,7 +75,7 @@ class CommunityBaseSettings(Settings):
     SESSION_COOKIE_DOMAIN = 'readthedocs.org'
     SESSION_COOKIE_HTTPONLY = True
     SESSION_COOKIE_AGE = 30 * 24 * 60 * 60  # 30 days
-    SESSION_SAVE_EVERY_REQUEST = True
+    SESSION_SAVE_EVERY_REQUEST = False
 
     @property
     def SESSION_COOKIE_SAMESITE(self):
@@ -89,7 +89,7 @@ class CommunityBaseSettings(Settings):
 
     # CSRF
     CSRF_COOKIE_HTTPONLY = True
-    CSRF_COOKIE_AGE = 30 * 24 * 60 * 60
+    CSRF_COOKIE_AGE = 30 * 24 * 60 * 60  # 30 days
 
     # Security & X-Frame-Options Middleware
     # https://docs.djangoproject.com/en/1.11/ref/middleware/#django.middleware.security.SecurityMiddleware


### PR DESCRIPTION
Currently, we have a 30 days expiry time for cookies with "save on every request"
enabled. That means users won't need to re-login if they hit at least one Read
the Docs page every 30 days.

In an attempt to reduce this "infinit session time", I'm disabling the "save on
every request". This way we are forcing the users to re-login every 30 days --no
matter if they hit a Read the Docs page during that time or not.

This will help us to know what are the active users because we will be able to
check `User.last_login` and get reasonable numbers. With the current
configuration, a user that used the platform _today_ could have a pretty old
`last_login` since we are not forcing re-login at all.

Discussion: https://github.com/readthedocs/meta/discussions/31