### PR TITLE
Subscriptions: Use djstripe event handlers

### DIFF
--- a/readthedocs/subscriptions/apps.py
+++ b/readthedocs/subscriptions/apps.py
@@ -10,3 +10,4 @@ class SubscriptionsConfig(AppConfig):
     def ready(self):
         import readthedocs.subscriptions.signals  # noqa
         import readthedocs.subscriptions.tasks  # noqa
+        import readthedocs.subscriptions.event_handlers  # noqa

--- a/readthedocs/subscriptions/apps.py
+++ b/readthedocs/subscriptions/apps.py
@@ -8,6 +8,6 @@ class SubscriptionsConfig(AppConfig):
     label = 'subscriptions'
 
     def ready(self):
+        import readthedocs.subscriptions.event_handlers  # noqa
         import readthedocs.subscriptions.signals  # noqa
         import readthedocs.subscriptions.tasks  # noqa
-        import readthedocs.subscriptions.event_handlers  # noqa

--- a/readthedocs/subscriptions/event_handlers.py
+++ b/readthedocs/subscriptions/event_handlers.py
@@ -71,7 +71,7 @@ def update_subscription(event):
         return
 
     _update_subscription_from_stripe(
-        rtd_subscription_id=rtd_subscription,
+        rtd_subscription=rtd_subscription,
         stripe_subscription_id=stripe_subscription_id,
     )
 

--- a/readthedocs/subscriptions/event_handlers.py
+++ b/readthedocs/subscriptions/event_handlers.py
@@ -19,7 +19,7 @@ log = structlog.get_logger(__name__)
 
 def _update_subscription_from_stripe(rtd_subscription, stripe_subscription_id):
     """Update the RTD subscription object given the new stripe subscription object."""
-    log.bind(stripe_subscription=stripe_subscription_id)
+    log.bind(stripe_subscription_id=stripe_subscription_id)
     stripe_subscription = djstripe.Subscription.objects.filter(
         id=stripe_subscription_id
     ).first()
@@ -34,8 +34,8 @@ def _update_subscription_from_stripe(rtd_subscription, stripe_subscription_id):
     )
     log.info(
         "Subscription updated.",
-        previous_stripe_subscription=previous_subscription_id,
-        subscription_status=stripe_subscription.status,
+        previous_stripe_subscription_id=previous_subscription_id,
+        stripe_subscription_status=stripe_subscription.status,
     )
 
     # Cancel the trial subscription if its trial has ended.
@@ -66,12 +66,12 @@ def update_subscription(event):
     if not rtd_subscription:
         log.info(
             "Stripe subscription isn't attached to a RTD object.",
-            stripe_subscription=stripe_subscription_id,
+            stripe_subscription_id=stripe_subscription_id,
         )
         return
 
     _update_subscription_from_stripe(
-        rtd_subscription=rtd_subscription,
+        rtd_subscription_id=rtd_subscription,
         stripe_subscription_id=stripe_subscription_id,
     )
 
@@ -104,7 +104,7 @@ def checkout_completed(event):
 def customer_updated_event(event):
     """Update the organization with the new information from the stripe customer."""
     stripe_customer = event.data["object"]
-    log.bind(customer=stripe_customer["id"])
+    log.bind(customer_id=stripe_customer["id"])
     organization = Organization.objects.filter(stripe_id=stripe_customer["id"]).first()
     if not organization:
         log.info("Customer isn't attached to an organization.")

--- a/readthedocs/subscriptions/event_handlers.py
+++ b/readthedocs/subscriptions/event_handlers.py
@@ -1,14 +1,17 @@
+"""
+Dj-stripe webhook handlers.
+
+https://docs.dj-stripe.dev/en/master/usage/webhooks/.
+"""
+import structlog
+from django.conf import settings
+from django.utils import timezone
+from djstripe import models as djstripe
 from djstripe import webhooks
 from djstripe.enums import SubscriptionStatus
 
-from django.utils import timezone
-
-import structlog
-from readthedocs.payments.utils import cancel_subscription as cancel_stripe_subscription
 from readthedocs.organizations.models import Organization
-from django.conf import settings
-from djstripe import models as djstripe
-
+from readthedocs.payments.utils import cancel_subscription as cancel_stripe_subscription
 from readthedocs.subscriptions.models import Subscription
 
 log = structlog.get_logger(__name__)
@@ -17,7 +20,9 @@ log = structlog.get_logger(__name__)
 def _update_subscription_from_stripe(rtd_subscription, stripe_subscription_id):
     """Update the RTD subscription object given the new stripe subscription object."""
     log.bind(stripe_subscription=stripe_subscription_id)
-    stripe_subscription = djstripe.Subscription.objects.filter(id=stripe_subscription_id).first()
+    stripe_subscription = djstripe.Subscription.objects.filter(
+        id=stripe_subscription_id
+    ).first()
     if not stripe_subscription:
         log.info("Stripe subscription not found.")
         return
@@ -34,15 +39,19 @@ def _update_subscription_from_stripe(rtd_subscription, stripe_subscription_id):
     )
 
     # Cancel the trial subscription if its trial has ended.
-    trial_ended = stripe_subscription.trial_end and stripe_subscription.trial_end < timezone.now()
-    is_trial_subscription = stripe_subscription.items.filter(price__id=settings.RTD_ORG_DEFAULT_STRIPE_PRICE).exists()
+    trial_ended = (
+        stripe_subscription.trial_end and stripe_subscription.trial_end < timezone.now()
+    )
+    is_trial_subscription = stripe_subscription.items.filter(
+        price__id=settings.RTD_ORG_DEFAULT_STRIPE_PRICE
+    ).exists()
     if (
         is_trial_subscription
         and trial_ended
         and stripe_subscription.status != SubscriptionStatus.canceled
     ):
         log.info(
-            'Trial ended, canceling subscription.',
+            "Trial ended, canceling subscription.",
         )
         cancel_stripe_subscription(stripe_subscription.id)
 
@@ -51,7 +60,9 @@ def _update_subscription_from_stripe(rtd_subscription, stripe_subscription_id):
 def update_subscription(event):
     """Update the RTD subscription object given the new stripe subscription."""
     stripe_subscription_id = event.data["object"]["id"]
