### PR TITLE
Fix missing indentation on reStructuredText badge code

### DIFF
--- a/readthedocs/templates/core/badge_markup.html
+++ b/readthedocs/templates/core/badge_markup.html
@@ -4,8 +4,8 @@
       <h4>reStructuredText</h4>
       <pre>
 .. image:: {{ badge_url }}
-:target: {{ site_url }}
-:alt: Documentation Status
+    :target: {{ site_url }}
+    :alt: Documentation Status
       </pre>
     </li>
     <li class="markdown">


### PR DESCRIPTION
Quickfix - don't believe this needs an issue.

Current code is syntactically wrong and raises `WARNING: Explicit markup ends without a blank line; unexpected unindent.`