### PR TITLE
Docs: validate Mastodon link

### DIFF
--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -4,8 +4,8 @@ Read the Docs: Documentation Simplified
 .. meta::
    :description lang=en: Automate building, versioning, and hosting of your technical documentation continuously on Read the Docs.
 
+.. Adds a hidden link for the purpose of validating Read the Docs' Mastodon profile
 .. raw:: html
-
    <a style="display: none;" rel="me" href="https://fosstodon.org/@readthedocs">Mastodon</a>
 
 `Read the Docs`_ simplifies software documentation

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -4,6 +4,10 @@ Read the Docs: Documentation Simplified
 .. meta::
    :description lang=en: Automate building, versioning, and hosting of your technical documentation continuously on Read the Docs.
 
+.. raw:: html
+
+   <a style="display: none;" rel="me" href="https://fosstodon.org/@readthedocs">Mastodon</a>
+
 `Read the Docs`_ simplifies software documentation
 by building, versioning, and hosting of your docs, automatically.
 This enables many "docs like code" workflows,


### PR DESCRIPTION
Use a hidded `a` to validate the Mastodon profile.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9764.org.readthedocs.build/en/9764/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9764.org.readthedocs.build/en/9764/

<!-- readthedocs-preview dev end -->