### PR TITLE
Add subset of tests to testing docs

### DIFF
--- a/docs/dev/tests.rst
+++ b/docs/dev/tests.rst
@@ -47,13 +47,12 @@ To target a specific environment:
 .. prompt:: bash
 
    tox -e py310
-   
+
 To run a subset of tests:
 
 .. prompt:: bash
 
    tox -e py310 -- -k test_celery
-
 
 The ``tox`` configuration has the following environments configured. You can
 target a single environment to limit the test suite:

--- a/docs/dev/tests.rst
+++ b/docs/dev/tests.rst
@@ -47,6 +47,13 @@ To target a specific environment:
 .. prompt:: bash
 
    tox -e py310
+   
+To run a subset of tests:
+
+.. prompt:: bash
+
+   tox -e py310 -- -k test_celery
+
 
 The ``tox`` configuration has the following environments configured. You can
 target a single environment to limit the test suite:


### PR DESCRIPTION


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9817.org.readthedocs.build/en/9817/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9817.org.readthedocs.build/en/9817/

<!-- readthedocs-preview dev end -->