### PR TITLE
Proxito: separate project slug extraction from request

### DIFF
--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -22,15 +22,18 @@ from readthedocs.proxito import constants
 log = structlog.get_logger(__name__)  # noqa
 
 
+def _extract_domain_from_netloc(netloc):
+    return netloc.lower().split(':')[0]
+
 def _unresolve_domain(domain):
     """
     Unresolve domain.
 
     We extract the project slug from the domain.
     """
-    host = request.get_host().lower().split(':')[0]
-    public_domain = settings.PUBLIC_DOMAIN.lower().split(':')[0]
-    external_domain = settings.RTD_EXTERNAL_VERSION_DOMAIN.lower().split(':')[0]
+    host = domain
+    public_domain = _extract_domain_from_netloc(settings.PUBLIC_DOMAIN)
+    external_domain = _extract_domain_from_netloc(settings.RTD_EXTERNAL_VERSION_DOMAIN)
 
     host_parts = host.split('.')
     public_domain_parts = public_domain.split('.')
@@ -38,68 +41,34 @@ def _unresolve_domain(domain):
 
     project_slug = None
 
-    # Explicit Project slug being passed in
-    if 'HTTP_X_RTD_SLUG' in request.META:
-        project_slug = request.META['HTTP_X_RTD_SLUG'].lower()
-        if Project.objects.filter(slug=project_slug).exists():
-            request.rtdheader = True
-            log.info('Setting project based on X_RTD_SLUG header.', project_slug=project_slug)
-            return project_slug
-
     if public_domain in host or host == 'proxito':
         # Serve from the PUBLIC_DOMAIN, ensuring it looks like `foo.PUBLIC_DOMAIN`
         if public_domain_parts == host_parts[1:]:
             project_slug = host_parts[0]
-            request.subdomain = True
             log.debug('Proxito Public Domain.', host=host)
-            if Domain.objects.filter(project__slug=project_slug).filter(
-                canonical=True,
-                https=True,
-            ).exists():
-                log.debug('Proxito Public Domain -> Canonical Domain Redirect.', host=host)
-                request.canonicalize = constants.REDIRECT_CANONICAL_CNAME
-            elif (
-                ProjectRelationship.objects.
-                filter(child__slug=project_slug).exists()
-            ):
-                log.debug('Proxito Public Domain -> Subproject Main Domain Redirect.', host=host)
-                request.canonicalize = constants.REDIRECT_SUBPROJECT_MAIN_DOMAIN
             return project_slug
 
         # TODO: This can catch some possibly valid domains (docs.readthedocs.io.com) for example
         # But these feel like they might be phishing, etc. so let's block them for now.
         log.warning('Weird variation on our hostname.', host=host)
-        return render(
-            request, 'core/dns-404.html', context={'host': host}, status=400
-        )
+        return None
 
     if external_domain in host:
         # Serve custom versions on external-host-domain
         if external_domain_parts == host_parts[1:]:
             try:
                 project_slug, version_slug = host_parts[0].rsplit('--', 1)
-                request.external_domain = True
-                request.host_version_slug = version_slug
                 log.debug('Proxito External Version Domain.', host=host)
                 return project_slug
             except ValueError:
                 log.warning('Weird variation on our hostname.', host=host)
-                return render(
-                    request, 'core/dns-404.html', context={'host': host}, status=400
-                )
+                return None
 
     # Serve CNAMEs
     domain = Domain.objects.filter(domain=host).first()
     if domain:
         project_slug = domain.project.slug
-        request.cname = True
-        request.domain = domain
         log.debug('Proxito CNAME.', host=host)
-
-        if domain.https and not request.is_secure():
-            # Redirect HTTP -> HTTPS (302) for this custom domain
-            log.debug('Proxito CNAME HTTPS Redirect.', host=host)
-            request.canonicalize = constants.REDIRECT_HTTPS
 
         # NOTE: consider redirecting non-canonical custom domains to the canonical one
         # Whether that is another custom domain or the public domain
@@ -108,9 +77,7 @@ def _unresolve_domain(domain):
 
     # Some person is CNAMEing to us without configuring a domain - 404.
     log.debug('CNAME 404.', host=host)
