### PR TITLE
Docs: 4 diátaxis categories at the top of the navigation sidebar (Diátaxis iteration 0)

### DIFF
--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -56,13 +56,44 @@ to help you create fantastic documentation for your project.
 .. toctree::
    :maxdepth: 2
    :hidden:
-   :caption: First steps
+   :caption: Tutorials
 
    /tutorial/index
    /intro/getting-started-with-sphinx
    /intro/getting-started-with-mkdocs
    /intro/import-guide
    /choosing-a-site
+
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+   :glob:
+   :caption: Explanation
+
+   /build-notifications
+
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+   :caption: How-to Guides
+   :glob:
+
+   /guides/authors
+   /guides/administrators
+   /guides/developers
+   /science
+   /examples
+
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+   :caption: Reference
+   :glob:
+
+   api/index
 
 
 Read the Docs feature overview
@@ -114,7 +145,6 @@ and some of the core features of Read the Docs.
    /server-side-search
    /analytics
    /pull-requests
-   /build-notifications
    /security-log
 
    /connected-accounts
@@ -159,16 +189,6 @@ and how to write successful documentation.
   Setup Build Notifications <build-notifications> |
   :doc:`More guides for developers and designers </guides/developers>`
 
-.. toctree::
- :maxdepth: 2
- :hidden:
- :caption: How-to Guides
-
- /guides/authors
- /guides/administrators
- /guides/developers
- /science
- /examples
 
 Advanced features of Read the Docs
 ----------------------------------
@@ -218,7 +238,6 @@ out of your documentation and Read the Docs.
    canonical-urls
 
 
-   api/index
 
 Read the Docs for Business
 --------------------------


### PR DESCRIPTION
Notice that this PR targets `diataxis/main`

Refs #9745

I opted to having all 4 categories at the top. That makes it easy to observe the end-result as well as grasping how much work is left (i.e. all the sections that are still left in the old categories below).