### PR TITLE
CI builds: Checkout main branch in a robust way

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - run: git submodule sync
       - run: git submodule update --init
       - run: git fetch origin main  # needed for comparisson in pre-commit
-      - run: git branch --track main origin/main  # needed for comparisson in pre-commit
+      - run: git branch -f --track main origin/main  # needed for comparisson in pre-commit
       - run: pip install --user 'tox<5'
       - run: tox -e pre-commit
       - run: tox -e migrations


### PR DESCRIPTION
Adds an -f switch to force resetting the branch in cases where Circle CI had already fetched it.

I'm still not sure about the exact mechanisms of the built-in Circle CI `checkout` step. At first I introduced this in a PR where `main` wasn't found as a reference - and it worked, the branch was added and pre-commit could compare changes in the PR to `main`.

But then in a later PR after this change, I got errors when `main` already exists.

```
git branch --track main origin/main

fatal: a branch named 'main' already exists
```

https://app.circleci.com/pipelines/github/readthedocs/readthedocs.org/6345/workflows/892de4a3-b7de-4f65-80c2-d7f4643d81f3/jobs/15361

I think the `-f` switch should do the work:

```
       -f, --force
           Reset <branchname> to <startpoint>, even if <branchname> exists already. Without -f, git branch refuses to change an existing
           branch. In combination with -d (or --delete), allow deleting the branch irrespective of its merged status. In combination with
           -m (or --move), allow renaming the branch even if the new branch name already exists, the same applies for -c (or --copy).
```