### PR TITLE
Docs: HTML form for getting in touch with Read the Docs for Science

### DIFF
--- a/docs/user/science.rst
+++ b/docs/user/science.rst
@@ -159,3 +159,110 @@ Read the Docs community for science is already big and keeps growing. The :exter
       :link: https://feature-engine.readthedocs.io/en/latest/
 
 .. Let's put some logos to sign off
+
+
+How would you use Read the Docs for Science?
+--------------------------------------------
+
+Would you like to get started with Read the Docs or understand more about the platform? Would you like to help us improve by telling us more about an already existing project?
+
+Please take 2 minutes to fill in this form.
+
+.. raw:: html
+
+    <form method="POST" action="fixme">
+
+.. list-table::
+   :widths: 30 70
+
+   * - Name:
+     - |input-name|
+   * - Email:
+     - |input-email|
+   * - What science department are you from, |br| which science field(s) do you work in?
+     - |input-deparment-science-field|
+   * - Which of these are important to you?
+     - |input-interests|
+   * - Tell us more about your usecase:
+     - |input-usecase|
+   * - Should we contact you?
+     - |input-contact-me|
+
+
+.. raw:: html
+
+    <p>
+      <button type="submit" class="btn btn-neutral" style="font-size: 150%">Submit form</button>
+    </p>
+    </form>
+
+
+.. |br| raw:: html
+
+   <br />
+
+.. |input-email| raw:: html
+
+    <input type="email" name="email">
+
+.. |input-name| raw:: html
+
+    <input type="text" name="name">
+
+.. |input-deparment-science-field| raw:: html
+
+    <textarea name="department-science-field" rows="10" style="width: 90%; height: 100px;"></textarea>
+
+.. |input-interests| raw:: html
+
+    <label for="what1">
+      <input id="what1" type="checkbox" name="interests-academic-publishing" value="1">
+      Academic publishing (PDFs)
+    </label>
+
+    <label for="what1">
+      <input id="what1" type="checkbox" name="interests-git-hosting" value="1">
+      Maintaining my project with Git
+    </label>
+
+    <label for="what1">
+      <input id="what1" type="checkbox" name="interests-visualizations" value="1">
+      Up-to-date visualizations and computations
+    </label>
+
+    <label for="what1">
+      <input id="what1" type="checkbox" name="interests-interactive" value="1">
+      Interactive visualizations for users
+    </label>
+
+    <label for="what1">
+      <input id="what1" type="checkbox" name="interests-collaboration" value="1">
+      Collaboration and/or getting more community contribution
+    </label>
+
+    <label for="what1">
+      <input id="what1" type="checkbox" name="interests-hosting-navigation" value="1">
+      Publishing and hosting courses and research departments
+    </label>
+
+    <label for="what1">
+      <input id="what1" type="checkbox" name="interests-search-analytics" value="1">
+      Search and analytics
+    </label>
+
+    <label for="what1">
+      <input id="what1" type="checkbox" name="interests-search-analytics" value="1">
+      Previewing new proposals (pull requests)
+    </label>
+
+.. |input-contact-me| raw:: html
+
+    <label for="what1">
+      <input id="what1" type="checkbox" name="contact-me" value="yes">
+      Yes please
+    </label>
+
+
+.. |input-usecase| raw:: html
+
+    <textarea name="usecase" rows="10" style="width: 90%; height: 100px;"></textarea>

--- a/docs/user/science.rst
+++ b/docs/user/science.rst
@@ -170,7 +170,13 @@ Please take 2 minutes to fill in this form.
 
 .. raw:: html
 
-    <form method="POST" action="fixme">
+    <form
+      method="POST"
+      name="fa-form-1"
+      action="https://webhook.frontapp.com/forms/036c4169294f3b04abaa/xP2Ulmxfcgl_mLJrFbGoefmVuqmH7DAfyHD9lt_qbk1heKFev5K8-TEhmpKc8dWdn-rv7bbZMMPjmffxl0mqGRUcrfyOzImtk8zEGJ04E1uuyPE28hqoHExtS20"
+      enctype="multipart/form-data"
+      accept-charset="utf-8"
+    >
 
 .. list-table::
    :widths: 30 70
@@ -254,6 +260,8 @@ Please take 2 minutes to fill in this form.
       <input id="what1" type="checkbox" name="interests-search-analytics" value="1">
       Previewing new proposals (pull requests)
     </label>
+
+    <input id="body" type="hidden" value="Science Docs Submission">
 
 .. |input-contact-me| raw:: html
 

--- a/docs/user/science.rst
+++ b/docs/user/science.rst
@@ -226,38 +226,38 @@ Please take 2 minutes to fill in this form.
       Academic publishing (PDFs)
     </label>
 
-    <label for="what1">
-      <input id="what1" type="checkbox" name="interests-git-hosting" value="1">
+    <label for="what2">
+      <input id="what2" type="checkbox" name="interests-git-hosting" value="1">
       Maintaining my project with Git
     </label>
 
-    <label for="what1">
-      <input id="what1" type="checkbox" name="interests-visualizations" value="1">
+    <label for="what3">
+      <input id="what3" type="checkbox" name="interests-visualizations" value="1">
       Up-to-date visualizations and computations
     </label>
 
-    <label for="what1">
-      <input id="what1" type="checkbox" name="interests-interactive" value="1">
+    <label for="what4">
+      <input id="what4" type="checkbox" name="interests-interactive" value="1">
       Interactive visualizations for users
     </label>
 
-    <label for="what1">
-      <input id="what1" type="checkbox" name="interests-collaboration" value="1">
+    <label for="what5">
+      <input id="what5" type="checkbox" name="interests-collaboration" value="1">
       Collaboration and/or getting more community contribution
     </label>
 
-    <label for="what1">
-      <input id="what1" type="checkbox" name="interests-hosting-navigation" value="1">
+    <label for="what6">
+      <input id="what6" type="checkbox" name="interests-hosting-navigation" value="1">
       Publishing and hosting courses and research departments
     </label>
 
-    <label for="what1">
-      <input id="what1" type="checkbox" name="interests-search-analytics" value="1">
+    <label for="what7">
+      <input id="what7" type="checkbox" name="interests-search-analytics" value="1">
       Search and analytics
     </label>
 
-    <label for="what1">
-      <input id="what1" type="checkbox" name="interests-search-analytics" value="1">
+    <label for="what8">
+      <input id="what8" type="checkbox" name="interests-search-analytics" value="1">
       Previewing new proposals (pull requests)
     </label>
 
@@ -265,8 +265,8 @@ Please take 2 minutes to fill in this form.
 
 .. |input-contact-me| raw:: html
 
-    <label for="what1">
-      <input id="what1" type="checkbox" name="contact-me" value="yes">
+    <label for="contact">
+      <input id="contact" type="checkbox" name="contact-me" value="yes">
       Yes please
     </label>
 

--- a/docs/user/science.rst
+++ b/docs/user/science.rst
@@ -261,7 +261,7 @@ Please take 2 minutes to fill in this form.
       Previewing new proposals (pull requests)
     </label>
 
-    <input id="body" type="hidden" value="Science Docs Submission">
+    <input id="body" name="body" type="hidden" value="Science Docs Submission">
 
 .. |input-contact-me| raw:: html
 


### PR DESCRIPTION
This is pending a Front endpoint for actually receiving form data.

![image](https://user-images.githubusercontent.com/374612/186439192-80e6c7ac-fd33-4fba-9104-eccd4f5d7c3c.png)


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9543.org.readthedocs.build/en/9543/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9543.org.readthedocs.build/en/9543/

<!-- readthedocs-preview dev end -->