### PR TITLE
Docs: Adding a pattern for reusing "Only on Read the Docs for Business" admonition (Diátaxis refactor)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ master_doc = "index"
 copyright = "Read the Docs, Inc & contributors"
 version = "8.9.0"
 release = version
-exclude_patterns = ["_build", "user/shared"]
+exclude_patterns = ["_build", "shared"]
 default_role = "obj"
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.10/", None),
@@ -129,10 +129,6 @@ man_pages = [
         ["Eric Holscher, Charlie Leifer, Bobby Grace"],
         1,
     )
-]
-
-exclude_patterns = [
-    # 'api' # needed for ``make gettext`` to not die.
 ]
 
 language = "en"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,7 +71,7 @@ master_doc = "index"
 copyright = "Read the Docs, Inc & contributors"
 version = "8.9.0"
 release = version
-exclude_patterns = ["_build"]
+exclude_patterns = ["_build", "user/shared"]
 default_role = "obj"
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.10/", None),

--- a/docs/user/commercial/organizations.rst
+++ b/docs/user/commercial/organizations.rst
@@ -1,8 +1,7 @@
 Organizations
 -------------
 
-.. note::
-    This feature only exists on `Read the Docs for Business <https://readthedocs.com/>`_.
+.. include:: /shared/admonition-rtd-business.rst
 
 Organizations allow you to segment who has access to what projects in your company.
 Your company will be represented as an Organization,

--- a/docs/user/commercial/privacy-level.rst
+++ b/docs/user/commercial/privacy-level.rst
@@ -1,9 +1,7 @@
 Project Privacy Level
 ---------------------
 
-.. note::
-
-   This feature only exists on `Read the Docs for Business <https://readthedocs.com/>`__.
+.. include:: /shared/admonition-rtd-business.rst
 
 By default, only users that belong to your organization can see the dashboard of your project and its builds.
 If you want users outside your organization and anonymous users to be able to see the dashboard of your project,

--- a/docs/user/commercial/sharing.rst
+++ b/docs/user/commercial/sharing.rst
@@ -1,9 +1,7 @@
 Sharing
 =======
 
-.. note::
-
-   This feature only exists on `Read the Docs for Business <https://readthedocs.com/>`__.
+.. include:: /shared/admonition-rtd-business.rst
 
 You can share your project with users outside of your company:
 
@@ -34,7 +32,7 @@ Enabling Sharing
 * Give that information to the person who you want to give access.
 
 .. note::
-   
+
    You can always revoke access in the same panel.
 
 Users can log out by using the :ref:`Log Out <versions:Logging out>` link in the RTD flyout menu.
@@ -85,7 +83,7 @@ The header has the form ``Authorization: Token <ACCESS_TOKEN>``.
 For example:
 
 .. prompt:: bash $
-   
+
    curl -H "Authorization: Token 19okmz5k0i6yk17jp70jlnv91v" https://docs.example.com/en/latest/example.html
 
 Basic Authorization
@@ -95,5 +93,5 @@ You can also use basic authorization, with the token as user and an empty passwo
 For example:
 
 .. prompt:: bash $
-   
+
    curl --url https://docs.example.com/en/latest/example.html --user '19okmz5k0i6yk17jp70jlnv91v:'

--- a/docs/user/commercial/single-sign-on.rst
+++ b/docs/user/commercial/single-sign-on.rst
@@ -1,10 +1,7 @@
 Single Sign-On
 ==============
 
-.. note::
-
-   This feature only exists on `Read the Docs for Business <https://readthedocs.com/>`__.
-
+.. include:: /shared/admonition-rtd-business.rst
 
 Single sign-on is supported on |com_brand| for all users.
 :abbr:`SSO (single sign-on)` will allow you to grant permissions to your organization's projects in an easy way.
@@ -34,10 +31,10 @@ your organization's detail page > :guilabel:`Settings` > :guilabel:`Authorizatio
 and selecting :guilabel:`GitHub, GitLab or Bitbucket` as provider.
 
 Note the users created under Read the Docs must have their GitHub, Bitbucket or GitLab
-:doc:`account connected </connected-accounts>` in order to make SSO work. 
+:doc:`account connected </connected-accounts>` in order to make SSO work.
 You can read more about `granting permissions on GitHub`_.
 
-.. warning:: Once you enable this option, your existing Read the Docs teams will not be used. 
+.. warning:: Once you enable this option, your existing Read the Docs teams will not be used.
 
 .. _granting permissions on GitHub: https://docs.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization
 

--- a/docs/user/shared/admonition-rtd-business.rst
+++ b/docs/user/shared/admonition-rtd-business.rst
@@ -1,0 +1,2 @@
+.. note::
+    This feature only exists on `Read the Docs for Business <https://readthedocs.com/>`_.


### PR DESCRIPTION
In preparation for Diátaxis, we want an easy way to mix Explanation, How-tos and References so "Read the Docs for Business" features can be listed next to all other features, rather than a separate parallel structure.

The proposal here is quite simple:

* Use a DRY pattern for including the same admonition in all current RTD4B features
* We can always adjust the text later, once we see it in different contexts. I don't think we need to spend time on that now, as we cannot see how/where the admonition box will appear. But I could add an action item for Iteration 4.

Related: #9745 

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9754.org.readthedocs.build/en/9754/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9754.org.readthedocs.build/en/9754/

<!-- readthedocs-preview dev end -->