### PR TITLE
Telemetry: include all the PyPI packages

### DIFF
--- a/readthedocs/telemetry/collectors.py
+++ b/readthedocs/telemetry/collectors.py
@@ -263,7 +263,6 @@ class BuildDataCollector:
             "--local",
             "--format",
             "json",
-            "--not-required",
         ]
         code, stdout, _ = self.run(*cmd)
         if code == 0 and stdout:


### PR DESCRIPTION
I made a mistake in
https://github.com/readthedocs/readthedocs.org/commit/383e7b5036195fcc07568328b2a7d89c32a6d940#diff-fa7bf6eca268be44eaac66b32c9aacdb2b99bbe50f2aebfbdfda8f7927203d39L156 because I inverted the logic and start using `--not-required` allways, when it should not be used at all 🤦

This commit fixes that issue.

A `test-builds` **without using** `--not-required` shows all the packages

```
(Pdb++) self.run(*['python', '-m', 'pip', 'list', '--pre', '--local', '--format', 'json'])
(0, '[{"name": "alabaster", "version": "0.7.12"}, {"name": "Babel", "version":
"2.11.0"}, {"name": "certifi", "version": "2022.9.24"}, {"name":
"charset-normalizer", "version": "2.1.1"}, {"name": "commonmark", "version":
"0.9.1"}, {"name": "docutils", "version": "0.17.1"}, {"name": "idna", "version":
"3.4"}, {"name": "imagesize", "version": "1.4.1"}, {"name": "Jinja2", "version":
"3.0.3"}, {"name": "MarkupSafe", "version": "2.1.1"}, {"name": "mock",
"version": "1.0.1"}, {"name": "packaging", "version": "21.3"}, {"name":
"Pillow", "version": "9.3.0"}, {"name": "pip", "version": "22.3.1"}, {"name":
"Pygments", "version": "2.13.0"}, {"name": "pyparsing", "version": "3.0.9"},
{"name": "pytz", "version": "2022.6"}, {"name": "readthedocs-sphinx-ext",
"version": "2.2.0"}, {"name": "recommonmark", "version": "0.5.0"}, {"name":
"requests", "version": "2.28.1"}, {"name": "setuptools", "version": "58.2.0"},
{"name": "six", "version": "1.16.0"}, {"name": "snowballstemmer", "version":
"2.2.0"}, {"name": "Sphinx", "version": "1.8.6"}, {"name": "sphinx-autorun",
"version": "1.1.1"}, {"name": "sphinx-rtd-theme", "version": "0.4.3"}, {"name":
"sphinxcontrib-serializinghtml", "version": "1.1.5"}, {"name":
"sphinxcontrib-websupport", "version": "1.2.4"}, {"name": "urllib3", "version":
"1.26.12"}, {"name": "wheel", "version": "0.38.4"}]\n', '')
```

The same build **using** `--not-required` shows just a few packages (exactly the ones that we are currently seeing in production right now)

```
(Pdb++) self.run(*['python', '-m', 'pip', 'list', '--pre', '--local', '--format', 'json', '--not-required'])
(0, '[{"name": "mock", "version": "1.0.1"}, {"name": "Pillow", "version":
"9.3.0"}, {"name": "pip", "version": "22.3.1"}, {"name":
"readthedocs-sphinx-ext", "version": "2.2.0"}, {"name": "recommonmark",
"version": "0.5.0"}, {"name": "sphinx-autorun", "version": "1.1.1"}, {"name":
"sphinx-rtd-theme", "version": "0.4.3"}, {"name": "wheel", "version":
"0.38.4"}]\n', '')
(Pdb++)
```

Closes https://github.com/readthedocs/meta/issues/75