### PR TITLE
Docs: cancel PR builds if there is no documentation changes

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -25,7 +25,7 @@ build:
       # If there are no changes (exit 0) we force the command to return with 183.
       # This is a special exit code on Read the Docs that will cancel the build immediately.
       - |
-        if [ $READTHEDOCS_VERSION_TYPE = "external" ];
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ];
         then
           ! git diff --quiet origin/main -- docs/ && exit 183;
         fi

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,6 +14,21 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
+  jobs:
+    post_checkout:
+      # https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition
+      #
+      # Cancel building pull requests when there aren't changed in the docs directory.
+      # `--quiet` exits with a 1 when there **are** changes,
+      # so we invert the logic with a !
+      #
+      # If there are no changes (exit 0) we force the command to return with 183.
+      # This is a special exit code on Read the Docs that will cancel the build immediately.
+      - |
+        if [ $READTHEDOCS_VERSION_TYPE = "external" ];
+        then
+          ! git diff --quiet origin/main -- docs/ && exit 183;
+        fi
 
 search:
   ranking:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,15 +19,14 @@ build:
       # https://docs.readthedocs.io/en/stable/build-customization.html#cancel-build-based-on-a-condition
       #
       # Cancel building pull requests when there aren't changed in the docs directory.
-      # `--quiet` exits with a 1 when there **are** changes,
-      # so we invert the logic with a !
       #
-      # If there are no changes (exit 0) we force the command to return with 183.
+      # If there are no changes (git diff exits with 0) we force the command to return with 183.
       # This is a special exit code on Read the Docs that will cancel the build immediately.
       - |
-        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ];
+        git diff --quiet origin/main -- docs/
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" && $? -eq 0 ];
         then
-          ! git diff --quiet origin/main -- docs/ && exit 183;
+          exit 183;
         fi
 
 search:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,8 +23,7 @@ build:
       # If there are no changes (git diff exits with 0) we force the command to return with 183.
       # This is a special exit code on Read the Docs that will cancel the build immediately.
       - |
-        git diff --quiet origin/main -- docs/
-        if [ "$READTHEDOCS_VERSION_TYPE" = "external" && $? -eq 0 ];
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- docs/;
         then
           exit 183;
         fi

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -25,6 +25,7 @@ build:
       - |
         if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- docs/;
         then
+          echo "No changes to docs/ - exiting the build.";
           exit 183;
         fi
 

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -146,7 +146,7 @@ Here is an example that cancels builds from pull requests when there are no chan
          # If there are no changes (exit 0) we force the command to return with 183.
          # This is a special exit code on Read the Docs that will cancel the build immediately.
          - |
-           if [ $READTHEDOCS_VERSION_TYPE = "external" ];
+           if [ "$READTHEDOCS_VERSION_TYPE" = "external" ];
            then
              ! git diff --quiet origin/main -- docs/ && exit 183;
            fi

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -140,15 +140,14 @@ Here is an example that cancels builds from pull requests when there are no chan
      jobs:
        post_checkout:
          # Cancel building pull requests when there aren't changed in the docs directory.
-         # `--quiet` exits with a 1 when there **are** changes,
-         # so we invert the logic with a !
          #
-         # If there are no changes (exit 0) we force the command to return with 183.
+         # If there are no changes (git diff exits with 0) we force the command to return with 183.
          # This is a special exit code on Read the Docs that will cancel the build immediately.
          - |
-           if [ "$READTHEDOCS_VERSION_TYPE" = "external" ];
+           git diff --quiet origin/main -- docs/
+           if [ "$READTHEDOCS_VERSION_TYPE" = "external" && $? -eq 0 ];
            then
-             ! git diff --quiet origin/main -- docs/ && exit 183;
+             exit 183;
            fi
 
 

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -144,8 +144,7 @@ Here is an example that cancels builds from pull requests when there are no chan
          # If there are no changes (git diff exits with 0) we force the command to return with 183.
          # This is a special exit code on Read the Docs that will cancel the build immediately.
          - |
-           git diff --quiet origin/main -- docs/
-           if [ "$READTHEDOCS_VERSION_TYPE" = "external" && $? -eq 0 ];
+           if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/main -- docs/;
            then
              exit 183;
            fi


### PR DESCRIPTION
Use the new feature to cancel builds if there are not documentation changes