### PR TITLE
Search: fix parsing of parameters inside sphinx domains

### DIFF
--- a/readthedocs/search/parsers.py
+++ b/readthedocs/search/parsers.py
@@ -545,11 +545,10 @@ class SphinxParser(GenericParser):
     def _parse_domain_tag(self, tag):
         """Returns the text from the description tag of the domain."""
 
-        # remove the 'dl', 'dt' and 'dd' tags from it
-        # because all the 'dd' and 'dt' tags are inside 'dl'
-        # and all 'dl' tags are already captured.
-        nodes_to_be_removed = tag.css('dl') + tag.css('dt') + tag.css('dd')
-        for node in nodes_to_be_removed:
+        # Remove all nested domains,
+        # since they are already parsed separately.
+        nested_domains = self._get_sphinx_domains(tag)
+        for node in nested_domains:
             if tag != node:
                 node.decompose()
 

--- a/readthedocs/search/tests/data/sphinx/out/page.json
+++ b/readthedocs/search/tests/data/sphinx/out/page.json
@@ -40,6 +40,6 @@
   ],
   "domain_data": {
     "test_py_module.test.Foo": "Docstring for class Foo. This text tests for the formatting of docstrings generated from output sphinx.ext.autodoc.",
-    "test_py_module.test.Foo.__init__": "Start the Foo."
+    "test_py_module.test.Foo.__init__": "Start the Foo. Parameters: qux (string) – The first argument to initialize class. spam (bool) – Spam me yes or no…"
   }
 }


### PR DESCRIPTION
We were removing all dl lists that were inside a domain in order to remove nested domains, but in doing so we were removing parameters (they are inside a dl list!).

Instead, let's reuse the method to detect sphinx domains.

<img src="https://front.com/assets/img/favicons/favicon-32x32.png" height="16" width="16" alt="Front logo" /> [Front conversations](https://app.frontapp.com/open/top_7dlzb)