### PR TITLE
Dependencies: pin django-structlog to 2.2.1

### DIFF
--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -149,7 +149,7 @@ django-simple-history==3.0.0
     # via -r requirements/pip.txt
 django-storages[boto3]==1.13.1
     # via -r requirements/pip.txt
-django-structlog==3.0.1
+django-structlog==2.2.0
     # via -r requirements/pip.txt
 django-taggit==3.0.0
     # via -r requirements/pip.txt

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -165,7 +165,7 @@ django-simple-history==3.0.0
     # via -r requirements/pip.txt
 django-storages[boto3]==1.13.1
     # via -r requirements/pip.txt
-django-structlog==3.0.1
+django-structlog==2.2.0
     # via -r requirements/pip.txt
 django-taggit==3.0.0
     # via -r requirements/pip.txt

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -150,7 +150,7 @@ django-simple-history==3.0.0
     # via -r requirements/pip.txt
 django-storages[boto3]==1.13.1
     # via -r requirements/pip.txt
-django-structlog==3.0.1
+django-structlog==2.2.0
     # via -r requirements/pip.txt
 django-taggit==3.0.0
     # via -r requirements/pip.txt

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -153,7 +153,7 @@ django-simple-history==3.0.0
     # via -r requirements/pip.txt
 django-storages[boto3]==1.13.1
     # via -r requirements/pip.txt
-django-structlog==3.0.1
+django-structlog==2.2.0
     # via -r requirements/pip.txt
 django-taggit==3.0.0
     # via -r requirements/pip.txt

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -111,6 +111,9 @@ django-debug-toolbar
 # For enabling content-security-policy
 django-csp
 
-django-structlog
+# Upgrading to 3.x requires some extra work
+# https://django-structlog.readthedocs.io/en/latest/upgrade_guide.html#upgrading-to-3-0
+django-structlog==2.2.0
+
 structlog
 dparse

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -109,7 +109,7 @@ django-simple-history==3.0.0
     # via -r requirements/pip.in
 django-storages[boto3]==1.13.1
     # via -r requirements/pip.in
-django-structlog==3.0.1
+django-structlog==2.2.0
     # via -r requirements/pip.in
 django-taggit==3.0.0
     # via -r requirements/pip.in

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -152,7 +152,7 @@ django-simple-history==3.0.0
     # via -r requirements/pip.txt
 django-storages[boto3]==1.13.1
     # via -r requirements/pip.txt
-django-structlog==3.0.1
+django-structlog==2.2.0
     # via -r requirements/pip.txt
 django-taggit==3.0.0
     # via -r requirements/pip.txt


### PR DESCRIPTION
Upgrading to 3.x requires some extra work:
https://django-structlog.readthedocs.io/en/latest/upgrade_guide.html#upgrading-to-3-0

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9535.org.readthedocs.build/en/9535/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9535.org.readthedocs.build/en/9535/

<!-- readthedocs-preview dev end -->