### PR TITLE
Logging: reduce verbosity

### DIFF
--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -264,7 +264,7 @@ def delete_closed_external_versions(limit=200, days=30 * 3):
                     link_to_build=True,
                 )
         except Exception:
-            log.exception(
+            log.warning(
                 "Failed to send status",
                 project_slug=version.project.slug,
                 version_slug=version.slug,

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -137,7 +137,7 @@ class BaseSphinx(BaseBuilder):
                 downloads = api.version(self.version.pk).get()['downloads']
                 subproject_urls = self.project.get_subproject_urls()
             except ConnectionError:
-                log.exception(
+                log.warning(
                     'Timeout while fetching versions/downloads/subproject_urls for Sphinx context.',
                     project_slug=self.project.slug,
                     version_slug=self.version.slug,

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -829,7 +829,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
             except Exception:
                 # Ideally this should just be an IOError
                 # but some storage backends unfortunately throw other errors
-                log.exception(
+                log.warning(
                     'Error copying to storage (not failing build)',
                     media_type=media_type,
                     from_path=from_path,
@@ -848,7 +848,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
             except Exception:
                 # Ideally this should just be an IOError
                 # but some storage backends unfortunately throw other errors
-                log.exception(
+                log.warning(
                     'Error deleting from storage (not failing build)',
                     media_type=media_type,
                     media_path=media_path,

--- a/readthedocs/projects/tasks/search.py
+++ b/readthedocs/projects/tasks/search.py
@@ -52,7 +52,7 @@ def fileify(version_pk, commit, build, search_ranking, search_ignore):
             search_ignore=search_ignore,
         )
     except Exception:
-        log.exception('Failed during ImportedFile creation')
+        log.warning("Failed during ImportedFile creation")
 
     # XXX: Don't access the sphinx domains table while we migrate the ID type
     # https://github.com/readthedocs/readthedocs.org/pull/9482.
@@ -60,12 +60,12 @@ def fileify(version_pk, commit, build, search_ranking, search_ignore):
         try:
             _create_intersphinx_data(version, commit, build)
         except Exception:
-            log.exception("Failed during SphinxDomain creation")
+            log.warning("Failed during SphinxDomain creation")
 
     try:
         _sync_imported_files(version, build)
     except Exception:
-        log.exception('Failed during ImportedFile syncing')
+        log.warning("Failed during ImportedFile syncing")
 
 
 def _sync_imported_files(version, build):

--- a/readthedocs/search/utils.py
+++ b/readthedocs/search/utils.py
@@ -1,7 +1,6 @@
 """Utilities related to reading and generating indexable search content."""
 
 import structlog
-
 from django.utils import timezone
 from django_elasticsearch_dsl.apps import DEDConfig
 from django_elasticsearch_dsl.registries import registry
@@ -33,7 +32,7 @@ def index_new_files(model, version, build):
         log.info('Indexing new objecst into search index.')
         doc_obj.update(queryset.iterator())
     except Exception:
-        log.exception('Unable to index a subset of files. Continuing.')
+        log.warning("Unable to index a subset of files. Continuing.")
 
 
 def remove_indexed_files(model, project_slug, version_slug=None, build_id=None):
@@ -69,7 +68,7 @@ def remove_indexed_files(model, project_slug, version_slug=None, build_id=None):
             documents = documents.exclude('term', build=build_id)
         documents.delete()
     except Exception:
-        log.exception('Unable to delete a subset of files. Continuing.')
+        log.warning("Unable to delete a subset of files. Continuing.")
 
 
 def _get_index(indices, index_name):
@@ -108,10 +107,7 @@ def _indexing_helper(html_objs_qs, wipe=False):
     else, html_objs are indexed.
     """
     from readthedocs.search.documents import PageDocument
-    from readthedocs.search.tasks import (
-        delete_objects_in_es,
-        index_objects_to_es,
-    )
+    from readthedocs.search.tasks import delete_objects_in_es, index_objects_to_es
 
     if html_objs_qs:
         obj_ids = []


### PR DESCRIPTION
We are doing nothing with these `log.exceptions` and they are not interfering
with the build process or the user experience. However, they are shown as
_errors_ in the logs when they shouldn't.

I'm reducing them to _warnings_ to reduce the log lines we should take attention.

Related to https://github.com/readthedocs/readthedocs-ops/issues/1168