### PR TITLE
Build: cancel old builds 

### DIFF
--- a/readthedocs/builds/tests/test_trigger_build.py
+++ b/readthedocs/builds/tests/test_trigger_build.py
@@ -1,0 +1,95 @@
+from unittest import mock
+
+import django_dynamic_fixture as fixture
+import pytest
+
+from readthedocs.builds.constants import (
+    BUILD_FINAL_STATES,
+    BUILD_STATE_BUILDING,
+    BUILD_STATE_CANCELLED,
+    BUILD_STATE_CLONING,
+    BUILD_STATE_FINISHED,
+    BUILD_STATE_INSTALLING,
+    BUILD_STATE_TRIGGERED,
+    BUILD_STATE_UPLOADING,
+)
+from readthedocs.builds.models import Build, Version
+from readthedocs.core.utils import trigger_build
+from readthedocs.projects.models import Feature, Project
+
+
+@pytest.mark.django_db
+class TestCancelOldBuilds:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.project = fixture.get(Project)
+        self.version = fixture.get(Version, project=self.project)
+        self.feature = fixture.get(Feature, feature_id=Feature.CANCEL_OLD_BUILDS)
+        self.feature.projects.add(self.project)
+
+    @pytest.mark.parametrize(
+        "state",
+        [
+            BUILD_STATE_TRIGGERED,
+            BUILD_STATE_CLONING,
+            BUILD_STATE_INSTALLING,
+            BUILD_STATE_BUILDING,
+            BUILD_STATE_UPLOADING,
+        ],
+    )
+    @mock.patch("readthedocs.core.utils.cancel_build")
+    @mock.patch("readthedocs.projects.tasks.builds.update_docs_task")
+    def test_cancel_old_running_build(self, update_docs_task, cancel_build, state):
+        # Create a running build
+        build = fixture.get(
+            Build, project=self.project, version=self.version, state=state
+        )
+
+        builds_count_before = Build.objects.count()
+
+        # Trigger a new build for the same project/version
+        result = trigger_build(
+            project=self.project,
+            version=self.version,
+        )
+
+        triggered_build = Build.objects.first()
+        builds_count_after = Build.objects.count()
+
+        cancel_build.assert_called_once_with(build)
+        assert result == (mock.ANY, triggered_build)
+        assert builds_count_before == builds_count_after - 1
+        assert update_docs_task.signature.called
+        assert update_docs_task.signature().apply_async.called
+
+    @pytest.mark.parametrize(
+        "state",
+        [
+            BUILD_STATE_CANCELLED,
+            BUILD_STATE_FINISHED,
+        ],
+    )
+    @mock.patch("readthedocs.core.utils.cancel_build")
+    @mock.patch("readthedocs.projects.tasks.builds.update_docs_task")
+    def test_not_cancel_old_finished_build(self, update_docs_task, cancel_build, state):
+        # Create a running build
+        build = fixture.get(
+            Build, project=self.project, version=self.version, state=state
+        )
+
+        builds_count_before = Build.objects.count()
+
+        # Trigger a new build for the same project/version
+        result = trigger_build(
+            project=self.project,
+            version=self.version,
+        )
+
+        triggered_build = Build.objects.first()
+        builds_count_after = Build.objects.count()
+
+        cancel_build.assert_not_called()
+        assert result == (mock.ANY, triggered_build)
+        assert builds_count_before == builds_count_after - 1
+        assert update_docs_task.signature.called
+        assert update_docs_task.signature().apply_async.called

--- a/readthedocs/builds/tests/test_views.py
+++ b/readthedocs/builds/tests/test_views.py
@@ -16,7 +16,7 @@ from readthedocs.organizations.models import Organization
 from readthedocs.projects.models import Project
 
 
-@mock.patch("readthedocs.builds.views.app")
+@mock.patch("readthedocs.core.utils.app")
 @override_settings(RTD_ALLOW_ORGANIZATIONS=False)
 class CancelBuildViewTests(TestCase):
     def setUp(self):

--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -289,11 +289,11 @@ def cancel_build(build):
     Depending on the current state of the build, it takes one approach or the other:
 
     - Triggered:
-        update the build status and tells Celery to revoke this task.
+        Update the build status and tells Celery to revoke this task.
         Workers will know about this and will discard it.
     - Running:
-        communicate Celery to force the termination of the current build
-        and relies on the worker to update the build's status correct.
+        Communicate Celery to force the termination of the current build
+        and rely on the worker to update the build's status.
     """
     # NOTE: `terminate=True` is required for the child to attend our call
     # immediately when it's running the build. Otherwise, it finishes the

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -2019,7 +2019,7 @@ class Feature(models.Model):
         (
             CANCEL_OLD_BUILDS,
             _(
-                "Cancel triggered/running builds when a new one for the same project/version arrives"
+                "Cancel triggered/running builds when a new one with same project/version arrives"
             ),
         ),
         (

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1859,12 +1859,13 @@ class Feature(models.Model):
     DEFAULT_TO_FUZZY_SEARCH = 'default_to_fuzzy_search'
     INDEX_FROM_HTML_FILES = 'index_from_html_files'
 
-    LIST_PACKAGES_INSTALLED_ENV = 'list_packages_installed_env'
-    VCS_REMOTE_LISTING = 'vcs_remote_listing'
-    SPHINX_PARALLEL = 'sphinx_parallel'
-    USE_SPHINX_BUILDERS = 'use_sphinx_builders'
-    DEDUPLICATE_BUILDS = 'deduplicate_builds'
-    DONT_CREATE_INDEX = 'dont_create_index'
+    LIST_PACKAGES_INSTALLED_ENV = "list_packages_installed_env"
+    VCS_REMOTE_LISTING = "vcs_remote_listing"
+    SPHINX_PARALLEL = "sphinx_parallel"
+    USE_SPHINX_BUILDERS = "use_sphinx_builders"
+    DEDUPLICATE_BUILDS = "deduplicate_builds"
+    CANCEL_OLD_BUILDS = "cancel_old_builds"
+    DONT_CREATE_INDEX = "dont_create_index"
 
     FEATURES = (
         (ALLOW_DEPRECATED_WEBHOOKS, _('Allow deprecated webhook views')),
@@ -2014,6 +2015,12 @@ class Feature(models.Model):
         (
             DEDUPLICATE_BUILDS,
             _('Mark duplicated builds as NOOP to be skipped by builders'),
+        ),
+        (
+            CANCEL_OLD_BUILDS,
+            _(
+                "Cancel triggered/running builds when a new one for the same project/version arrives"
+            ),
         ),
         (
             DONT_CREATE_INDEX,


### PR DESCRIPTION
> NOTE: I split the work in different commits to make it easier to review.

This PR implements a simple logic to cancel old running builds when a new
build for the same project/version arrives:

1. look for running builds for the same project/version
2. if there are any, it cancels them all one by one via Celery's revoke method
3. trigger a new build for the current commit received

Note that this new feature is behind a feature flag (`CANCEL_OLD_BUILDS`) for
now so we can start testing it on some projects that have shown their interest
on this feature.

The current behavior for `DEDUPLICATE_BUILDS` will be replaced by this new logic
in the future. However, it was not removed in this commit since it's still
useful for projects that won't be using the new feature flag yet.

Closes https://github.com/readthedocs/readthedocs.org/issues/8961

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9549.org.readthedocs.build/en/9549/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9549.org.readthedocs.build/en/9549/

<!-- readthedocs-preview dev end -->