### PR TITLE
Redirects: merge query params from the redirect and original request

### DIFF
--- a/readthedocs/proxito/tests/test_old_redirects.py
+++ b/readthedocs/proxito/tests/test_old_redirects.py
@@ -258,7 +258,7 @@ class UserRedirectTests(MockStorageMixin, BaseDocServing):
             'http://project.dev.readthedocs.io/en/latest/tutorial/install.html',
         )
 
-    def test_redirect_with_query_params(self):
+    def test_redirect_with_query_params_from_url(self):
         self._storage_exists([
             '/media/html/project/latest/tutorial/install.html',
         ])
@@ -276,6 +276,38 @@ class UserRedirectTests(MockStorageMixin, BaseDocServing):
         self.assertEqual(
             r['Location'],
             'http://project.dev.readthedocs.io/en/latest/tutorial/install.html?foo=bar',
+        )
+
+    def test_redirect_with_query_params_to_url(self):
+        self._storage_exists(
+            [
+                "/media/html/project/latest/tutorial/install.html",
+            ]
+        )
+        Redirect.objects.create(
+            project=self.project,
+            redirect_type="page",
+            from_url="/install.html",
+            to_url="/tutorial/install.html?query=one",
+        )
+        r = self.client.get(
+            "/install.html",
+            HTTP_HOST="project.dev.readthedocs.io",
+        )
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(
+            r["Location"],
+            "http://project.dev.readthedocs.io/en/latest/tutorial/install.html?query=one",
+        )
+
+        r = self.client.get(
+            "/install.html?query=two",
+            HTTP_HOST="project.dev.readthedocs.io",
+        )
+        self.assertEqual(r.status_code, 302)
+        self.assertEqual(
+            r["Location"],
+            "http://project.dev.readthedocs.io/en/latest/tutorial/install.html?query=two&query=one",
         )
 
     def test_redirect_exact(self):

--- a/readthedocs/proxito/views/mixins.py
+++ b/readthedocs/proxito/views/mixins.py
@@ -1,6 +1,6 @@
 import copy
 import mimetypes
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import parse_qsl, urlencode, urlparse
 
 import structlog
 from django.conf import settings
@@ -286,15 +286,15 @@ class ServeRedirectMixin:
         :rtype: HttpResponseRedirect or HttpResponsePermanentRedirect
         """
         # `proxito_path` doesn't include query params.
-        query = urlparse(request.get_full_path()).query
+        query_list = parse_qsl(
+            urlparse(request.get_full_path()).query,
+            keep_blank_values=True,
+        )
 
         # Combine the query params from the original request with the ones from the redirect.
         redirect_parsed = urlparse(redirect_path)
-        redirect_query = urlencode(parse_qs(redirect_parsed.query))
-        if redirect_query:
-            if query:
-                query += "&"
-            query += redirect_query
+        query_list.extend(parse_qsl(redirect_parsed.query, keep_blank_values=True))
+        query = urlencode(query_list)
         new_path = redirect_parsed._replace(query=query).geturl()
 
         # Re-use the domain and protocol used in the current request.

--- a/readthedocs/proxito/views/mixins.py
+++ b/readthedocs/proxito/views/mixins.py
@@ -1,6 +1,6 @@
 import copy
 import mimetypes
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlencode, urlparse
 
 import structlog
 from django.conf import settings
@@ -290,7 +290,7 @@ class ServeRedirectMixin:
 
         # Combine the query params from the original request with the ones from the redirect.
         redirect_parsed = urlparse(redirect_path)
-        redirect_query = redirect_parsed.query
+        redirect_query = urlencode(parse_qs(redirect_parsed.query))
         if redirect_query:
             if query:
                 query += "&"

--- a/readthedocs/proxito/views/mixins.py
+++ b/readthedocs/proxito/views/mixins.py
@@ -287,8 +287,15 @@ class ServeRedirectMixin:
         """
         # `proxito_path` doesn't include query params.
         query = urlparse(request.get_full_path()).query
-        # Pass the query params from the original request to the redirect.
-        new_path = urlparse(redirect_path)._replace(query=query).geturl()
+
+        # Combine the query params from the original request with the ones from the redirect.
+        redirect_parsed = urlparse(redirect_path)
+        redirect_query = redirect_parsed.query
+        if redirect_query:
+            if query:
+                query += "&"
+            query += redirect_query
+        new_path = redirect_parsed._replace(query=query).geturl()
 
         # Re-use the domain and protocol used in the current request.
         # Redirects shouldn't change the domain, version or language.


### PR DESCRIPTION
We were overriding the query parameters
instead of adding them.

I'm adding the ones from the redirect at the end
(should take precedence on some frameworks).
We could get fancy and replace them instead of adding
them, but it gets tricky when we have an array...
So I think this implementation should be fine.

Closes https://github.com/readthedocs/readthedocs.org/issues/9401