### PR TITLE
Requirements: update them with `pur`

### DIFF
--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -7,6 +7,6 @@ gunicorn==20.1.0
 django-redis-cache==3.0.1
 
 #For resizing images
-pillow==9.1.0
+pillow==9.2.0
 
 structlog-sentry==1.4.0

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -4,15 +4,15 @@
 -r debug.txt
 
 # https://www.psycopg.org/docs/install.html#psycopg-vs-psycopg-binary
-psycopg2-binary==2.9.2  # pyup: ignore
+psycopg2-binary==2.9.3  # pyup: ignore
 
 django-redis-cache==3.0.1
 
 # For resizing images
-pillow==9.1.0
+pillow==9.2.0
 
 # run tests
-tox==3.25.0
+tox==3.25.1
 
 # Used together with structlog to have nicer logs locally
-rich==12.3.0
+rich==12.5.1

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -1,21 +1,21 @@
 # Base packages
 
-pip==22.0.4
-virtualenv==20.14.1
+pip==22.2.2
+virtualenv==20.16.3
 
-django==3.2.13  # pyup: <3.3
-django-extensions==3.1.5
+django==4.1  # pyup: <3.3
+django-extensions==3.2.0
 django-polymorphic==3.1.0
 django-autoslug==1.9.8
-django-simple-history==3.0.0
+django-simple-history==3.1.1
 
 djangorestframework==3.13.1
 
 # For intersphinx during builds
-Sphinx==4.5.0
+Sphinx==5.1.1
 
 # Filtering for the REST API
-django-filter==21.1
+django-filter==22.1
 
 drf-flex-fields==0.9.8
 drf-extensions==0.7.1
@@ -27,29 +27,28 @@ django-vanilla-views==3.0.0
 # dependency as well.
 jsonfield==3.1.0
 
-requests==2.27.1
+requests==2.28.1
 requests-toolbelt==0.9.1
 slumber==0.7.1
-# awscli (requirements/docker.txt) isn't compatible with pyyaml >= 5.5.
-pyyaml==5.4.1  # pyup: ignore
+pyyaml==6.0
 Pygments==2.12.0
 
 # Downgrade redis to 3.5.3 (latest 3.x release) because pip raises this error:
 # django-redis-cache 2.1.3 depends on redis<4.0
-redis==3.5.3  # pyup: ignore
+redis==4.3.4  # pyup: ignore
 
-celery==5.2.6
+celery==5.2.7
 
-django-allauth==0.50.0
+django-allauth==0.51.0
 requests-oauthlib==1.3.1
 
 GitPython==3.1.27
 
 # Search
-elasticsearch==7.17.3  # pyup: <8.0.0
+elasticsearch==8.3.3  # pyup: <8.0.0
 elasticsearch-dsl==7.4.0  # pyup: <8.0
 django-elasticsearch-dsl==7.2.2  # pyup: <8.0
-selectolax==0.3.7
+selectolax==0.3.8
 
 # embed
 pyquery==1.4.3
@@ -57,20 +56,20 @@ pyquery==1.4.3
 # NOTE: this dep can be removed in python 3.7 in favor of ``date.fromisoformat``
 python-dateutil==2.8.2
 
-orjson==3.6.8
+orjson==3.7.11
 
 # Utils
 django-gravatar2==1.4.4
 pytz==2022.1
 django-kombu==0.9.4
-stripe==2.74.0
-regex==2022.4.24
+stripe==4.0.2
+regex==2022.7.25
 # NOTE: djstripe overrides the stripe api version
 # globally, when updating make sure our code is compatible
 # with the version used by djstripe.
 # See STRIPE_API_VERSION https://dj-stripe.dev/reference/settings/.
-dj-stripe==2.6.1
-markdown==3.3.6
+dj-stripe==2.6.2
+markdown==3.4.1
 
 # unicode-slugify==0.1.5 is not released on PyPI yet
 git+https://github.com/mozilla/unicode-slugify@b696c37#egg=unicode-slugify==0.1.5
@@ -91,19 +90,19 @@ packaging==21.3
 
 # django-cors-middleware==1.5.0 fails with
 # AttributeError: 'dict' object has no attribute 'has_header'
-django-cors-middleware==1.4.0  # pyup: ignore
+django-cors-middleware==1.5.0  # pyup: ignore
 
 # User agent parsing - used for analytics purposes
 user-agents==2.2.0
 
-django-storages[boto3]==1.12.3
+django-storages[boto3]==1.13.1
 
 
 # Required only in development and linting
-django-debug-toolbar==3.3.0
+django-debug-toolbar==3.5.0
 
 # For enabling content-security-policy
 django-csp==3.7
 
-django-structlog==2.2.0
-structlog==21.5.0
+django-structlog==3.0.1
+structlog==22.1.0

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -8,9 +8,9 @@ pytest-custom-exit-code==0.3.0
 pytest-django==4.5.2
 pytest-cov==3.0.0
 
-Mercurial==6.1.1
+Mercurial==6.2
 
 yamale==2.2.0  # pyup: <3.0
-pytest-mock==3.7.0
+pytest-mock==3.8.2
 
 requests-mock==1.9.3


### PR DESCRIPTION
Use `pur` and run it manually because `pyup` has been broken lately. See
https://github.com/readthedocs/readthedocs.org/issues/9273

So, I went ahead and use `pur` which does exactly the same but it requires a
manual run. I updated all the requirements we are tracking as `txt` but I
haven't touched the `in` since that is using a different tool.