### PR TITLE
Docs: Move "Choosing between our two platforms" to Explanation (Diátaxis)

### DIFF
--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -67,7 +67,6 @@ to help you create fantastic documentation for your project.
    /intro/getting-started-with-sphinx
    /intro/getting-started-with-mkdocs
    /intro/import-guide
-   /choosing-a-site
 
 
 .. toctree::
@@ -76,6 +75,7 @@ to help you create fantastic documentation for your project.
    :glob:
    :caption: Explanation
 
+   /choosing-a-site
    /build-notifications
    /downloadable-documentation
 


### PR DESCRIPTION
This is one of the easier refactors. I haven't seen any suggestions for a new title, and I think this is a good "Explanation" title.

Refs: #9746

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9784.org.readthedocs.build/en/9784/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9784.org.readthedocs.build/en/9784/

<!-- readthedocs-preview dev end -->