### PR TITLE
Build: skip build based on commands' exit codes

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -151,12 +151,7 @@ This other example shows how to cancel a build if the commit message contains ``
        post_checkout:
          # Use `git log` to check if the latest commit contains "skip ci",
          # in that case exit the command with 183 to cancel the build
-         - |
-           case `git --no-pager log --pretty="tformat:%s" -1`
-           in *"skip ci"*)
-             exit 183;;
-           *);;
-           esac
+         - (git --no-pager log --pretty="tformat:%s -- %b" -1 | grep -viq "skip ci") || exit 183
 
 
 Generate documentation from annotated sources with Doxygen

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -109,8 +109,8 @@ Skip build based on a condition
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 There may be situations where you want to skip a build that was automatically triggered when someone on your team pushed to the repository.
-Skipping builds will allow you to speed up review times and also help us to reduce costs in our servers.
-The following situations are good examples to skip a build:
+Skipping builds will allow you to speed up review times and also help us reduce server costs and ultimately our environmental footprint.
+Consider the following scenarios:
 
 * the build depends on an external situation that's not met yet
 * there were no changes on the documentation files
@@ -120,7 +120,9 @@ and exits with code ``439`` to skip it, or ``0`` to continue building the docume
 If any of the commands return this particular exit code,
 Read the Docs will stop the build immediately,
 mark it as "Cancelled",
-and communicate GitHub/GitLab that the build succeeded (green tick) so the pull request is in a mergeable state.
+and communicate to your Git platform (GitHub/GitLab) that the build succeeded (green tick ✅) so the pull request is in a mergeable state.
+
+Here is an example that exits the build when there are no changes to the ``docs/`` folder compared to the ``origin/main`` branch.
 
 .. code-block:: yaml
    :caption: .readthedocs.yaml

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -73,7 +73,7 @@ There are some caveats to knowing when using user-defined jobs:
 * Environment variables are expanded in the commands (see :doc:`environment-variables`)
 * Each command is executed in a new shell process, so modifications done to the shell environment do not persist between commands
 * Any command returning non-zero exit code will cause the build to fail immediately
-  (note there is a special exit code to :ref:`skip the build <build-customization:skip-build-based-on-a-condition>`)
+  (note there is a special exit code to `skip the build <skip-build-based-on-a-condition>`_)
 * ``build.os`` and ``build.tools`` are required when using ``build.jobs``
 
 

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -122,7 +122,7 @@ Read the Docs will stop the build immediately,
 mark it as "Cancelled",
 and communicate to your Git platform (GitHub/GitLab) that the build succeeded (green tick ✅) so the pull request is in a mergeable state.
 
-Here is an example that skip build from pull requests when there are no changes to the ``docs/`` folder compared to the ``origin/main`` branch.
+Here is an example that skip build from pull requests when there are no changes to the ``docs/`` folder compared to the ``origin/main`` branch:
 
 .. code-block:: yaml
    :caption: .readthedocs.yaml
@@ -142,6 +142,22 @@ Here is an example that skip build from pull requests when there are no changes 
          # This is a special exit code on Read the Docs that will cancel the build immediately.
          - if [ $READTHEDOCS_VERSION_TYPE = "external" ]; then ! git diff --quiet origin/main -- docs/ && exit 439; fi
 
+
+This other example shows how to skip a build if the commit message contains ``skip ci`` on it:
+
+.. code-block:: yaml
+   :caption: .readthedocs.yaml
+
+   version: 2
+   build:
+     os: "ubuntu-22.04"
+     tools:
+       python: "3.11"
+     jobs:
+       post_checkout:
+         # Use `git log` to check if the latest commit contains "skip ci",
+         # in that case exit the command with 439 to skip the build
+         - case `git --no-pager log --pretty="tformat:%s" -1` in *"skip ci"*) exit 439;; *);; esac
 
 
 Generate documentation from annotated sources with Doxygen

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -132,8 +132,12 @@ and communicate GitHub/GitLab that the build succeeded (green tick) so the pull 
        python: "3.11"
      jobs:
        post_checkout:
-         # Check if there were changes in the "docs/" directory
-         # and return 439 to skip the build if there weren't
+         # Skip build when there aren't changed in docs directory.
+         # `--quiet` exits with a 1 when there **are** changes,
+         # so we invert the logic with a !
+         #
+         # If there are no changes (exit 0) we force the command to return with 439.
+         # This is a special exit code on Read the Docs that will cancel the build immediately.
          - ! git diff --quiet origin/main -- docs/ && exit 439
 
 

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -112,6 +112,21 @@ When a command exits with code ``183``,
 Read the Docs will cancel the build immediately.
 You can use this approach to cancel builds that you don't want to complete based on some conditional logic.
 
