### PR TITLE
Build: upgrade `commonmark` to 0.9.1

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -182,7 +182,7 @@ class Virtualenv(PythonEnvironment):
             [
                 "mock==1.0.1",
                 "alabaster>=0.7,<0.8,!=0.7.5",
-                "commonmark==0.8.1",
+                "commonmark==0.9.1",
                 "recommonmark==0.5.0",
             ]
         )

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -582,7 +582,7 @@ class TestBuildTask(BuildEnvironmentBase):
                     "pillow",
                     "mock==1.0.1",
                     "alabaster>=0.7,<0.8,!=0.7.5",
-                    "commonmark==0.8.1",
+                    "commonmark==0.9.1",
                     "recommonmark==0.5.0",
                     "sphinx<2",
                     "sphinx-rtd-theme<0.5",


### PR DESCRIPTION
Currently, we are installing an older version of `commonmark` that has some
problems with newer versions of Python. Upgrading it to 0.9.1 seems to solve
this problem.

See #9562 for a detailed explanation of the problem

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9563.org.readthedocs.build/en/9563/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9563.org.readthedocs.build/en/9563/

<!-- readthedocs-preview dev end -->