### PR TITLE
Added Vale linter bot 

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,13 @@
+StylesPath = vale/styles
+MinAlertLevel = suggestion
+Vocab = Blog
+
+
+[*.{md,rst}]
+
+
+BasedOnStyles = Vale, RTD
+
+
+Vale.Spelling = YES
+Vale.Repetition = YES

--- a/Swap.yml
+++ b/Swap.yml
@@ -1,0 +1,6 @@
+extends: substitution
+message: Use '%s' instead of '%s'
+level: error
+swap:
+  Read The Docs: Read the Docs
+  RTD: Read the Docs

--- a/vale-linter.yml
+++ b/vale-linter.yml
@@ -1,0 +1,26 @@
+# Configuration of the Vale Linter ProBot tool
+
+Vale:
+
+  # If this feature is enabled or disabled
+  Enabled: true
+ #Remove comment if needed to enable the bot.
+ #Enabled: false
+
+  Paths:
+    # Path to the vale configuration file
+    Configuration: ".vale.ini"
+
+    # Path to the folder of Vale docstyles to use/copy
+    # NOTE: If you update the styles path in _vale.ini remember to update this path too
+    Styles: "vale/styles/"
+
+  Success: 
+    Header: "PASSED"
+    Message: "The Vale Docs linter did not find any issues."
+
+
+  Error: 
+    Header: "FAILED"
+    Message: "Try again"
+    


### PR DESCRIPTION
Addresses Issue #5876 

Added Vale linter bot to search for and replaces incorrect spellings of Read the Docs including RTD and Read The Docs. Linter bot also checks for spelling errors and repetitions.

Co-Author: @IvanMart57
Co-Author: @Melodyncr

Reference: https://www.shwetashetye.com/blog/vale/ 

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9521.org.readthedocs.build/en/9521/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9521.org.readthedocs.build/en/9521/

<!-- readthedocs-preview dev end -->