### PR TITLE
Build details page: normalize/trim command paths

### DIFF
--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -1,5 +1,7 @@
 """Defines serializers for each of our models."""
 
+import re
+from django.conf import settings
 from allauth.socialaccount.models import SocialAccount
 from rest_framework import serializers
 
@@ -127,10 +129,32 @@ class VersionAdminSerializer(VersionSerializer):
 class BuildCommandSerializer(serializers.ModelSerializer):
 
     run_time = serializers.ReadOnlyField()
+    command = serializers.SerializerMethodField()
 
     class Meta:
         model = BuildCommandResult
         exclude = []
+
+    def get_command(self, obj):
+        # HACK: remove unreadable paths from the command outputs when returning it from the API.
+        # We could make this change at build level, but we want to avoid undoable issues from now
+        # and hack a small solution to fix the immediate problem.
+        #
+        # This converts:
+        #   $ /usr/src/app/checkouts/readthedocs.org/user_builds/<container_hash>/<project_slug>/envs/<version_slug>/bin/python
+        #   $ /home/docs/checkouts/readthedocs.org/user_builds/<project_slug>/envs/<version_slug>/bin/python
+        # into
+        #   $ python
+        project_slug = obj.build.version.project.slug
+        version_slug = obj.build.version.slug
+
+        docroot = settings.DOCROOT
+        # Remove Docker hash from DOCROOT when running it locally
+        if settings.RTD_DOCKER_COMPOSE:
+            docroot = re.sub('/[0-9a-z]+/?$', '', settings.DOCROOT, count=1)
+
+        command = re.sub(f'{docroot}/[0-9a-z]+/{project_slug}/envs/{version_slug}(/bin/)?', '', obj.command, count=1)
+        return command
 
 
 class BuildSerializer(serializers.ModelSerializer):

--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -1,8 +1,9 @@
 """Defines serializers for each of our models."""
 
 import re
-from django.conf import settings
+
 from allauth.socialaccount.models import SocialAccount
+from django.conf import settings
 from rest_framework import serializers
 
 from readthedocs.builds.models import Build, BuildCommandResult, Version
@@ -147,18 +148,18 @@ class BuildCommandSerializer(serializers.ModelSerializer):
         #   $ python
         project_slug = obj.build.version.project.slug
         version_slug = obj.build.version.slug
-        docroot = settings.DOCROOT.rstrip('/')  # remove trailing '/'
+        docroot = settings.DOCROOT.rstrip("/")  # remove trailing '/'
 
         # Remove Docker hash from DOCROOT when running it locally
         # DOCROOT contains the Docker container hash (e.g. b7703d1b5854).
         # We have to remove it from the DOCROOT it self since it changes each time we spin up a new Docker instance locally.
-        container_hash = '/'
+        container_hash = "/"
         if settings.RTD_DOCKER_COMPOSE:
-            docroot = re.sub('/[0-9a-z]+/?$', '', settings.DOCROOT, count=1)
-            container_hash = '/[0-9a-z]+/'
+            docroot = re.sub("/[0-9a-z]+/?$", "", settings.DOCROOT, count=1)
+            container_hash = "/[0-9a-z]+/"
 
-        regex = f'{docroot}{container_hash}{project_slug}/envs/{version_slug}(/bin/)?'
-        command = re.sub(regex, '', obj.command, count=1)
+        regex = f"{docroot}{container_hash}{project_slug}/envs/{version_slug}(/bin/)?"
+        command = re.sub(regex, "", obj.command, count=1)
         return command
 
 

--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -142,8 +142,10 @@ class BuildCommandSerializer(serializers.ModelSerializer):
         # and hack a small solution to fix the immediate problem.
         #
         # This converts:
-        #   $ /usr/src/app/checkouts/readthedocs.org/user_builds/<container_hash>/<project_slug>/envs/<version_slug>/bin/python
-        #   $ /home/docs/checkouts/readthedocs.org/user_builds/<project_slug>/envs/<version_slug>/bin/python
+        #   $ /usr/src/app/checkouts/readthedocs.org/user_builds/
+        #        <container_hash>/<project_slug>/envs/<version_slug>/bin/python
+        #   $ /home/docs/checkouts/readthedocs.org/user_builds/
+        #        <project_slug>/envs/<version_slug>/bin/python
         # into
         #   $ python
         project_slug = obj.build.version.project.slug
@@ -152,7 +154,8 @@ class BuildCommandSerializer(serializers.ModelSerializer):
 
         # Remove Docker hash from DOCROOT when running it locally
         # DOCROOT contains the Docker container hash (e.g. b7703d1b5854).
-        # We have to remove it from the DOCROOT it self since it changes each time we spin up a new Docker instance locally.
+        # We have to remove it from the DOCROOT it self since it changes each time
+        # we spin up a new Docker instance locally.
         container_hash = "/"
         if settings.RTD_DOCKER_COMPOSE:
             docroot = re.sub("/[0-9a-z]+/?$", "", settings.DOCROOT, count=1)

--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -147,13 +147,18 @@ class BuildCommandSerializer(serializers.ModelSerializer):
         #   $ python
         project_slug = obj.build.version.project.slug
         version_slug = obj.build.version.slug
+        docroot = settings.DOCROOT.rstrip('/')  # remove trailing '/'
 
-        docroot = settings.DOCROOT
         # Remove Docker hash from DOCROOT when running it locally
+        # DOCROOT contains the Docker container hash (e.g. b7703d1b5854).
+        # We have to remove it from the DOCROOT it self since it changes each time we spin up a new Docker instance locally.
+        container_hash = '/'
         if settings.RTD_DOCKER_COMPOSE:
             docroot = re.sub('/[0-9a-z]+/?$', '', settings.DOCROOT, count=1)
+            container_hash = '/[0-9a-z]+/'
 
-        command = re.sub(f'{docroot}/[0-9a-z]+/{project_slug}/envs/{version_slug}(/bin/)?', '', obj.command, count=1)
+        regex = f'{docroot}{container_hash}{project_slug}/envs/{version_slug}(/bin/)?'
+        command = re.sub(regex, '', obj.command, count=1)
         return command
 
 


### PR DESCRIPTION
Small hack to trim/normalize command paths when displaying them to the user under the build detail's page.

This is a simple hack and there are more we can do here. Probably, there are some edge cases this is not catching. However, the worst it can happens is the path not being trimmed.

## Before 

![Screenshot_2022-12-15_18-48-01](https://user-images.githubusercontent.com/244656/207931680-6e95eb5b-4c2b-4b17-b32e-5eb93c579fba.png)

## After

![Screenshot_2022-12-15_18-47-45](https://user-images.githubusercontent.com/244656/207931735-70bc2eba-ce94-47aa-8d70-e1996a26df37.png)
