### PR TITLE
Unresolver: support external versions for single version projects

### DIFF
--- a/readthedocs/core/unresolver.py
+++ b/readthedocs/core/unresolver.py
@@ -263,7 +263,7 @@ class Unresolver:
          this is used to call this function recursively when
          resolving the path from a subproject (we don't support subprojects of subprojects).
         :param external_version_slug: Slug of the external version.
-         Used as the default version for single version projects
+         Used instead of the default version for single version projects
          being served under an external domain.
 
         :returns: A tuple with: project, version, and file name.

--- a/readthedocs/rtd_tests/tests/test_unresolver.py
+++ b/readthedocs/rtd_tests/tests/test_unresolver.py
@@ -205,6 +205,40 @@ class UnResolverTests(ResolverBase):
         self.assertEqual(parts.version, version)
         self.assertEqual(parts.filename, "/index.html")
 
+    def test_external_version_single_version_project(self):
+        self.pip.single_version = True
+        self.pip.save()
+        version = get(
+            Version,
+            project=self.pip,
+            type=EXTERNAL,
+            slug="10",
+            active=True,
+        )
+        parts = unresolve("https://pip--10.dev.readthedocs.build/")
+        self.assertEqual(parts.parent_project, self.pip)
+        self.assertEqual(parts.project, self.pip)
+        self.assertEqual(parts.version, version)
+        self.assertEqual(parts.filename, "/index.html")
+
+    def test_unexisting_external_version_single_version_project(self):
+        self.pip.single_version = True
+        self.pip.save()
+        parts = unresolve("https://pip--10.dev.readthedocs.build/")
+        self.assertEqual(parts.parent_project, self.pip)
+        self.assertEqual(parts.project, self.pip)
+        self.assertEqual(parts.version, None)
+        self.assertEqual(parts.filename, None)
+
+    def test_non_external_version_single_version_project(self):
+        self.pip.single_version = True
+        self.pip.save()
+        parts = unresolve("https://pip--latest.dev.readthedocs.build/")
+        self.assertEqual(parts.parent_project, self.pip)
+        self.assertEqual(parts.project, self.pip)
+        self.assertEqual(parts.version, None)
+        self.assertEqual(parts.filename, None)
+
     def test_unresolve_external_version_no_existing_version(self):
         parts = unresolve("https://pip--10.dev.readthedocs.build/en/10/")
         self.assertEqual(parts.parent_project, self.pip)


### PR DESCRIPTION
I'm passing the external version slug to the _unresolve_path method, so we can query the version from inside that function.

Also changed the prefetch_related calls to select_related, since that's what we want (prefetch_related will do a separate query instead of just one).