### PR TITLE
Invitations: delete related invitations when deleting an object

### DIFF
--- a/readthedocs/invitations/apps.py
+++ b/readthedocs/invitations/apps.py
@@ -10,3 +10,6 @@ from django.apps import AppConfig
 class InvitationsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "readthedocs.invitations"
+
+    def ready(self):
+        import readthedocs.invitations.signals  # noqa

--- a/readthedocs/invitations/signals.py
+++ b/readthedocs/invitations/signals.py
@@ -1,0 +1,23 @@
+import structlog
+from django.db.models.signals import pre_delete
+from django.dispatch import receiver
+
+from readthedocs.invitations.models import Invitation
+from readthedocs.organizations.models import Organization, Team
+from readthedocs.projects.models import Project
+
+log = structlog.get_logger(__name__)
+
+
+@receiver(pre_delete, sender=Project)
+@receiver(pre_delete, sender=Organization)
+@receiver(pre_delete, sender=Team)
+def delete_related_invitations(sender, instance, **kwargs):
+    invitations = Invitation.objects.for_object(instance)
+    log.info(
+        "Deleting related invitations.",
+        object_type=sender.__name__.lower(),
+        object_id=instance.pk,
+        count=invitations.count(),
+    )
+    invitations.delete()

--- a/readthedocs/invitations/signals.py
+++ b/readthedocs/invitations/signals.py
@@ -1,3 +1,5 @@
+"""Invitations related signals."""
+
 import structlog
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
@@ -9,10 +11,17 @@ from readthedocs.projects.models import Project
 log = structlog.get_logger(__name__)
 
 
+# pylint: disable=unused-argument
 @receiver(pre_delete, sender=Project)
 @receiver(pre_delete, sender=Organization)
 @receiver(pre_delete, sender=Team)
 def delete_related_invitations(sender, instance, **kwargs):
+    """
+    Delete related invitations of an object.
+
+    Generic foreign keys don't have a way to cascade delete,
+    so we need to do it manually.
+    """
     invitations = Invitation.objects.for_object(instance)
     log.info(
         "Deleting related invitations.",

--- a/readthedocs/invitations/tests/test_signals.py
+++ b/readthedocs/invitations/tests/test_signals.py
@@ -1,0 +1,37 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django_dynamic_fixture import get
+
+from readthedocs.invitations.models import Invitation
+from readthedocs.organizations.models import Organization, Team
+from readthedocs.projects.models import Project
+
+
+class TestSignals(TestCase):
+    def setUp(self):
+        self.user = get(User)
+        self.project = get(Project, users=[self.user])
+        self.organization = get(
+            Organization, owners=[self.user], projects=[self.project]
+        )
+        self.team = get(Team, organization=self.organization)
+        self.another_user = get(User)
+
+        for obj in [self.project, self.organization, self.team]:
+            Invitation.objects.invite(
+                from_user=self.user,
+                obj=obj,
+                to_user=self.another_user,
+            )
+
+    def test_delete_related_object(self):
+        self.assertEqual(Invitation.objects.all().count(), 3)
+
+        self.project.delete()
+        self.assertEqual(Invitation.objects.all().count(), 2)
+
+        self.team.delete()
+        self.assertEqual(Invitation.objects.all().count(), 1)
+
+        self.organization.delete()
+        self.assertEqual(Invitation.objects.all().count(), 0)


### PR DESCRIPTION
GenericForeignKey doesn't have an `on_delete=CASCADE` option,
so we need to do this manually.



<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9582.org.readthedocs.build/en/9582/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9582.org.readthedocs.build/en/9582/

<!-- readthedocs-preview dev end -->