### PR TITLE
Docs: update instructions to install deps with Poetry

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -310,7 +310,7 @@ Install dependencies with Poetry
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Projects managed with `Poetry <https://python-poetry.org/>`__,
-can use the ``post_create_environment`` user-defined job to use Poetry for installing Python dependencies.
+can use the ``post_create_environment`` user-defined job to install Poetry and ``post_install`` to install Python dependencies.
 Take a look at the following example:
 
 
@@ -326,24 +326,16 @@ Take a look at the following example:
      jobs:
        post_create_environment:
          # Install poetry
-         # https://python-poetry.org/docs/#installing-with-the-official-installer
-         - curl -sSL https://install.python-poetry.org | python3 -
+         - pip install poetry
          # Tell poetry to not use a virtual environment
-         - $HOME/.local/bin/poetry config virtualenvs.create false
-       pre_install:
-         # Export project dependencies to requirements.txt
-         - $HOME/.local/bin/poetry export --with docs > docs/requirements.txt
+         - poetry config virtualenvs.create false
+       post_install:
+         # Install dependencies with 'docs' dependency group
+         # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
+         - poetry install --with docs
 
    sphinx:
      configuration: docs/conf.py
-   
-   python:
-     install:
-       # Install exported dependencies
-       - requirements: docs/requirements.txt
-       # Optional: install current package if imported from `docs/conf.py`
-       - method: pip
-         path: .
 
 
 Override the build process

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -310,7 +310,7 @@ Install dependencies with Poetry
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Projects managed with `Poetry <https://python-poetry.org/>`__,
-can use the ``post_create_environment`` user-defined job to install Poetry and ``post_install`` to install Python dependencies.
+can use the ``post_create_environment`` user-defined job to use Poetry for installing Python dependencies.
 Take a look at the following example:
 
 
@@ -326,10 +326,10 @@ Take a look at the following example:
      jobs:
        post_create_environment:
          # Install poetry
+         # https://python-poetry.org/docs/#installing-manually
          - pip install poetry
          # Tell poetry to not use a virtual environment
          - poetry config virtualenvs.create false
-       post_install:
          # Install dependencies with 'docs' dependency group
          # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
          - poetry install --with docs

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -326,12 +326,12 @@ Take a look at the following example:
      jobs:
        post_create_environment:
          # Install poetry
-         # https://python-poetry.org/docs/#osx--linux--bashonwindows-install-instructions
-         - curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+         # https://python-poetry.org/docs/#installing-with-the-official-installer
+         - curl -sSL https://install.python-poetry.org | python3 -
          # Tell poetry to not use a virtual environment
-         - $HOME/.poetry/bin/poetry config virtualenvs.create false
+         - $HOME/.local/bin/poetry config virtualenvs.create false
          # Install project's dependencies
-         - $HOME/.poetry/bin/poetry install
+         - $HOME/.local/bin/poetry install
 
    sphinx:
      configuration: docs/conf.py

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -330,11 +330,20 @@ Take a look at the following example:
          - curl -sSL https://install.python-poetry.org | python3 -
          # Tell poetry to not use a virtual environment
          - $HOME/.local/bin/poetry config virtualenvs.create false
-         # Install project's dependencies
-         - $HOME/.local/bin/poetry install
+       pre_install:
+         # Export project dependencies to requirements.txt
+         - $HOME/.local/bin/poetry export --with docs > docs/requirements.txt
 
    sphinx:
      configuration: docs/conf.py
+   
+   python:
+     install:
+       # Install exported dependencies
+       - requirements: docs/requirements.txt
+       # Optional: install current package if imported from `docs/conf.py`
+       - method: pip
+         path: .
 
 
 Override the build process


### PR DESCRIPTION
Updating instructions with the [latest from the offiical docs](https://python-poetry.org/docs/#installing-with-the-official-installer).

> The previous get-poetry.py and install-poetry.py installers are deprecated.

Fix #9740 

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9743.org.readthedocs.build/en/9743/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9743.org.readthedocs.build/en/9743/

<!-- readthedocs-preview dev end -->