### PR TITLE
Docs: hosting integrations for `build.commands`

### DIFF
--- a/docs/user/guides/hosting-integrations.rst
+++ b/docs/user/guides/hosting-integrations.rst
@@ -1,6 +1,7 @@
 Hosting Integrations
 ====================
 
+
 .. This document is not ready to be presented to our users and tell them to integrate with us.
    It has been more useful as an internal exercise to understand how our integrations work,
    and be able to standardize and migrate them out from the build process to a JavaScript library.

--- a/docs/user/guides/hosting-integrations.rst
+++ b/docs/user/guides/hosting-integrations.rst
@@ -42,7 +42,6 @@ These are all the hosting features that Read the Docs provides by default:
    Read more in our blog post
    `Knowing more about how people use our service <https://blog.readthedocs.com/knowing-more-about-ourselves/>`_
 
-
 `Advertisement`_
    Ad shown on documentation pages that helps Read the Docs to be sustainable.
    Read more at :doc:`advertising`.
@@ -94,6 +93,119 @@ a ``div`` tag is required to define *where* the flyout menu will be displayed.
 This tag has to be added inside the ``<body>`` tag:
 
 .. code-block:: html
+   :linenos:
 
    <!-- Manually added to show the Read the Docs flyout -->
    <div id="readthedocs-embed-flyout"></div>
+
+
+Telemetry
+---------
+
+Read the Docs expects the file ``_build/json/telemetry.json`` once the build has finished.
+This file contains a list of doctool extensions/plugins installed to perform the build
+and also the HTML theme used.
+
+The data is organized in a JSON file as follows:
+
+.. code-block:: json
+   :linenos:
+
+   {
+     "extensions": [
+       "module.extension"
+     ],
+     "html_theme": "name"
+   }
+
+
+Advertisement
+-------------
+
+Advertisement makes Read the Docs sustainable and free for Open Source projects.
+Similarly to the flyout_, it requires including the same Javascript and stylesheet files
+(you can copy the code from the previous section),
+plus a ``div`` specifying *where* the Ad should be shown:
+.. NOTE: should we tell people to integrate it using the ``readthedocs-doc-embed.js`` file,
+   or should they use the EthicalAds client directly?
+
+.. code-block:: html
+   :linenos:
+
+   <!-- Manually added to show Ethical Ads -->
+   <div id="rtd-stickybox-container">
+     <div class="raised" data-ea-publisher="readthedocs" data-ea-type="image" data-ea-style="stickybox"></div>
+   </div>
+
+
+.. note::
+
+   Make sure to not include the Javascript and stylesheet twice when integrating the Flyout_ and Advertisement_.
+   That chunk of HTML code is exactly the same and shared between both.
+   They should be included only once in the page.
+
+
+External (pull request) version warning
+---------------------------------------
+
+On each build built from a pull requests,
+a warning banner is added to communicate readers this particular version of the documentation is not in production
+and it's still under review.
+
+Read the Docs adds the following HTML to create the warning admonition:
+.. NOTE: we should standardize this by providing the CSS as well and making it sticky (maybe at the top).
+   Now, it's injected at a particular place in the HTML structure --which won't be general for all the doctools.
+   Besides, we are inject it using a Sphinx extension that may differ what's the outputed HTML (based on docutils version).
+
+.. code-block:: html
+   :lienos:
+   :emphasize-lines: 5,7
+
+   <div class="admonition warning">
+     <p class="admonition-title">Warning</p>
+     <p>
+       This page
+       <a class="reference external" href="https://readthedocs.org/projects/<project-slug>/builds/<build-id>/">was created </a>
+       from a pull request
+       (<a class="reference external" href="https://github.com/<gh-username>/<gh-repository>/pull/pr-number">#PRNUMBER</a>).
+     </p>
+   </div>
+
+Note in the highlighted lines there are some placeholders for:
+
+* Read the Docs' project slug
+* Read the Docs' build id
+* GitHub username
+* GitHub pull request number
+
+These placeholders should be replaced by the real values.
+
+
+Version warning
+---------------
+
+Read the Docs adds a warning banner at the top of each documentation page
+when the reader visits an old page when there is a newer version of the same page available.
+.. NOTE: this has the same non-standardized issue as the "External version warning"
+
+
+.. code-block:: html
+   :lienos:
+   :emphasize-lines: 5,7
+
+   <div class="admonition warning">
+     <p class="admonition-title">Warning</p>
+     <p>
+       This page documents version
+       <a class="reference" href="https://<slug>.readthedocs.io/<lang>/<version>"><version></a>.
+       The latest version is
+       <a class="reference" href="https://<slug>.readthedocs.io/<lang>/<version>"><version></a>.
+     </p>
+   </div>
+
+Note in the highlighted lines there are some placeholders for:
+
+* Read the Docs' project slug
+* Read the Docs' language
+* Read the Docs' current version (old)
+* Read the Docs' new version

--- a/docs/user/guides/hosting-integrations.rst
+++ b/docs/user/guides/hosting-integrations.rst
@@ -85,7 +85,7 @@ These files have to be added inside the ``<head>`` tag:
    }
    </script>
 
