### PR TITLE
Domains: add expired queryset

### DIFF
--- a/readthedocs/domains/querysets.py
+++ b/readthedocs/domains/querysets.py
@@ -11,6 +11,9 @@ from readthedocs.projects.querysets import RelatedProjectQuerySet
 
 
 class DomainQueryset(RelatedProjectQuerySet):
+
+    """Domain querysets."""
+
     def pending(self, include_recently_expired=False):
         max_date = timezone.now() - timedelta(
             days=settings.RTD_CUSTOM_DOMAINS_VALIDATION_PERIOD

--- a/readthedocs/domains/querysets.py
+++ b/readthedocs/domains/querysets.py
@@ -1,5 +1,7 @@
 """Querysets for domain related models."""
 
+from datetime import timedelta
+
 from django.conf import settings
 from django.db.models import Q
 from django.utils import timezone
@@ -10,7 +12,7 @@ from readthedocs.projects.querysets import RelatedProjectQuerySet
 
 class DomainQueryset(RelatedProjectQuerySet):
     def pending(self, include_recently_expired=False):
-        max_date = timezone.now() - timezone.timedelta(
+        max_date = timezone.now() - timedelta(
             days=settings.RTD_CUSTOM_DOMAINS_VALIDATION_PERIOD
         )
         queryset = self.exclude(
@@ -19,6 +21,27 @@ class DomainQueryset(RelatedProjectQuerySet):
         if include_recently_expired:
             return queryset.filter(validation_process_start__date__gte=max_date)
         return queryset.filter(validation_process_start__date__gt=max_date)
+
+    def expired(self, when=None):
+        """
+        Return domains that have their validation process expired.
+
+        :param when: If given, return domains that expired on this date only.
+        """
+        queryset = self.exclude(
+            Q(ssl_status=SSL_STATUS_VALID) | Q(skip_validation=True)
+        )
+        if when:
+            start_date = when - timedelta(
+                days=settings.RTD_CUSTOM_DOMAINS_VALIDATION_PERIOD
+            )
+            queryset = queryset.filter(validation_process_start__date=start_date)
+        else:
+            max_date = timezone.now() - timedelta(
+                days=settings.RTD_CUSTOM_DOMAINS_VALIDATION_PERIOD
+            )
+            queryset = queryset.filter(validation_process_start__date__lte=max_date)
+        return queryset
 
     def valid(self):
         return self.filter(ssl_status=SSL_STATUS_VALID)

--- a/readthedocs/domains/tests/test_querysets.py
+++ b/readthedocs/domains/tests/test_querysets.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase
@@ -33,7 +35,7 @@ class TestQuerysets(TestCase):
         self.domain_recently_expired = get(
             Domain, project=self.project, ssl_status=SSL_STATUS_PENDING
         )
-        self.domain_recently_expired.validation_process_start -= timezone.timedelta(
+        self.domain_recently_expired.validation_process_start -= timedelta(
             days=settings.RTD_CUSTOM_DOMAINS_VALIDATION_PERIOD
         )
         self.domain_recently_expired.save()
@@ -41,7 +43,7 @@ class TestQuerysets(TestCase):
         self.domain_expired = get(
             Domain, project=self.project, ssl_status=SSL_STATUS_PENDING
         )
-        self.domain_expired.validation_process_start -= timezone.timedelta(
+        self.domain_expired.validation_process_start -= timedelta(
             days=settings.RTD_CUSTOM_DOMAINS_VALIDATION_PERIOD + 10
         )
         self.domain_expired.save()
@@ -59,3 +61,16 @@ class TestQuerysets(TestCase):
     def test_valid(self):
         domains = set(Domain.objects.valid().all())
         self.assertEqual(domains, {self.domain})
+
+    def test_expired(self):
+        # All expired domains.
+        domains = set(Domain.objects.expired())
+        self.assertEqual(domains, {self.domain_expired, self.domain_recently_expired})
+
+        # Domains that expired today.
+        domains = set(Domain.objects.expired(when=timezone.now()))
+        self.assertEqual(domains, {self.domain_recently_expired})
+
+        # Domains that expired 10 days ago.
+        domains = set(Domain.objects.expired(when=timezone.now() - timedelta(days=10)))
+        self.assertEqual(domains, {self.domain_expired})


### PR DESCRIPTION
This is going to be used in rtd-ext
to remove expired domains from CF.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9667.org.readthedocs.build/en/9667/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9667.org.readthedocs.build/en/9667/

<!-- readthedocs-preview dev end -->