### PR TITLE
Add link to the build notifications guide

### DIFF
--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -137,7 +137,7 @@ and some of the core features of Read the Docs.
 How-to Guides
 -------------
 
-These guides will help walk you through specific use cases
+These guides will help you walk through specific use cases
 related to Read the Docs itself, documentation tools like Sphinx and MkDocs
 and how to write successful documentation.
 
@@ -151,7 +151,7 @@ and how to write successful documentation.
   :doc:`/guides/technical-docs-seo-guide` |
   :doc:`/guides/manage-translations-sphinx` |
   :doc:`/guides/private-submodules` |
-  Setup Build Notifications <build-notifications> |
+  :doc:`/guides/build-notifications`|
   :doc:`More guides for administrators </guides/administrators>`
 
 * **For developers and designers**:
@@ -160,7 +160,7 @@ and how to write successful documentation.
   :doc:`/guides/reproducible-builds` |
   :doc:`/guides/embedding-content` |
   :doc:`/guides/conda` |
-  Setup Build Notifications <build-notifications> |
+  :doc:`/guides/build-notifications`|
   :doc:`More guides for developers and designers </guides/developers>`
 
 .. toctree::

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -151,7 +151,7 @@ and how to write successful documentation.
   :doc:`/guides/technical-docs-seo-guide` |
   :doc:`/guides/manage-translations-sphinx` |
   :doc:`/guides/private-submodules` |
-  :doc:`/guides/build-notifications`|
+  :doc:`/guides/build-notifications` |
   :doc:`More guides for administrators </guides/administrators>`
 
 * **For developers and designers**:
@@ -160,7 +160,7 @@ and how to write successful documentation.
   :doc:`/guides/reproducible-builds` |
   :doc:`/guides/embedding-content` |
   :doc:`/guides/conda` |
-  :doc:`/guides/build-notifications`|
+  :doc:`/guides/build-notifications` |
   :doc:`More guides for developers and designers </guides/developers>`
 
 .. toctree::


### PR DESCRIPTION


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9814.org.readthedocs.build/en/9814/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9814.org.readthedocs.build/en/9814/

<!-- readthedocs-preview dev end -->