### PR TITLE
OAuth: re-sync `RemoteRepository` on login

### DIFF
--- a/readthedocs/oauth/apps.py
+++ b/readthedocs/oauth/apps.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 
 """OAuth app config."""
 
@@ -7,3 +6,6 @@ from django.apps import AppConfig
 
 class OAuthConfig(AppConfig):
     name = 'readthedocs.oauth'
+
+    def ready(self):
+        import readthedocs.oauth.signals  # noqa

--- a/readthedocs/oauth/signals.py
+++ b/readthedocs/oauth/signals.py
@@ -1,0 +1,24 @@
+import structlog
+from allauth.account.signals import user_logged_in
+from django.contrib.auth.models import User
+from django.dispatch import receiver
+
+from readthedocs.oauth.tasks import sync_remote_repositories
+
+log = structlog.get_logger(__name__)
+
+
+@receiver(user_logged_in, sender=User)
+def sync_remote_repositories_on_login(sender, request, user, *args, **kwargs):
+    """
+    Sync ``RemoteRepository`` objects when a user logs in via Social Login.
+
+    This function will trigger a background task that will pull down
+    repositories from all the user's Social Account connected and create/update
+    their ``RemoteRepository`` in our database.
+    """
+    log.info(
+        "Triggering sync RemoteRepository in background on login.",
+        user_username=user.username,
+    )
+    sync_remote_repositories.delay(user.pk)


### PR DESCRIPTION
Copy the logic from `readthedocs-corporate` to resync `RemoteRepository` each
time the user logs in. We are forcing users to re-login every 30 days minimum.

Related: https://github.com/readthedocs/readthedocs.org/pull/9402