### PR TITLE
Settings: enable `django-debug-toolbar` when Django Admin is enabled

### DIFF
--- a/dockerfiles/settings/proxito.py
+++ b/dockerfiles/settings/proxito.py
@@ -6,9 +6,11 @@ from .docker_compose import DockerBaseSettings
 class ProxitoDevSettings(CommunityProxitoSettingsMixin, DockerBaseSettings):
 
     # El Proxito does not have django-debug-toolbar installed
-    DEBUG_TOOLBAR_CONFIG = {
-        'SHOW_TOOLBAR_CALLBACK': lambda request: False,
-    }
+    @property
+    def DEBUG_TOOLBAR_CONFIG(self):
+        return {
+            'SHOW_TOOLBAR_CALLBACK': lambda request: False,
+        }
 
 
 ProxitoDevSettings.load_settings(__name__)

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -48,8 +48,11 @@ class CommunityBaseSettings(Settings):
 
     @property
     def DEBUG_TOOLBAR_CONFIG(self):
+        def _show_debug_toolbar(request):
+            return request.environ.get('SERVER_NAME', None) != 'testserver' and self.SHOW_DEBUG_TOOLBAR
+
         return {
-            'SHOW_TOOLBAR_CALLBACK': lambda request: self.SHOW_DEBUG_TOOLBAR
+            'SHOW_TOOLBAR_CALLBACK': _show_debug_toolbar,
         }
 
     @property

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -46,6 +46,24 @@ class CommunityBaseSettings(Settings):
     # Debug settings
     DEBUG = True
 
+    @property
+    def DEBUG_TOOLBAR_CONFIG(self):
+        return {
+            'SHOW_TOOLBAR_CALLBACK': lambda request: self.SHOW_DEBUG_TOOLBAR
+        }
+
+    @property
+    def SHOW_DEBUG_TOOLBAR(self):
+        """
+        Show django-debug-toolbar on DEBUG or if the Django Admin is allowed.
+
+        This will show the debug toolbar on:
+
+          - Docker local instance
+          - web-extra production instance
+        """
+        return self.DEBUG or self.ALLOW_ADMIN
+
     # Domains and URLs
     RTD_IS_PRODUCTION = False
     PRODUCTION_DOMAIN = 'readthedocs.org'
@@ -228,6 +246,9 @@ class CommunityBaseSettings(Settings):
             apps.append('readthedocsext.spamfighting')
         if self.RTD_EXT_THEME_ENABLED:
             apps.append('readthedocsext.theme')
+        if self.SHOW_DEBUG_TOOLBAR:
+            apps.append('debug_toolbar')
+
         return apps
 
     @property
@@ -246,24 +267,31 @@ class CommunityBaseSettings(Settings):
     def USE_PROMOS(self):  # noqa
         return 'readthedocsext.donate' in self.INSTALLED_APPS
 
