### PR TITLE
Logging: log time spent to upload build artifacts

### DIFF
--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -517,6 +517,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         pdf = self.data.outcomes['pdf']
         epub = self.data.outcomes['epub']
 
+        time_before_store_build_artifacts = timezone.now()
         # Store build artifacts to storage (local or cloud storage)
         self.store_build_artifacts(
             html=html,
@@ -524,6 +525,10 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
             localmedia=localmedia,
             pdf=pdf,
             epub=epub,
+        )
+        log.info(
+            "Store build artifacts finished.",
+            time=(timezone.now() - time_before_store_build_artifacts).seconds,
         )
 
         # NOTE: we are updating the db version instance *only* when


### PR DESCRIPTION
Start collecting how much time (in seconds) it takes to upload all the build
artifacts for each project.

Related #9448

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9568.org.readthedocs.build/en/9568/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9568.org.readthedocs.build/en/9568/

<!-- readthedocs-preview dev end -->