+.. note:: Why 183 was chosen for the exit code?
+
+   It's the word "skip" encoded in ASCII.
+   Then it's taken the 256 modulo of it because
+   `the Unix implementation does this automatically <https://tldp.org/LDP/abs/html/exitcodes.html>`_
+   for exit codes greater than 255.
+
+   .. code-block:: python
+
+      >>> sum(list('skip'.encode('ascii')))
+      439
+      >>> 439 % 256
+      183
+
+
 Here is an example that cancels builds from pull requests when there are no changes to the ``docs/`` folder compared to the ``origin/main`` branch:
 
 .. code-block:: yaml

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -122,7 +122,7 @@ Read the Docs will stop the build immediately,
 mark it as "Cancelled",
 and communicate to your Git platform (GitHub/GitLab) that the build succeeded (green tick ✅) so the pull request is in a mergeable state.
 
-Here is an example that exits the build when there are no changes to the ``docs/`` folder compared to the ``origin/main`` branch.
+Here is an example that skip build from pull requests when there are no changes to the ``docs/`` folder compared to the ``origin/main`` branch.
 
 .. code-block:: yaml
    :caption: .readthedocs.yaml
@@ -134,13 +134,13 @@ Here is an example that exits the build when there are no changes to the ``docs/
        python: "3.11"
      jobs:
        post_checkout:
-         # Skip build when there aren't changed in docs directory.
+         # Skip building pull requests when there aren't changed in the docs directory.
          # `--quiet` exits with a 1 when there **are** changes,
          # so we invert the logic with a !
          #
          # If there are no changes (exit 0) we force the command to return with 439.
          # This is a special exit code on Read the Docs that will cancel the build immediately.
-         - ! git diff --quiet origin/main -- docs/ && exit 439
+         - if [ $READTHEDOCS_VERSION_TYPE = "external" ]; then ! git diff --quiet origin/main -- docs/ && exit 439; fi
 
 
 

--- a/docs/user/builds.rst
+++ b/docs/user/builds.rst
@@ -68,6 +68,46 @@ The following are the pre-defined jobs executed by Read the Docs:
     it's possible to run user-defined commands and :doc:`customize the build process <build-customization>`.
 
 
+When to cancel builds
+---------------------
+
+There may be situations where you want to cancel a particular running build.
+Cancelling running builds will allow your team to speed up review times and also help us reduce server costs and ultimately,
+our environmental footprint.
+
+Consider the following scenarios:
+
+* the build has an external dependency that hasn't been updated
+* there were no changes on the documentation files
+* many other use cases that can be solved with custom logic
+
+For these scenarios,
+Read the Docs supports three different mechanisms to cancel a running build:
+
+:Manually:
+
+   Once a build was triggered,
+   project administrators can go to the build detail page
+   and click the button "Cancel build".
+
+:Automatically:
+
+   When Read the Docs detects a push to a branch that it's currently building the documentation,
+   it cancels the running build and start a new build using the latest commit from the new push.
+
+:Programatically:
+
+   You can use user-defined commands on ``build.jobs`` or ``build.commands`` (see :doc:`build-customization`)
+   to check for a condition and exit it with the code ``183`` if you want to cancel the running build or ``0``, otherwise.
+
+   In this case, Read the Docs will communicate to your Git platform (GitHub/GitLab) that the build succeeded (green tick ✅)
+   so the pull request is in a mergeable state.
+
+   .. tip::
+
+      Take a look at :ref:`build-customization:cancel build based on a condition` section for some examples.
+
+
 Build resources
 ---------------
 

--- a/readthedocs/doc_builder/constants.py
+++ b/readthedocs/doc_builder/constants.py
@@ -1,12 +1,10 @@
-# -*- coding: utf-8 -*-
 
 """Doc build constants."""
 
-import structlog
 import re
 
+import structlog
 from django.conf import settings
-
 
 log = structlog.get_logger(__name__)
 
@@ -30,3 +28,11 @@ DOCKER_TIMEOUT_EXIT_CODE = 42
 DOCKER_OOM_EXIT_CODE = 137
 
 DOCKER_HOSTNAME_MAX_LEN = 64
+
+# Why 183 exit code?
+#
+# >>> sum(list('skip'.encode('ascii')))
+# 439
+# >>> 439 % 256
+# 183
+RTD_SKIP_BUILD_EXIT_CODE = 183

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -30,8 +30,9 @@ from .constants import (
     DOCKER_SOCKET,
     DOCKER_TIMEOUT_EXIT_CODE,
     DOCKER_VERSION,
+    RTD_SKIP_BUILD_EXIT_CODE,
 )
-from .exceptions import BuildAppError, BuildUserError
+from .exceptions import BuildAppError, BuildUserError, BuildUserSkip
 
 log = structlog.get_logger(__name__)
 
