### PR TITLE
OAuth: unify the exception used for the user message

### DIFF
--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -7,6 +7,7 @@ from allauth.socialaccount.models import SocialAccount
 from allauth.socialaccount.providers import registry
 from django.conf import settings
 from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
 from oauthlib.oauth2.rfc6749.errors import InvalidClientIdError
 from requests.exceptions import RequestException
 from requests_oauthlib import OAuth2Session
@@ -17,6 +18,11 @@ log = structlog.get_logger(__name__)
 class SyncServiceError(Exception):
 
     """Error raised when a service failed to sync."""
+
+    INVALID_OR_REVOKED_ACCESS_TOKEN = _(
+        "Our access to your following accounts was revoked: {provider}. "
+        "Please, reconnect them from your social account connections."
+    )
 
 
 class Service:
@@ -152,10 +158,9 @@ class Service:
                 # valid. Probably the user has revoked the access to our App. He
                 # needs to reconnect his account
                 raise SyncServiceError(
-                    'Our access to your {provider} account was revoked. '
-                    'Please, reconnect it from your social account connections.'.format(
-                        provider=self.provider_name,
-                    ),
+                    SyncServiceError.INVALID_OR_REVOKED_ACCESS_TOKEN.format(
+                        provider=self.provider_name
+                    )
                 )
 
             next_url = self.get_next_url_to_paginate(resp)
@@ -165,8 +170,12 @@ class Service:
             return results
         # Catch specific exception related to OAuth
         except InvalidClientIdError:
-            log.warning('access_token or refresh_token failed.', url=url)
-            raise Exception('You should reconnect your account')
+            log.warning("access_token or refresh_token failed.", url=url)
+            raise SyncServiceError(
+                SyncServiceError.INVALID_OR_REVOKED_ACCESS_TOKEN.format(
+                    provider=self.provider_name
+                )
+            )
         # Catch exceptions with request or deserializing JSON
         except (RequestException, ValueError):
             # Response data should always be JSON, still try to log if not

--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -48,8 +48,9 @@ class BitbucketService(Service):
         except (TypeError, ValueError):
             log.warning('Error syncing Bitbucket repositories')
             raise SyncServiceError(
-                'Could not sync your Bitbucket repositories, '
-                'try reconnecting your account'
+                SyncServiceError.INVALID_OR_REVOKED_ACCESS_TOKEN.format(
+                    provider=self.vcs_provider_slug
+                )
             )
 
         # Because privileges aren't returned with repository data, run query
@@ -104,8 +105,9 @@ class BitbucketService(Service):
         except ValueError:
             log.warning('Error syncing Bitbucket organizations')
             raise SyncServiceError(
-                'Could not sync your Bitbucket workspace repositories, '
-                'try reconnecting your account',
+                SyncServiceError.INVALID_OR_REVOKED_ACCESS_TOKEN.format(
+                    provider=self.vcs_provider_slug
+                )
             )
 
         return remote_organizations, remote_repositories

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -44,8 +44,9 @@ class GitHubService(Service):
         except (TypeError, ValueError):
             log.warning('Error syncing GitHub repositories')
             raise SyncServiceError(
-                'Could not sync your GitHub repositories, '
-                'try reconnecting your account'
+                SyncServiceError.INVALID_OR_REVOKED_ACCESS_TOKEN.format(
+                    provider=self.vcs_provider_slug
+                )
             )
         return remote_repositories
 
@@ -76,8 +77,9 @@ class GitHubService(Service):
         except (TypeError, ValueError):
             log.warning('Error syncing GitHub organizations')
             raise SyncServiceError(
-                'Could not sync your GitHub organizations, '
-                'try reconnecting your account'
+                SyncServiceError.INVALID_OR_REVOKED_ACCESS_TOKEN.format(
+                    provider=self.vcs_provider_slug
+                )
             )
 
         return remote_organizations, remote_repositories

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -87,8 +87,9 @@ class GitLabService(Service):
         except (TypeError, ValueError):
             log.warning('Error syncing GitLab repositories')
             raise SyncServiceError(
-                'Could not sync your GitLab repositories, '
-                'try reconnecting your account'
+                SyncServiceError.INVALID_OR_REVOKED_ACCESS_TOKEN.format(
+                    provider=self.vcs_provider_slug
+                )
             )
 
         return remote_repositories
@@ -157,8 +158,9 @@ class GitLabService(Service):
         except (TypeError, ValueError):
             log.warning('Error syncing GitLab organizations')
             raise SyncServiceError(
-                'Could not sync your GitLab organization, '
-                'try reconnecting your account'
+                SyncServiceError.INVALID_OR_REVOKED_ACCESS_TOKEN.format(
+                    provider=self.vcs_provider_slug
+                )
             )
 
         return remote_organizations, remote_repositories

--- a/readthedocs/oauth/tasks.py
+++ b/readthedocs/oauth/tasks.py
@@ -3,7 +3,6 @@
 import structlog
 from allauth.socialaccount.providers import registry as allauth_registry
 from django.contrib.auth.models import User
-from django.utils.translation import gettext_lazy as _
 
 from readthedocs.core.permissions import AdminPermission
 from readthedocs.core.utils.tasks import PublicTask, user_id_matches_or_superuser
@@ -46,12 +45,10 @@ def sync_remote_repositories(user_id):
             except SyncServiceError:
                 failed_services.add(service.provider_name)
     if failed_services:
-        msg = _(
-            'Our access to your following accounts was revoked: {providers}. '
-            'Please, reconnect them from your social account connections.'
-        )
-        raise Exception(
-            msg.format(providers=', '.join(failed_services))
+        raise SyncServiceError(
+            SyncServiceError.INVALID_OR_REVOKED_ACCESS_TOKEN.format(
+                provider=", ".join(failed_services)
+            )
         )
 
 


### PR DESCRIPTION
Small refactor to re-use the same message when communicating to the user. We
always need to tell them to re-connect their account.