### PR TITLE
Telemetry: collect user's requirements

### DIFF
--- a/readthedocs/telemetry/admin.py
+++ b/readthedocs/telemetry/admin.py
@@ -1,5 +1,5 @@
 """Telemetry admin."""
-
+# pylint: disable=no-self-use
 
 from django.contrib import admin
 
@@ -10,12 +10,27 @@ from readthedocs.telemetry.models import BuildData
 @admin.register(BuildData)
 class BuildDataAdmin(admin.ModelAdmin):
 
+    """Admin class for BuildData model."""
+
     fields = ("created", "modified", "pretty_data")
     readonly_fields = (
         "created",
         "modified",
         "pretty_data",
     )
+    list_display = ("created", "_get_project", "_get_version", "_get_build")
+
+    @admin.display(description="Project")
+    def _get_project(self, obj):
+        return obj.data.get("project", {}).get("slug")
+
+    @admin.display(description="Version")
+    def _get_version(self, obj):
+        return obj.data.get("version", {}).get("slug")
+
+    @admin.display(description="Build")
+    def _get_build(self, obj):
+        return obj.data.get("build", {}).get("id")
 
     # pylint: disable=no-self-use
     def pretty_data(self, instance):

--- a/readthedocs/telemetry/admin.py
+++ b/readthedocs/telemetry/admin.py
@@ -1,5 +1,4 @@
 """Telemetry admin."""
-# pylint: disable=no-self-use
 
 from django.contrib import admin
 
@@ -20,14 +19,17 @@ class BuildDataAdmin(admin.ModelAdmin):
     )
     list_display = ("created", "_get_project", "_get_version", "_get_build")
 
+    # pylint: disable=no-self-use
     @admin.display(description="Project")
     def _get_project(self, obj):
         return obj.data.get("project", {}).get("slug")
 
+    # pylint: disable=no-self-use
     @admin.display(description="Version")
     def _get_version(self, obj):
         return obj.data.get("version", {}).get("slug")
 
+    # pylint: disable=no-self-use
     @admin.display(description="Build")
     def _get_build(self, obj):
         return obj.data.get("build", {}).get("id")

--- a/readthedocs/telemetry/collectors.py
+++ b/readthedocs/telemetry/collectors.py
@@ -155,14 +155,16 @@ class BuildDataCollector:
                     ).serialize()
                     dependencies = df.get("dependencies", [])
                     for requirement in dependencies:
-                        name = requirement.get("name").lower()
+                        name = requirement.get("name", "").lower()
+                        if not name:
+                            continue
 
                         # If the user defines a specific version in the
                         # requirements file, we save it Otherwise, we don't
                         # because we don't know which version will be
                         # installed.
                         version = "undefined"
-                        specs = str(requirement.get("specs"))
+                        specs = str(requirement.get("specs", ""))
                         if specs:
                             if specs.startswith("=="):
                                 version = specs.replace("==", "", 1)

--- a/readthedocs/telemetry/collectors.py
+++ b/readthedocs/telemetry/collectors.py
@@ -58,6 +58,12 @@ class BuildDataCollector:
         Data that can be extracted from the database (project/organization)
         isn't collected here.
         """
+
+        # NOTE: we could run each command inside a try/except block to have a
+        # more granular protection and be able to save data from those commands
+        # that didn't fail. Otherwise, if one command fails, all the data for
+        # this Build is lost.
+
         data = {}
         data["config"] = {"user": self.config.source_config}
         data["os"] = self._get_operating_system()

--- a/readthedocs/telemetry/collectors.py
+++ b/readthedocs/telemetry/collectors.py
@@ -129,7 +129,19 @@ class BuildDataCollector:
         return []
 
     def _get_user_pip_packages(self):
-        """Get all the packages to be installed defined by the user."""
+        """
+        Get all the packages to be installed defined by the user.
+
+        It parses all the requirements files specified in the config file by
+        the user (python.install.requirements) using ``dparse`` --a 3rd party
+        package.
+
+        If the version of the package is explicit (==) it saves that particular
+        version. Otherwise, if it's not defined, it saves ``undefined`` and if
+        it's a non deterministic operation (like >=, <= or ~=) it saves
+        ``unknown`` in the version.
+
+        """
         results = []
         # pylint: disable=too-many-nested-blocks
         for install in self.config.python.install:

--- a/readthedocs/telemetry/tests/test_collectors.py
+++ b/readthedocs/telemetry/tests/test_collectors.py
@@ -89,22 +89,16 @@ class TestBuildDataCollector(TestCase):
         )
 
     def test_get_user_pip_packages(self, run):
+        self.collector.config = self._get_build_config(
+            {"python": {"install": [{"requirements": "docs/requirements.txt"}]}}
+        )
         out = dedent(
             """
