### PR TITLE
Unresolver: port changes from #9540

### DIFF
--- a/readthedocs/core/unresolver.py
+++ b/readthedocs/core/unresolver.py
@@ -249,7 +249,7 @@ class Unresolver:
             # Serve from the PUBLIC_DOMAIN, ensuring it looks like `foo.PUBLIC_DOMAIN`.
             if public_domain == root_domain:
                 project_slug = subdomain
-                log.info("Public domain.", domain=domain)
+                log.debug("Public domain.", domain=domain)
                 return project_slug, None, False
 
             # TODO: This can catch some possibly valid domains (docs.readthedocs.io.com)
@@ -260,7 +260,7 @@ class Unresolver:
         # Serve PR builds on external_domain host.
         if external_domain == root_domain:
             try:
-                log.info("External versions domain.", domain=domain)
+                log.debug("External versions domain.", domain=domain)
                 project_slug, _ = subdomain.rsplit("--", maxsplit=1)
                 return project_slug, None, True
             except ValueError:
@@ -272,7 +272,7 @@ class Unresolver:
             Domain.objects.filter(domain=domain).prefetch_related("project").first()
         )
         if domain_object:
-            log.info("Custom domain.", domain=domain)
+            log.debug("Custom domain.", domain=domain)
             project_slug = domain_object.project.slug
             return project_slug, domain_object, False
 


### PR DESCRIPTION
https://github.com/readthedocs/readthedocs.org/pull/9540 was
merged to rel only, I'm porting the changes to main.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9542.org.readthedocs.build/en/9542/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9542.org.readthedocs.build/en/9542/

<!-- readthedocs-preview dev end -->