### PR TITLE
Admin: install `debug_toolbar`

### DIFF
--- a/readthedocs/core/finders.py
+++ b/readthedocs/core/finders.py
@@ -18,7 +18,7 @@ class DebugToolbarFinder(AppDirectoriesFinder):
     we avoid this issue when running the `admin` instance.
     """
 
-    def __init__(self, app_names=None, *args, **kwargs):
+    def __init__(self, *args, app_names=None, **kwargs):
         app_config = DebugToolbarConfig.create("debug_toolbar")
         self.apps = [app_config.name]
         self.storages = {

--- a/readthedocs/core/finders.py
+++ b/readthedocs/core/finders.py
@@ -19,7 +19,7 @@ class DebugToolbarFinder(AppDirectoriesFinder):
     """
 
     def __init__(self, app_names=None, *args, **kwargs):
-        app_config = DebugToolbarConfig.create('debug_toolbar')
+        app_config = DebugToolbarConfig.create("debug_toolbar")
         self.apps = [app_config.name]
         self.storages = {
             app_config.name: self.storage_class(

--- a/readthedocs/core/finders.py
+++ b/readthedocs/core/finders.py
@@ -1,0 +1,31 @@
+import os
+
+from debug_toolbar.apps import DebugToolbarConfig
+from django.contrib.staticfiles.finders import AppDirectoriesFinder
+
+
+class DebugToolbarFinder(AppDirectoriesFinder):
+
+    """
+    Finder to copy the static files for `debug_toolbar` even if it's not installed.
+
+    We want to do this because we run `collectstatic` from `web` instance
+    which does not have `debug_toolbar` installed.
+    Then, when running the `admin` instance from `web-extra` with `debug_toolbar` installed,
+    if fails because it does not find the static files.
+
+    By forcing collecting these static files even when `debug_toolbar` is not installed,
+    we avoid this issue when running the `admin` instance.
+    """
+
+    def __init__(self, app_names=None, *args, **kwargs):
+        app_config = DebugToolbarConfig.create('debug_toolbar')
+        self.apps = [app_config.name]
+        self.storages = {
+            app_config.name: self.storage_class(
+                os.path.join(
+                    app_config.path,
+                    self.source_dir,
+                )
+            )
+        }

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -250,13 +250,8 @@ class CommunityBaseSettings(Settings):
             apps.append('readthedocsext.spamfighting')
         if self.RTD_EXT_THEME_ENABLED:
             apps.append('readthedocsext.theme')
-
-        # We always have to install this application,
-        # even if we don't show the toolbar later.
-        # This is because `collectstatic` needs it to copy the static files.
-        # Otherwise, it fails due
-        # "Missing staticfiles manifest entry for 'debug_toolbar/*'"
-        apps.append('debug_toolbar')
+        if self.SHOW_DEBUG_TOOLBAR:
+            apps.append('debug_toolbar')
 
         return apps
 
@@ -356,6 +351,7 @@ class CommunityBaseSettings(Settings):
     STATICFILES_FINDERS = [
         'readthedocs.core.static.SelectiveFileSystemFinder',
         'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+        'readthedocs.core.finders.DebugToolbarFinder',
     ]
     PYTHON_MEDIA = False
 

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -250,8 +250,13 @@ class CommunityBaseSettings(Settings):
             apps.append('readthedocsext.spamfighting')
         if self.RTD_EXT_THEME_ENABLED:
             apps.append('readthedocsext.theme')
-        if self.SHOW_DEBUG_TOOLBAR:
-            apps.append('debug_toolbar')
+
+        # We always have to install this application,
+        # even if we don't show the toolbar later.
+        # This is because `collectstatic` needs it to copy the static files.
+        # Otherwise, it fails due
+        # "Missing staticfiles manifest entry for 'debug_toolbar/*'"
+        apps.append('debug_toolbar')
 
         return apps
 


### PR DESCRIPTION
This application needs to be installed if we want to enable it later in the `web-extra` instance. Otherwise, it fails due the static files are not in the manifest.

By installing it by default, `collectstatic` will find this application and copy these static files and add them in the manifest.

Note this application will only be used if `SHOW_DEBUG_TOOLBAR=True`, which is `False` by default.