### PR TITLE
Query: minor improvement

### DIFF
--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -99,7 +99,11 @@ def finish_inactive_builds():
     # Set time as maximum celery task time limit + 5m
     time_limit = 7200 + 300
     delta = datetime.timedelta(seconds=time_limit)
-    query = ~Q(state__in=BUILD_FINAL_STATES) & Q(date__lte=timezone.now() - delta)
+    query = (
+        ~Q(state__in=BUILD_FINAL_STATES)
+        & Q(date__lt=timezone.now() - delta)
+        & Q(date__gt=timezone.now() - datetime.timedelta(days=1))
+    )
 
     builds_finished = 0
     builds = Build.objects.filter(query)[:50]


### PR DESCRIPTION
Limit the builds to those that are from the last day (we won't have a build length that's greater than 1 day). This will reduce the rows required to parse since we have an index there. Also, remove the "equal" part from "less than equal" from the query because it makes no sense.

This may help with some of the db problems we were facing in last weeks.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9634.org.readthedocs.build/en/9634/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9634.org.readthedocs.build/en/9634/

<!-- readthedocs-preview dev end -->