### PR TITLE
Adds more basic info to the default 404 page

### DIFF
--- a/readthedocs/templates/404.html
+++ b/readthedocs/templates/404.html
@@ -16,7 +16,7 @@
 {% block language-select-form %}{% endblock %}
 
 {% block content %}
-<p>{% blocktrans context "404 page" %}This is a 404 error page. The link you have followed or the URL that you entered did not work. It might be that the documentation has been updated.{% endblocktrans %}</p>
+<p>{% blocktrans context "404 page" %}This is a 404 error page. The link you have followed or the URL that you entered does not exist. It might be that the documentation has been updated, or this page has been removed.{% endblocktrans %}</p>
 
 <a href="/">{% blocktrans with site_name=request.get_host|default:_("this site") context "404 page" %}Back to the front page of {{ site_name }}{% endblocktrans %}</a>
 

--- a/readthedocs/templates/404.html
+++ b/readthedocs/templates/404.html
@@ -15,7 +15,11 @@
 {# Hide the language select form so we don't set a CSRF cookie #}
 {% block language-select-form %}{% endblock %}
 
+<p>{% blocktrans context "404 page" %}This is a 404 page. The link you have followed or the URL that you entered did not work. It might be that the documentation has been updated.{% endblocktrans %}</p>
+
 {% block content %}
+<a href="/">{% blocktrans context "404 page" %}Back to the main page{% endblocktrans %}</a>
+
 <pre style="line-height: 1.25; white-space: pre;">
 
         \          SORRY            /

--- a/readthedocs/templates/404.html
+++ b/readthedocs/templates/404.html
@@ -15,7 +15,7 @@
 {# Hide the language select form so we don't set a CSRF cookie #}
 {% block language-select-form %}{% endblock %}
 
-<p>{% blocktrans context "404 page" %}This is a 404 page. The link you have followed or the URL that you entered did not work. It might be that the documentation has been updated.{% endblocktrans %}</p>
+<p>{% blocktrans context "404 page" %}This is a 404 error page. The link you have followed or the URL that you entered did not work. It might be that the documentation has been updated.{% endblocktrans %}</p>
 
 {% block content %}
 <a href="/">{% blocktrans context "404 page" %}Back to the main page{% endblocktrans %}</a>

--- a/readthedocs/templates/404.html
+++ b/readthedocs/templates/404.html
@@ -15,10 +15,10 @@
 {# Hide the language select form so we don't set a CSRF cookie #}
 {% block language-select-form %}{% endblock %}
 
+{% block content %}
 <p>{% blocktrans context "404 page" %}This is a 404 error page. The link you have followed or the URL that you entered did not work. It might be that the documentation has been updated.{% endblocktrans %}</p>
 
-{% block content %}
-<a href="/">{% blocktrans context "404 page" %}Back to the main page{% endblocktrans %}</a>
+<a href="/">{% blocktrans with site_name=request.get_host|default:_("this site") context "404 page" %}Back to the front page of {{ site_name }}{% endblocktrans %}</a>
 
 <pre style="line-height: 1.25; white-space: pre;">
 


### PR DESCRIPTION
Addresses #2551 with a very simple improvement. The 404 page context is still unaware of what project it belongs to, that should follow in a different update.

TODO:

* [x] Verify that this is covered by a test

![image](https://user-images.githubusercontent.com/374612/195377961-3643e242-e9d7-43b4-b48d-046b8ef0c3e7.png)


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9656.org.readthedocs.build/en/9656/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9656.org.readthedocs.build/en/9656/

<!-- readthedocs-preview dev end -->