-    return render(
-        request, 'core/dns-404.html', context={'host': host}, status=404
-    )
+    return None
 
 
 def map_host_to_project_slug(request):  # pylint: disable=too-many-return-statements

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -22,6 +22,97 @@ from readthedocs.proxito import constants
 log = structlog.get_logger(__name__)  # noqa
 
 
+def _unresolve_domain(domain):
+    """
+    Unresolve domain.
+
+    We extract the project slug from the domain.
+    """
+    host = request.get_host().lower().split(':')[0]
+    public_domain = settings.PUBLIC_DOMAIN.lower().split(':')[0]
+    external_domain = settings.RTD_EXTERNAL_VERSION_DOMAIN.lower().split(':')[0]
+
+    host_parts = host.split('.')
+    public_domain_parts = public_domain.split('.')
+    external_domain_parts = external_domain.split('.')
+
+    project_slug = None
+
+    # Explicit Project slug being passed in
+    if 'HTTP_X_RTD_SLUG' in request.META:
+        project_slug = request.META['HTTP_X_RTD_SLUG'].lower()
+        if Project.objects.filter(slug=project_slug).exists():
+            request.rtdheader = True
+            log.info('Setting project based on X_RTD_SLUG header.', project_slug=project_slug)
+            return project_slug
+
+    if public_domain in host or host == 'proxito':
+        # Serve from the PUBLIC_DOMAIN, ensuring it looks like `foo.PUBLIC_DOMAIN`
+        if public_domain_parts == host_parts[1:]:
+            project_slug = host_parts[0]
+            request.subdomain = True
+            log.debug('Proxito Public Domain.', host=host)
+            if Domain.objects.filter(project__slug=project_slug).filter(
+                canonical=True,
+                https=True,
+            ).exists():
+                log.debug('Proxito Public Domain -> Canonical Domain Redirect.', host=host)
+                request.canonicalize = constants.REDIRECT_CANONICAL_CNAME
+            elif (
+                ProjectRelationship.objects.
+                filter(child__slug=project_slug).exists()
+            ):
+                log.debug('Proxito Public Domain -> Subproject Main Domain Redirect.', host=host)
+                request.canonicalize = constants.REDIRECT_SUBPROJECT_MAIN_DOMAIN
+            return project_slug
+
+        # TODO: This can catch some possibly valid domains (docs.readthedocs.io.com) for example
+        # But these feel like they might be phishing, etc. so let's block them for now.
+        log.warning('Weird variation on our hostname.', host=host)
+        return render(
+            request, 'core/dns-404.html', context={'host': host}, status=400
+        )
+
+    if external_domain in host:
+        # Serve custom versions on external-host-domain
+        if external_domain_parts == host_parts[1:]:
+            try:
+                project_slug, version_slug = host_parts[0].rsplit('--', 1)
+                request.external_domain = True
+                request.host_version_slug = version_slug
+                log.debug('Proxito External Version Domain.', host=host)
+                return project_slug
+            except ValueError:
+                log.warning('Weird variation on our hostname.', host=host)
+                return render(
+                    request, 'core/dns-404.html', context={'host': host}, status=400
+                )
+
+    # Serve CNAMEs
+    domain = Domain.objects.filter(domain=host).first()
+    if domain:
+        project_slug = domain.project.slug
+        request.cname = True
+        request.domain = domain
+        log.debug('Proxito CNAME.', host=host)
+
+        if domain.https and not request.is_secure():
+            # Redirect HTTP -> HTTPS (302) for this custom domain
+            log.debug('Proxito CNAME HTTPS Redirect.', host=host)
+            request.canonicalize = constants.REDIRECT_HTTPS
+
+        # NOTE: consider redirecting non-canonical custom domains to the canonical one
+        # Whether that is another custom domain or the public domain
+
+        return project_slug
+
+    # Some person is CNAMEing to us without configuring a domain - 404.
+    log.debug('CNAME 404.', host=host)
+    return render(
+        request, 'core/dns-404.html', context={'host': host}, status=404
+    )
+
+
 def map_host_to_project_slug(request):  # pylint: disable=too-many-return-statements
     """
     Take the request and map the host to the proper project slug.


### PR DESCRIPTION
This is so we can use the project slug extraction in the new implementation of the unresolver. The refactor is split into several commits.