### PR TITLE
OAuth: add logging for imported GitHub RemoteRepository

### DIFF
--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -115,6 +115,7 @@ class GitHubService(Service):
                         "GitHub repository created with different remote_id but exact full_name.",
                         fields=fields,
                         old_remote_repository=_old_remote_repository.__dict__,
+                        imported=_old_remote_repository.projects.exists(),
                     )
 
             owner_type = fields["owner"]["type"]


### PR DESCRIPTION
Add extra key to differentiate when this issue happens on GH repositories that we just track, from GH repositories that are also imported in our platform.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9590.org.readthedocs.build/en/9590/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9590.org.readthedocs.build/en/9590/

<!-- readthedocs-preview dev end -->