### PR TITLE
Dashboard: right-floating elements should go before inline text

### DIFF
--- a/readthedocs/templates/projects/project_version_list.html
+++ b/readthedocs/templates/projects/project_version_list.html
@@ -31,8 +31,6 @@ Versions
                 {% block active-versions %}
                   {% with absolute_url=version.get_absolute_url %}
                   <li class="module-item">
-                    {# Link to the docs #}
-                    <a class="module-item-title" href="{{ absolute_url }}">{{ version.slug }}</a>
 
                     {% if is_project_admin %}
                       <span class="right-menu">
@@ -53,6 +51,9 @@ Versions
                         <li><a href="{{ absolute_url }}">{% trans "View Docs" %}</a></li>
                       </ul>
                     {% endif %}
+
+                    {# Link to the docs #}
+                    <a class="module-item-title" href="{{ absolute_url }}">{{ version.slug }}</a>
 
                   </li>
                   {% endwith %}


### PR DESCRIPTION
Wrapping and floating gets messed up with long branch names. And yes, we probably want to rewrite all this, use flexbox etc :)

Before:

![image](https://user-images.githubusercontent.com/374612/193599203-be5b5e34-244d-4217-b317-0f0b8519d880.png)

After:

![image](https://user-images.githubusercontent.com/374612/193599372-7d68cd0c-2898-4f3b-8ea1-2cb25c102ba7.png)


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9637.org.readthedocs.build/en/9637/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9637.org.readthedocs.build/en/9637/

<!-- readthedocs-preview dev end -->