### PR TITLE
Fix Circle CI builds: Tox 4 compatibility, add external commands to allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - checkout
       - run: git submodule sync
       - run: git submodule update --init
-      - run: pip install --user tox
+      - run: pip install --user 'tox<4'
       - run: tox -c tox.embedapi.ini
 
   checks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,8 @@ jobs:
       - checkout
       - run: git submodule sync
       - run: git submodule update --init
+      - run: git fetch origin main  # needed for comparisson in pre-commit
+      - run: git branch --track main origin/main  # needed for comparisson in pre-commit
       - run: pip install --user tox
       - run: scripts/circle/install_node.sh
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,17 +44,17 @@ jobs:
       - run: git fetch origin main  # needed for comparisson in pre-commit
       - run: git branch --track main origin/main  # needed for comparisson in pre-commit
       - run: pip install --user tox
+      - run: tox -e pre-commit
+      - run: tox -e migrations
+      - run: tox -e lint
+      - run: tox -e docs
+      - run: tox -e docs-dev
       - run: scripts/circle/install_node.sh
       - run:
           name: Add node to the path
           command: |
             echo 'export PATH=~/.nvm/versions/node/v${NODE_VERSION}/bin:$PATH' >> $BASH_ENV
             source $BASH_ENV
-      - run: tox -e migrations
-      - run: tox -e pre-commit
-      - run: tox -e lint
-      - run: tox -e docs
-      - run: tox -e docs-dev
       - run: tox -e eslint
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - checkout
       - run: git submodule sync
       - run: git submodule update --init
-      - run: pip install --user tox
+      - run: pip install --user 'tox<5'
       - run: tox -e py310
       - codecov/upload
 
@@ -43,7 +43,7 @@ jobs:
       - run: git submodule update --init
       - run: git fetch origin main  # needed for comparisson in pre-commit
       - run: git branch --track main origin/main  # needed for comparisson in pre-commit
-      - run: pip install --user tox
+      - run: pip install --user 'tox<5'
       - run: tox -e pre-commit
       - run: tox -e migrations
       - run: tox -e lint

--- a/tox.embedapi.ini
+++ b/tox.embedapi.ini
@@ -3,14 +3,16 @@
 #
 # NOTE: Sphinx 1.8 and 2.0 are not tested anymore because of some
 # incompatibilities with Python 3.10 and sphinxcontrib-bibtex
-envlist = sphinx-{21,22,23,24,30,31,32,33,34,42,43,44,45,50,latest,24-docutils-016,34-docutils-017}
+envlist = sphinx-{21,22,23,24,30,31,32,33,34,42,43,44,45,50,latest,24docutils016,34docutils017}
 
 [testenv]
 description = run test suite for the EmbedAPIv3
+allowlist_externals =
+    sh
 install_command =
     # Install requirements in multiple steps because we don't want to install
     # Sphinx from `requirements/pip.txt` but from the `deps=` field.
-    /bin/sh -c ' \
+    sh -c ' \
         cat {toxinidir}/requirements/pip.txt | grep -v "Sphinx" > {toxinidir}/requirements/embedapi.txt; \
         sed {toxinidir}/requirements/testing.txt -e "s|pip.txt|embedapi.txt|g" > {toxinidir}/requirements/testing.embedapi.txt; \
         pip install -r {toxinidir}/requirements/testing.embedapi.txt; \
@@ -33,8 +35,8 @@ deps =
     sphinx-latest: Sphinx
     # Keep at least one Sphinx version with docutils 0.16 and 0.17 since the
     # HTML generated changes a little between them
-    sphinx-24-docutils-016: Sphinx~=2.4.0 docutils==0.16
-    sphinx-34-docutils-017: Sphinx~=3.4.0 docutils==0.17
+    sphinx-24docutils016: Sphinx~=2.4.0 docutils==0.16
+    sphinx-34docutils017: Sphinx~=3.4.0 docutils==0.17
     sphinxcontrib-bibtex~=2.3.0
     jinja2<3.1.0
 setenv =

