### PR TITLE
Subscriptions: don't remove stripe id on canceled subscriptions

### DIFF
--- a/readthedocs/subscriptions/managers.py
+++ b/readthedocs/subscriptions/managers.py
@@ -102,12 +102,7 @@ class SubscriptionManager(models.Manager):
         else:
             log.error("Plan not found, skipping plan update.")
 
-        if stripe_subscription.status == 'canceled':
-            # Remove ``stripe_id`` when canceled so the customer can
-            # re-subscribe using our form.
-            rtd_subscription.stripe_id = None
-
-        elif stripe_subscription.status == 'active' and end_date:
+        if stripe_subscription.status == "active" and end_date:
             # Save latest active date (end_date) to notify owners about their subscription
             # is ending and disable this organization after N days of unpaid. We check for
             # ``active`` here because Stripe will continue sending updates for the

--- a/readthedocs/subscriptions/tests/test_event_handlers.py
+++ b/readthedocs/subscriptions/tests/test_event_handlers.py
@@ -127,7 +127,7 @@ class TestStripeEventHandlers(TestCase):
         event_handlers.update_subscription(event=event)
 
         subscription.refresh_from_db()
-        self.assertIsNone(subscription.stripe_id)
+        self.assertEqual(subscription.stripe_id, stripe_subscription.id)
         self.assertEqual(subscription.status, SubscriptionStatus.canceled)
 
     def test_subscription_checkout_completed_event(self):


### PR DESCRIPTION
Setting the ID to none, may break our subscription update code, since we won't have that ID in our DB anymore.

https://github.com/readthedocs/readthedocs.org/blob/a615beba5028702646672a7b0a62d46507c22545/readthedocs/subscriptions/event_handlers.py#L79-L86

This was being used as a way to identify when to allow users to buy a subscription, but now we are just checking if the status is "canceled".

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9693.org.readthedocs.build/en/9693/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9693.org.readthedocs.build/en/9693/

<!-- readthedocs-preview dev end -->