### PR TITLE
Clean up some old code that's not used

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -84,7 +84,6 @@ from readthedocs.projects.constants import (
 )
 from readthedocs.projects.models import APIProject, Project
 from readthedocs.projects.version_handling import determine_stable_version
-from readthedocs.storage import build_environment_storage
 
 log = structlog.get_logger(__name__)
 
@@ -373,11 +372,6 @@ class Version(TimeStampedModel):
         return self.type == BRANCH
 
     @property
-    def supports_wipe(self):
-        """Return True if version is not external."""
-        return self.type != EXTERNAL
-
-    @property
     def is_sphinx_type(self):
         return self.documentation_type in {SPHINX, SPHINX_HTMLDIR, SPHINX_SINGLEHTML}
 
@@ -424,13 +418,6 @@ class Version(TimeStampedModel):
         conf_py_path = os.path.relpath(conf_py_path, checkout_prefix)
         return conf_py_path
 
-    def get_build_path(self):
-        """Return version build path if path exists, otherwise `None`."""
-        path = self.project.checkout_path(version=self.slug)
-        if os.path.exists(path):
-            return path
-        return None
-
     def get_storage_paths(self):
         """
         Return a list of all build artifact storage paths for this version.
@@ -450,10 +437,6 @@ class Version(TimeStampedModel):
             )
 
         return paths
-
-    def get_storage_environment_cache_path(self):
-        """Return the path of the cached environment tar file."""
-        return build_environment_storage.join(self.project.slug, f'{self.slug}.tar')
 
     def get_github_url(
             self,

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -775,6 +775,9 @@ class Project(models.Model):
 
     @property
     def clean_repo(self):
+        # NOTE: this method is used only when the project is going to be clonned.
+        # It probably makes sense to do a data migrations and force "Import Project"
+        # form to validate it's an HTTPS URL when importing new ones
         if self.repo.startswith('http://github.com'):
             return self.repo.replace('http://github.com', 'https://github.com')
         return self.repo
@@ -801,47 +804,6 @@ class Project(models.Model):
     def artifact_path(self, type_, version=LATEST):
         """The path to the build html docs in the project."""
         return os.path.join(self.doc_path, 'artifacts', version, type_)
-
-    def full_build_path(self, version=LATEST):
-        """The path to the build html docs in the project."""
-        return os.path.join(self.conf_dir(version), '_build', 'html')
-
-    def full_latex_path(self, version=LATEST):
-        """The path to the build LaTeX docs in the project."""
-        return os.path.join(self.conf_dir(version), '_build', 'latex')
-
-    def full_epub_path(self, version=LATEST):
-        """The path to the build epub docs in the project."""
-        return os.path.join(self.conf_dir(version), '_build', 'epub')
-
-    # There is currently no support for building man/dash formats, but we keep
-    # the support there for existing projects. They might have already existing
-    # legacy builds.
-
-    def full_man_path(self, version=LATEST):
-        """The path to the build man docs in the project."""
-        return os.path.join(self.conf_dir(version), '_build', 'man')
-
-    def full_dash_path(self, version=LATEST):
-        """The path to the build dash docs in the project."""
-        return os.path.join(self.conf_dir(version), '_build', 'dash')
-
-    def full_json_path(self, version=LATEST):
-        """The path to the build json docs in the project."""
-        json_path = os.path.join(self.conf_dir(version), '_build', 'json')
-        return json_path
-
-    def full_singlehtml_path(self, version=LATEST):
-        """The path to the build singlehtml docs in the project."""
-        return os.path.join(self.conf_dir(version), '_build', 'singlehtml')
-
-    def rtd_build_path(self, version=LATEST):
-        """The destination path where the built docs are copied."""
-        return os.path.join(self.doc_path, 'rtd-builds', version)
-
-    def static_metadata_path(self):
-        """The path to the static metadata JSON settings file."""
-        return os.path.join(self.doc_path, 'metadata.json')
 
     def conf_file(self, version=LATEST):
         """Find a ``conf.py`` file in the project checkout."""

--- a/readthedocs/rtd_tests/tests/test_version.py
+++ b/readthedocs/rtd_tests/tests/test_version.py
@@ -87,12 +87,6 @@ class TestVersionModel(VersionMixin, TestCase):
     def test_commit_name_for_external_version(self):
         self.assertEqual(self.external_version.commit_name, self.external_version.identifier)
 
-    def test_version_does_not_support_wipe(self):
-        self.assertFalse(self.external_version.supports_wipe)
-
-    def test_version_supports_wipe(self):
-        self.assertTrue(self.branch_version.supports_wipe)
-
     @override_settings(
         PRODUCTION_DOMAIN='readthedocs.org',
         PUBLIC_DOMAIN='readthedocs.io',


### PR DESCRIPTION
I found some of these methods confusing when writing new code. One of them seemed to do what I wanted, but it was using old tricks (find a `conf.py` instead of using `sphinx.configuration` key from the config file).

I think it's a good idea to remove them to avoid mistakes in the future. It seems they are not used anywhere and it's safe to remove them.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9659.org.readthedocs.build/en/9659/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9659.org.readthedocs.build/en/9659/

<!-- readthedocs-preview dev end -->