### PR TITLE
Telemetry: not collect Sphinx data if there is no `conf.py`

### DIFF
--- a/readthedocs/telemetry/collectors.py
+++ b/readthedocs/telemetry/collectors.py
@@ -112,6 +112,10 @@ class BuildDataCollector:
         if self._get_doctool_name() != "sphinx":
             return data
 
+        # The project does not define a `conf.py` or does not have one
+        if not self.config.sphinx.configuration:
+            return data
+
         conf_py_dir = os.path.join(
             self.checkout_path,
             os.path.dirname(self.config.sphinx.configuration),


### PR DESCRIPTION
Avoid failing the collection of data if the project does not define a `conf.py` or doesn't even have one.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9695.org.readthedocs.build/en/9695/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9695.org.readthedocs.build/en/9695/

<!-- readthedocs-preview dev end -->