### PR TITLE
Teams: don't send email notification when users adds themselves to a team

### DIFF
--- a/readthedocs/organizations/forms.py
+++ b/readthedocs/organizations/forms.py
@@ -270,7 +270,8 @@ class OrganizationTeamMemberForm(forms.Form):
                 .exists()
             ):
                 member = self.team.organization.add_member(user, self.team)
-                member.send_add_notification(self.request)
+                if user != self.request.user:
+                    member.send_add_notification(self.request)
                 return user
             invitation, _ = Invitation.objects.invite(
                 from_user=self.request.user,

--- a/readthedocs/organizations/tests/test_orgs.py
+++ b/readthedocs/organizations/tests/test_orgs.py
@@ -447,3 +447,18 @@ class OrganizationTeamMemberTests(OrganizationTestCase):
         self.assertEqual(self.team.members.count(), 2)
         self.assertEqual(Invitation.objects.for_object(self.team).count(), 0)
         send_email.assert_called_once()
+
+    @mock.patch("readthedocs.organizations.utils.send_email")
+    def test_invite_myuself_to_team(self, send_email):
+        self.assertEqual(self.team.members.count(), 0)
+        resp = self.client.post(
+            reverse(
+                "organization_team_member_add",
+                args=[self.organization.slug, self.team.slug],
+            ),
+            data={"username_or_email": self.owner.username},
+        )
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(self.team.members.count(), 1)
+        self.assertEqual(Invitation.objects.for_object(self.team).count(), 0)
+        send_email.assert_not_called()


### PR DESCRIPTION


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9511.org.readthedocs.build/en/9511/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9511.org.readthedocs.build/en/9511/

<!-- readthedocs-preview dev end -->