### PR TITLE
Update Transifex link

### DIFF
--- a/docs/dev/contribute.rst
+++ b/docs/dev/contribute.rst
@@ -85,7 +85,7 @@ approve suggestions.
 If you don't see your language in our list of approved languages for any of our
 projects, feel free to suggest the language on Transifex to start the process.
 
-.. _our projects on Transifex: https://www.transifex.com/projects/p/readthedocs/
+.. _our projects on Transifex: https://explore.transifex.com/readthedocs/
 
 Triaging issues
 ---------------


### PR DESCRIPTION
fix #9522

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9531.org.readthedocs.build/en/9531/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9531.org.readthedocs.build/en/9531/

<!-- readthedocs-preview dev end -->