### PR TITLE
Development: disable NGINX logs

### DIFF
--- a/dockerfiles/nginx/proxito.conf.template
+++ b/dockerfiles/nginx/proxito.conf.template
@@ -3,6 +3,10 @@ server {
     listen 80 default_server;
     server_name $NGINX_PROXITO_SERVER_NAME;
 
+    # Docker Compose's "logging.driver: none" is not working anymore.
+    # So, we are disabling the logs from NGINX directly.
+    access_log off;
+
     # TODO: serve the favicon.ico from the project/version itself instead
     location /favicon.ico {
         proxy_pass http://storage:9000/static/images/favicon.ico;

--- a/dockerfiles/nginx/web.conf.template
+++ b/dockerfiles/nginx/web.conf.template
@@ -4,6 +4,10 @@ server {
     # This should match settings.PRODUCTION_DOMAIN
     server_name $NGINX_WEB_SERVER_NAME;
 
+    # Docker Compose's "logging.driver: none" is not working anymore.
+    # So, we are disabling the logs from NGINX directly.
+    access_log off;
+
     location /favicon.ico {
         proxy_pass http://storage:9000/static/images/favicon.ico;
         break;


### PR DESCRIPTION
We were using `logging.driver: none` on Docker Compose's file,
but it stopped working and I was not able to enable it again.
So, for now, I'm just disabling the logging from NGINX itself because they are
too annoying when working locally.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9569.org.readthedocs.build/en/9569/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9569.org.readthedocs.build/en/9569/

<!-- readthedocs-preview dev end -->