### PR TITLE
Docker Compose v2 compatibility

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,4 @@
 COMPOSE_PROJECT_NAME=community
+# Current setup assumes Docker Compose v1. In v2, underscores are replaced by dashes in image and network
+# names, which breaks the assumption.
+COMPOSE_COMPATIBILITY=true

--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 COMPOSE_PROJECT_NAME=community
-# Current setup assumes Docker Compose v1. In v2, underscores are replaced by dashes in image and network
-# names, which breaks the assumption.
+# Current setup assumes Docker Compose v1.
+# In v2, underscores are replaced by dashes in image and network names,
+# which breaks the assumption.
 COMPOSE_COMPATIBILITY=true

--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -279,58 +279,6 @@ you have to follow these steps:
 Once this is done, you should be able to trigger a new build on that project and it should succeed.
 
 
-Network connection failures
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-After starting up your services with ``inv docker.up``, you might not be able to connect to the ``web`` instance on ``http://devthedocs.org:80``.
-Firstly, check all the outputs from Docker Compose to see that one of the instances hasn't crashed for a particular reason.
-If everything is up and running, it's likely related to a Docker network issue.
-
-In many cases, it can help to bring down any existing containers and docker networks.
-
-.. code-block:: console
-
-    # Give Docker Compose a chance to clean up what it can
-    inv docker.down
-    # After this step, you can try to start Docker Compose again
-    inv docker.up
-
-
-If it still doesn't work, we need to gather some more information to understand the issue.
-Have a look at how your networking traffic is routed:
-
-.. code-block:: console
-
-    # Run the command "route" to see how network traffic is routed.
-    route
-
-This should contain a network interface ``br-<docker-id>`` handling traffic for the subnet ``10.10.0.0``.
-If you have several networks handling traffic for that subnet, that's an issue you need to solve.
-This can happen because of Docker but you might also have other services occupying the subnet.
-
-It's a good idea to run ``docker network prune`` to remove Docker's unused network devices.
-If the problem persists, you may want to reboot or manually remove the network device,
-for instance with ``sudo ifconfig <device> down``.
-
-You may also want to have a look at how the containers are connected to the network:
-
-.. code-block:: console
-
-    docker network inspect community_readthedocs
-
-Finally, try attaching to the ``web`` instance and test connections via telnet:
-
-.. code-block:: console
-
-    # Connect to the web instance
-    inv docker.shell
-    # Once in the web instance, try to telnet the database instance
-    telnet database 5432
-
-Notice that the web instance automatically shuts down after some time if it cannot connect to the database.
-You will want to attach to it right after it has launched.
-
-
 Core team standards
 -------------------
 

--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -26,6 +26,17 @@ A development setup can be hosted by your laptop, in a VM, on a separate server 
 Set up your environment
 -----------------------
 
+.. warning::
+
+    The environment is developed and mainly tested on Docker Compose v1.x.
+    If you are running Docker Compose 2.x, please define the environment variable ``COMPOSE_COMPATIBILITY=true``
+    or make sure that the repository's ``.env`` file is loaded:
+
+    .. code-block:: console
+
+        source .env
+
+
 #. Clone the ``readthedocs.org`` repository:
 
    .. prompt:: bash

--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -4,8 +4,8 @@ Development Installation
 .. meta::
    :description lang=en: Install a local development instance of Read the Docs with our step by step guide.
 
-These are development setup and :ref:`standards <install:Core team standards>` that are followed to by the core development team. If you are a contributor to Read the Docs,
-it might a be a good idea to follow these guidelines as well.
+These are development setup and :ref:`standards <install:Core team standards>` that are followed to by the core development team.
+If you are a contributor to Read the Docs, it might a be a good idea to follow these guidelines as well.
 
 Requirements
 ------------