-    MIDDLEWARE = (
-        'readthedocs.core.middleware.NullCharactersMiddleware',
-        'readthedocs.core.middleware.ReadTheDocsSessionMiddleware',
-        'django.middleware.locale.LocaleMiddleware',
-        'django.middleware.common.CommonMiddleware',
-        'django.middleware.security.SecurityMiddleware',
-        'django.middleware.csrf.CsrfViewMiddleware',
-        'django.middleware.clickjacking.XFrameOptionsMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.messages.middleware.MessageMiddleware',
-        'dj_pagination.middleware.PaginationMiddleware',
-        'corsheaders.middleware.CorsMiddleware',
-        'csp.middleware.CSPMiddleware',
-        'readthedocs.core.middleware.ReferrerPolicyMiddleware',
-        'simple_history.middleware.HistoryRequestMiddleware',
-        'readthedocs.core.logs.ReadTheDocsRequestMiddleware',
-        'django_structlog.middlewares.CeleryMiddleware',
-    )
+    @property
+    def MIDDLEWARE(self):
+        middlewares = [
+            'readthedocs.core.middleware.NullCharactersMiddleware',
+            'readthedocs.core.middleware.ReadTheDocsSessionMiddleware',
+            'django.middleware.locale.LocaleMiddleware',
+            'django.middleware.common.CommonMiddleware',
+            'django.middleware.security.SecurityMiddleware',
+            'django.middleware.csrf.CsrfViewMiddleware',
+            'django.middleware.clickjacking.XFrameOptionsMiddleware',
+            'django.contrib.auth.middleware.AuthenticationMiddleware',
+            'django.contrib.messages.middleware.MessageMiddleware',
+            'dj_pagination.middleware.PaginationMiddleware',
+            'corsheaders.middleware.CorsMiddleware',
+            'csp.middleware.CSPMiddleware',
+            'readthedocs.core.middleware.ReferrerPolicyMiddleware',
+            'simple_history.middleware.HistoryRequestMiddleware',
+            'readthedocs.core.logs.ReadTheDocsRequestMiddleware',
+            'django_structlog.middlewares.CeleryMiddleware',
+        ]
+        if self.SHOW_DEBUG_TOOLBAR:
+            middlewares.insert(0, 'debug_toolbar.middleware.DebugToolbarMiddleware')
+        return middlewares
+
+
 
     AUTHENTICATION_BACKENDS = (
         # Needed to login by username in Django admin, regardless of `allauth`

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -45,6 +45,7 @@ class CommunityBaseSettings(Settings):
 
     # Debug settings
     DEBUG = True
+    RTD_FORCE_SHOW_DEBUG_TOOLBAR = False
 
     @property
     def DEBUG_TOOLBAR_CONFIG(self):
@@ -58,14 +59,14 @@ class CommunityBaseSettings(Settings):
     @property
     def SHOW_DEBUG_TOOLBAR(self):
         """
-        Show django-debug-toolbar on DEBUG or if the Django Admin is allowed.
+        Show django-debug-toolbar on DEBUG or if it's forced by RTD_FORCE_SHOW_DEBUG_TOOLBAR.
 
         This will show the debug toolbar on:
 
           - Docker local instance
           - web-extra production instance
         """
-        return self.DEBUG or self.ALLOW_ADMIN
+        return self.DEBUG or self.RTD_FORCE_SHOW_DEBUG_TOOLBAR
 
     # Domains and URLs
     RTD_IS_PRODUCTION = False

--- a/readthedocs/settings/dev.py
+++ b/readthedocs/settings/dev.py
@@ -66,19 +66,6 @@ class CommunityDevSettings(CommunityBaseSettings):
         logging['disable_existing_loggers'] = False
         return logging
 
-    @property
-    def INSTALLED_APPS(self):
-        apps = super().INSTALLED_APPS
-        apps.append('debug_toolbar')
-        return apps
-
-    @property
-    def MIDDLEWARE(self):
-        middlewares = list(super().MIDDLEWARE)
-        middlewares.insert(0, 'debug_toolbar.middleware.DebugToolbarMiddleware')
-        return middlewares
-
-
 CommunityDevSettings.load_settings(__name__)
 
 if not os.environ.get('DJANGO_SETTINGS_SKIP_LOCAL', False):

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -139,14 +139,6 @@ class DockerBaseSettings(CommunityDevSettings):
             },
         }
 
-    def show_debug_toolbar(request):
-        from django.conf import settings
-        return settings.DEBUG
-
-    DEBUG_TOOLBAR_CONFIG = {
-        'SHOW_TOOLBAR_CALLBACK': show_debug_toolbar,
-    }
-
     ACCOUNT_EMAIL_VERIFICATION = "none"
     SESSION_COOKIE_DOMAIN = None
     CACHES = {

--- a/readthedocs/urls.py
+++ b/readthedocs/urls.py
@@ -164,7 +164,7 @@ if settings.READ_THE_DOCS_EXTENSIONS:
 if settings.ALLOW_ADMIN:
     groups.append(admin_urls)
 
-if settings.DEBUG:
+if settings.SHOW_DEBUG_TOOLBAR:
     import debug_toolbar
 
     debug_urls += [


### PR DESCRIPTION
Small refactor to allow the `django-debug-toolbar` on:

- Docker development instance
- web-extra instance

This will help us to debug some SQL queries and others in production using a private and protected instance.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9641.org.readthedocs.build/en/9641/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9641.org.readthedocs.build/en/9641/

<!-- readthedocs-preview dev end -->