@@ -468,6 +469,8 @@ class BaseEnvironment:
                     project_slug=self.project.slug if self.project else '',
                     version_slug=self.version.slug if self.version else '',
                 )
+            elif build_cmd.exit_code == RTD_SKIP_BUILD_EXIT_CODE:
+                raise BuildUserSkip()
             else:
                 # TODO: for now, this still outputs a generic error message
                 # that is the same across all commands. We could improve this

--- a/readthedocs/doc_builder/exceptions.py
+++ b/readthedocs/doc_builder/exceptions.py
@@ -42,6 +42,13 @@ class BuildUserError(BuildBaseException):
     )
 
 
+class BuildUserSkip(BuildUserError):
+    message = gettext_noop(
+        "This build was cancelled due the magic exit code was returned by a commmand."
+    )
+    state = BUILD_STATE_CANCELLED
+
+
 class ProjectBuildsSkippedError(BuildUserError):
     message = gettext_noop('Builds for this project are temporarily disabled')
 

--- a/readthedocs/doc_builder/exceptions.py
+++ b/readthedocs/doc_builder/exceptions.py
@@ -44,7 +44,7 @@ class BuildUserError(BuildBaseException):
 
 class BuildUserSkip(BuildUserError):
     message = gettext_noop(
-        "This build was cancelled due the magic exit code was returned by a commmand."
+        "This build was manually skipped using a command exit code."
     )
     state = BUILD_STATE_CANCELLED
 

--- a/readthedocs/doc_builder/exceptions.py
+++ b/readthedocs/doc_builder/exceptions.py
@@ -43,9 +43,7 @@ class BuildUserError(BuildBaseException):
 
 
 class BuildUserSkip(BuildUserError):
-    message = gettext_noop(
-        "This build was manually skipped using a command exit code."
-    )
+    message = gettext_noop("This build was manually skipped using a command exit code.")
     state = BUILD_STATE_CANCELLED
 
 

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -495,19 +495,19 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
                 version_type = self.data.version.type
 
             # NOTE: autoflake gets confused here. We need the NOQA for now.
-            status = BUILD_STATUS_FAILURE  # noqa
+            status = BUILD_STATUS_FAILURE
             if isinstance(exc, BuildUserSkip):
                 # The build was skipped by returning the magic exit code,
                 # marked as CANCELLED, but communicated to GitHub as successful.
                 # This is because the PR has to be available for merging when the build
                 # was skipped on purpose.
-                status = BUILD_STATUS_SUCCESS  # noqa
+                status = BUILD_STATUS_SUCCESS
 
             send_external_build_status(
                 version_type=version_type,
                 build_pk=self.data.build['id'],
                 commit=self.data.build_commit,
-                status=BUILD_STATUS_FAILURE,
+                status=status,
             )
 
         # Update build object

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -44,6 +44,7 @@ from readthedocs.doc_builder.exceptions import (
     BuildCancelled,
     BuildMaxConcurrencyError,
     BuildUserError,
+    BuildUserSkip,
     MkDocsYAMLParseError,
     ProjectBuildsSkippedError,
     YAMLParseError,
@@ -280,6 +281,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         YAMLParseError,
         BuildCancelled,
         BuildUserError,
+        BuildUserSkip,
         RepositoryError,
         MkDocsYAMLParseError,
         ProjectConfigurationError,
@@ -289,6 +291,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
     exceptions_without_notifications = (
         BuildCancelled,
         BuildMaxConcurrencyError,
+        BuildUserSkip,
         ProjectBuildsSkippedError,
     )
 


### PR DESCRIPTION
Define a particular exit code (439) to skip a build.

If any of the commands returns this exit code, the build will be cancelled automatically and won't run any of the following commands. When this happens, the build will be marked as `cancelled` and no email/webhook notifications will be sent.

Why 439 was chosen for the exit code?

It's the word "skip" encoded in ASCII. Then it's taken the 256 modulo of it because the Unix implementation does this automatically for exit codes greater than 255

```
>>> sum(list('skip'.encode('ascii')))
439
>>> 439 % 256
183
```

----

I opened this PR in draft because there are some things to discuss and decide yet. It's just a proof of concept for now.

- Do we need a new `skipped` status?
- Should we send "build status" notification as `success`?
- Is it possible to write the message in gray instead of red and avoid the word "Error"?

The following is an example of how it looks locally:

![Screenshot_2022-10-10_17-00-05](https://user-images.githubusercontent.com/244656/194898980-ed329e80-ad15-4d4a-80df-95d1e858927e.png)

I created a branch on test-builds that can be used for this: https://github.com/readthedocs/test-builds/compare/skip-build-command?expand=1

Closes #871 
Closes #8545