### PR TITLE
Docs: add an example for custom domain input

### DIFF
--- a/docs/user/custom-domains.rst
+++ b/docs/user/custom-domains.rst
@@ -21,7 +21,7 @@ To setup your custom domain, follow these steps:
 
 #. Go the :guilabel:`Admin` tab of your project.
 #. Click on :guilabel:`Domains`.
-#. Enter your domain.
+#. Enter the domain where you want to serve the documentation from (e.g. ``docs.example.com``).
 #. Mark the :guilabel:`Canonical` option if you want use this domain
    as your :doc:`canonical domain </canonical-urls>`.
 #. Click on :guilabel:`Add`.


### PR DESCRIPTION
Closes #9729

cc @tudortimi

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9733.org.readthedocs.build/en/9733/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9733.org.readthedocs.build/en/9733/

<!-- readthedocs-preview dev end -->