### PR TITLE
Static files: don't 500 on invalid paths

### DIFF
--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -1159,6 +1159,23 @@ class TestAdditionalDocViews(BaseDocServing):
             resp.headers["Cache-Tag"], "project,project:rtd-staticfiles,rtd-staticfiles"
         )
 
+    @override_settings(
+        RTD_STATICFILES_STORAGE="readthedocs.rtd_tests.storage.BuildMediaFileSystemStorageTest"
+    )
+    @mock.patch("readthedocs.proxito.views.serve.staticfiles_storage")
+    def test_serve_invalid_static_file(self, staticfiles_storage):
+        staticfiles_storage.url.side_effect = Exception
+        paths = ["../", "foo/../bar"]
+        for path in paths:
+            resp = self.client.get(
+                reverse(
+                    "proxito_static_files",
+                    args=[path],
+                ),
+                HTTP_HOST="project.readthedocs.io",
+            )
+            self.assertEqual(resp.status_code, 404)
+
 
 @override_settings(
     ALLOW_PRIVATE_REPOS=True,

--- a/readthedocs/proxito/urls.py
+++ b/readthedocs/proxito/urls.py
@@ -34,8 +34,7 @@ pip.rtd.io/_/api/*
 """
 
 from django.conf import settings
-from django.conf.urls import re_path
-from django.urls import include
+from django.urls import include, path, re_path
 from django.views import defaults
 
 from readthedocs.constants import pattern_opts
@@ -110,12 +109,8 @@ proxied_urls = [
     ),
     # Serve static files
     # /_/static/file.js
-    re_path(
-        r"^{DOC_PATH_PREFIX}static/"
-        r"(?P<filename>{filename_slug})$".format(
-            DOC_PATH_PREFIX=DOC_PATH_PREFIX,
-            **pattern_opts,
-        ),
+    path(
+        f"{DOC_PATH_PREFIX}static/<path:filename>",
         ServeStaticFiles.as_view(),
         name="proxito_static_files",
     ),

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -681,7 +681,16 @@ class ServeStaticFiles(CDNCacheControlMixin, CDNCacheTagsMixin, ServeDocsMixin, 
         # This is needed for the _get_project
         # method for the CDNCacheTagsMixin class.
         self.project = project
-        storage_url = staticfiles_storage.url(filename)
+
+        # We are catching a broader exception,
+        # since depending on the storage backend,
+        # an invalid path may raise a different exception.
+        try:
+            storage_url = staticfiles_storage.url(filename)
+        except Exception as e:
+            log.info("Invalid filename.", filename=filename, exc_info=e)
+            raise Http404
+
         path = urlparse(storage_url)._replace(scheme="", netloc="").geturl()
         return self._serve_static_file(request, path)
 


### PR DESCRIPTION
Currently any invalid path will raise a `ParamValidationError` error (this is an error from boto3).

And currently we also accept empty paths

https://github.com/readthedocs/readthedocs.org/blob/a615beba5028702646672a7b0a62d46507c22545/readthedocs/constants.py#L13

Instead of using a re_path, use just a path with a `path` route pattern.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9694.org.readthedocs.build/en/9694/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9694.org.readthedocs.build/en/9694/

<!-- readthedocs-preview dev end -->