### PR TITLE
CI Builds: Conditional builds with path filtering

### DIFF
--- a/.circleci/config-conditional-builds.yml
+++ b/.circleci/config-conditional-builds.yml
@@ -16,7 +16,10 @@ jobs:
           ES_JAVA_OPTS: -Xms750m -Xmx750m
     steps:
       - when:
-          condition: build-code
+          condition:
+            or:
+              - build-code
+              - equal: [ main, << pipeline.git.branch >> ]
           steps:
             - checkout
             - run: git submodule sync
@@ -30,7 +33,10 @@ jobs:
       - image: 'cimg/python:3.10'
     steps:
       - when:
-          condition: build-code
+          condition:
+            or:
+              - build-code
+              - equal: [ main, << pipeline.git.branch >> ]
           steps:
             - checkout
             - run: git submodule sync

--- a/.circleci/config-conditional-builds.yml
+++ b/.circleci/config-conditional-builds.yml
@@ -1,0 +1,74 @@
+version: 2.1
+
+orbs:
+  codecov: codecov/codecov@3.2.2
+
+jobs:
+  tests:
+    docker:
+      - image: 'cimg/python:3.10'
+        environment:
+          TOX_POSARGS: ''
+      - image: 'docker.elastic.co/elasticsearch/elasticsearch:7.14.0'
+        name: search
+        environment:
+          discovery.type: single-node
+          ES_JAVA_OPTS: -Xms750m -Xmx750m
+    steps:
+      - when:
+          condition: build-code
+          steps:
+            - checkout
+            - run: git submodule sync
+            - run: git submodule update --init
+            - run: pip install --user 'tox<5'
+            - run: tox -e py310
+            - codecov/upload
+
+  tests-embedapi:
+    docker:
+      - image: 'cimg/python:3.10'
+    steps:
+      - when:
+          condition: build-code
+          steps:
+            - checkout
+            - run: git submodule sync
+            - run: git submodule update --init
+            - run: pip install --user 'tox<4'
+            - run: tox -c tox.embedapi.ini
+
+  checks:
+    docker:
+      - image: 'cimg/python:3.10'
+        environment:
+          NODE_VERSION: 10.17.0
+    # This could also be done more conditionally like the former tests
+    steps:
+      - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
+      - run: git fetch origin main  # needed for comparisson in pre-commit
+      - run: git branch -f --track main origin/main  # needed for comparisson in pre-commit
+      - run: pip install --user 'tox<5'
+      - run: tox -e migrations
+      - run: tox -e pre-commit
+      - run: tox -e lint
+      - run: scripts/circle/install_node.sh
+      - run:
+          name: Add node to the path
+          command: |
+            echo 'export PATH=~/.nvm/versions/node/v${NODE_VERSION}/bin:$PATH' >> $BASH_ENV
+            source $BASH_ENV
+      - run: tox -e eslint
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - checks
+      - tests
+      - tests-embedapi:
+          requires:
+            - checks
+            - tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,3 +17,6 @@ workflows:
             pytest.* build-code true
             tox.* build-code true
             package.* build-code true
+            \.circleci/* build-code true
+            common build-code true
+            setup.* build-code true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,67 +1,19 @@
 version: 2.1
 
+setup: true
+
 orbs:
-  codecov: codecov/codecov@3.2.2
-
-jobs:
-  tests:
-    docker:
-      - image: 'cimg/python:3.10'
-        environment:
-          TOX_POSARGS: ''
-      - image: 'docker.elastic.co/elasticsearch/elasticsearch:7.14.0'
-        name: search
-        environment:
-          discovery.type: single-node
-          ES_JAVA_OPTS: -Xms750m -Xmx750m
-    steps:
-      - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
-      - run: pip install --user 'tox<5'
-      - run: tox -e py310
-      - codecov/upload
-
-  tests-embedapi:
-    docker:
-      - image: 'cimg/python:3.10'
-    steps:
-      - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
-      - run: pip install --user 'tox<4'
-      - run: tox -c tox.embedapi.ini
-
-  checks:
-    docker:
-      - image: 'cimg/python:3.10'
-        environment:
-          NODE_VERSION: 10.17.0
-    steps:
-      - checkout
-      - run: git submodule sync
-      - run: git submodule update --init
-      - run: git fetch origin main  # needed for comparisson in pre-commit
-      - run: git branch -f --track main origin/main  # needed for comparisson in pre-commit
-      - run: pip install --user 'tox<5'
-      - run: tox -e pre-commit
-      - run: tox -e migrations
-      - run: tox -e lint
-      - run: scripts/circle/install_node.sh
-      - run:
-          name: Add node to the path
-          command: |
-            echo 'export PATH=~/.nvm/versions/node/v${NODE_VERSION}/bin:$PATH' >> $BASH_ENV
-            source $BASH_ENV
-      - run: tox -e eslint
+  path-filtering: circleci/path-filtering@0.1.3
 
 workflows:
-  version: 2
-  test:
+  generate-config:
     jobs:
-      - checks
-      - tests
-      - tests-embedapi:
-          requires:
-            - checks
-            - tests
+      - path-filtering/filter:
+          base-revision: main
+          config-path: .circleci/config-conditional-builds.yml
+          mapping: |
+            requirements/.* build-code true
+            readthedocs/.* build-code true
+            pytest.* build-code true
+            tox.* build-code true
+            package.* build-code true


### PR DESCRIPTION
Benefits of conditional builds:

1. Tests are over 45 minutes, so they are valuable to skip them when it's easy and risk-free.
1. Documentation PRs (we have a lot of them) will have a much quicker feedback time.
 
Because of the many current documentation PRs, the timing for "conditional builds" will be really good.

* [x] Step 1: Make path filtering work
* [ ] Step 2: Discuss and adjust the actual paths and filters!
* [ ] Step 3: Apply path filters (and other conditions that we might want)