### PR TITLE
Docs: Adds Jupyter Book to examples table

### DIFF
--- a/docs/user/examples.rst
+++ b/docs/user/examples.rst
@@ -31,7 +31,7 @@ Sphinx and MkDocs examples
    * - Jupyter Book
      - Jupyter Book and Sphinx
      - `[Git] <https://github.com/readthedocs-examples/example-jupyter-book/>`__ `[Rendered] <https://example-jupyter-book.readthedocs.io/>`__
-     - Jupyter Book w/ popular integrations configured for RTD
+     - Jupyter Book with popular integrations configured
 
 
 Real-life examples

--- a/docs/user/examples.rst
+++ b/docs/user/examples.rst
@@ -28,6 +28,10 @@ Sphinx and MkDocs examples
      - MkDocs
      - `[Git] <https://github.com/readthedocs-examples/example-mkdocs-basic/>`__ `[Rendered] <https://example-mkdocs-basic.readthedocs.io/en/latest/>`__
      - Basic example of using MkDocs
+   * - Jupyter Book
+     - Jupyter Book and Sphinx
+     - `[Git] <https://github.com/readthedocs-examples/example-jupyter-book/>`__ `[Rendered] <https://example-jupyter-book.readthedocs.io/>`__
+     - Jupyter Book w/ popular integrations configured for RTD
 
 
 Real-life examples


### PR DESCRIPTION
Not sure how this current example table should look wrt. headline.. proposing to rename it to "List of current example projects", supposing that we might have a list of "outdated" examples or "unmaintained examples".

Before:

![image](https://user-images.githubusercontent.com/374612/180797481-d4cc3707-fb59-445d-8a7d-21f083241776.png)

After:

![image](https://user-images.githubusercontent.com/374612/180520578-6476450b-3c51-4809-b192-7060ae113cda.png)
