### PR TITLE
Config file: update JSON schema

### DIFF
--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -803,7 +803,9 @@ Schema
 
 You can see the complete schema
 `here <https://github.com/readthedocs/readthedocs.org/blob/main/readthedocs/rtd_tests/fixtures/spec/v2/schema.json>`_.
+This schema is available at `Schema Store`_, use it with your favorite editor for validation and autocompletion.
 
+.. _Schema Store: https://www.schemastore.org/
 
 Legacy ``build`` specification
 ------------------------------

--- a/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
+++ b/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
@@ -218,7 +218,7 @@
             },
             "commands": {
               "title": "Build commands",
-              "description": "Override the whole build process with custom commands. None of the commands from build.jobs will be executed.",
+              "description": "Override the whole build process with custom commands. When using this option, none of the commands from build.jobs will be executed.",
               "type": "array",
               "items": {
                 "title": "Custom commands",

--- a/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
+++ b/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
@@ -59,7 +59,7 @@
           "properties": {
             "image": {
               "title": "Image",
-              "description": "Deprecated in favor of build.os.\n\nThe build docker image to be used.",
+              "description": "DEPRECATED: use build.os instead.\n\nThe build docker image to be used.",
               "enum": [
                 "stable",
                 "latest"
@@ -241,7 +241,7 @@
       "properties": {
         "version": {
           "title": "Version",
-          "description": "Deprecated in favor of build.tools.python.\n\nThe Python version (this depends on the build image).",
+          "description": "DEPRECATED: use build.tools.python instead.\n\nThe Python version to activate for your build (availability of Python versions depend on the build image).",
           "type": "string",
           "enum": [
             "2",

--- a/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
+++ b/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$comment": "https://docs.readthedocs.io/en/stable/config-file/index.html",
   "title": "Read the Docs",
   "description": "Read the Docs configuration file.",
@@ -59,12 +59,13 @@
           "properties": {
             "image": {
               "title": "Image",
-              "description": "The build docker image to be used.",
+              "description": "Deprecated in favor of build.os.\n\nThe build docker image to be used.",
               "enum": [
                 "stable",
                 "latest"
               ],
-              "default": "latest"
+              "default": "latest",
+              "deprecated": true
             },
             "apt_packages": {
               "title": "APT Packages",
@@ -214,6 +215,15 @@
                 "type": "string"
               },
               "default": []
+            },
+            "commands": {
+              "title": "Build commands",
+              "description": "Override the whole build process with custom commands. None of the commands from build.jobs will be executed.",
+              "type": "array",
+              "items": {
+                "title": "Custom commands",
+                "type": "string"
+              }
             }
           },
           "required": [
@@ -231,7 +241,7 @@
       "properties": {
         "version": {
           "title": "Version",
-          "description": "The Python version (this depends on the build image).",
+          "description": "Deprecated in favor of build.tools.python.\n\nThe Python version (this depends on the build image).",
           "type": "string",
           "enum": [
             "2",
@@ -245,7 +255,8 @@
             "3.7",
             "3.8"
           ],
-          "default": "3"
+          "default": "3",
+          "deprecated": true
         },
         "system_packages": {
           "title": "System Packages",


### PR DESCRIPTION
- Add build.commands
- Mark deprecated attributes as such
- Mention a little more about how the schema can be used :)

If you are using https://github.com/redhat-developer/vscode-yaml, you should be able to preview this by adding this modeline at the top of your rtd.yaml file

```yaml
# yaml-language-server: $schema=https://raw.githubusercontent.com/readthedocs/readthedocs.org/update-json-schema/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
```

Closes https://github.com/readthedocs/readthedocs.org/issues/9822

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9830.org.readthedocs.build/en/9830/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9830.org.readthedocs.build/en/9830/

<!-- readthedocs-preview dev end -->