### PR TITLE
Abandoned Projects policy: Relax reachability requirement

### DIFF
--- a/docs/user/abandoned-projects.rst
+++ b/docs/user/abandoned-projects.rst
@@ -41,8 +41,8 @@ Reachability
 
 The user of Read the Docs is solely responsible for being reachable by the core team
 for matters concerning projects that the user owns. In every case where
-contacting the user is necessary, the core team will try to do so at least
-three times, using the following means of contact:
+contacting the user is necessary, the core team will try to do so,
+using the following means of contact:
 
 * E-mail address on file in the user's profile
 * E-mail addresses found in the given project's documentation


### PR DESCRIPTION
There has been a lot of different suggestions up, but I think this one is the easiest to process for now.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9783.org.readthedocs.build/en/9783/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9783.org.readthedocs.build/en/9783/

<!-- readthedocs-preview dev end -->