### PR TITLE
OAuth: save refresh token

### DIFF
--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -133,6 +133,7 @@ class Service:
 
         def _updater(data):
             token.token = data['access_token']
+            token.token_secret = data.get("refresh_token")
             token.expires_at = timezone.make_aware(
                 datetime.fromtimestamp(data['expires_at']),
             )

--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -133,7 +133,7 @@ class Service:
 
         def _updater(data):
             token.token = data['access_token']
-            token.token_secret = data.get("refresh_token")
+            token.token_secret = data.get("refresh_token", "")
             token.expires_at = timezone.make_aware(
                 datetime.fromtimestamp(data['expires_at']),
             )


### PR DESCRIPTION
We aren't saving the refresh_token, this is needed to refresh expired tokens, GitLab recently set an expiration time for their tokens https://gitlab.com/gitlab-org/gitlab/-/issues/21745.

Sadly, there is no other way of getting new tokens than users manually reconnecting their accounts.

Closes https://github.com/readthedocs/readthedocs.org/issues/9548