### PR TITLE
Fix typo in build concurrency logging

### DIFF
--- a/readthedocs/builds/querysets.py
+++ b/readthedocs/builds/querysets.py
@@ -243,7 +243,7 @@ class BuildQuerySet(models.QuerySet):
         log.info(
             'Concurrent builds.',
             project_slug=project.slug,
-            concurent=concurrent,
+            concurrent=concurrent,
             max_concurrent=max_concurrent,
         )
         if concurrent >= max_concurrent:


### PR DESCRIPTION


<!-- readthedocs-preview docs start -->
----
:books: Documentation preview :books:: https://docs--9499.org.readthedocs.build/en/9499/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
----
:books: Documentation preview :books:: https://dev--9499.org.readthedocs.build/en/9499/

<!-- readthedocs-preview dev end -->