--- a/tox.embedapi.ini
+++ b/tox.embedapi.ini
@@ -4,7 +4,7 @@
 #
 # NOTE: Sphinx 1.8 and 2.0 are not tested anymore because of some
 # incompatibilities with Python 3.10 and sphinxcontrib-bibtex
-envlist = sphinx-{21,22,23,24,30,31,32,33,34,42,43,44,45,50,latest,24docutils016,34docutils017}
+envlist = sphinx-{21,22,23,24,30,31,32,33,34,42,43,44,45,50,latest,24-docutils-016,34-docutils-017}
 
 [testenv]
 description = run test suite for the EmbedAPIv3
@@ -36,8 +36,8 @@ deps =
     sphinx-latest: Sphinx
     # Keep at least one Sphinx version with docutils 0.16 and 0.17 since the
     # HTML generated changes a little between them
-    sphinx-24docutils016: Sphinx~=2.4.0 docutils==0.16
-    sphinx-34docutils017: Sphinx~=3.4.0 docutils==0.17
+    sphinx-24-docutils-016: Sphinx~=2.4.0 docutils==0.16
+    sphinx-34-docutils-017: Sphinx~=3.4.0 docutils==0.17
     sphinxcontrib-bibtex~=2.3.0
     jinja2<3.1.0
 setenv =

--- a/tox.embedapi.ini
+++ b/tox.embedapi.ini
@@ -1,4 +1,5 @@
 [tox]
+# NOTE: Currently tox 3 is required, breaks with tox 4, possibly basepython 3.10 needs to be defined
 # NOTE: Sphinx 3.5 and 4.x < 4.2 fails with Python 3.10 because of a typing issue
 #
 # NOTE: Sphinx 1.8 and 2.0 are not tested anymore because of some

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ commands =
 [testenv:migrations]
 description = check for missing migrations
 commands =
-    ./manage.py makemigrations --check --dry-run
+    python manage.py makemigrations --check --dry-run
 
 [testenv:lint]
 description = run linter (prospector) to ensure the source code corresponds to our coding standards

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ commands =
 [testenv:migrations]
 description = check for missing migrations
 commands =
-    python manage.py makemigrations --check --dry-run
+    {base_python} manage.py makemigrations --check --dry-run
 
 [testenv:lint]
 description = run linter (prospector) to ensure the source code corresponds to our coding standards

--- a/tox.ini
+++ b/tox.ini
@@ -18,13 +18,16 @@ deps =
 basepython =
     python3.10
 commands =
-    /bin/sh -c '\
+    sh -c '\
         export DJANGO_SETTINGS_MODULE=readthedocs.settings.test; \
         pytest --cov-report=xml --cov-config .coveragerc --cov=. --pyargs readthedocs --suppress-no-test-exit-code -m "not proxito and not embed_api" {posargs:{env:TOX_POSARGS:-m "not search and not proxito and not embed_api"}}'
 
-    /bin/sh -c '\
+    sh -c '\
         export DJANGO_SETTINGS_MODULE=readthedocs.settings.proxito.test; \
         pytest --cov-report=xml --cov-config .coveragerc --cov=. --cov-append --pyargs readthedocs -m proxito --suppress-no-test-exit-code {posargs}'
+allowlist_externals =
+    sh
+    git
 
 [testenv:docs]
 description = Build readthedocs user documentation

--- a/tox.ini
+++ b/tox.ini
@@ -78,7 +78,7 @@ commands =
     pre-commit run --from-ref main --to-ref HEAD
 
 [testenv:eslint]
-whitelist_externals = npm
+allowlist_externals = npm
 description = run the JavaScript linter (requires `npm install`)
 commands =
     npm run lint
@@ -86,7 +86,7 @@ commands =
 [testenv:coverage]
 description = shows the coverage report
 deps = coverage
-whitelist_externals = echo
+allowlist_externals = echo
 commands =
     coverage report --show-missing
     coverage html


### PR DESCRIPTION
Since we haven't pinned tox, we will have to make adjustments quite quickly when they introduce breaking changes.

See:

https://tox.wiki/en/latest/faq.html#breaking-changes-in-tox-4

Because it took a long time to get build outputs, I did a small optimization of the order of pipeline jobs so all the node-based stuff is pushed to the end.