-    rtd_subscription = Subscription.objects.filter(stripe_id=stripe_subscription_id).first()
+    rtd_subscription = Subscription.objects.filter(
+        stripe_id=stripe_subscription_id
+    ).first()
     if not rtd_subscription:
         log.info(
             "Stripe subscription isn't attached to a RTD object.",

--- a/readthedocs/subscriptions/event_handlers.py
+++ b/readthedocs/subscriptions/event_handlers.py
@@ -1,0 +1,109 @@
+from djstripe import webhooks
+from djstripe.enums import SubscriptionStatus
+
+from django.utils import timezone
+
+import structlog
+from readthedocs.payments.utils import cancel_subscription as cancel_stripe_subscription
+from readthedocs.organizations.models import Organization
+from django.conf import settings
+from djstripe import models as djstripe
+
+from readthedocs.subscriptions.models import Subscription
+
+log = structlog.get_logger(__name__)
+
+
+def _update_subscription_from_stripe(rtd_subscription, stripe_subscription_id):
+    """Update the RTD subscription object given the new stripe subscription object."""
+    log.bind(stripe_subscription=stripe_subscription_id)
+    stripe_subscription = djstripe.Subscription.objects.filter(id=stripe_subscription_id).first()
+    if not stripe_subscription:
+        log.info("Stripe subscription not found.")
+        return
+
+    previous_subscription_id = rtd_subscription.stripe_id
+    Subscription.objects.update_from_stripe(
+        rtd_subscription=rtd_subscription,
+        stripe_subscription=stripe_subscription,
+    )
+    log.info(
+        "Subscription updated.",
+        previous_stripe_subscription=previous_subscription_id,
+        subscription_status=stripe_subscription.status,
+    )
+
+    # Cancel the trial subscription if its trial has ended.
+    trial_ended = stripe_subscription.trial_end and stripe_subscription.trial_end < timezone.now()
+    is_trial_subscription = stripe_subscription.items.filter(price__id=settings.RTD_ORG_DEFAULT_STRIPE_PRICE).exists()
+    if (
+        is_trial_subscription
+        and trial_ended
+        and stripe_subscription.status != SubscriptionStatus.canceled
+    ):
+        log.info(
+            'Trial ended, canceling subscription.',
+        )
+        cancel_stripe_subscription(stripe_subscription.id)
+
+
+@webhooks.handler("customer.subscription.updated", "customer.subscription.deleted")
+def update_subscription(event):
+    """Update the RTD subscription object given the new stripe subscription."""
+    stripe_subscription_id = event.data["object"]["id"]
+    rtd_subscription = Subscription.objects.filter(stripe_id=stripe_subscription_id).first()
+    if not rtd_subscription:
+        log.info(
+            "Stripe subscription isn't attached to a RTD object.",
+            stripe_subscription=stripe_subscription_id,
+        )
+        return
+
+    _update_subscription_from_stripe(
+        rtd_subscription=rtd_subscription,
+        stripe_subscription_id=stripe_subscription_id,
+    )
+
+
+@webhooks.handler("checkout.session.completed")
+def checkout_completed(event):
+    """
+    Handle the creation of a new subscription via stripe checkout.
+
+    Stripe checkout will create a new subscription,
+    so we need to replace the older one with the new one.
+    """
+    customer_id = event.data["object"]["customer"]
+    organization = Organization.objects.filter(stripe_customer__id=customer_id).first()
+    if not organization:
+        log.info(
+            "Customer isn't attached to an organization.",
+            customer_id=customer_id,
+        )
+        return
+
+    stripe_subscription_id = event.data["object"]["subscription"]
+    _update_subscription_from_stripe(
+        rtd_subscription=organization.subscription,
+        stripe_subscription_id=stripe_subscription_id,
+    )
+
+
+@webhooks.handler("customer.updated")
+def customer_updated_event(event):
+    """Update the organization with the new information from the stripe customer."""
+    stripe_customer = event.data["object"]
+    log.bind(customer=stripe_customer["id"])
+    organization = Organization.objects.filter(stripe_id=stripe_customer["id"]).first()
+    if not organization:
+        log.info("Customer isn't attached to an organization.")
+
+    new_email = stripe_customer["email"]
+    if organization.email != new_email:
+        organization.email = new_email
+        organization.save()
+        log.info(
+            "Organization billing email updated.",
+            organization_slug=organization.slug,
+            email=new_email,
+        )

--- a/readthedocs/subscriptions/event_handlers.py
+++ b/readthedocs/subscriptions/event_handlers.py
@@ -43,7 +43,7 @@ def _update_subscription_from_stripe(rtd_subscription, stripe_subscription_id):
         stripe_subscription.trial_end and stripe_subscription.trial_end < timezone.now()
     )
     is_trial_subscription = stripe_subscription.items.filter(
-        price__id=settings.RTD_ORG_DEFAULT_STRIPE_PRICE
+        price__id=settings.RTD_ORG_DEFAULT_STRIPE_SUBSCRIPTION_PRICE
     ).exists()
     if (
         is_trial_subscription

--- a/readthedocs/subscriptions/managers.py
+++ b/readthedocs/subscriptions/managers.py
@@ -1,11 +1,8 @@
 """Subscriptions managers."""
 
-from datetime import datetime
-
 import structlog
 from django.conf import settings
 from django.db import models
-from django.utils import timezone
 
 from readthedocs.core.history import set_change_reason
 from readthedocs.subscriptions.utils import get_or_create_stripe_subscription
@@ -69,26 +66,9 @@ class SubscriptionManager(models.Manager):
         # subscription is ``canceled``. I'm assuming that ``current_period_end``
         # will have the same value than ``ended_at``
         # https://stripe.com/docs/api/subscriptions/object?lang=python#subscription_object-current_period_end
-        start_date = getattr(stripe_subscription, 'current_period_start', None)
-        end_date = getattr(stripe_subscription, 'current_period_end', None)
+        start_date = stripe_subscription.current_period_start
+        end_date = stripe_subscription.current_period_end
         log.bind(stripe_subscription=stripe_subscription.id)
-
-        try:
-            start_date = timezone.make_aware(
-                datetime.fromtimestamp(start_date),
-            )
-            end_date = timezone.make_aware(
-                datetime.fromtimestamp(end_date),
-            )
-        except TypeError:
-            log.error(
-                'Stripe subscription invalid date.',
-                start_date=start_date,
-                end_date=end_date,
-            )
-            start_date = None
-            end_date = None
-            trial_end_date = None
 
         rtd_subscription.status = stripe_subscription.status
 
@@ -103,18 +83,9 @@ class SubscriptionManager(models.Manager):
             rtd_subscription.stripe_id = stripe_subscription.id
 
         # Update trial end date if it's present
-        trial_end_date = getattr(stripe_subscription, 'trial_end', None)
+        trial_end_date = stripe_subscription.trial_end
         if trial_end_date:
-            try:
-                trial_end_date = timezone.make_aware(
-                    datetime.fromtimestamp(trial_end_date),
-                )
-                rtd_subscription.trial_end_date = trial_end_date
-            except TypeError:
-                log.error(
-                    'Stripe subscription trial end date invalid. ',
-                    trial_end_date=trial_end_date,
-                )
+            rtd_subscription.trial_end_date = trial_end_date
 
         # Update the plan in case it was changed from the Portal.
         # This mostly just updates the UI now that we're using the Stripe Portal.
@@ -123,7 +94,7 @@ class SubscriptionManager(models.Manager):
         # but that attribute is deprecated, and it's null if the subscription has more than
         # one item, we have a couple of subscriptions that have more than
         # one item, so we use the first that is found in our DB.
-        for stripe_item in stripe_subscription["items"].data:
+        for stripe_item in stripe_subscription.items.prefetch_related("price").all():
             plan = self._get_plan(stripe_item.price)
             if plan:
                 rtd_subscription.plan = plan

--- a/readthedocs/subscriptions/tests/test_event_handlers.py
+++ b/readthedocs/subscriptions/tests/test_event_handlers.py
@@ -1,0 +1,660 @@
+# Avoid signature verification.
+@mock.patch.object(stripe.WebhookSignature, 'verify_header', new=mock.MagicMock)
+@override_settings(
+    STRIPE_WEBHOOK_SECRET="1234",
+    RTD_ORG_DEFAULT_STRIPE_PRICE="trialing",
+)
+class StripeTests(TestCase):
+
+    """Tests for Stripe API endpoint."""
+
+    def setUp(self):
+        self.organization = fixture.get(Organization, slug='org')
+        fixture.get(
+            Plan,
+            stripe_id='trialing',
+            slug='trialing',
+        )
+        fixture.get(
+            Plan,
+            stripe_id='basic',
+        )
+        fixture.get(
+            Plan,
+            stripe_id='advanced',
+        )
+
+    def test_subscription_updated_event(self):
+        """Test handled event."""
+
+        payload = """
+        {
+            "id": "evt_197I3KKFrzSMUWUvE44wEYfC",
+            "object": "event",
+            "api_version": "2016-07-06",
+            "created": 1477114098,
+            "data": {
+                "object": {
+                    "id": "sub_9LtsU02uvjO6Ed",
+                    "object": "subscription",
+                    "application_fee_percent": null,
+                    "cancel_at_period_end": false,
+                    "canceled_at": null,
+                    "created": 1476137811,
+                    "current_period_end": 1479792497,
+                    "current_period_start": 1477114097,
+                    "customer": "cus_9LtsPRYe4yJSOQ",
+                    "discount": null,
+                    "ended_at": null,
+                    "livemode": false,
+                    "metadata": {
+                    },
+                    "items": {
+                        "object": "list",
+                        "data": [
+                            {
+                                "id": "si_KMl5ZOLb8CzMyM",
+                                "object": "subscription_item",
+                                "billing_thresholds": null,
+                                "created": 1633632209,
+                                "metadata": {},
+                                "price": {
+                                    "id": "advanced",
+                                    "object": "price",
+                                    "unit_amount": 1500,
+                                    "unit_amount_decimal": "1500",
+                                    "created": 1475279464,
+                                    "currency": "usd",
+                                    "recurring": {
+                                        "aggregate_usage": null,
+                                        "interval": "month",
+                                        "interval_count": 1,
+                                        "trial_period_days": 30,
+                                        "usage_type": "licensed"
+                                    },
+                                    "livemode": false,
+                                    "metadata": {
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "quantity": 1,
+                    "start_date": 1477114097,
+                    "status": "active",
+                    "tax_percent": null,
+                    "trial_end": null,
+                    "trial_start": null
+                },
+                "previous_attributes": {
+                    "current_period_end": 1478733360,
+                    "current_period_start": 1476137811,
+                    "start_date": 1476137811,
+                    "status": "active",
+                    "trial_end": 1478733360,
+                    "trial_start": 1476137811
+                }
+            },
+            "livemode": false,
+            "pending_webhooks": 0,
+            "request": "req_9Q8JSVL19hmjmN",
+            "type": "customer.subscription.updated"
+        }
+        """
+        subscription = fixture.get(
+            Subscription, stripe_id='sub_9LtsU02uvjO6Ed',
+            status='trialing',
+        )
+        client = APIClient()
+        resp = client.post(
+            '/api/v2/stripe/',
+            json.loads(payload),
+            format='json',
+            HTTP_STRIPE_SIGNATURE='',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data['updated'], True)
+        self.assertEqual(resp.data['subscription_id'], 'sub_9LtsU02uvjO6Ed')
+        subscription = Subscription.objects.get(stripe_id='sub_9LtsU02uvjO6Ed')
+        self.assertEqual(subscription.status, 'active')
+        self.assertIsNotNone(subscription.trial_end_date)
+        self.assertEqual(subscription.end_date.timestamp(), 1479792497.0)
+
+    def test_unhandled_event(self):
+        """Test unhandled event."""
+
+        payload = """
+        {
+            "id": "evt_197I3KKFrzSMUWUvE44wEYfC",
+            "object": "event",
+            "api_version": "2016-07-06",
+            "created": 1477114098,
+            "data": {
+                "object": {}
+            },
+            "livemode": false,
+            "pending_webhooks": 0,
+            "request": "req_9Q8JSVL19hmjmN",
+            "type": "account.updated"
+        }
+        """
+
+        subscription = fixture.get(
+            Subscription, stripe_id='sub_9LtsU02uvjO6Ed',
+            status='trialing',
+        )
+        client = APIClient()
+        resp = client.post(
+            '/api/v2/stripe/',
+            json.loads(payload),
+            format='json',
+            HTTP_STRIPE_SIGNATURE='',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_reenabled_organization_on_subscription_updated_event(self):
+        """Organization is re-enabled when subscription is active."""
+
+        payload = """
+        {
+            "id": "evt_197I3KKFrzSMUWUvE44wEYfC",
+            "object": "event",
+            "api_version": "2016-07-06",
+            "created": 1477114098,
+            "data": {
+                "object": {
+                    "id": "sub_9LtsU02uvjO6Ed",
+                    "object": "subscription",
+                    "application_fee_percent": null,
+                    "cancel_at_period_end": false,
+                    "canceled_at": null,
+                    "created": 1476137811,
+                    "current_period_end": 1479792497,
+                    "current_period_start": 1477114097,
+                    "customer": "cus_9LtsPRYe4yJSOQ",
+                    "discount": null,
+                    "ended_at": null,
+                    "livemode": false,
+                    "metadata": {
+                    },
+                    "items": {
+                        "object": "list",
+                        "data": [
+                            {
+                                "id": "si_KMl5ZOLb8CzMyM",
+                                "object": "subscription_item",
+                                "billing_thresholds": null,
+                                "created": 1633632209,
+                                "metadata": {},
+                                "price": {
+                                    "id": "advanced",
+                                    "object": "price",
+                                    "unit_amount": 1500,
+                                    "unit_amount_decimal": "1500",
+                                    "created": 1475279464,
+                                    "currency": "usd",
+                                    "recurring": {
+                                        "aggregate_usage": null,
+                                        "interval": "month",
+                                        "interval_count": 1,
+                                        "trial_period_days": 30,
+                                        "usage_type": "licensed"
+                                    },
+                                    "livemode": false,
+                                    "metadata": {
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "quantity": 1,
+                    "start_date": 1477114097,
+                    "status": "active",
+                    "tax_percent": null,
+                    "trial_end": null,
+                    "trial_start": null
+                },
+                "previous_attributes": {
+                    "current_period_end": 1478733360,
+                    "current_period_start": 1476137811,
+                    "start_date": 1476137811,
+                    "status": "active",
+                    "trial_end": 1478733360,
+                    "trial_start": 1476137811
+                }
+            },
+            "livemode": false,
+            "pending_webhooks": 0,
+            "request": "req_9Q8JSVL19hmjmN",
+            "type": "customer.subscription.updated"
+        }
+        """
+
+        organization = fixture.get(
+            Organization,
+            disabled=True,
+        )
+        subscription = fixture.get(
+            Subscription,
+            organization=organization,
+            stripe_id='sub_9LtsU02uvjO6Ed',
+            status='canceled',
+        )
+        client = APIClient()
+        self.assertTrue(organization.disabled)
+        resp = client.post(
+            '/api/v2/stripe/',
+            json.loads(payload),
+            format='json',
+            HTTP_STRIPE_SIGNATURE='',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data['updated'], True)
+        self.assertEqual(resp.data['subscription_id'], 'sub_9LtsU02uvjO6Ed')
+        subscription = Subscription.objects.get(stripe_id='sub_9LtsU02uvjO6Ed')
+        organization.refresh_from_db()
+        self.assertEqual(subscription.status, 'active')
+        self.assertIsNotNone(subscription.trial_end_date)
+        self.assertFalse(organization.disabled)
+        self.assertEqual(subscription.end_date.timestamp(), 1479792497.0)
+
+    def test_subscription_deleted_event(self):
+        payload = """
+        {
+            "id": "evt_1Ji1kgKFrzSMUWUv4vtbtGT9",
+            "object": "event",
+            "api_version": "2020-08-27",
+            "created": 1633632933,
+            "data": {
+                "object": {
+                    "id": "sub_1Ji1YyKFrzSMUWUvPghVBB66",
+                    "object": "subscription",
+                    "application_fee_percent": null,
+                    "automatic_tax": {
+                        "enabled": false
+                    },
+                    "billing_cycle_anchor": 1633632293,
+                    "billing_thresholds": null,
+                    "cancel_at": null,
+                    "cancel_at_period_end": false,
+                    "canceled_at": 1633632565,
+                    "collection_method": "charge_automatically",
+                    "created": 1633632208,
+                    "current_period_end": 1636310693,
+                    "current_period_start": 1633632293,
+                    "customer": "cus_KMl5qf77rIpBWv",
+                    "days_until_due": null,
+                    "default_payment_method": "pm_1Ji1aJKFrzSMUWUv4mRVcupr",
+                    "default_source": null,
+                    "default_tax_rates": [],
+                    "discount": null,
+                    "ended_at": 1633632933,
+                    "items": {
+                        "object": "list",
+                        "data": [
+                            {
+                                "id": "si_KMl5ZOLb8CzMyM",
+                                "object": "subscription_item",
+                                "billing_thresholds": null,
+                                "created": 1633632209,
+                                "metadata": {},
+                                "price": {
+                                    "id": "advanced",
+                                    "object": "price",
+                                    "active": true,
+                                    "billing_scheme": "per_unit",
+                                    "created": 1475279464,
+                                    "currency": "usd",
+                                    "livemode": false,
+                                    "lookup_key": null,
+                                    "metadata": {
+                                        "SSO": "Single Sign-On"
+                                    },
+                                    "nickname": "Includes Custom Domains and more!",
+                                    "product": "prod_BV0U8VTu4d8E4h",
+                                    "recurring": {
+                                        "aggregate_usage": null,
+                                        "interval": "month",
+                                        "interval_count": 1,
+                                        "trial_period_days": 30,
+                                        "usage_type": "licensed"
+                                    },
+                                    "tax_behavior": "unspecified",
+                                    "tiers_mode": null,
+                                    "transform_quantity": null,
+                                    "type": "recurring",
+                                    "unit_amount": 15000,
+                                    "unit_amount_decimal": "15000"
+                                },
+                                "quantity": 1,
+                                "subscription": "sub_1Ji1YyKFrzSMUWUvPghVBB66",
+                                "tax_rates": []
+                            }
+                        ],
+                        "has_more": false,
+                        "total_count": 1,
+                        "url": "/v1/subscription_items?subscription=sub_1Ji1YyKFrzSMUWUvPghVBB66"
+                    },
+                    "latest_invoice": "in_1Ji1d7KFrzSMUWUvIg9rpjUE",
+                    "livemode": false,
+                    "metadata": {},
+                    "next_pending_invoice_item_invoice": null,
+                    "pause_collection": null,
+                    "payment_settings": {
+                        "payment_method_options": null,
+                        "payment_method_types": null
+                    },
+                    "pending_invoice_item_interval": null,
+                    "pending_setup_intent": null,
+                    "pending_update": null,
+                    "quantity": 1,
+                    "schedule": null,
+                    "start_date": 1633632208,
+                    "status": "canceled",
+                    "transfer_data": null,
+                    "trial_end": 1633632292,
+                    "trial_start": 1633632208
+                }
+            },
+            "livemode": false,
+            "pending_webhooks": 3,
+            "request": {
+                "id": "req_LltV9EVcHShY68",
+                "idempotency_key": null
+            },
+            "type": "customer.subscription.deleted"
+        }
+        """
+        subscription = fixture.get(
+            Subscription,
+            organization=self.organization,
+            stripe_id='sub_1Ji1YyKFrzSMUWUvPghVBB66',
+            status='active',
+        )
+        client = APIClient()
+        resp = client.post(
+            '/api/v2/stripe/',
+            json.loads(payload),
+            format='json',
+            HTTP_STRIPE_SIGNATURE='',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data['updated'], True)
+        self.assertIsNone(resp.data['subscription_id'])
+        self.assertEqual(resp.data['previous_subscription_id'], 'sub_1Ji1YyKFrzSMUWUvPghVBB66')
+        subscription.refresh_from_db()
+        self.assertIsNone(subscription.stripe_id)
+        self.assertEqual(subscription.status , 'canceled')
+
+    @mock.patch.object(stripe.Subscription, 'retrieve')
+    def test_subscription_checkout_completed_event(self, subscription_retrieve_mock):
+        payload = """
+        {
+            "id": "evt_1Ji12qKFrzSMUWUvnGxsOJEd",
+            "object": "event",
+            "api_version": "2020-08-27",
+            "created": 1633630215,
+            "data": {
+                "object": {
+                    "id": "cs_test_a1UpM7pDdpXqqgZC6lQDC2HRMo5d1wW9fNX0ZiBCm6vRqTgZJZx6brwNan",
+                    "object": "checkout.session",
+                    "after_expiration": null,
+                    "allow_promotion_codes": null,
+                    "amount_subtotal": 5000,
+                    "amount_total": 5000,
+                    "automatic_tax": {
+                        "enabled": false,
+                        "status": null
+                    },
+                    "billing_address_collection": null,
+                    "cancel_url": "http://6c9f-186-66-172-152.ngrok.io/organizations/foo/subscription/",
+                    "client_reference_id": null,
+                    "consent": null,
+                    "consent_collection": null,
+                    "currency": "usd",
+                    "customer": "cus_KMiHJXFHpLkcRP",
+                    "customer_details": {
+                        "email": "admin@admin.com",
+                        "tax_exempt": "none",
+                        "tax_ids": []
+                    },
+                    "customer_email": null,
+                    "expires_at": 1633716598,
+                    "livemode": false,
+                    "locale": null,
+                    "metadata": {},
+                    "mode": "subscription",
+                    "payment_intent": null,
+                    "payment_method_options": {},
+                    "payment_method_types": [
+                        "card"
+                    ],
+                    "payment_status": "paid",
+                    "recovered_from": null,
+                    "setup_intent": "seti_1Ji12mKFrzSMUWUvMrvmajcF",
+                    "shipping": null,
+                    "shipping_address_collection": null,
+                    "submit_type": null,
+                    "subscription": "sub_9LtsU02uvjO6Ed",
+                    "success_url": "http://6c9f-186-66-172-152.ngrok.io/organizations/foo/subscription/?upgraded=true",
+                    "total_details": {
+                        "amount_discount": 0,
+                        "amount_shipping": 0,
+                        "amount_tax": 0
+                    },
+                    "url": null
+                }
+            },
+            "livemode": false,
+            "pending_webhooks": 5,
+            "request": {
+                "id": null,
+                "idempotency_key": null
+            },
+            "type": "checkout.session.completed"
+        }
+        """
+
+        self.organization.stripe_id = 'cus_KMiHJXFHpLkcRP'
+        self.organization.save()
+        subscription_retrieve_mock.return_value = stripe.Subscription.construct_from(
+            values={
+                "id": "sub_9LtsU02uvjO6Ed",
+                "canceled_at": None,
+                "created": 1476137811,
+                "current_period_end": 1479792497,
+                "current_period_start": 1477114097,
+                "customer": "cus_KMiHJXFHpLkcRP",
+                "items": {
+                    "object": "list",
+                    "data": [
+                        {
+                            "id": "si_KOcEsHCktPUedU",
+                            "object": "subscription_item",
+                            "price": {
+                                "id": "advanced",
+                                "object": "price",
+                                "unit_amount": 1500,
+                                "unit_amount_decimal": "1500",
+                                "created": 1475279464,
+                                "currency": "usd",
+                                "recurring": {
+                                    "aggregate_usage": None,
+                                    "interval": "month",
+                                    "interval_count": 1,
+                                    "trial_period_days": 30,
+                                    "usage_type": "licensed",
+                                },
+                            },
+                        }
+                    ],
+                },
+                "start_date": 1477114097,
+                "status": "active",
+                "trial_end": None,
+                "trial_start": None,
+            },
+            key=None,
+        )
+        subscription = fixture.get(
+            Subscription,
+            organization=self.organization,
+            stripe_id=None,
+            status='canceled',
+        )
+        client = APIClient()
+        resp = client.post(
+            '/api/v2/stripe/',
+            json.loads(payload),
+            format='json',
+            HTTP_STRIPE_SIGNATURE='',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data['updated'], True)
+        self.assertEqual(resp.data['subscription_id'], 'sub_9LtsU02uvjO6Ed')
+        self.assertEqual(resp.data['previous_subscription_id'], None)
+        subscription.refresh_from_db()
+        self.assertEqual(subscription.stripe_id, 'sub_9LtsU02uvjO6Ed')
+        self.assertEqual(subscription.status , 'active')
+
+    @mock.patch('readthedocsinc.api.v2.views.cancel_subscription')
+    def test_cancel_subscription_after_trial_has_ended(self, cancel_subscription_mock):
+        payload = """
+        {
+            "id": "evt_1Jjp3aKFrzSMUWUvIfMwnfw3",
+            "object": "event",
+            "api_version": "2020-08-27",
+            "created": 1634060789,
+            "data": {
+                "object": {
+                    "id": "sub_1JjozxKFrzSMUWUvkgpVXQt8",
+                    "object": "subscription",
+                    "application_fee_percent": null,
+                    "automatic_tax": {
+                        "enabled": false
+                    },
+                    "billing_cycle_anchor": 1634060789,
+                    "billing_thresholds": null,
+                    "cancel_at": null,
+                    "cancel_at_period_end": false,
+                    "canceled_at": null,
+                    "collection_method": "charge_automatically",
+                    "created": 1634060565,
+                    "current_period_end": 1636739189,
+                    "current_period_start": 1634060789,
+                    "customer": "cus_KOcEOz4gd3lN8X",
+                    "days_until_due": null,
+                    "default_payment_method": null,
+                    "default_source": null,
+                    "default_tax_rates": [
+                    ],
+                    "discount": null,
+                    "ended_at": null,
+                    "items": {
+                        "object": "list",
+                        "data": [
+                        {
+                            "id": "si_KOcEsHCktPUedU",
+                            "object": "subscription_item",
+                            "billing_thresholds": null,
+                            "created": 1634060565,
+                            "metadata": {
+                            },
+                            "price": {
+                            "id": "trialing",
+                            "object": "price",
+                            "active": true,
+                            "billing_scheme": "per_unit",
+                            "created": 1629733210,
+                            "currency": "usd",
+                            "livemode": false,
+                            "lookup_key": null,
+                            "metadata": {
+                            },
+                            "nickname": null,
+                            "product": "prod_K1qnUPyioLO51V",
+                            "recurring": {
+                                "aggregate_usage": null,
+                                "interval": "month",
+                                "interval_count": 1,
+                                "trial_period_days": 30,
+                                "usage_type": "licensed"
+                            },
+                            "tax_behavior": "unspecified",
+                            "tiers_mode": null,
+                            "transform_quantity": null,
+                            "type": "recurring",
+                            "unit_amount": 0,
+                            "unit_amount_decimal": "0"
+                            },
+                            "quantity": 1,
+                            "subscription": "sub_1JjozxKFrzSMUWUvkgpVXQt8",
+                            "tax_rates": [
+                            ]
+                        }
+                        ],
+                        "has_more": false,
+                        "total_count": 1,
+                        "url": "/v1/subscription_items?subscription=sub_1JjozxKFrzSMUWUvkgpVXQt8"
+                    },
+                    "latest_invoice": "in_1Jjp3ZKFrzSMUWUvN9pqY3ub",
+                    "livemode": false,
+                    "metadata": {
+                    },
+                    "next_pending_invoice_item_invoice": null,
+                    "pause_collection": null,
+                    "payment_settings": {
+                        "payment_method_options": null,
+                        "payment_method_types": null
+                    },
+                    "pending_invoice_item_interval": null,
+                    "pending_setup_intent": "seti_1JjozxKFrzSMUWUvTmU4SztV",
+                    "pending_update": null,
+                    "quantity": 1,
+                    "schedule": null,
+                    "start_date": 1634060565,
+                    "status": "active",
+                    "transfer_data": null,
+                    "trial_end": 1634060788,
+                    "trial_start": 1634060565
+                },
+                "previous_attributes": {
+                    "billing_cycle_anchor": 1636652565,
+                    "current_period_end": 1636652565,
+                    "current_period_start": 1634060565,
+                    "latest_invoice": "in_1JjozxKFrzSMUWUvhLCv0xy9",
+                    "status": "trialing",
+                    "trial_end": 1636652565
+                }
+            },
+            "livemode": false,
+            "pending_webhooks": 3,
+            "request": {
+                "id": "req_dloiXHqk7BR4rQ",
+                "idempotency_key": null
+            },
+            "type": "customer.subscription.updated"
+        }
+        """
+        subscription = fixture.get(
+            Subscription,
+            organization=self.organization,
+            stripe_id='sub_1JjozxKFrzSMUWUvkgpVXQt8',
+            status='active',
+        )
+        self.organization.stripe_id = 'cus_KMiHJXFHpLkcRP'
+        self.organization.save()
+        client = APIClient()
+        resp = client.post(
+            '/api/v2/stripe/',
+            json.loads(payload),
+            format='json',
+            HTTP_STRIPE_SIGNATURE='',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data['updated'], True)
+        self.assertEqual(resp.data['subscription_id'], 'sub_1JjozxKFrzSMUWUvkgpVXQt8')
+        subscription.refresh_from_db()
+        self.assertEqual(subscription.status, 'active')
+        self.assertTrue(subscription.is_trial_ended)
+        cancel_subscription_mock.assert_called_once_with("sub_1JjozxKFrzSMUWUvkgpVXQt8")

--- a/readthedocs/subscriptions/tests/test_event_handlers.py
+++ b/readthedocs/subscriptions/tests/test_event_handlers.py
@@ -15,7 +15,7 @@ from readthedocs.subscriptions.models import Plan, Subscription
 @override_settings(
     RTD_ALLOW_ORGANIZATIONS=True,
     STRIPE_WEBHOOK_SECRET="1234",
-    RTD_ORG_DEFAULT_STRIPE_PRICE="trialing",
+    RTD_ORG_DEFAULT_STRIPE_SUBSCRIPTION_PRICE="trialing",
 )
 class TestEventHandlers(TestCase):
 

--- a/readthedocs/subscriptions/tests/test_event_handlers.py
+++ b/readthedocs/subscriptions/tests/test_event_handlers.py
@@ -1,13 +1,15 @@
-from django.utils import timezone
-from django.test import TestCase, override_settings
-from djstripe.enums import SubscriptionStatus
-from django_dynamic_fixture import get
 from unittest import mock
-from djstripe import models as djstripe
 
-from readthedocs.subscriptions import event_handlers
+from django.test import TestCase, override_settings
+from django.utils import timezone
+from django_dynamic_fixture import get
+from djstripe import models as djstripe
+from djstripe.enums import SubscriptionStatus
+
 from readthedocs.organizations.models import Organization
+from readthedocs.subscriptions import event_handlers
 from readthedocs.subscriptions.models import Plan, Subscription
+
 
 # Avoid signature verification.
 @override_settings(
@@ -20,8 +22,8 @@ class TestEventHandlers(TestCase):
     """Tests for Stripe API endpoint."""
 
     def setUp(self):
-        self.organization = get(Organization, slug='org', email="test@example.com")
-        get(Plan, stripe_id='trialing', slug='trialing')
+        self.organization = get(Organization, slug="org", email="test@example.com")
+        get(Plan, stripe_id="trialing", slug="trialing")
 
     def test_subscription_updated_event(self):
         """Test handled event."""
@@ -35,12 +37,15 @@ class TestEventHandlers(TestCase):
             current_period_end=end_date,
             trial_end=end_date,
         )
-        event = get(djstripe.Event, data={
-            "object": {
-                "id": "sub_9LtsU02uvjO6Ed",
-                "object": "subscription",
-            }
-        })
+        event = get(
+            djstripe.Event,
+            data={
+                "object": {
+                    "id": "sub_9LtsU02uvjO6Ed",
+                    "object": "subscription",
+                }
+            },
+        )
         subscription = get(
             Subscription,
             stripe_id=stripe_subscription.id,
@@ -65,12 +70,15 @@ class TestEventHandlers(TestCase):
             current_period_end=end_date,
             trial_end=end_date,
         )
-        event = get(djstripe.Event, data={
-            "object": {
-                "id": "sub_9LtsU02uvjO6Ed",
-                "object": "subscription",
-            }
-        })
+        event = get(
+            djstripe.Event,
+            data={
+                "object": {
+                    "id": "sub_9LtsU02uvjO6Ed",
+                    "object": "subscription",
+                }
+            },
+        )
 
         organization = get(Organization, disabled=True)
         subscription = get(
@@ -101,12 +109,15 @@ class TestEventHandlers(TestCase):
             current_period_end=end_date,
             trial_end=end_date,
         )
-        event = get(djstripe.Event, data={
-            "object": {
-                "id": "sub_9LtsU02uvjO6Ed",
-                "object": "subscription",
-            }
-        })
+        event = get(
+            djstripe.Event,
+            data={
+                "object": {
+                    "id": "sub_9LtsU02uvjO6Ed",
+                    "object": "subscription",
+                }
+            },
+        )
         subscription = get(
             Subscription,
             organization=self.organization,
@@ -118,10 +129,10 @@ class TestEventHandlers(TestCase):
 
         subscription.refresh_from_db()
         self.assertIsNone(subscription.stripe_id)
-        self.assertEqual(subscription.status , SubscriptionStatus.canceled)
+        self.assertEqual(subscription.status, SubscriptionStatus.canceled)
 
     def test_subscription_checkout_completed_event(self):
-        customer = get(djstripe.Customer, id='cus_KMiHJXFHpLkcRP')
+        customer = get(djstripe.Customer, id="cus_KMiHJXFHpLkcRP")
         self.organization.stripe_customer = customer
         self.organization.save()
 
@@ -135,14 +146,17 @@ class TestEventHandlers(TestCase):
             current_period_end=end_date,
             trial_end=end_date,
         )
-        event = get(djstripe.Event, data={
-            "object": {
-                "id": "cs_test_a1UpM7pDdpXqqgZC6lQDC2HRMo5d1wW9fNX0ZiBCm6vRqTgZJZx6brwNan",
-                "object": "checkout.session",
-                "customer": customer.id,
-                "subscription": stripe_subscription.id,
-            }
-        })
+        event = get(
+            djstripe.Event,
+            data={
+                "object": {
+                    "id": "cs_test_a1UpM7pDdpXqqgZC6lQDC2HRMo5d1wW9fNX0ZiBCm6vRqTgZJZx6brwNan",
+                    "object": "checkout.session",
+                    "customer": customer.id,
+                    "subscription": stripe_subscription.id,
+                }
+            },
+        )
 
         subscription = get(
             Subscription,
@@ -155,10 +169,12 @@ class TestEventHandlers(TestCase):
 
         subscription.refresh_from_db()
         self.assertEqual(subscription.stripe_id, stripe_subscription.id)
-        self.assertEqual(subscription.status , SubscriptionStatus.active)
+        self.assertEqual(subscription.status, SubscriptionStatus.active)
 
-    @mock.patch('readthedocs.subscriptions.event_handlers.cancel_stripe_subscription')
-    def test_cancel_trial_subscription_after_trial_has_ended(self, cancel_subscription_mock):
+    @mock.patch("readthedocs.subscriptions.event_handlers.cancel_stripe_subscription")
+    def test_cancel_trial_subscription_after_trial_has_ended(
+        self, cancel_subscription_mock
+    ):
         start_date = timezone.now()
         end_date = timezone.now() + timezone.timedelta(days=30)
         stripe_subscription = get(
@@ -170,13 +186,21 @@ class TestEventHandlers(TestCase):
             trial_end=start_date,
         )
         price = get(djstripe.Price, id="trialing")
-        get(djstripe.SubscriptionItem, id="si_KOcEsHCktPUedU", price=price, subscription=stripe_subscription)
-        event = get(djstripe.Event, data={
-            "object": {
-                "id": "sub_9LtsU02uvjO6Ed",
-                "object": "subscription",
-            }
-        })
+        get(
+            djstripe.SubscriptionItem,
+            id="si_KOcEsHCktPUedU",
+            price=price,
+            subscription=stripe_subscription,
+        )
+        event = get(
+            djstripe.Event,
+            data={
+                "object": {
+                    "id": "sub_9LtsU02uvjO6Ed",
+                    "object": "subscription",
+                }
+            },
+        )
         subscription = get(
             Subscription,
             organization=self.organization,
@@ -191,8 +215,10 @@ class TestEventHandlers(TestCase):
         self.assertTrue(subscription.is_trial_ended)
         cancel_subscription_mock.assert_called_once_with(stripe_subscription.id)
 
-    @mock.patch('readthedocs.subscriptions.event_handlers.cancel_stripe_subscription')
-    def test_dont_cancel_normal_subscription_after_trial_has_ended(self, cancel_subscription_mock):
+    @mock.patch("readthedocs.subscriptions.event_handlers.cancel_stripe_subscription")
+    def test_dont_cancel_normal_subscription_after_trial_has_ended(
+        self, cancel_subscription_mock
+    ):
         start_date = timezone.now()
         end_date = timezone.now() + timezone.timedelta(days=30)
         stripe_subscription = get(
@@ -204,13 +230,21 @@ class TestEventHandlers(TestCase):
             trial_end=start_date,
         )
         price = get(djstripe.Price, id="advanced")
-        get(djstripe.SubscriptionItem, id="si_KOcEsHCktPUedU", price=price, subscription=stripe_subscription)
-        event = get(djstripe.Event, data={
-            "object": {
-                "id": "sub_9LtsU02uvjO6Ed",
-                "object": "subscription",
-            }
-        })
+        get(
+            djstripe.SubscriptionItem,
+            id="si_KOcEsHCktPUedU",
+            price=price,
+            subscription=stripe_subscription,
+        )
+        event = get(
+            djstripe.Event,
+            data={
+                "object": {
+                    "id": "sub_9LtsU02uvjO6Ed",
+                    "object": "subscription",
+                }
+            },
+        )
         subscription = get(
             Subscription,
             organization=self.organization,
@@ -226,16 +260,21 @@ class TestEventHandlers(TestCase):
         cancel_subscription_mock.assert_not_called()
 
     def test_customer_updated_event(self):
-        customer = get(djstripe.Customer, id='cus_KMiHJXFHpLkcRP', email="new@example.com")
+        customer = get(
+            djstripe.Customer, id="cus_KMiHJXFHpLkcRP", email="new@example.com"
+        )
         self.organization.stripe_customer = customer
         self.organization.save()
 
-        event = get(djstripe.Event, data={
-            "object": {
-                "id": customer.id,
-                "email": customer.email,
-            }
-        })
+        event = get(
+            djstripe.Event,
+            data={
+                "object": {
+                    "id": customer.id,
+                    "email": customer.email,
+                }
+            },
+        )
 
         self.assertNotEqual(self.organization.email, customer.email)
 

--- a/readthedocs/subscriptions/tests/test_event_handlers.py
+++ b/readthedocs/subscriptions/tests/test_event_handlers.py
@@ -11,13 +11,11 @@ from readthedocs.subscriptions import event_handlers
 from readthedocs.subscriptions.models import Plan, Subscription
 
 
-# Avoid signature verification.
 @override_settings(
     RTD_ALLOW_ORGANIZATIONS=True,
-    STRIPE_WEBHOOK_SECRET="1234",
     RTD_ORG_DEFAULT_STRIPE_SUBSCRIPTION_PRICE="trialing",
 )
-class TestEventHandlers(TestCase):
+class TestStripeEventHandlers(TestCase):
 
     """Tests for Stripe API endpoint."""
 

--- a/readthedocs/subscriptions/tests/test_event_handlers.py
+++ b/readthedocs/subscriptions/tests/test_event_handlers.py
@@ -1,660 +1,244 @@
+from django.utils import timezone
+from django.test import TestCase, override_settings
+from djstripe.enums import SubscriptionStatus
+from django_dynamic_fixture import get
+from unittest import mock
+from djstripe import models as djstripe
+
+from readthedocs.subscriptions import event_handlers
+from readthedocs.organizations.models import Organization
+from readthedocs.subscriptions.models import Plan, Subscription
+
 # Avoid signature verification.
-@mock.patch.object(stripe.WebhookSignature, 'verify_header', new=mock.MagicMock)
 @override_settings(
+    RTD_ALLOW_ORGANIZATIONS=True,
     STRIPE_WEBHOOK_SECRET="1234",
     RTD_ORG_DEFAULT_STRIPE_PRICE="trialing",
 )
-class StripeTests(TestCase):
+class TestEventHandlers(TestCase):
 
     """Tests for Stripe API endpoint."""
 
     def setUp(self):
-        self.organization = fixture.get(Organization, slug='org')
-        fixture.get(
-            Plan,
-            stripe_id='trialing',
-            slug='trialing',
-        )
-        fixture.get(
-            Plan,
-            stripe_id='basic',
-        )
-        fixture.get(
-            Plan,
-            stripe_id='advanced',
-        )
+        self.organization = get(Organization, slug='org', email="test@example.com")
+        get(Plan, stripe_id='trialing', slug='trialing')
 
     def test_subscription_updated_event(self):
         """Test handled event."""
-
-        payload = """
-        {
-            "id": "evt_197I3KKFrzSMUWUvE44wEYfC",
-            "object": "event",
-            "api_version": "2016-07-06",
-            "created": 1477114098,
-            "data": {
-                "object": {
-                    "id": "sub_9LtsU02uvjO6Ed",
-                    "object": "subscription",
-                    "application_fee_percent": null,
-                    "cancel_at_period_end": false,
-                    "canceled_at": null,
-                    "created": 1476137811,
-                    "current_period_end": 1479792497,
-                    "current_period_start": 1477114097,
-                    "customer": "cus_9LtsPRYe4yJSOQ",
-                    "discount": null,
-                    "ended_at": null,
-                    "livemode": false,
-                    "metadata": {
-                    },
-                    "items": {
-                        "object": "list",
-                        "data": [
-                            {
-                                "id": "si_KMl5ZOLb8CzMyM",
-                                "object": "subscription_item",
-                                "billing_thresholds": null,
-                                "created": 1633632209,
-                                "metadata": {},
-                                "price": {
-                                    "id": "advanced",
-                                    "object": "price",
-                                    "unit_amount": 1500,
-                                    "unit_amount_decimal": "1500",
-                                    "created": 1475279464,
-                                    "currency": "usd",
-                                    "recurring": {
-                                        "aggregate_usage": null,
-                                        "interval": "month",
-                                        "interval_count": 1,
-                                        "trial_period_days": 30,
-                                        "usage_type": "licensed"
-                                    },
-                                    "livemode": false,
-                                    "metadata": {
-                                    }
-                                }
-                            }
-                        ]
-                    },
-                    "quantity": 1,
-                    "start_date": 1477114097,
-                    "status": "active",
-                    "tax_percent": null,
-                    "trial_end": null,
-                    "trial_start": null
-                },
-                "previous_attributes": {
-                    "current_period_end": 1478733360,
-                    "current_period_start": 1476137811,
-                    "start_date": 1476137811,
-                    "status": "active",
-                    "trial_end": 1478733360,
-                    "trial_start": 1476137811
-                }
-            },
-            "livemode": false,
-            "pending_webhooks": 0,
-            "request": "req_9Q8JSVL19hmjmN",
-            "type": "customer.subscription.updated"
-        }
-        """
-        subscription = fixture.get(
-            Subscription, stripe_id='sub_9LtsU02uvjO6Ed',
-            status='trialing',
+        start_date = timezone.now()
+        end_date = timezone.now() + timezone.timedelta(days=30)
+        stripe_subscription = get(
+            djstripe.Subscription,
+            id="sub_9LtsU02uvjO6Ed",
+            status=SubscriptionStatus.active,
+            current_period_start=start_date,
+            current_period_end=end_date,
+            trial_end=end_date,
         )
-        client = APIClient()
-        resp = client.post(
-            '/api/v2/stripe/',
-            json.loads(payload),
-            format='json',
-            HTTP_STRIPE_SIGNATURE='',
+        event = get(djstripe.Event, data={
+            "object": {
+                "id": "sub_9LtsU02uvjO6Ed",
+                "object": "subscription",
+            }
+        })
+        subscription = get(
+            Subscription,
+            stripe_id=stripe_subscription.id,
+            status=SubscriptionStatus.trialing,
         )
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        self.assertEqual(resp.data['updated'], True)
-        self.assertEqual(resp.data['subscription_id'], 'sub_9LtsU02uvjO6Ed')
-        subscription = Subscription.objects.get(stripe_id='sub_9LtsU02uvjO6Ed')
-        self.assertEqual(subscription.status, 'active')
-        self.assertIsNotNone(subscription.trial_end_date)
-        self.assertEqual(subscription.end_date.timestamp(), 1479792497.0)
+        event_handlers.update_subscription(event=event)
 
-    def test_unhandled_event(self):
-        """Test unhandled event."""
-
-        payload = """
-        {
-            "id": "evt_197I3KKFrzSMUWUvE44wEYfC",
-            "object": "event",
-            "api_version": "2016-07-06",
-            "created": 1477114098,
-            "data": {
-                "object": {}
-            },
-            "livemode": false,
-            "pending_webhooks": 0,
-            "request": "req_9Q8JSVL19hmjmN",
-            "type": "account.updated"
-        }
-        """
-
-        subscription = fixture.get(
-            Subscription, stripe_id='sub_9LtsU02uvjO6Ed',
-            status='trialing',
-        )
-        client = APIClient()
-        resp = client.post(
-            '/api/v2/stripe/',
-            json.loads(payload),
-            format='json',
-            HTTP_STRIPE_SIGNATURE='',
-        )
-        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        subscription.refresh_from_db()
+        self.assertEqual(subscription.status, SubscriptionStatus.active)
+        self.assertEqual(subscription.trial_end_date, end_date)
+        self.assertEqual(subscription.end_date, end_date)
 
     def test_reenabled_organization_on_subscription_updated_event(self):
         """Organization is re-enabled when subscription is active."""
-
-        payload = """
-        {
-            "id": "evt_197I3KKFrzSMUWUvE44wEYfC",
-            "object": "event",
-            "api_version": "2016-07-06",
-            "created": 1477114098,
-            "data": {
-                "object": {
-                    "id": "sub_9LtsU02uvjO6Ed",
-                    "object": "subscription",
-                    "application_fee_percent": null,
-                    "cancel_at_period_end": false,
-                    "canceled_at": null,
-                    "created": 1476137811,
-                    "current_period_end": 1479792497,
-                    "current_period_start": 1477114097,
-                    "customer": "cus_9LtsPRYe4yJSOQ",
-                    "discount": null,
-                    "ended_at": null,
-                    "livemode": false,
-                    "metadata": {
-                    },
-                    "items": {
-                        "object": "list",
-                        "data": [
-                            {
-                                "id": "si_KMl5ZOLb8CzMyM",
-                                "object": "subscription_item",
-                                "billing_thresholds": null,
-                                "created": 1633632209,
-                                "metadata": {},
-                                "price": {
-                                    "id": "advanced",
-                                    "object": "price",
-                                    "unit_amount": 1500,
-                                    "unit_amount_decimal": "1500",
-                                    "created": 1475279464,
-                                    "currency": "usd",
-                                    "recurring": {
-                                        "aggregate_usage": null,
-                                        "interval": "month",
-                                        "interval_count": 1,
-                                        "trial_period_days": 30,
-                                        "usage_type": "licensed"
-                                    },
-                                    "livemode": false,
-                                    "metadata": {
-                                    }
-                                }
-                            }
-                        ]
-                    },
-                    "quantity": 1,
-                    "start_date": 1477114097,
-                    "status": "active",
-                    "tax_percent": null,
-                    "trial_end": null,
-                    "trial_start": null
-                },
-                "previous_attributes": {
-                    "current_period_end": 1478733360,
-                    "current_period_start": 1476137811,
-                    "start_date": 1476137811,
-                    "status": "active",
-                    "trial_end": 1478733360,
-                    "trial_start": 1476137811
-                }
-            },
-            "livemode": false,
-            "pending_webhooks": 0,
-            "request": "req_9Q8JSVL19hmjmN",
-            "type": "customer.subscription.updated"
-        }
-        """
-
-        organization = fixture.get(
-            Organization,
-            disabled=True,
+        start_date = timezone.now()
+        end_date = timezone.now() + timezone.timedelta(days=30)
+        stripe_subscription = get(
+            djstripe.Subscription,
+            id="sub_9LtsU02uvjO6Ed",
+            status=SubscriptionStatus.active,
+            current_period_start=start_date,
+            current_period_end=end_date,
+            trial_end=end_date,
         )
-        subscription = fixture.get(
+        event = get(djstripe.Event, data={
+            "object": {
+                "id": "sub_9LtsU02uvjO6Ed",
+                "object": "subscription",
+            }
+        })
+
+        organization = get(Organization, disabled=True)
+        subscription = get(
             Subscription,
             organization=organization,
-            stripe_id='sub_9LtsU02uvjO6Ed',
-            status='canceled',
+            stripe_id=stripe_subscription.id,
+            status=SubscriptionStatus.canceled,
         )
-        client = APIClient()
         self.assertTrue(organization.disabled)
-        resp = client.post(
-            '/api/v2/stripe/',
-            json.loads(payload),
-            format='json',
-            HTTP_STRIPE_SIGNATURE='',
-        )
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        self.assertEqual(resp.data['updated'], True)
-        self.assertEqual(resp.data['subscription_id'], 'sub_9LtsU02uvjO6Ed')
-        subscription = Subscription.objects.get(stripe_id='sub_9LtsU02uvjO6Ed')
+
+        event_handlers.update_subscription(event=event)
+
+        subscription.refresh_from_db()
         organization.refresh_from_db()
-        self.assertEqual(subscription.status, 'active')
-        self.assertIsNotNone(subscription.trial_end_date)
+        self.assertEqual(subscription.status, SubscriptionStatus.active)
+        self.assertEqual(subscription.trial_end_date, end_date)
+        self.assertEqual(subscription.end_date, end_date)
         self.assertFalse(organization.disabled)
-        self.assertEqual(subscription.end_date.timestamp(), 1479792497.0)
 
     def test_subscription_deleted_event(self):
-        payload = """
-        {
-            "id": "evt_1Ji1kgKFrzSMUWUv4vtbtGT9",
-            "object": "event",
-            "api_version": "2020-08-27",
-            "created": 1633632933,
-            "data": {
-                "object": {
-                    "id": "sub_1Ji1YyKFrzSMUWUvPghVBB66",
-                    "object": "subscription",
-                    "application_fee_percent": null,
-                    "automatic_tax": {
-                        "enabled": false
-                    },
-                    "billing_cycle_anchor": 1633632293,
-                    "billing_thresholds": null,
-                    "cancel_at": null,
-                    "cancel_at_period_end": false,
-                    "canceled_at": 1633632565,
-                    "collection_method": "charge_automatically",
-                    "created": 1633632208,
-                    "current_period_end": 1636310693,
-                    "current_period_start": 1633632293,
-                    "customer": "cus_KMl5qf77rIpBWv",
-                    "days_until_due": null,
-                    "default_payment_method": "pm_1Ji1aJKFrzSMUWUv4mRVcupr",
-                    "default_source": null,
-                    "default_tax_rates": [],
-                    "discount": null,
-                    "ended_at": 1633632933,
-                    "items": {
-                        "object": "list",
-                        "data": [
-                            {
-                                "id": "si_KMl5ZOLb8CzMyM",
-                                "object": "subscription_item",
-                                "billing_thresholds": null,
-                                "created": 1633632209,
-                                "metadata": {},
-                                "price": {
-                                    "id": "advanced",
-                                    "object": "price",
-                                    "active": true,
-                                    "billing_scheme": "per_unit",
-                                    "created": 1475279464,
-                                    "currency": "usd",
-                                    "livemode": false,
-                                    "lookup_key": null,
-                                    "metadata": {
-                                        "SSO": "Single Sign-On"
-                                    },
-                                    "nickname": "Includes Custom Domains and more!",
-                                    "product": "prod_BV0U8VTu4d8E4h",
-                                    "recurring": {
-                                        "aggregate_usage": null,
-                                        "interval": "month",
-                                        "interval_count": 1,
-                                        "trial_period_days": 30,
-                                        "usage_type": "licensed"
-                                    },
-                                    "tax_behavior": "unspecified",
-                                    "tiers_mode": null,
-                                    "transform_quantity": null,
-                                    "type": "recurring",
-                                    "unit_amount": 15000,
-                                    "unit_amount_decimal": "15000"
-                                },
-                                "quantity": 1,
-                                "subscription": "sub_1Ji1YyKFrzSMUWUvPghVBB66",
-                                "tax_rates": []
-                            }
-                        ],
-                        "has_more": false,
-                        "total_count": 1,
-                        "url": "/v1/subscription_items?subscription=sub_1Ji1YyKFrzSMUWUvPghVBB66"
-                    },
-                    "latest_invoice": "in_1Ji1d7KFrzSMUWUvIg9rpjUE",
-                    "livemode": false,
-                    "metadata": {},
-                    "next_pending_invoice_item_invoice": null,
-                    "pause_collection": null,
-                    "payment_settings": {
-                        "payment_method_options": null,
-                        "payment_method_types": null
-                    },
-                    "pending_invoice_item_interval": null,
-                    "pending_setup_intent": null,
-                    "pending_update": null,
-                    "quantity": 1,
-                    "schedule": null,
-                    "start_date": 1633632208,
-                    "status": "canceled",
-                    "transfer_data": null,
-                    "trial_end": 1633632292,
-                    "trial_start": 1633632208
-                }
-            },
-            "livemode": false,
-            "pending_webhooks": 3,
-            "request": {
-                "id": "req_LltV9EVcHShY68",
-                "idempotency_key": null
-            },
-            "type": "customer.subscription.deleted"
-        }
-        """
-        subscription = fixture.get(
+        start_date = timezone.now()
+        end_date = timezone.now() + timezone.timedelta(days=30)
+        stripe_subscription = get(
+            djstripe.Subscription,
+            id="sub_9LtsU02uvjO6Ed",
+            status=SubscriptionStatus.canceled,
+            current_period_start=start_date,
+            current_period_end=end_date,
+            trial_end=end_date,
+        )
+        event = get(djstripe.Event, data={
+            "object": {
+                "id": "sub_9LtsU02uvjO6Ed",
+                "object": "subscription",
+            }
+        })
+        subscription = get(
             Subscription,
             organization=self.organization,
-            stripe_id='sub_1Ji1YyKFrzSMUWUvPghVBB66',
-            status='active',
+            stripe_id=stripe_subscription.id,
+            status=SubscriptionStatus.active,
         )
-        client = APIClient()
-        resp = client.post(
-            '/api/v2/stripe/',
-            json.loads(payload),
-            format='json',
-            HTTP_STRIPE_SIGNATURE='',
-        )
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        self.assertEqual(resp.data['updated'], True)
-        self.assertIsNone(resp.data['subscription_id'])
-        self.assertEqual(resp.data['previous_subscription_id'], 'sub_1Ji1YyKFrzSMUWUvPghVBB66')
+
+        event_handlers.update_subscription(event=event)
+
         subscription.refresh_from_db()
         self.assertIsNone(subscription.stripe_id)
-        self.assertEqual(subscription.status , 'canceled')
+        self.assertEqual(subscription.status , SubscriptionStatus.canceled)
 
-    @mock.patch.object(stripe.Subscription, 'retrieve')
-    def test_subscription_checkout_completed_event(self, subscription_retrieve_mock):
-        payload = """
-        {
-            "id": "evt_1Ji12qKFrzSMUWUvnGxsOJEd",
-            "object": "event",
-            "api_version": "2020-08-27",
-            "created": 1633630215,
-            "data": {
-                "object": {
-                    "id": "cs_test_a1UpM7pDdpXqqgZC6lQDC2HRMo5d1wW9fNX0ZiBCm6vRqTgZJZx6brwNan",
-                    "object": "checkout.session",
-                    "after_expiration": null,
-                    "allow_promotion_codes": null,
-                    "amount_subtotal": 5000,
-                    "amount_total": 5000,
-                    "automatic_tax": {
-                        "enabled": false,
-                        "status": null
-                    },
-                    "billing_address_collection": null,
-                    "cancel_url": "http://6c9f-186-66-172-152.ngrok.io/organizations/foo/subscription/",
-                    "client_reference_id": null,
-                    "consent": null,
-                    "consent_collection": null,
-                    "currency": "usd",
-                    "customer": "cus_KMiHJXFHpLkcRP",
-                    "customer_details": {
-                        "email": "admin@admin.com",
-                        "tax_exempt": "none",
-                        "tax_ids": []
-                    },
-                    "customer_email": null,
-                    "expires_at": 1633716598,
-                    "livemode": false,
-                    "locale": null,
-                    "metadata": {},
-                    "mode": "subscription",
-                    "payment_intent": null,
-                    "payment_method_options": {},
-                    "payment_method_types": [
-                        "card"
-                    ],
-                    "payment_status": "paid",
-                    "recovered_from": null,
-                    "setup_intent": "seti_1Ji12mKFrzSMUWUvMrvmajcF",
-                    "shipping": null,
-                    "shipping_address_collection": null,
-                    "submit_type": null,
-                    "subscription": "sub_9LtsU02uvjO6Ed",
-                    "success_url": "http://6c9f-186-66-172-152.ngrok.io/organizations/foo/subscription/?upgraded=true",
-                    "total_details": {
-                        "amount_discount": 0,
-                        "amount_shipping": 0,
-                        "amount_tax": 0
-                    },
-                    "url": null
-                }
-            },
-            "livemode": false,
-            "pending_webhooks": 5,
-            "request": {
-                "id": null,
-                "idempotency_key": null
-            },
-            "type": "checkout.session.completed"
-        }
-        """
-
-        self.organization.stripe_id = 'cus_KMiHJXFHpLkcRP'
+    def test_subscription_checkout_completed_event(self):
+        customer = get(djstripe.Customer, id='cus_KMiHJXFHpLkcRP')
+        self.organization.stripe_customer = customer
         self.organization.save()
-        subscription_retrieve_mock.return_value = stripe.Subscription.construct_from(
-            values={
-                "id": "sub_9LtsU02uvjO6Ed",
-                "canceled_at": None,
-                "created": 1476137811,
-                "current_period_end": 1479792497,
-                "current_period_start": 1477114097,
-                "customer": "cus_KMiHJXFHpLkcRP",
-                "items": {
-                    "object": "list",
-                    "data": [
-                        {
-                            "id": "si_KOcEsHCktPUedU",
-                            "object": "subscription_item",
-                            "price": {
-                                "id": "advanced",
-                                "object": "price",
-                                "unit_amount": 1500,
-                                "unit_amount_decimal": "1500",
-                                "created": 1475279464,
-                                "currency": "usd",
-                                "recurring": {
-                                    "aggregate_usage": None,
-                                    "interval": "month",
-                                    "interval_count": 1,
-                                    "trial_period_days": 30,
-                                    "usage_type": "licensed",
-                                },
-                            },
-                        }
-                    ],
-                },
-                "start_date": 1477114097,
-                "status": "active",
-                "trial_end": None,
-                "trial_start": None,
-            },
-            key=None,
+
+        start_date = timezone.now()
+        end_date = timezone.now() + timezone.timedelta(days=30)
+        stripe_subscription = get(
+            djstripe.Subscription,
+            id="sub_9LtsU02uvjO6Ed",
+            status=SubscriptionStatus.active,
+            current_period_start=start_date,
+            current_period_end=end_date,
+            trial_end=end_date,
         )
-        subscription = fixture.get(
+        event = get(djstripe.Event, data={
+            "object": {
+                "id": "cs_test_a1UpM7pDdpXqqgZC6lQDC2HRMo5d1wW9fNX0ZiBCm6vRqTgZJZx6brwNan",
+                "object": "checkout.session",
+                "customer": customer.id,
+                "subscription": stripe_subscription.id,
+            }
+        })
+
+        subscription = get(
             Subscription,
             organization=self.organization,
             stripe_id=None,
-            status='canceled',
+            status=SubscriptionStatus.canceled,
         )
-        client = APIClient()
-        resp = client.post(
-            '/api/v2/stripe/',
-            json.loads(payload),
-            format='json',
-            HTTP_STRIPE_SIGNATURE='',
-        )
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        self.assertEqual(resp.data['updated'], True)
-        self.assertEqual(resp.data['subscription_id'], 'sub_9LtsU02uvjO6Ed')
-        self.assertEqual(resp.data['previous_subscription_id'], None)
-        subscription.refresh_from_db()
-        self.assertEqual(subscription.stripe_id, 'sub_9LtsU02uvjO6Ed')
-        self.assertEqual(subscription.status , 'active')
 
-    @mock.patch('readthedocsinc.api.v2.views.cancel_subscription')
-    def test_cancel_subscription_after_trial_has_ended(self, cancel_subscription_mock):
-        payload = """
-        {
-            "id": "evt_1Jjp3aKFrzSMUWUvIfMwnfw3",
-            "object": "event",
-            "api_version": "2020-08-27",
-            "created": 1634060789,
-            "data": {
-                "object": {
-                    "id": "sub_1JjozxKFrzSMUWUvkgpVXQt8",
-                    "object": "subscription",
-                    "application_fee_percent": null,
-                    "automatic_tax": {
-                        "enabled": false
-                    },
-                    "billing_cycle_anchor": 1634060789,
-                    "billing_thresholds": null,
-                    "cancel_at": null,
-                    "cancel_at_period_end": false,
-                    "canceled_at": null,
-                    "collection_method": "charge_automatically",
-                    "created": 1634060565,
-                    "current_period_end": 1636739189,
-                    "current_period_start": 1634060789,
-                    "customer": "cus_KOcEOz4gd3lN8X",
-                    "days_until_due": null,
-                    "default_payment_method": null,
-                    "default_source": null,
-                    "default_tax_rates": [
-                    ],
-                    "discount": null,
-                    "ended_at": null,
-                    "items": {
-                        "object": "list",
-                        "data": [
-                        {
-                            "id": "si_KOcEsHCktPUedU",
-                            "object": "subscription_item",
-                            "billing_thresholds": null,
-                            "created": 1634060565,
-                            "metadata": {
-                            },
-                            "price": {
-                            "id": "trialing",
-                            "object": "price",
-                            "active": true,
-                            "billing_scheme": "per_unit",
-                            "created": 1629733210,
-                            "currency": "usd",
-                            "livemode": false,
-                            "lookup_key": null,
-                            "metadata": {
-                            },
-                            "nickname": null,
-                            "product": "prod_K1qnUPyioLO51V",
-                            "recurring": {
-                                "aggregate_usage": null,
-                                "interval": "month",
-                                "interval_count": 1,
-                                "trial_period_days": 30,
-                                "usage_type": "licensed"
-                            },
-                            "tax_behavior": "unspecified",
-                            "tiers_mode": null,
-                            "transform_quantity": null,
-                            "type": "recurring",
-                            "unit_amount": 0,
-                            "unit_amount_decimal": "0"
-                            },
-                            "quantity": 1,
-                            "subscription": "sub_1JjozxKFrzSMUWUvkgpVXQt8",
-                            "tax_rates": [
-                            ]
-                        }
-                        ],
-                        "has_more": false,
-                        "total_count": 1,
-                        "url": "/v1/subscription_items?subscription=sub_1JjozxKFrzSMUWUvkgpVXQt8"
-                    },
-                    "latest_invoice": "in_1Jjp3ZKFrzSMUWUvN9pqY3ub",
-                    "livemode": false,
-                    "metadata": {
-                    },
-                    "next_pending_invoice_item_invoice": null,
-                    "pause_collection": null,
-                    "payment_settings": {
-                        "payment_method_options": null,
-                        "payment_method_types": null
-                    },
-                    "pending_invoice_item_interval": null,
-                    "pending_setup_intent": "seti_1JjozxKFrzSMUWUvTmU4SztV",
-                    "pending_update": null,
-                    "quantity": 1,
-                    "schedule": null,
-                    "start_date": 1634060565,
-                    "status": "active",
-                    "transfer_data": null,
-                    "trial_end": 1634060788,
-                    "trial_start": 1634060565
-                },
-                "previous_attributes": {
-                    "billing_cycle_anchor": 1636652565,
-                    "current_period_end": 1636652565,
-                    "current_period_start": 1634060565,
-                    "latest_invoice": "in_1JjozxKFrzSMUWUvhLCv0xy9",
-                    "status": "trialing",
-                    "trial_end": 1636652565
-                }
-            },
-            "livemode": false,
-            "pending_webhooks": 3,
-            "request": {
-                "id": "req_dloiXHqk7BR4rQ",
-                "idempotency_key": null
-            },
-            "type": "customer.subscription.updated"
-        }
-        """
-        subscription = fixture.get(
+        event_handlers.checkout_completed(event=event)
+
+        subscription.refresh_from_db()
+        self.assertEqual(subscription.stripe_id, stripe_subscription.id)
+        self.assertEqual(subscription.status , SubscriptionStatus.active)
+
+    @mock.patch('readthedocs.subscriptions.event_handlers.cancel_stripe_subscription')
+    def test_cancel_trial_subscription_after_trial_has_ended(self, cancel_subscription_mock):
+        start_date = timezone.now()
+        end_date = timezone.now() + timezone.timedelta(days=30)
+        stripe_subscription = get(
+            djstripe.Subscription,
+            id="sub_9LtsU02uvjO6Ed",
+            status=SubscriptionStatus.active,
+            current_period_start=start_date,
+            current_period_end=end_date,
+            trial_end=start_date,
+        )
+        price = get(djstripe.Price, id="trialing")
+        get(djstripe.SubscriptionItem, id="si_KOcEsHCktPUedU", price=price, subscription=stripe_subscription)
+        event = get(djstripe.Event, data={
+            "object": {
+                "id": "sub_9LtsU02uvjO6Ed",
+                "object": "subscription",
+            }
+        })
+        subscription = get(
             Subscription,
             organization=self.organization,
-            stripe_id='sub_1JjozxKFrzSMUWUvkgpVXQt8',
-            status='active',
+            stripe_id=stripe_subscription.id,
+            status=SubscriptionStatus.active,
         )
-        self.organization.stripe_id = 'cus_KMiHJXFHpLkcRP'
-        self.organization.save()
-        client = APIClient()
-        resp = client.post(
-            '/api/v2/stripe/',
-            json.loads(payload),
-            format='json',
-            HTTP_STRIPE_SIGNATURE='',
-        )
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        self.assertEqual(resp.data['updated'], True)
-        self.assertEqual(resp.data['subscription_id'], 'sub_1JjozxKFrzSMUWUvkgpVXQt8')
+
+        event_handlers.update_subscription(event=event)
+
         subscription.refresh_from_db()
-        self.assertEqual(subscription.status, 'active')
+        self.assertEqual(subscription.status, SubscriptionStatus.active)
         self.assertTrue(subscription.is_trial_ended)
-        cancel_subscription_mock.assert_called_once_with("sub_1JjozxKFrzSMUWUvkgpVXQt8")
+        cancel_subscription_mock.assert_called_once_with(stripe_subscription.id)
+
+    @mock.patch('readthedocs.subscriptions.event_handlers.cancel_stripe_subscription')
+    def test_dont_cancel_normal_subscription_after_trial_has_ended(self, cancel_subscription_mock):
+        start_date = timezone.now()
+        end_date = timezone.now() + timezone.timedelta(days=30)
+        stripe_subscription = get(
+            djstripe.Subscription,
+            id="sub_9LtsU02uvjO6Ed",
+            status=SubscriptionStatus.active,
+            current_period_start=start_date,
+            current_period_end=end_date,
+            trial_end=start_date,
+        )
+        price = get(djstripe.Price, id="advanced")
+        get(djstripe.SubscriptionItem, id="si_KOcEsHCktPUedU", price=price, subscription=stripe_subscription)
+        event = get(djstripe.Event, data={
+            "object": {
+                "id": "sub_9LtsU02uvjO6Ed",
+                "object": "subscription",
+            }
+        })
+        subscription = get(
+            Subscription,
+            organization=self.organization,
+            stripe_id=stripe_subscription.id,
+            status=SubscriptionStatus.active,
+        )
+
+        event_handlers.update_subscription(event=event)
+
+        subscription.refresh_from_db()
+        self.assertEqual(subscription.status, SubscriptionStatus.active)
+        self.assertTrue(subscription.is_trial_ended)
+        cancel_subscription_mock.assert_not_called()
+
+    def test_customer_updated_event(self):
+        customer = get(djstripe.Customer, id='cus_KMiHJXFHpLkcRP', email="new@example.com")
+        self.organization.stripe_customer = customer
+        self.organization.save()
+
+        event = get(djstripe.Event, data={
+            "object": {
+                "id": customer.id,
+                "email": customer.email,
+            }
+        })
+
+        self.assertNotEqual(self.organization.email, customer.email)
+
+        event_handlers.customer_updated_event(event=event)
+        self.organization.refresh_from_db()
+        self.assertEqual(self.organization.email, customer.email)

--- a/readthedocs/subscriptions/tests/test_event_handlers.py
+++ b/readthedocs/subscriptions/tests/test_event_handlers.py
@@ -4,6 +4,7 @@ from django.test import TestCase, override_settings
 from django.utils import timezone
 from django_dynamic_fixture import get
 from djstripe import models as djstripe
+from djstripe import webhooks
 from djstripe.enums import SubscriptionStatus
 
 from readthedocs.organizations.models import Organization
@@ -279,3 +280,16 @@ class TestStripeEventHandlers(TestCase):
         event_handlers.customer_updated_event(event=event)
         self.organization.refresh_from_db()
         self.assertEqual(self.organization.email, customer.email)
+
+    def test_register_events(self):
+        def test_func():
+            pass
+
+        with override_settings(RTD_ALLOW_ORGANIZATIONS=False):
+            event_handlers.handler("event")(test_func)
+
+        self.assertEqual(webhooks.registrations["event"], [])
+
+        with override_settings(RTD_ALLOW_ORGANIZATIONS=True):
+            event_handlers.handler("event")(test_func)
+        self.assertEqual(webhooks.registrations["event"], [test_func])

--- a/readthedocs/subscriptions/tests/test_models.py
+++ b/readthedocs/subscriptions/tests/test_models.py
@@ -1,8 +1,8 @@
 import django_dynamic_fixture as fixture
 from django.test import TestCase, override_settings
 from django.utils import timezone
-from django_dynamic_fixture.ddf import BadDataError
 from django_dynamic_fixture import get
+from django_dynamic_fixture.ddf import BadDataError
 from djstripe import models as djstripe
 from djstripe.enums import SubscriptionStatus
 
@@ -61,12 +61,17 @@ class SubscriptionTests(TestCase):
             trial_end=end_date,
         )
         price = get(djstripe.Price, id="advanced")
-        get(djstripe.SubscriptionItem, id="si_KOcEsHCktPUedU", price=price, subscription=stripe_subscription)
+        get(
+            djstripe.SubscriptionItem,
+            id="si_KOcEsHCktPUedU",
+            price=price,
+            subscription=stripe_subscription,
+        )
 
         subscription = fixture.get(
             Subscription,
-            stripe_id='sub_foo',
-            status='trialing',
+            stripe_id=stripe_subscription.id,
+            status=SubscriptionStatus.trialing,
         )
         Subscription.objects.update_from_stripe(
             rtd_subscription=subscription,
@@ -110,12 +115,17 @@ class SubscriptionTests(TestCase):
             trial_end=end_date,
         )
         price = get(djstripe.Price, id="advanced")
-        get(djstripe.SubscriptionItem, id="si_KOcEsHCktPUedU", price=price, subscription=stripe_subscription)
+        get(
+            djstripe.SubscriptionItem,
+            id="si_KOcEsHCktPUedU",
+            price=price,
+            subscription=stripe_subscription,
+        )
 
         subscription = fixture.get(
             Subscription,
             stripe_id='sub_foo',
-            status='trialing',
+            status=SubscriptionStatus.trialing,
         )
         Subscription.objects.update_from_stripe(
             rtd_subscription=subscription,

--- a/readthedocs/subscriptions/tests/test_models.py
+++ b/readthedocs/subscriptions/tests/test_models.py
@@ -1,10 +1,10 @@
-from datetime import datetime
-
 import django_dynamic_fixture as fixture
 from django.test import TestCase, override_settings
 from django.utils import timezone
 from django_dynamic_fixture.ddf import BadDataError
-from stripe import Subscription as StripeSubscription
+from django_dynamic_fixture import get
+from djstripe import models as djstripe
+from djstripe.enums import SubscriptionStatus
 
 from readthedocs.organizations.models import Organization
 from readthedocs.subscriptions.models import Plan, Subscription
@@ -50,28 +50,19 @@ class SubscriptionTests(TestCase):
 
     def test_update(self):
         """Test update from stripe."""
-        stripe_subscription = StripeSubscription.construct_from(
-            {
-                'id': 'sub_foo',
-                'status': 'active',
-                'current_period_start': 120778389,
-                'current_period_end': 123456789,
-                'trial_end': 1475437877,
-                "items": {
-                    "object": "list",
-                    "data": [
-                        {
-                            "id": "si_KOcEsHCktPUedU",
-                            "object": "subscription_item",
-                            "price": {
-                                "id": "advanced",
-                            },
-                        },
-                    ],
-                },
-            },
-            None,
+        start_date = timezone.now()
+        end_date = timezone.now() + timezone.timedelta(days=30)
+        stripe_subscription = get(
+            djstripe.Subscription,
+            id="sub_foo",
+            status=SubscriptionStatus.active,
+            current_period_start=start_date,
+            current_period_end=end_date,
+            trial_end=end_date,
         )
+        price = get(djstripe.Price, id="advanced")
+        get(djstripe.SubscriptionItem, id="si_KOcEsHCktPUedU", price=price, subscription=stripe_subscription)
+
         subscription = fixture.get(
             Subscription,
             stripe_id='sub_foo',
@@ -85,33 +76,16 @@ class SubscriptionTests(TestCase):
         self.assertEqual(subscription.status, 'active')
         self.assertEqual(
             subscription.end_date,
-            timezone.make_aware(datetime.fromtimestamp(123456789)),
+            end_date,
         )
         self.assertEqual(
             subscription.trial_end_date,
-            timezone.make_aware(datetime.fromtimestamp(1475437877)),
+            end_date,
         )
 
         # Cancel event
-        stripe_subscription = StripeSubscription.construct_from(
-            {
-                'id': 'sub_foo',
-                'status': 'unpaid',
-                "items": {
-                    "object": "list",
-                    "data": [
-                        {
-                            "id": "si_KOcEsHCktPUedU",
-                            "object": "subscription_item",
-                            "price": {
-                                "id": "advanced",
-                            },
-                        },
-                    ],
-                },
-            },
-            None,
-        )
+        stripe_subscription.status = SubscriptionStatus.unpaid
+        stripe_subscription.save()
         Subscription.objects.update_from_stripe(
             rtd_subscription=subscription,
             stripe_subscription=stripe_subscription,
@@ -120,30 +94,24 @@ class SubscriptionTests(TestCase):
         self.assertEqual(subscription.status, 'unpaid')
         self.assertEqual(
             subscription.trial_end_date,
-            timezone.make_aware(datetime.fromtimestamp(1475437877)),
+            end_date,
         )
 
     def test_replace_subscription(self):
         """Test update from stripe."""
-        stripe_subscription = StripeSubscription.construct_from(
-            {
-                'id': 'sub_bar',
-                'status': 'active',
-                "items": {
-                    "object": "list",
-                    "data": [
-                        {
-                            "id": "si_KOcEsHCktPUedU",
-                            "object": "subscription_item",
-                            "price": {
-                                "id": "advanced",
-                            },
-                        },
-                    ],
-                },
-            },
-            None,
+        start_date = timezone.now()
+        end_date = timezone.now() + timezone.timedelta(days=30)
+        stripe_subscription = get(
+            djstripe.Subscription,
+            id="sub_bar",
+            status=SubscriptionStatus.active,
+            current_period_start=start_date,
+            current_period_end=end_date,
+            trial_end=end_date,
         )
+        price = get(djstripe.Price, id="advanced")
+        get(djstripe.SubscriptionItem, id="si_KOcEsHCktPUedU", price=price, subscription=stripe_subscription)
+
         subscription = fixture.get(
             Subscription,
             stripe_id='sub_foo',


### PR DESCRIPTION
Instead of using our own stripe webhook handler, just use djstripe.
All this logic comes from .com, but now instead of dealing with a stripe event, we have a djstripe event object and have access to all djstripe models.

I have tested this locally with stripe in testing mode.


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9651.org.readthedocs.build/en/9651/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9651.org.readthedocs.build/en/9651/

<!-- readthedocs-preview dev end -->