-Note that you have to change lines 24-25 with your project and version slugs.
+Note that you have to change the highlighted lines with your project and version slugs.
 
 Besides including these files,
 a ``div`` tag is required to define *where* the flyout menu will be displayed.

--- a/docs/user/guides/hosting-integrations.rst
+++ b/docs/user/guides/hosting-integrations.rst
@@ -64,7 +64,7 @@ These files have to be added inside the ``<head>`` tag:
 
 .. code-block:: html
    :linenos:
-   :emphasize-lines: 24,25
+   :emphasize-lines: 22,23
 
    <script
      crossorigin="anonymous"

--- a/docs/user/guides/hosting-integrations.rst
+++ b/docs/user/guides/hosting-integrations.rst
@@ -1,11 +1,13 @@
 Hosting Integrations
 ====================
 
-Read the Docs performs some actions by default when building documentation for its users to.
-These actions integrate the documentation project with multiple hosting features Read the Docs offers.
-However, when using ``build.commands`` configuration (see :doc:`build-customization`),
-the build process is overriden completely and it's the user responsibility to integrate these features.
-This page explains how to manually integrate these features when Read the Docs cannot do it automatically.
+This page explains the manual steps required to integrate all the hosting features when overriding the build process by using ``build.commands`` configuration
+(see :doc:`build-customization`).
+As Read the Docs does not have control over the build process,
+it cannot install and inject the required extensions to automatically integrate them.
+You are encourage to read this document and understand the "behind the scenes" to integrate these features by yourself.
+This can be done by running user-defined commands in the build process or by creating a doctool extensions
+that execute these actions as part of the build itself.
 
 These are all the hosting features that Read the Docs provides by default:
 

--- a/docs/user/guides/hosting-integrations.rst
+++ b/docs/user/guides/hosting-integrations.rst
@@ -1,0 +1,104 @@
+Hosting Integrations
+====================
+
+Read the Docs performs some actions by default when building documentation for its users to.
+These actions integrate the documentation project with multiple hosting features Read the Docs offers.
+However, when using ``build.commands`` configuration (see :doc:`build-customization`),
+the build process is overriden completely and it's the user responsibility to integrate these features.
+This page explains how to manually integrate these features when Read the Docs cannot do it automatically.
+
+These are all the hosting features that Read the Docs provides by default:
+
+`Flyout menu`_
+
+   Menu displaying on all documentation pages containing the list of active versions,
+   downloadable formats and other useful links.
+   Read more at :doc:`flyout-menu`.
+
+`Search index`_
+
+   Smart search index powered by Elasticsearch able to differentiate between regular text,
+   function names in code, and search in all subprojects, among others.
+   Read more at :doc:`server-side-search`.
+
+`Search as you type`_
+
+   Level up your search by providing immediate feedback while the user is typing.
+   Read more at :doc:`advanced-search.html#enable-search-as-you-type-in-your-documentation`.
+
+`Version warning`_
+
+   Banner displayed on old versions when there is a newer version available,
+   communicating readers they may be careful since they are reading an older version of the documentation.
+   Read more at :doc:`versions#version-warning`.
+
+`External (pull request) version warning`_
+
+   Benner displayed on versions of the documentation built from an external version (pull request),
+   warning readers this is not the final version of this documentation.
+   Read more at :doc:`pull-requests`.
+
+`Telemetry`_
+
+   .. TODO: write a new page explaining this and link it from here.
+
+   Build data stored by Read the Docs (e.g. Python packages installed) for better understanding about
+   how users use the platform and keep it stable.
+   Read more in our blog post
+   `Knowing more about how people use our service <https://blog.readthedocs.com/knowing-more-about-ourselves/>`_
+
+`Advertisement`_
+
+   Ad shown on documentation pages that helps Read the Docs to be sustainable.
+   Read more at :doc:`advertising`.
+
+
+.. TODO: explain "Visual diff" when we have it available for our users.
+
+
+Flyout menu
+-----------
+
+Displying the flyout menu, requires adding some Javascript and CSS files in each of the documentation pages.
+These files have to be added inside the ``<head>`` tag:
+
+.. raw:: html
+   :linenos:
+   :highlight: 24-25
+
+   <script
+     crossorigin="anonymous"
+     integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4="
+     src="https://code.jquery.com/jquery-3.6.0.min.js">
+   </script>
+   <script
+     async="async"
+     src="/_/static/javascript/readthedocs-doc-embed.js">
+   </script>
+
+   <link
+     rel="stylesheet"
+     href="/_/static/css/readthedocs-doc-embed.css"
+     type="text/css" />
+   <link
+     rel="stylesheet"
+     type="text/css"
+     href="/_/static/css/badge_only.css" />
+
+   <script type="text/javascript">
+   READTHEDOCS_DATA = {
+     "project": "<your project slug>",
+     "version": "<the version of your project>",
+   }
+   </script>
+
+Note that you have to change lines 24-25 with your project and version slugs.
+
+Besides including these files,
+a ``div`` tag is required to define *where* the flyout menu will be displayed.
+This tag has to be added inside the ``<body>`` tag:
+
+.. raw:: html
+
+   <!-- Manually added to show the Read the Docs flyout -->
+   <div id="readthedocs-embed-flyout"></div>

