### PR TITLE
GHA: only run the preview links action on `docs/` path

### DIFF
--- a/.github/workflows/pr-preview-links.yaml
+++ b/.github/workflows/pr-preview-links.yaml
@@ -3,6 +3,8 @@ on:
   pull_request_target:
     types:
       - opened
+    paths:
+      - "docs/**"
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
Instead of adding a preview link for every single PR opened, the action will only be called if there is a modification in the `docs/` direction. This is only to avoid the a little the noise when there is no documentation changes.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9696.org.readthedocs.build/en/9696/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9696.org.readthedocs.build/en/9696/

<!-- readthedocs-preview dev end -->