### PR TITLE
Embed API: strip leading `/` before joining path

### DIFF
--- a/readthedocs/embed/v3/tests/test_internal_pages.py
+++ b/readthedocs/embed/v3/tests/test_internal_pages.py
@@ -42,18 +42,17 @@ class TestEmbedAPIv3InternalPages:
             yield read_mock
         return f
 
-    def _patch_storage_open(self, storage_mock, content):
-        storage_mock.exists.return_value = True
-        storage_mock.open.side_effect = self._mock_open(content)
-
-    @pytest.mark.sphinx('html', srcdir=srcdir, freshenv=True)
-    @mock.patch('readthedocs.embed.v3.views.build_media_storage')
-    def test_default_main_section(self, build_media_storage, app, client):
+    @pytest.mark.sphinx("html", srcdir=srcdir, freshenv=True)
+    @mock.patch("readthedocs.embed.v3.views.build_media_storage.open")
+    @mock.patch("readthedocs.embed.v3.views.build_media_storage.exists")
+    def test_default_main_section(self, storage_exists, storage_open, app, client):
         app.build()
         path = app.outdir / 'index.html'
         assert path.exists() is True
         content = open(path).read()
-        self._patch_storage_open(build_media_storage, content)
+
+        storage_exists.return_value = True
+        storage_open.side_effect = self._mock_open(content)
 
         params = {
             'url': 'https://project.readthedocs.io/en/latest/',

--- a/readthedocs/embed/v3/views.py
+++ b/readthedocs/embed/v3/views.py
@@ -90,9 +90,10 @@ class EmbedAPIBase(EmbedAPIMixin, CDNCacheTagsMixin, APIView):
             include_file=False,
             version_type=version.type,
         )
+        relative_filename = filename.lstrip("/")
         file_path = build_media_storage.join(
             storage_path,
-            filename,
+            relative_filename,
         )
         try:
             with build_media_storage.open(file_path) as fd:  # pylint: disable=invalid-name


### PR DESCRIPTION


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9565.org.readthedocs.build/en/9565/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9565.org.readthedocs.build/en/9565/

<!-- readthedocs-preview dev end -->