--- a/docs/user/guides/hosting-integrations.rst
+++ b/docs/user/guides/hosting-integrations.rst
@@ -234,7 +234,7 @@ Besides, if the user defines a Google Analytics code, pageviews will also be sen
 
 .. code-block:: html
    :linenos:
-   :emphasize-lines: 4
+   :emphasize-lines: 3
 
    <script type="text/javascript">
    READTHEDOCS_DATA = {

--- a/docs/user/guides/hosting-integrations.rst
+++ b/docs/user/guides/hosting-integrations.rst
@@ -10,45 +10,38 @@ This page explains how to manually integrate these features when Read the Docs c
 These are all the hosting features that Read the Docs provides by default:
 
 `Flyout menu`_
-
    Menu displaying on all documentation pages containing the list of active versions,
    downloadable formats and other useful links.
    Read more at :doc:`flyout-menu`.
 
 `Search index`_
-
    Smart search index powered by Elasticsearch able to differentiate between regular text,
    function names in code, and search in all subprojects, among others.
    Read more at :doc:`server-side-search`.
 
 `Search as you type`_
-
    Level up your search by providing immediate feedback while the user is typing.
    Read more at :doc:`advanced-search.html#enable-search-as-you-type-in-your-documentation`.
 
 `Version warning`_
-
    Banner displayed on old versions when there is a newer version available,
    communicating readers they may be careful since they are reading an older version of the documentation.
    Read more at :doc:`versions#version-warning`.
 
 `External (pull request) version warning`_
-
    Benner displayed on versions of the documentation built from an external version (pull request),
    warning readers this is not the final version of this documentation.
    Read more at :doc:`pull-requests`.
 
+.. TODO: write a new page explaining this and link it from here.
 `Telemetry`_
-
-   .. TODO: write a new page explaining this and link it from here.
-
    Build data stored by Read the Docs (e.g. Python packages installed) for better understanding about
    how users use the platform and keep it stable.
    Read more in our blog post
    `Knowing more about how people use our service <https://blog.readthedocs.com/knowing-more-about-ourselves/>`_
 
-`Advertisement`_
 
+`Advertisement`_
    Ad shown on documentation pages that helps Read the Docs to be sustainable.
    Read more at :doc:`advertising`.
 

--- a/docs/user/guides/hosting-integrations.rst
+++ b/docs/user/guides/hosting-integrations.rst
@@ -126,6 +126,7 @@ Advertisement makes Read the Docs sustainable and free for Open Source projects.
 Similarly to the flyout_, it requires including the same Javascript and stylesheet files
 (you can copy the code from the previous section),
 plus a ``div`` specifying *where* the Ad should be shown:
+
 .. NOTE: should we tell people to integrate it using the ``readthedocs-doc-embed.js`` file,
    or should they use the EthicalAds client directly?
 
@@ -153,6 +154,7 @@ a warning banner is added to communicate readers this particular version of the 
 and it's still under review.
 
 Read the Docs adds the following HTML to create the warning admonition:
+
 .. NOTE: we should standardize this by providing the CSS as well and making it sticky (maybe at the top).
    Now, it's injected at a particular place in the HTML structure --which won't be general for all the doctools.
    Besides, we are inject it using a Sphinx extension that may differ what's the outputed HTML (based on docutils version).
@@ -186,6 +188,7 @@ Version warning
 
 Read the Docs adds a warning banner at the top of each documentation page
 when the reader visits an old page when there is a newer version of the same page available.
+
 .. NOTE: this has the same non-standardized issue as the "External version warning"
 
 

--- a/docs/user/guides/hosting-integrations.rst
+++ b/docs/user/guides/hosting-integrations.rst
@@ -1,6 +1,13 @@
 Hosting Integrations
 ====================
 
+.. This document is not ready to be presented to our users and tell them to integrate with us.
+   It has been more useful as an internal exercise to understand how our integrations work,
+   and be able to standardize and migrate them out from the build process to a JavaScript library.
+
+   Note there are already some integrations that happens statically at build time by using a Sphinx extension,
+   or application code, and there are others that happen dynamically via our current JavaScript library.
+
 This page explains the manual steps required to integrate all the hosting features when overriding the build process by using ``build.commands`` configuration
 (see :doc:`build-customization`).
 As Read the Docs does not have control over the build process,

--- a/docs/user/guides/hosting-integrations.rst
+++ b/docs/user/guides/hosting-integrations.rst
@@ -62,7 +62,7 @@ Flyout menu
 Displying the flyout menu, requires adding some Javascript and CSS files in each of the documentation pages.
 These files have to be added inside the ``<head>`` tag:
 
-.. raw:: html
+.. code-block:: html
    :linenos:
    :highlight: 24-25
 
@@ -98,7 +98,7 @@ Besides including these files,
 a ``div`` tag is required to define *where* the flyout menu will be displayed.
 This tag has to be added inside the ``<body>`` tag:
 
-.. raw:: html
+.. code-block:: html
 
    <!-- Manually added to show the Read the Docs flyout -->
    <div id="readthedocs-embed-flyout"></div>

--- a/docs/user/guides/hosting-integrations.rst
+++ b/docs/user/guides/hosting-integrations.rst
@@ -46,6 +46,10 @@ These are all the hosting features that Read the Docs provides by default:
    Ad shown on documentation pages that helps Read the Docs to be sustainable.
    Read more at :doc:`advertising`.
 
+`Google Analytics`_
+   Google Analytics integration to track pageviews on your documentation.
+   Read more at :doc:`analytics:Enabling Google Analytics on your Project`.
+
 
 .. TODO: explain "Visual diff" when we have it available for our users.
 
@@ -212,3 +216,26 @@ Note in the highlighted lines there are some placeholders for:
 * Read the Docs' language
 * Read the Docs' current version (old)
 * Read the Docs' new version
+
+
+Google Analytics
+----------------
+
+Read the Docs uses Google Analytics behind the scenes to track pageviews.
+Besides, if the user defines a Google Analytics code, pageviews will also be sent to it.
+
+.. code-block:: html
+   :lienos:
+   :emphasize-lines: 4
+
+   <script type="text/javascript">
+   READTHEDOCS_DATA = {
+     "user_analytics_code": "<your GA code>",
+   }
+   </script>
+
+.. The GA4 JavaScript required for this is inject dynamically at:
+   https://github.com/readthedocs/readthedocs.org/blob/cfecfb9b7da783aa856ffad82ea5cec474d2f31c/media/javascript/readthedocs-analytics.js#L9-L44
+
+   In that file, "global_analytics_code" and "user_analytics_code" is injected
+   via the readthedocs-sphinx-ext.

--- a/docs/user/guides/hosting-integrations.rst
+++ b/docs/user/guides/hosting-integrations.rst
@@ -59,12 +59,12 @@ These are all the hosting features that Read the Docs provides by default:
 Flyout menu
 -----------
 
-Displying the flyout menu, requires adding some Javascript and CSS files in each of the documentation pages.
+Displying the flyout menu requires adding some Javascript and CSS files in each of the documentation pages.
 These files have to be added inside the ``<head>`` tag:
 
 .. code-block:: html
    :linenos:
-   :highlight: 24-25
+   :emphasize-lines: 24,25
 
    <script
      crossorigin="anonymous"

--- a/docs/user/guides/hosting-integrations.rst
+++ b/docs/user/guides/hosting-integrations.rst
@@ -10,7 +10,7 @@ Hosting Integrations
    or application code, and there are others that happen dynamically via our current JavaScript library.
 
 This page explains the manual steps required to integrate all the hosting features when overriding the build process by using ``build.commands`` configuration
-(see :doc:`build-customization`).
+(see :doc:`/build-customization`).
 As Read the Docs does not have control over the build process,
 it cannot install and inject the required extensions to automatically integrate them.
 You are encourage to read this document and understand the "behind the scenes" to integrate these features by yourself.
@@ -22,26 +22,26 @@ These are all the hosting features that Read the Docs provides by default:
 `Flyout menu`_
    Menu displaying on all documentation pages containing the list of active versions,
    downloadable formats and other useful links.
-   Read more at :doc:`flyout-menu`.
+   Read more at :doc:`/flyout-menu`.
 
 `Search index`_
    Smart search index powered by Elasticsearch able to differentiate between regular text,
    function names in code, and search in all subprojects, among others.
-   Read more at :doc:`server-side-search`.
+   Read more at :doc:`/server-side-search`.
 
 `Search as you type`_
    Level up your search by providing immediate feedback while the user is typing.
-   Read more at :doc:`advanced-search.html#enable-search-as-you-type-in-your-documentation`.
+   Read more at :doc:`/advanced-search.html#enable-search-as-you-type-in-your-documentation`.
 
 `Version warning`_
    Banner displayed on old versions when there is a newer version available,
    communicating readers they may be careful since they are reading an older version of the documentation.
-   Read more at :doc:`versions#version-warning`.
+   Read more at :doc:`/versions#version-warning`.
 
 `External (pull request) version warning`_
    Benner displayed on versions of the documentation built from an external version (pull request),
    warning readers this is not the final version of this documentation.
-   Read more at :doc:`pull-requests`.
+   Read more at :doc:`/pull-requests`.
 
 .. TODO: write a new page explaining this and link it from here.
 `Telemetry`_
@@ -52,11 +52,11 @@ These are all the hosting features that Read the Docs provides by default:
 
 `Advertisement`_
    Ad shown on documentation pages that helps Read the Docs to be sustainable.
-   Read more at :doc:`advertising`.
+   Read more at :doc:`/advertising`.
 
 `Google Analytics`_
    Google Analytics integration to track pageviews on your documentation.
-   Read more at :doc:`analytics:Enabling Google Analytics on your Project`.
+   Read more at :doc:`/analytics:Enabling Google Analytics on your Project`.
 
 
 .. TODO: explain "Visual diff" when we have it available for our users.

--- a/docs/user/guides/hosting-integrations.rst
+++ b/docs/user/guides/hosting-integrations.rst
@@ -171,7 +171,7 @@ Read the Docs adds the following HTML to create the warning admonition:
    Besides, we are inject it using a Sphinx extension that may differ what's the outputed HTML (based on docutils version).
 
 .. code-block:: html
-   :lienos:
+   :linenos:
    :emphasize-lines: 5,7
 
    <div class="admonition warning">
@@ -204,7 +204,7 @@ when the reader visits an old page when there is a newer version of the same pag
 
 
 .. code-block:: html
-   :lienos:
+   :linenos:
    :emphasize-lines: 5,7
 
    <div class="admonition warning">
@@ -232,7 +232,7 @@ Read the Docs uses Google Analytics behind the scenes to track pageviews.
 Besides, if the user defines a Google Analytics code, pageviews will also be sent to it.
 
 .. code-block:: html
-   :lienos:
+   :linenos:
    :emphasize-lines: 4
 
    <script type="text/javascript">


### PR DESCRIPTION
Initial file to start documenting hosting integrations.

This is not ready to review or merge. I'm just pushing this changes to ask for an early quick review to know if this is the direction we want to follow with this document. 

Document at https://docs--9755.org.readthedocs.build/en/9755/guides/hosting-integrations.html

Related #9036
Related https://github.com/readthedocs/meta/issues/71
Related https://github.com/readthedocs/meta/discussions/35

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9755.org.readthedocs.build/en/9755/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9755.org.readthedocs.build/en/9755/

<!-- readthedocs-preview dev end -->