@@ -282,7 +282,9 @@ Once this is done, you should be able to trigger a new build on that project and
 Network connection failures
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-After starting up your services with ``inv docker.up``, you might not be able to connect to the ``web`` instance on ``http://devthedocs.org:80``. Firstly, check all the outputs from Docker Compose to see that one of the instances hasn't crashed for a particular reason. If everything is up and running, it's likely related to a Docker network issue.
+After starting up your services with ``inv docker.up``, you might not be able to connect to the ``web`` instance on ``http://devthedocs.org:80``.
+Firstly, check all the outputs from Docker Compose to see that one of the instances hasn't crashed for a particular reason.
+If everything is up and running, it's likely related to a Docker network issue.
 
 Firstly, ensure that ``devthedocs.org`` resolves to ``10.10.0.100``. If not, you can add it in your system's ``/etc/hosts``:
 
@@ -300,9 +302,13 @@ You should also have a look at your routing table:
     # Run the command "route" to see how network traffic is routed.
     route
 
-This should contain a network interface ``br-<docker-id>`` handling traffic for the subnet ``10.10.0.0``. If you have several networks handling traffic for that subnet, that's an issue you need to solve. This can happen because of Docker but you might also have other services occupying the subnet.
+This should contain a network interface ``br-<docker-id>`` handling traffic for the subnet ``10.10.0.0``.
+If you have several networks handling traffic for that subnet, that's an issue you need to solve.
+This can happen because of Docker but you might also have other services occupying the subnet.
 
-It's a good idea to run ``docker network prune`` to remove Docker's unused network devices. If the problem persists, you may want to reboot or manually remove the network device, for instance with ``sudo ifconfig <device> down``.
+It's a good idea to run ``docker network prune`` to remove Docker's unused network devices.
+If the problem persists, you may want to reboot or manually remove the network device,
+for instance with ``sudo ifconfig <device> down``.
 
 You may also want to have a look at how the containers are connected to the network:
 
@@ -319,7 +325,8 @@ Finally, try attaching to the ``web`` instance and test connections via telnet:
     # Once in the web instance, try to telnet the database instance
     telnet database 5432
 
-Notice that the web instance automatically shuts down after some time if it cannot connect to the database. You will want to attach to it right after it has launched.
+Notice that the web instance automatically shuts down after some time if it cannot connect to the database.
+You will want to attach to it right after it has launched.
 
 
 Core team standards

--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -227,7 +227,7 @@ Troubleshooting
 .. warning::
 
     The environment is developed and mainly tested on Docker Compose v1.x.
-    If you are running Docker Compose 2.x, the environment ``COMPOSE_COMPATIBILITY=true`` is needed.
+    If you are running Docker Compose 2.x, please make sure you have ``COMPOSE_COMPATIBILITY=true`` set.
     This is automatically loaded via the ``.env`` file.
     If you want to ensure that the file is loaded, run:
 

--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -286,16 +286,18 @@ After starting up your services with ``inv docker.up``, you might not be able to
 Firstly, check all the outputs from Docker Compose to see that one of the instances hasn't crashed for a particular reason.
 If everything is up and running, it's likely related to a Docker network issue.
 
-Firstly, ensure that ``devthedocs.org`` resolves to ``10.10.0.100``. If not, you can add it in your system's ``/etc/hosts``:
+In many cases, it can help to bring down any existing containers and docker networks.
 
 .. code-block:: console
 
-    # Opens a text editor.
-    # Add a line containing this:
-    #   10.10.0.100 devthedocs.org
-    sudo nano /etc/hosts
+    # Give Docker Compose a chance to clean up what it can
+    inv docker.down
+    # After this step, you can try to start Docker Compose again
+    inv docker.up
 
-You should also have a look at your routing table:
+
+If it still doesn't work, we need to gather some more information to understand the issue.
+Have a look at how your networking traffic is routed:
 
 .. code-block:: console
 


### PR DESCRIPTION
This PR adds an important line in our `.env`.

The issue with Docker Compose v2 is that they decided to use `-` as a separator instead if `_`. So for instance, images are then tagged as `community-server:latest` and not `community_server:latest` etc. `COMPOSE_COMPATIBILITY=true` fixes this.

~I wrote something in the documentation about this, and I also added a troubleshooting section on Docker networking based on fresh experience.~ Removed again due to push-back.

In the future, once everyone on the team is using Docker Compose v2, we could remove the option and replace underscores with dashes.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9759.org.readthedocs.build/en/9759/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9759.org.readthedocs.build/en/9759/

<!-- readthedocs-preview dev end -->