### PR TITLE
Template: fix build details page link

### DIFF
--- a/readthedocs/templates/builds/build_detail.html
+++ b/readthedocs/templates/builds/build_detail.html
@@ -178,7 +178,7 @@ $(document).ready(function () {
     {% if build.finished and build.config.build.commands %}
     <div class="build-ideas">
       <p>
-        {% blocktrans trimmed with config_file_link="https://docs.readthedocs.io/page/build-customization.html#override-the-build-process-completely" %}
+        {% blocktrans trimmed with config_file_link="https://docs.readthedocs.io/page/build-customization.html#override-the-build-process" %}
         <strong>The <code>"build.commands"</code> feature is in beta, and could have backwards incompatible changes while in beta.</strong>
         Read more at <a href="{{ config_file_link }}">our documentation</a> to find out its limitations and potential issues.
         {% endblocktrans %}


### PR DESCRIPTION


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9662.org.readthedocs.build/en/9662/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9662.org.readthedocs.build/en/9662/

<!-- readthedocs-preview dev end -->