### PR TITLE
Redirects: check only for hostname and path for infinite redirects

### DIFF
--- a/readthedocs/proxito/tests/test_old_redirects.py
+++ b/readthedocs/proxito/tests/test_old_redirects.py
@@ -183,6 +183,48 @@ class UserRedirectTests(MockStorageMixin, BaseDocServing):
             "http://project.dev.readthedocs.io/en/latest/tutorial/install.html",
         )
 
+    def test_infinite_redirect(self):
+        host = "project.dev.readthedocs.io"
+        fixture.get(
+            Redirect,
+            project=self.project,
+            redirect_type="exact",
+            from_url="/en/latest/install.html",
+            to_url="/en/latest/install.html",
+        )
+        with pytest.raises(Http404):
+            self.client.get(
+                "/en/latest/install.html",
+                HTTP_HOST=host,
+            )
+
+        with pytest.raises(Http404):
+            self.client.get(
+                "/en/latest/install.html?foo=bar",
+                HTTP_HOST=host,
+            )
+
+    def test_infinite_redirect_changing_protocol(self):
+        host = "project.dev.readthedocs.io"
+        fixture.get(
+            Redirect,
+            project=self.project,
+            redirect_type="exact",
+            from_url="/en/latest/install.html",
+            to_url=f"https://{host}/en/latest/install.html",
+        )
+        with pytest.raises(Http404):
+            self.client.get(
+                "/en/latest/install.html",
+                HTTP_HOST=host,
+            )
+
+        with pytest.raises(Http404):
+            self.client.get(
+                "/en/latest/install.html?foo=bar",
+                HTTP_HOST=host,
+            )
+
     def test_redirect_prefix_infinite(self):
         """
         Avoid infinite redirects.
@@ -622,6 +664,7 @@ class UserForcedRedirectTests(BaseDocServing):
         self.assertEqual(r.status_code, 404)
 
     def test_infinite_redirect(self):
+        host = "project.dev.readthedocs.io"
         fixture.get(
             Redirect,
             project=self.project,
@@ -632,6 +675,34 @@ class UserForcedRedirectTests(BaseDocServing):
         )
         r = self.client.get(
             "/en/latest/install.html",
+            HTTP_HOST=host,
+        )
+        self.assertEqual(r.status_code, 200)
+
+        r = self.client.get(
+            "/en/latest/install.html?foo=bar",
+            HTTP_HOST=host,
+        )
+        self.assertEqual(r.status_code, 200)
+
+    def test_infinite_redirect_changing_protocol(self):
+        host = "project.dev.readthedocs.io"
+        fixture.get(
+            Redirect,
+            project=self.project,
+            redirect_type="exact",
+            from_url="/install.html",
+            to_url=f"https://{host}/install.html",
+            force=True,
+        )
+        r = self.client.get(
+            "/en/latest/install.html",
+            HTTP_HOST=host,
+        )
+        self.assertEqual(r.status_code, 200)
+
+        r = self.client.get(
+            "/en/latest/install.html?foo=bar",
             HTTP_HOST="project.dev.readthedocs.io",
         )
         self.assertEqual(r.status_code, 200)

--- a/readthedocs/proxito/views/mixins.py
+++ b/readthedocs/proxito/views/mixins.py
@@ -308,7 +308,14 @@ class ServeRedirectMixin:
             http_status_code=http_status,
         )
 
-        if request.build_absolute_uri(proxito_path) == new_path:
+        new_path_parsed = urlparse(new_path)
+        old_path_parsed = urlparse(request.build_absolute_uri(proxito_path))
+        # Check explicitly only the path and hostname, since a different
+        # protocol or query parameters could lead to a infinite redirect.
+        if (
+            new_path_parsed.hostname == old_path_parsed.hostname
+            and new_path_parsed.path == old_path_parsed.path
+        ):
             # check that we do have a response and avoid infinite redirect
             log.warning(
                 'Infinite Redirect: FROM URL is the same than TO URL.',


### PR DESCRIPTION
We were comparing the proxito_path
which doesn't include query parameters with the final URL, which does
include them, causing an infinite redirect.

This same thing could happen if someone writes a redirect to
`http://`, we redirect to the https version, then the redirect will
redirect to the http version again.

<!-- readthedocs-preview docs start -->
----
:books: Documentation preview :books:: https://docs--9463.org.readthedocs.build/en/9463/

<!-- readthedocs-preview docs end -->