### PR TITLE
Fix silent, then loud failure after Tox 4 upgrade

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ setenv =
     LANG=en_US.UTF-8
     LC_ALL=en_US.UTF-8
     DJANGO_SETTINGS_SKIP_LOCAL=True
-passenv = CI TRAVIS TRAVIS_* HOME
+passenv = CI,TRAVIS,TRAVIS_*,HOME
 deps =
   -r requirements/testing.txt
   debug: -r requirements/debug.txt


### PR DESCRIPTION
All our builds started breaking again. I hope Tox stops behaving like this.

We should start managing Tox in a `requirements_tox.txt` so version specifications can be managed instead of putting version info in Circle CI config.

Tox 4.0.6 breaks for a good reason! It breaks when a behavior changed in Tox 4 (only comma-separated lists, whitespaces not allowed) and old values of `passenv` were silently parsed wrongly.

Ref: https://github.com/tox-dev/tox/issues/2658