### PR TITLE
Embed API: fix CORS check

### DIFF
--- a/readthedocs/core/signals.py
+++ b/readthedocs/core/signals.py
@@ -85,7 +85,7 @@ def decide_if_cors(sender, request, **kwargs):  # pylint: disable=unused-argumen
                 return True
 
             project = unresolved.project
-            version_slug = unresolved.version_slug
+            version_slug = unresolved.version.slug
         else:
             project_slug = request.GET.get('project', None)
             version_slug = request.GET.get('version', None)

--- a/readthedocs/rtd_tests/tests/test_middleware.py
+++ b/readthedocs/rtd_tests/tests/test_middleware.py
@@ -148,6 +148,23 @@ class TestCORSMiddleware(TestCase):
         resp = self.middleware.process_response(request, {})
         self.assertNotIn('Access-Control-Allow-Origin', resp)
 
+    def test_embed_api_external_url(self):
+        request = self.factory.get(
+            "/api/v2/embed/",
+            {"url": "https://pip.readthedocs.io/en/latest/index.hml"},
+            HTTP_ORIGIN="http://my.valid.domain",
+        )
+        resp = self.middleware.process_response(request, {})
+        self.assertIn("Access-Control-Allow-Origin", resp)
+
+        request = self.factory.get(
+            "/api/v2/embed/",
+            {"url": "https://docs.example.com/en/latest/index.hml"},
+            HTTP_ORIGIN="http://my.valid.domain",
+        )
+        resp = self.middleware.process_response(request, {})
+        self.assertIn("Access-Control-Allow-Origin", resp)
+
     @mock.patch('readthedocs.core.signals._has_donate_app')
     def test_sustainability_endpoint_allways_allowed(self, has_donate_app):
         has_donate_app.return_value = True


### PR DESCRIPTION


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9564.org.readthedocs.build/en/9564/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9564.org.readthedocs.build/en/9564/

<!-- readthedocs-preview dev end -->