### PR TITLE
Use Read the Docs action v1

### DIFF
--- a/.github/workflows/pr-preview-links.yaml
+++ b/.github/workflows/pr-preview-links.yaml
@@ -11,6 +11,6 @@ jobs:
   pr-preview-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: readthedocs/readthedocs-preview@main
+      - uses: readthedocs/actions/preview@v1
         with:
           project-slug: "docs"


### PR DESCRIPTION
Read the Docs repository was renamed from `readthedocs/readthedocs-preview` to `readthedocs/actions/`. Now, the `preview` action is under `readthedocs/actions/preview` and is tagged as `v1`

<!-- readthedocs-preview docs start -->
----
:books: Documentation preview :books:: https://docs--9487.org.readthedocs.build/en/9487/

<!-- readthedocs-preview docs end -->