### PR TITLE
Treat latest pre-release as stable when no other stable releases

### DIFF
--- a/readthedocs/projects/version_handling.py
+++ b/readthedocs/projects/version_handling.py
@@ -138,25 +138,34 @@ def determine_stable_version(version_list):
     :param version_list: list of versions
     :type version_list: list(readthedocs.builds.models.Version)
 
-    :returns: version considered the most recent stable one or ``None`` if there
-              is no stable version in the list
+    :returns: version considered the most recent stable one, the latest
+              pre-release if there is no stable version in the list or
+              ``None`` if there are no versions in the list
 
     :rtype: readthedocs.builds.models.Version
     """
     versions = sort_versions(version_list)
-    versions = [
-        (version_obj, comparable)
+
+    if not versions:
+        # No versions, so no info we can give
+        return None
+
+    stable_versions = [
+        version_obj
         for version_obj, comparable in versions
         if not comparable.is_prerelease
     ]
 
-    if versions:
+    if stable_versions:
         # We take preference for tags over branches. If we don't find any tag,
         # we just return the first branch found.
-        for version_obj, comparable in versions:
+        for version_obj in stable_versions:
             if version_obj.type == TAG:
                 return version_obj
 
-        version_obj, comparable = versions[0]
-        return version_obj
-    return None
+        return stable_versions[0]
+
+    # There are no stable versions, so we just treat the latest pre-release as
+    # the stable one.
+    version_obj, _ = versions[0]
+    return version_obj

--- a/readthedocs/projects/version_handling.py
+++ b/readthedocs/projects/version_handling.py
@@ -3,11 +3,7 @@ import unicodedata
 
 from packaging.version import InvalidVersion, Version
 
-from readthedocs.builds.constants import (
-    LATEST_VERBOSE_NAME,
-    STABLE_VERBOSE_NAME,
-    TAG,
-)
+from readthedocs.builds.constants import LATEST_VERBOSE_NAME, STABLE_VERBOSE_NAME, TAG
 from readthedocs.vcs_support.backends import backend_cls
 
 


### PR DESCRIPTION
## Quick summary

I recently started using readthedocs to host the documentation of one of my projects and found out that `stable` was pointing to an old stable tag, so I went ahead and deleted the really old stable tag to hopefully get it to detect my latest development release as the newest stable, but got no luck in it, `stable` got stuck in the commit that that old tag was tagged to.

This PR changes the behavior of this to fallback to the newest pre-release as the most "stable" one, which is more in-line to what other services provide (ie, PyPI).

~~*I was unable to get the test suite running locally, so there is a very high chance that this PR will not pass it. I read through the Developer Guide to no luck, so if it does fail, I will make sure to fix it right away :)*~~