### PR TITLE
Fix docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,7 +84,7 @@ intersphinx_mapping = {
     "ipywidgets": ("https://ipywidgets.readthedocs.io/en/7.6.3/", None),
     "jupytext": ("https://jupytext.readthedocs.io/en/stable/", None),
     "ipyleaflet": ("https://ipyleaflet.readthedocs.io/en/latest/", None),
-    "poliastro": ("https://docs.poliastro.space/en/v0.15.2/", None),
+    "poliastro": ("https://docs.poliastro.space/en/stable/", None),
     "qiskit": ("https://qiskit.org/documentation/", None),
     "myst-parser": ("https://myst-parser.readthedocs.io/en/v0.15.1/", None),
     "writethedocs": ("https://www.writethedocs.org/", None),


### PR DESCRIPTION
Looks like poliastro deletes its old versions,
so, let's just use the stable version.