### PR TITLE
GitHub Action: add link to Pull Request preview

### DIFF
--- a/.github/workflows/pr-preview-links.yaml
+++ b/.github/workflows/pr-preview-links.yaml
@@ -1,0 +1,16 @@
+name: Read the Docs Pull Request Preview
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  pr-preview-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/readthedocs-preview@main
+        with:
+          project-slug: "docs"


### PR DESCRIPTION
Use https://github.com/readthedocs/readthedocs-preview/ to add a link to Pull
Request's descriptions with the link to the documentation preview.