### PR TITLE
Logging: add extra log info for oauth

### DIFF
--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -39,6 +39,11 @@ class Service:
         self.session = None
         self.user = user
         self.account = account
+        log.bind(
+            user_username=self.user.username,
+            social_provider=self.provider_id,
+            social_account_id=self.account.pk,
+        )
 
     @classmethod
     def for_user(cls, user):


### PR DESCRIPTION
This will help us a little more when debugging revoked accounts, for example.