### PR TITLE
Docs: configure linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,6 +73,7 @@ version = "9.1.0"
 release = version
 exclude_patterns = ["_build", "shared"]
 default_role = "obj"
+intersphinx_timeout = 3  # 3 seconds timeout
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.10/", None),
     "django": (
@@ -191,6 +192,9 @@ notfound_context = {
 <p>Try using the search box or go to the homepage.</p>
 """,
 }
+linkcheck_retries = 2
+linkcheck_timeout = 1
+linkcheck_workers = 10
 linkcheck_ignore = [
     r"http://127\.0\.0\.1",
     r"http://localhost",

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -245,7 +245,7 @@ This helps ensure that all external links are still valid and readers aren't lin
        python: "3.10"
      jobs:
        pre_build:
-         - python -m sphinx -b linkcheck docs/ _build/linkcheck
+         - python -m sphinx -b linkcheck -D linkcheck_timeout=1 docs/ _build/linkcheck
 
 
 Support Git LFS (Large File Storage)


### PR DESCRIPTION
Define timeout, retries and workers.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9810.org.readthedocs.build/en/9810/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9810.org.readthedocs.build/en/9810/

<!-- readthedocs-preview dev end -->