### PR TITLE
Preview: add links to `dev` documentation

### DIFF
--- a/.github/workflows/pr-preview-links.yaml
+++ b/.github/workflows/pr-preview-links.yaml
@@ -14,3 +14,7 @@ jobs:
       - uses: readthedocs/actions/preview@v1
         with:
           project-slug: "docs"
+
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "dev"


### PR DESCRIPTION
We have `docs` and `dev` Read the Docs projects tied to this repository.
This PR enables the GitHub Action for `dev`.

<!-- readthedocs-preview docs start -->
----
:books: Documentation preview :books:: https://docs--9491.org.readthedocs.build/en/9491/

<!-- readthedocs-preview docs end -->