### PR TITLE
Add dependency to docs requirements

### DIFF
--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -9,6 +9,7 @@ sphinx-intl==2.0.1
 sphinx-design==0.2.0
 sphinx-multiproject==1.0.0rc1
 readthedocs-sphinx-search==0.1.1
+sphinxcontrib-video @ git+https://github.com/readthedocs/sphinxcontrib-video
 
 # Test out hoverxref
 git+https://github.com/readthedocs/sphinx-hoverxref

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -49,6 +49,8 @@ myst-parser==0.17.2
     # via -r docs.in
 packaging==21.3
     # via sphinx
+pbr==5.10.0
+    # via sphinxcontrib-video
 pygments==2.12.0
     # via
     #   -r docs.in
@@ -120,6 +122,8 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
+sphinxcontrib-video @ git+https://github.com/readthedocs/sphinxcontrib-video
+    # via -r docs.in
 sphinxemoji==0.2.0
     # via -r docs.in
 tornado==6.1
@@ -135,5 +139,3 @@ urllib3==1.26.9
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools
-
-sphinxcontrib-video @ git+https://github.com/readthedocs/sphinxcontrib-video/


### PR DESCRIPTION
This was added manually to the file instead of using piptools.

<!-- readthedocs-preview docs start -->
----
:books: Documentation preview :books:: https://docs--9494.org.readthedocs.build/en/9494/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
----
:books: Documentation preview :books:: https://dev--9494.org.readthedocs.build/en/9494/

<!-- readthedocs-preview dev end -->