### PR TITLE
OAuth: add logging for GitHub RemoteRepository

### DIFF
--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -105,6 +105,7 @@ class GitHubService(Service):
                 vcs_provider=self.vcs_provider_slug,
             )
 
+            # TODO: Just for debugging, remove after #xxx is solved.
             if created:
                 _old_remote_repository = RemoteRepository.objects.filter(
                     full_name=fields["full_name"], vcs_provider=self.vcs_provider_slug

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -105,7 +105,7 @@ class GitHubService(Service):
                 vcs_provider=self.vcs_provider_slug,
             )
 
-            # TODO: Just for debugging, remove after #xxx is solved.
+            # TODO: For debugging: https://github.com/readthedocs/readthedocs.org/pull/9449.
             if created:
                 _old_remote_repository = RemoteRepository.objects.filter(
                     full_name=fields["full_name"], vcs_provider=self.vcs_provider_slug


### PR DESCRIPTION
Trying to find out why we are creating multiple `RemoteRepository` with
different `remote_id` but exact `html_url`/`full_name`.

Reference: https://github.com/readthedocs/readthedocs-corporate/issues/1447