### PR TITLE
Docs: Re-scope Intersphinx article as a how-to

### DIFF
--- a/docs/user/guides/authors.rst
+++ b/docs/user/guides/authors.rst
@@ -14,6 +14,6 @@ and :doc:`/intro/getting-started-with-mkdocs`.
    :maxdepth: 1
 
    cross-referencing-with-sphinx
-   intersphinx
+   Link to external projects (Intersphinx) <intersphinx>
    jupyter
    Migrate from rST to MyST <migrate-rest-myst>

--- a/docs/user/guides/intersphinx.rst
+++ b/docs/user/guides/intersphinx.rst
@@ -1,5 +1,7 @@
-Link to Other Projects' Documentation With Intersphinx
-======================================================
+How to link to other documentation projects with Intersphinx
+============================================================
+
+This section shows you how to maintain references to named sections of other external Sphinx projects.
 
 You may be familiar with using the :ref:`:ref: role <sphinx:ref-role>` to
 :doc:`link to any location of your docs </guides/cross-referencing-with-sphinx>`.

--- a/docs/user/guides/intersphinx.rst
+++ b/docs/user/guides/intersphinx.rst
@@ -1,4 +1,4 @@
-How to link to other documentation projects with Intersphinx
+How to Link to Other Documentation Projects With Intersphinx
 ============================================================
 
 This section shows you how to maintain references to named sections of other external Sphinx projects.


### PR DESCRIPTION
Uses the method laid out by @evildmp in #9620

Reviewers:

* Do you agree with the altered (Diátaxis'ized) scoping of the article? (title/navigation/intro)
* Any small text tweaks welcome

Side-note: We should track these small changes through an issue and perhaps also a Github tag.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9622.org.readthedocs.build/en/9622/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9622.org.readthedocs.build/en/9622/

<!-- readthedocs-preview dev end -->