### PR TITLE
Docs: improve "Badges" page

### DIFF
--- a/docs/user/badges.rst
+++ b/docs/user/badges.rst
@@ -2,26 +2,24 @@ Status Badges
 =============
 
 Status badges let you show the state of your documentation to your users.
+They will show if the latest build has passed, failed, or is in an unknown state.
 They are great for embedding in your README,
 or putting inside your actual doc pages.
+
+You can see a badge in action in the `Read the Docs README`_.
 
 Display states
 --------------
 
-Badges have the following stats:
+Badges have the following states which can be shown to users:
 
-* **Green** for passing
-* **Red** for failing
-* **Yellow** for unknown states
+* **Green**: ``passing`` - the last build was successful.
+* **Red**: ``failing`` - the last build failed.
+* **Yellow**: ``unknown`` - we couldn't figure out the status of your last build.
 
-By default,
-badges link back to your project's documentation page on Read the Docs.
-
-Here are a few examples:
+An example of each is shown here:
 
 |green| |nbsp| |red| |nbsp| |yellow|
-
-You can see it in action in the `Read the Docs README`_.
 
 Style
 -----

--- a/docs/user/badges.rst
+++ b/docs/user/badges.rst
@@ -1,17 +1,21 @@
-Badges
-======
+Status Badges
+=============
 
-Badges let you show the state of your documentation to your users.
+Status badges let you show the state of your documentation to your users.
 They are great for embedding in your README,
 or putting inside your actual doc pages.
 
-Status badges
--------------
+Display states
+--------------
 
-They will display in green for passing,
-red for failing,
-and yellow for unknown states.
-They will link back to your project's documentation page on Read the Docs.
+Badges have the following stats:
+
+* green for passing
+* red for failing
+* yellow for unknown states
+
+By default,
+badges link back to your project's documentation page on Read the Docs.
 
 Here are a few examples:
 
@@ -22,13 +26,14 @@ You can see it in action in the `Read the Docs README`_.
 Style
 -----
 
-You can pass the ``style`` GET argument to get custom styled badges same as you would for `shields.io <https://shields.io/>`_.
-By default, ``flat`` style is used.
+You can pass the ``style`` GET argument to get custom styled badges.
+This allows you to match the look and feel of your website.
+By default, the ``flat`` style is used.
 
 +---------------+---------------------+
 | Style         | Badge               |
 +===============+=====================+
-| flat          | |Flat Badge|        |
+| flat - default| |Flat Badge|        |
 +---------------+---------------------+
 | flat-square   | |Flat-Square Badge| |
 +---------------+---------------------+
@@ -46,26 +51,25 @@ By default, ``flat`` style is used.
 .. |Social Badge| image:: https://readthedocs.org/projects/pip/badge/?version=latest&style=social
 
 
-Version
--------
+Version-specific badges
+-----------------------
 
 You can change the version of the documentation your badge points to.
-To do this, you can pass the ``version`` GET argmento to the badge URL.
+To do this, you can pass the ``version`` GET argument to the badge URL.
 By default, it will point at the *default version* you have specified for your project.
 
 The badge URL looks like this::
 
-    https://readthedocs.org/projects/pip/badge/?version=v3.x
+    https://readthedocs.org/projects/docs/badge/?version=latest
 
 
-Project pages
--------------
+Badges on dashboard pages
+-------------------------
 
-On each :term:`project home`'s page there is a badge that communicates the status of the default version.
+On each :term:`project home` page there is a badge that communicates the status of the default version.
 If you click on the badge icon,
 you will be given snippets for reStructuredText, Markdown, and HTML
 to make embedding it easier.
-
 
 .. _Read the Docs README: https://github.com/readthedocs/readthedocs.org/blob/main/README.rst
 .. |green| image:: https://assets.readthedocs.org/static/projects/badges/passing-flat.svg

--- a/docs/user/badges.rst
+++ b/docs/user/badges.rst
@@ -5,29 +5,28 @@ Badges let you show the state of your documentation to your users.
 They are great for embedding in your README,
 or putting inside your actual doc pages.
 
-Status Badges
+Status badges
 -------------
 
 They will display in green for passing,
 red for failing,
 and yellow for unknown states.
+They will link back to your project's documentation page on Read the Docs.
 
 Here are a few examples:
 
 |green| |nbsp| |red| |nbsp| |yellow|
 
 You can see it in action in the `Read the Docs README`_.
-They will link back to your project's documentation page on Read the Docs.
 
 Style
 -----
 
-Now you can pass the ``style`` GET argument,
-to get custom styled badges same as you would for shields.io.
-If no argument is passed, ``flat`` is used as default.
+You can pass the ``style`` GET argument to get custom styled badges same as you would for `shields.io <https://shields.io/>`_.
+By default, ``flat`` style is used.
 
 +---------------+---------------------+
-| STYLE         | BADGE               |
+| Style         | Badge               |
 +===============+=====================+
 | flat          | |Flat Badge|        |
 +---------------+---------------------+
@@ -47,30 +46,28 @@ If no argument is passed, ``flat`` is used as default.
 .. |Social Badge| image:: https://readthedocs.org/projects/pip/badge/?version=latest&style=social
 
 
-Project Pages
+Version
+-------
+
+You can change the version of the documentation your badge points to.
+To do this, you can pass the ``version`` GET argmento to the badge URL.
+By default, it will point at the *default version* you have specified for your project.
+
+The badge URL looks like this::
+
+    https://readthedocs.org/projects/pip/badge/?version=v3.x
+
+
+Project pages
 -------------
 
-You will now see badges embedded in your `project page`_.
-The default badge will be pointed at the *default version* you have specified for your project.
-The badge URLs look like this::
-
-    https://readthedocs.org/projects/pip/badge/?version=latest&style=plastic
-
-You can replace the version argument with any version that you want to show a badge for.
+On each :term:`project home`'s page there is a badge that communicates the status of the default version.
 If you click on the badge icon,
-you will be given snippets for RST, Markdown, and HTML;
+you will be given snippets for reStructuredText, Markdown, and HTML
 to make embedding it easier.
-
-If you leave the version argument off,
-it will default to your latest version.
-This is probably best to include in your README,
-since it will stay up to date with your Read the Docs project::
-
-    https://readthedocs.org/projects/pip/badge/
 
 
 .. _Read the Docs README: https://github.com/readthedocs/readthedocs.org/blob/main/README.rst
-.. _project page: https://readthedocs.org/projects/pip/
 .. |green| image:: https://assets.readthedocs.org/static/projects/badges/passing-flat.svg
 .. |red| image:: https://assets.readthedocs.org/static/projects/badges/failing-flat.svg
 .. |yellow| image:: https://assets.readthedocs.org/static/projects/badges/unknown-flat.svg

--- a/docs/user/badges.rst
+++ b/docs/user/badges.rst
@@ -10,9 +10,9 @@ Display states
 
 Badges have the following stats:
 
-* green for passing
-* red for failing
-* yellow for unknown states
+* **Green** for passing
+* **Red** for failing
+* **Yellow** for unknown states
 
 By default,
 badges link back to your project's documentation page on Read the Docs.


### PR DESCRIPTION
Clean it up a little and re-order the content.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9580.org.readthedocs.build/en/9580/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9580.org.readthedocs.build/en/9580/

<!-- readthedocs-preview dev end -->