### PR TITLE
Builds: concurrency small optimization

### DIFF
--- a/readthedocs/builds/querysets.py
+++ b/readthedocs/builds/querysets.py
@@ -205,9 +205,9 @@ class BuildQuerySet(models.QuerySet):
         """
         limit_reached = False
         query = Q(
-            project__slug=project.slug,
+            project=project,
             # Limit builds to 5 hours ago to speed up the query
-            date__gte=timezone.now() - datetime.timedelta(hours=5),
+            date__gt=timezone.now() - datetime.timedelta(hours=5),
         )
 
         if project.main_language_project:


### PR DESCRIPTION
By using the `project_id` instead the `project_slug`, we remove the `Nested Loop` and use the index `builds_buil_project_fea68c_idx` which is optimized for `(project_id, date)`.

Besides, I changed `__gte` by `__gt`.

Neither of these will gives us a lot of optimization, but since I just saw them, I'm pushing these changes.

New SQL query:

```
docs=> EXPLAIN ANALYZE SELECT *
  FROM "builds_build"
 INNER JOIN "projects_project"
    ON ("builds_build"."project_id" = "projects_project"."id")
 WHERE ("builds_build"."date" > '2022-09-14T10:10:35.123817+00:00'::timestamptz AND "projects_project"."id" = '74581')
 ORDER BY "builds_build"."date" DESC;
                                                                          QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=0.98..17.03 rows=1 width=1328) (actual time=0.012..0.013 rows=0 loops=1)
   ->  Index Scan Backward using builds_buil_project_fea68c_idx on builds_build  (cost=0.56..8.58 rows=1 width=265) (actual time=0.012..0.012 rows=0 loops=1)
         Index Cond: ((project_id = 74581) AND (date > '2022-09-14 10:10:35.123817+00'::timestamp with time zone))
   ->  Index Scan using projects_project_pkey on projects_project  (cost=0.42..8.44 rows=1 width=1055) (never executed)
         Index Cond: (id = 74581)
 Planning Time: 0.289 ms
 Execution Time: 0.058 ms
(7 rows)
```

Old SQL query:

```
docs=> EXPLAIN ANALYZE SELECT *
 FROM "builds_build"
INNER JOIN "projects_project"
   ON ("builds_build"."project_id" = "projects_project"."id")
WHERE ("builds_build"."date" > '2022-09-14T10:10:35.123817+00:00'::timestamptz AND "projects_project"."slug" = 'docs')
ORDER BY "builds_build"."date" DESC;
                                                                         QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=17.04..17.05 rows=1 width=1328) (actual time=0.033..0.033 rows=0 loops=1)
   Sort Key: builds_build.date DESC
   Sort Method: quicksort  Memory: 25kB
   ->  Nested Loop  (cost=0.98..17.03 rows=1 width=1328) (actual time=0.028..0.028 rows=0 loops=1)
         ->  Index Scan using projects_project_slug_uniq on projects_project  (cost=0.42..8.44 rows=1 width=1055) (actual time=0.017..0.018 rows=1 loops=1)
               Index Cond: ((slug)::text = 'docs'::text)
         ->  Index Scan using builds_buil_project_fea68c_idx on builds_build  (cost=0.56..8.58 rows=1 width=265) (actual time=0.008..0.008 rows=0 loops=1)
               Index Cond: ((project_id = projects_project.id) AND (date > '2022-09-14 10:10:35.123817+00'::timestamp with time zone))
 Planning Time: 0.429 ms
 Execution Time: 0.089 ms
(10 rows)
```

> Note this query is simplified to reduce it to only the changes I'm proposing
> here. The original query is way more complex.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9602.org.readthedocs.build/en/9602/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9602.org.readthedocs.build/en/9602/

<!-- readthedocs-preview dev end -->