### PR TITLE
Search: use path for API URL

### DIFF
--- a/readthedocs/urls.py
+++ b/readthedocs/urls.py
@@ -90,7 +90,7 @@ organization_urls = [
 api_urls = [
     re_path(r'^api/v2/', include('readthedocs.api.v2.urls')),
     # Keep `search_api` at root level, so the test does not fail for other API
-    re_path(r"^api/v2/search/$", include("readthedocs.search.api.v2.urls")),
+    path("api/v2/search/", include("readthedocs.search.api.v2.urls")),
     # Deprecated
     re_path(r'^api/v1/embed/', include('readthedocs.embed.urls')),
     re_path(r'^api/v2/embed/', include('readthedocs.embed.urls')),


### PR DESCRIPTION
The current re_path is valid, but looks werid.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9646.org.readthedocs.build/en/9646/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9646.org.readthedocs.build/en/9646/

<!-- readthedocs-preview dev end -->