### PR TITLE
ci: add minimum GitHub at the workflow level for pip-tools.yaml

### DIFF
--- a/.github/workflows/pip-tools.yaml
+++ b/.github/workflows/pip-tools.yaml
@@ -11,6 +11,9 @@ on:
     # Run weekly on day 0 at 00:00 UTC
     - cron: "0 0 * * 0"
 
+permissions:
+  contents: read
+
 jobs:
   update-dependencies:
     permissions:


### PR DESCRIPTION
Creating this PR as per @stsewd's comment https://github.com/readthedocs/readthedocs.org/pull/9597#issuecomment-1251275658. Please review this PR when you get a chance.

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9617.org.readthedocs.build/en/9617/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9617.org.readthedocs.build/en/9617/

<!-- readthedocs-preview dev end -->