### PR TITLE
Telemetry: track Sphinx `extensions` and `html_theme` variables

### DIFF
--- a/readthedocs/telemetry/collectors.py
+++ b/readthedocs/telemetry/collectors.py
@@ -91,6 +91,7 @@ class BuildDataCollector:
             },
         }
         data["doctool"] = self._get_doctool()
+        return data
 
     def _get_doctool_name(self):
         if self.version.is_sphinx_type:

--- a/readthedocs/telemetry/collectors.py
+++ b/readthedocs/telemetry/collectors.py
@@ -102,8 +102,8 @@ class BuildDataCollector:
             return "sphinx"
         elif self.config.mkdocs:
             return "mkdocs"
-        else:
-            return "generic"
+
+        return "generic"
 
     def _get_doctool_extensions(self):
         if self._get_doctool_name() != "sphinx":

--- a/readthedocs/telemetry/collectors.py
+++ b/readthedocs/telemetry/collectors.py
@@ -93,10 +93,10 @@ class BuildDataCollector:
         data["doctool"] = self._get_doctool()
 
     def _get_doctool_name(self):
-        if self.version.is_sphinx_type():
+        if self.version.is_sphinx_type:
             return "sphinx"
 
-        if self.version.is_mkdocs_type():
+        if self.version.is_mkdocs_type:
             return "mkdocs"
 
         return "generic"

--- a/readthedocs/telemetry/collectors.py
+++ b/readthedocs/telemetry/collectors.py
@@ -121,8 +121,7 @@ class BuildDataCollector:
             with open(filepath, "r") as json_file:
                 content = json_file.read()
             data.update(self._safe_json_loads(content, {}))
-            return data
-        return []
+        return data
 
     def _get_all_conda_packages(self):
         """

--- a/readthedocs/telemetry/collectors.py
+++ b/readthedocs/telemetry/collectors.py
@@ -98,10 +98,10 @@ class BuildDataCollector:
         return data
 
     def _get_doctool_name(self):
-        if self.config.sphinx:
+        if self.version.is_sphinx_type():
             return "sphinx"
 
-        if self.config.mkdocs:
+        if self.version.is_mkdocs_type():
             return "mkdocs"
 
         return "generic"

--- a/readthedocs/telemetry/collectors.py
+++ b/readthedocs/telemetry/collectors.py
@@ -100,7 +100,8 @@ class BuildDataCollector:
     def _get_doctool_name(self):
         if self.config.sphinx:
             return "sphinx"
-        elif self.config.mkdocs:
+
+        if self.config.mkdocs:
             return "mkdocs"
 
         return "generic"


### PR DESCRIPTION
Pretty simple implementation to track Sphinx's extensions and theme. This is not the best implementation, but I think it could be good as a first start.

The new `doctool` key added will have this shape:

```
  "doctool": {
    "extensions": [
      "readthedocs_ext.readthedocs",
      "notfound.extension",
      "autoapi.extension",
      "sphinx_tabs.tabs",
      "sphinx-prompt",
      "sphinxemoji.sphinxemoji"
    ],
    "name": "sphinx",
    "theme": "sphinx_rtd_theme"
  },
```

Closes #9627
Requires: https://github.com/readthedocs/readthedocs-sphinx-ext/pull/117

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9639.org.readthedocs.build/en/9639/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9639.org.readthedocs.build/en/9639/

<!-- readthedocs-preview dev end -->