### PR TITLE
Templates: minor typo

### DIFF
--- a/readthedocs/domains/templates/domains/notifications/pending_domain_configuration_site.html
+++ b/readthedocs/domains/templates/domains/notifications/pending_domain_configuration_site.html
@@ -4,5 +4,5 @@
   Go to the <a href="{{ domain_url }}">domain page</a> and click on "Save" to restart the process.
 {% else %}
   The configuration of your custom domain <code>{{ domain.domain }}</code> is pending.
-  Go to the <a href="{{ domain_url }}">doain page</a> and follow the instructions to complete it.
+  Go to the <a href="{{ domain_url }}">domain page</a> and follow the instructions to complete it.
 {% endif %}


### PR DESCRIPTION

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9560.org.readthedocs.build/en/9560/
<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9560.org.readthedocs.build/en/9560/
<!-- readthedocs-preview dev end -->