-            [
-                {
-                    "name": "requests-mock",
-                    "version": "1.8.0"
-                },
-                {
-                    "name": "requests-toolbelt",
-                    "version": "0.9.1"
-                },
-                {
-                    "name": "rstcheck",
-                    "version": "3.3.1"
-                }
-            ]
+            requests-mock==1.8.0
+            requests-toolbelt==0.9.1
+            rstcheck==3.3.1
+            Sphinx>=5  # >= specs
+            requests   # no specs
             """
         )
         run.return_value = (0, out, "")
@@ -114,6 +108,8 @@ class TestBuildDataCollector(TestCase):
                 {"name": "requests-mock", "version": "1.8.0"},
                 {"name": "requests-toolbelt", "version": "0.9.1"},
                 {"name": "rstcheck", "version": "3.3.1"},
+                {"name": "sphinx", "version": "unknown"},  # >= specs
+                {"name": "requests", "version": "undefined"},  # no specs
             ],
         )
 

--- a/readthedocs/telemetry/tests/test_collectors.py
+++ b/readthedocs/telemetry/tests/test_collectors.py
@@ -109,7 +109,7 @@ class TestBuildDataCollector(TestCase):
         )
         run.return_value = (0, out, "")
         self.assertEqual(
-            self.collector._get_pip_packages(include_all=False),
+            self.collector._get_user_pip_packages(),
             [
                 {"name": "requests-mock", "version": "1.8.0"},
                 {"name": "requests-toolbelt", "version": "0.9.1"},
@@ -138,7 +138,7 @@ class TestBuildDataCollector(TestCase):
         )
         run.return_value = (0, out, "")
         self.assertEqual(
-            self.collector._get_pip_packages(include_all=True),
+            self.collector._get_all_pip_packages(),
             [
                 {"name": "requests-mock", "version": "1.8.0"},
                 {"name": "requests-toolbelt", "version": "0.9.1"},

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -167,6 +167,8 @@ docutils==0.17.1
     # via
     #   -r requirements/pip.txt
     #   sphinx
+dparse==0.5.2
+    # via -r requirements/pip.txt
 drf-extensions==0.7.1
     # via -r requirements/pip.txt
 drf-flex-fields==0.9.8
@@ -236,6 +238,7 @@ packaging==21.3
     # via
     #   -r requirements/pip.txt
     #   docker
+    #   dparse
     #   sphinx
 pillow==9.2.0
     # via -r requirements/deploy.in
@@ -375,6 +378,10 @@ structlog==22.1.0
     #   django-structlog
 structlog-sentry==1.4.0
     # via -r requirements/deploy.in
+toml==0.10.2
+    # via
+    #   -r requirements/pip.txt
+    #   dparse
 ua-parser==0.15.1
     # via
     #   -r requirements/pip.txt

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -183,6 +183,8 @@ docutils==0.17.1
     # via
     #   -r requirements/pip.txt
     #   sphinx
+dparse==0.5.2
+    # via -r requirements/pip.txt
 drf-extensions==0.7.1
     # via -r requirements/pip.txt
 drf-flex-fields==0.9.8
@@ -273,6 +275,7 @@ packaging==21.3
     # via
     #   -r requirements/pip.txt
     #   docker
+    #   dparse
     #   sphinx
     #   tox
 parso==0.8.3
@@ -457,6 +460,8 @@ structlog==22.1.0
 toml==0.10.2
     # via
     #   -r requirements/debug.txt
+    #   -r requirements/pip.txt
+    #   dparse
     #   ipdb
     #   tox
 tox==3.25.1

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -171,6 +171,8 @@ docutils==0.17.1
     #   sphinx
     #   sphinx-rtd-theme
     #   sphinx-tabs
+dparse==0.5.2
+    # via -r requirements/pip.txt
 drf-extensions==0.7.1
     # via -r requirements/pip.txt
 drf-flex-fields==0.9.8
@@ -251,6 +253,7 @@ packaging==21.3
     # via
     #   -r requirements/pip.txt
     #   docker
+    #   dparse
     #   sphinx
 pbr==5.10.0
     # via sphinxcontrib-video
@@ -425,6 +428,10 @@ structlog==22.1.0
     # via
     #   -r requirements/pip.txt
     #   django-structlog
+toml==0.10.2
+    # via
+    #   -r requirements/pip.txt
+    #   dparse
 tornado==6.2
     # via livereload
 typing-extensions==4.3.0

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -173,6 +173,8 @@ docutils==0.17.1
     #   sphinx
 dodgy==0.2.1
     # via prospector
+dparse==0.5.2
+    # via -r requirements/pip.txt
 drf-extensions==0.7.1
     # via -r requirements/pip.txt
 drf-flex-fields==0.9.8
@@ -255,6 +257,7 @@ packaging==21.3
     # via
     #   -r requirements/pip.txt
     #   docker
+    #   dparse
     #   requirements-detector
     #   sphinx
 pep8-naming==0.10.0
@@ -430,6 +433,8 @@ structlog==22.1.0
     #   django-structlog
 toml==0.10.2
     # via
+    #   -r requirements/pip.txt
+    #   dparse
     #   pylint
     #   requirements-detector
 ua-parser==0.15.1

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -113,3 +113,4 @@ django-csp
 
 django-structlog
 structlog
+dparse

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -127,6 +127,8 @@ docutils==0.17.1
     # via
     #   -r requirements/pip.in
     #   sphinx
+dparse==0.5.2
+    # via -r requirements/pip.in
 drf-extensions==0.7.1
     # via -r requirements/pip.in
 drf-flex-fields==0.9.8
@@ -175,6 +177,7 @@ packaging==21.3
     # via
     #   -r requirements/pip.in
     #   docker
+    #   dparse
     #   sphinx
 platformdirs==2.5.2
     # via virtualenv
@@ -272,6 +275,8 @@ structlog==22.1.0
     # via
     #   -r requirements/pip.in
     #   django-structlog
+toml==0.10.2
+    # via dparse
 ua-parser==0.15.1
     # via user-agents
 unicode-slugify @ git+https://github.com/mozilla/unicode-slugify@b696c37

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -170,6 +170,8 @@ docutils==0.17.1
     # via
     #   -r requirements/pip.txt
     #   sphinx
+dparse==0.5.2
+    # via -r requirements/pip.txt
 drf-extensions==0.7.1
     # via -r requirements/pip.txt
 drf-flex-fields==0.9.8
@@ -241,6 +243,7 @@ packaging==21.3
     # via
     #   -r requirements/pip.txt
     #   docker
+    #   dparse
     #   pytest
     #   sphinx
 platformdirs==2.5.2
@@ -397,6 +400,10 @@ structlog==22.1.0
     # via
     #   -r requirements/pip.txt
     #   django-structlog
+toml==0.10.2
+    # via
+    #   -r requirements/pip.txt
+    #   dparse
 tomli==2.0.1
     # via pytest
 ua-parser==0.15.1


### PR DESCRIPTION
We are saving `packages.pip.user` that are "top level packages" --which does not
mean anything too useful for our purposes.

The original idea was to have `packages.pip.all` that list all the packages
installed in the virtual environment and `packages.pip.user` that list all the
packages installed because the user specified them in the requirements file.

This PR parses all requirements files specified by the user and saves packages'
names and versions into `packages.pip.user`. These ones are pretty useful to
know what projects are specifically defining/pinning a package.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9514.org.readthedocs.build/en/9514/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9514.org.readthedocs.build/en/9514/

<!-- readthedocs-preview dev end -->