### PR TITLE
doc_builder: Search for `pyproject.toml` as requirements file

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -259,7 +259,7 @@ class Virtualenv(PythonEnvironment):
                 ).docs_dir()
             )
             paths = [docs_dir, '']
-            req_files = ['pip_requirements.txt', 'requirements.txt']
+            req_files = ['pip_requirements.txt', 'requirements.txt', 'pyproject.toml']
             for path, req_file in itertools.product(paths, req_files):
                 test_path = os.path.join(self.checkout_path, path, req_file)
                 if os.path.exists(test_path):


### PR DESCRIPTION
This commit enables that beside from `pip_requirements.txt` and `requirements.txt`, the doc builder also searches for a `pyproject.toml` as requirements file. 

`pyproject.toml` files are a modern implementation for storing project metadata, [including dependencies](https://packaging.python.org/en/latest/specifications/declaring-project-metadata/#dependencies-optional-dependencies), as defined in [PEP 621](https://peps.python.org/pep-0621/). With this new search behaviour that includes `pyproject.toml` files, project following PEP 621 can enable Read the Docs and write a `.readthedocs.yaml` file without explicitly having to specify the requirements file, just like when using a `requirements.txt` file.

It's probably best for some documentation and tests to also be added for requirements defined in `pyproject.toml` files, please let me know where and how to add them! :)