### PR TITLE
Docs: Use current year instead of hard-coded 2010

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@ for more information read https://sphinx-multiproject.readthedocs.io/.
 
 import os
 import sys
+from datetime import datetime
 
 import sphinx_rtd_theme
 from multiproject.utils import get_project
@@ -68,7 +69,7 @@ docset = get_project(multiproject_projects)
 templates_path = ["_templates"]
 
 master_doc = "index"
-copyright = "2010, Read the Docs, Inc & contributors"
+copyright = "{}, Read the Docs, Inc & contributors".format(datetime.now().year)
 version = "8.7.0"
 release = version
 exclude_patterns = ["_build"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,6 @@ for more information read https://sphinx-multiproject.readthedocs.io/.
 
 import os
 import sys
-from datetime import datetime
 
 import sphinx_rtd_theme
 from multiproject.utils import get_project
@@ -69,7 +68,7 @@ docset = get_project(multiproject_projects)
 templates_path = ["_templates"]
 
 master_doc = "index"
-copyright = "{}, Read the Docs, Inc & contributors".format(datetime.now().year)
+copyright = "Read the Docs, Inc & contributors"
 version = "8.7.0"
 release = version
 exclude_patterns = ["_build"]


### PR DESCRIPTION
Writing "2010" in the Copyright notice gives a wrong impression that whatever documentation article is displayed hasn't been updated since. And many of them aren't even written in 2010, so it's also factually very wrong :)