### PR TITLE
Custom urlconf: support serving static files

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -676,7 +676,7 @@ class Project(models.Model):
         """
         from readthedocs.projects.views.public import ProjectDownloadMedia
         from readthedocs.proxito.urls import core_urls
-        from readthedocs.proxito.views.serve import ServeDocs
+        from readthedocs.proxito.views.serve import ServeDocs, ServeStaticFiles
         from readthedocs.proxito.views.utils import proxito_404_page_handler
 
         class ProxitoURLConf:
@@ -700,6 +700,15 @@ class Project(models.Model):
                         **pattern_opts),
                     ProjectDownloadMedia.as_view(same_domain_url=True),
                     name='user_proxied_downloads'
+                ),
+                re_path(
+                    r"{proxied_api_url}static/"
+                    r"(?P<filename>{filename_slug})$".format(
+                        proxied_api_url=re.escape(self.proxied_api_url),
+                        **pattern_opts,
+                    ),
+                    ServeStaticFiles.as_view(),
+                    name="proxito_static_files",
                 ),
             ]
             docs_urls = [

--- a/readthedocs/proxito/tests/test_middleware.py
+++ b/readthedocs/proxito/tests/test_middleware.py
@@ -310,6 +310,16 @@ class MiddlewareURLConfTests(TestCase):
             'Inserted RTD Footer',
         )
 
+    @override_settings(
+        RTD_STATICFILES_STORAGE="readthedocs.rtd_tests.storage.BuildMediaFileSystemStorageTest"
+    )
+    def test_middleware_urlconf_subpath_static_files(self):
+        resp = self.client.get(
+            "/subpath/to/_/static/javascript/readthedocs-doc-embed.js",
+            HTTP_HOST=self.domain,
+        )
+        self.assertEqual(resp.status_code, 200)
+
     def test_urlconf_is_escaped(self):
         self.pip.urlconf = '3.6/$version/$language/$filename'
         self.pip.save()


### PR DESCRIPTION
The URL was missing in the custom urlconf

<!-- readthedocs-preview docs start -->
----
:books: Documentation preview :books:: https://docs--9496.org.readthedocs.build/en/9496/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
----
:books: Documentation preview :books:: https://dev--9496.org.readthedocs.build/en/9496/

<!-- readthedocs-preview dev end -->