### PR TITLE
Build details page: normalize/trim command paths (second attempt)

### DIFF
--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -167,7 +167,7 @@ class BuildCommandReadOnlySerializer(BuildCommandSerializer):
         container_hash = "/"
         if settings.RTD_DOCKER_COMPOSE:
             docroot = re.sub("/[0-9a-z]+/?$", "", settings.DOCROOT, count=1)
-            container_hash = "/[0-9a-z]+/"
+            container_hash = "/([0-9a-z]+/)?"
 
         regex = f"{docroot}{container_hash}{project_slug}/envs/{version_slug}(/bin/)?"
         command = re.sub(regex, "", obj.command, count=1)

--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -1,6 +1,9 @@
 """Defines serializers for each of our models."""
 
+import re
+
 from allauth.socialaccount.models import SocialAccount
+from django.conf import settings
 from rest_framework import serializers
 
 from readthedocs.builds.models import Build, BuildCommandResult, Version
@@ -133,11 +136,49 @@ class BuildCommandSerializer(serializers.ModelSerializer):
         exclude = []
 
 
+class BuildCommandUISerializer(BuildCommandSerializer):
+    """
+    Serializer used on GETs to trimm the commands' path.
+
+    Remove unreadable paths from the command outputs when returning it from the API.
+    We could make this change at build level, but we want to avoid undoable issues from now
+    and hack a small solution to fix the immediate problem.
+
+    This converts:
+        $ /usr/src/app/checkouts/readthedocs.org/user_builds/
+            <container_hash>/<project_slug>/envs/<version_slug>/bin/python
+        $ /home/docs/checkouts/readthedocs.org/user_builds/
+            <project_slug>/envs/<version_slug>/bin/python
+    into
+        $ python
+    """
+
+    command = serializers.SerializerMethodField()
+
+    def get_command(self, obj):
+        project_slug = obj.build.version.project.slug
+        version_slug = obj.build.version.slug
+        docroot = settings.DOCROOT.rstrip("/")  # remove trailing '/'
+
+        # Remove Docker hash from DOCROOT when running it locally
+        # DOCROOT contains the Docker container hash (e.g. b7703d1b5854).
+        # We have to remove it from the DOCROOT it self since it changes each time
+        # we spin up a new Docker instance locally.
+        container_hash = "/"
+        if settings.RTD_DOCKER_COMPOSE:
+            docroot = re.sub("/[0-9a-z]+/?$", "", settings.DOCROOT, count=1)
+            container_hash = "/[0-9a-z]+/"
+
+        regex = f"{docroot}{container_hash}{project_slug}/envs/{version_slug}(/bin/)?"
+        command = re.sub(regex, "", obj.command, count=1)
+        return command
+
+
 class BuildSerializer(serializers.ModelSerializer):
 
     """Build serializer for user display, doesn't display internal fields."""
 
-    commands = BuildCommandSerializer(many=True, read_only=True)
+    commands = BuildCommandUISerializer(many=True, read_only=True)
     project_slug = serializers.ReadOnlyField(source='project.slug')
     version_slug = serializers.ReadOnlyField(source='get_version_slug')
     docs_url = serializers.SerializerMethodField()
@@ -162,9 +203,15 @@ class BuildAdminSerializer(BuildSerializer):
 
     """Build serializer for display to admin users and build instances."""
 
+    commands = BuildCommandSerializer(many=True, read_only=True)
+
     class Meta(BuildSerializer.Meta):
         # `_config` should be excluded to avoid conflicts with `config`
         exclude = ('_config',)
+
+
+class BuildAdminUISerializer(BuildAdminSerializer):
+    commands = BuildCommandUISerializer(many=True, read_only=True)
 
 
 class SearchIndexSerializer(serializers.Serializer):

--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -139,7 +139,7 @@ class BuildCommandSerializer(serializers.ModelSerializer):
 class BuildCommandReadOnlySerializer(BuildCommandSerializer):
 
     """
-    Serializer used on GETs to trimm the commands' path.
+    Serializer used on GETs to trim the commands' path.
 
     Remove unreadable paths from the command outputs when returning it from the API.
     We could make this change at build level, but we want to avoid undoable issues from now

--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -137,6 +137,7 @@ class BuildCommandSerializer(serializers.ModelSerializer):
 
 
 class BuildCommandReadOnlySerializer(BuildCommandSerializer):
+
     """
     Serializer used on GETs to trimm the commands' path.
 
@@ -185,8 +186,10 @@ class BuildSerializer(serializers.ModelSerializer):
     - It doesn't display internal fields (builder, _config)
     - It's read-only for multiple fields (commands, project_slug, etc)
 
-    Staff users should use either BuildAdminSerializer for write operations (e.g. builders hitting the API),
-    or BuildAdminReadOnlySerializer for read-only actions (e.g. dashboard retrieving build details)
+    Staff users should use either:
+
+    - BuildAdminSerializer for write operations (e.g. builders hitting the API),
+    - BuildAdminReadOnlySerializer for read-only actions (e.g. dashboard retrieving build details)
     """
 
     commands = BuildCommandReadOnlySerializer(many=True, read_only=True)
@@ -227,6 +230,7 @@ class BuildAdminSerializer(BuildSerializer):
 
 
 class BuildAdminReadOnlySerializer(BuildAdminSerializer):
+
     """
     Build serializer to retrieve Build objects from the dashboard.
 

--- a/readthedocs/api/v2/views/model_views.py
+++ b/readthedocs/api/v2/views/model_views.py
@@ -239,7 +239,7 @@ class BuildViewSet(DisableListEndpoint, UserSelectViewSet):
         if self.request.user.is_staff:
             # Logic copied from `UserSelectViewSet.get_serializer_class`
             # and extended to check for GET method
-            if self.request.action in ["list", "retrieve"]:
+            if self.action in ["list", "retrieve"]:
                 return BuildAdminReadOnlySerializer  # Staff read-onlyl
             return BuildAdminSerializer  # Staff write-only
         return BuildSerializer  # Non-staff

--- a/readthedocs/api/v2/views/model_views.py
+++ b/readthedocs/api/v2/views/model_views.py
@@ -23,6 +23,7 @@ from readthedocs.storage import build_commands_storage
 from ..permissions import APIPermission, APIRestrictedPermission, IsOwner
 from ..serializers import (
     BuildAdminSerializer,
+    BuildAdminUISerializer,
     BuildCommandSerializer,
     BuildSerializer,
     DomainSerializer,
@@ -224,10 +225,24 @@ class VersionViewSet(DisableListEndpoint, UserSelectViewSet):
 class BuildViewSet(DisableListEndpoint, UserSelectViewSet):
     permission_classes = [APIRestrictedPermission]
     renderer_classes = (JSONRenderer, PlainTextBuildRenderer)
-    serializer_class = BuildSerializer
-    admin_serializer_class = BuildAdminSerializer
     model = Build
     filterset_fields = ('project__slug', 'commit')
+
+    def get_serializer_class(self):
+        """
+        Return the proper serializer for UI and Admin.
+
+        This ViewSet has a sligtly different pattern since we want to
+        pre-process the `command` field before returning it to the user, and we
+        also want to have a specific serializer for admins.
+        """
+        if self.request.user.is_staff:
+            # Logic copied from `UserSelectViewSet.get_serializer_class`
+            # and extended to check for GET method
+            if self.request.method == "GET":
+                return BuildAdminUISerializer
+            return BuildAdminSerializer
+        return BuildSerializer
 
     @decorators.action(
         detail=False,

--- a/readthedocs/api/v2/views/model_views.py
+++ b/readthedocs/api/v2/views/model_views.py
@@ -238,10 +238,10 @@ class BuildViewSet(DisableListEndpoint, UserSelectViewSet):
         """
         if self.request.user.is_staff:
             # Logic copied from `UserSelectViewSet.get_serializer_class`
-            # and extended to check for GET method
-            if self.action in ["list", "retrieve"]:
-                return BuildAdminReadOnlySerializer  # Staff read-onlyl
-            return BuildAdminSerializer  # Staff write-only
+            # and extended to choose serializer from self.action
+            if self.action not in ["list", "retrieve"]:
+                return BuildAdminSerializer  # Staff write-only
+            return BuildAdminReadOnlySerializer  # Staff read-only
         return BuildSerializer  # Non-staff
 
     @decorators.action(

--- a/readthedocs/api/v2/views/model_views.py
+++ b/readthedocs/api/v2/views/model_views.py
@@ -22,8 +22,8 @@ from readthedocs.storage import build_commands_storage
 
 from ..permissions import APIPermission, APIRestrictedPermission, IsOwner
 from ..serializers import (
+    BuildAdminReadOnlySerializer,
     BuildAdminSerializer,
-    BuildAdminUISerializer,
     BuildCommandSerializer,
     BuildSerializer,
     DomainSerializer,
@@ -239,10 +239,10 @@ class BuildViewSet(DisableListEndpoint, UserSelectViewSet):
         if self.request.user.is_staff:
             # Logic copied from `UserSelectViewSet.get_serializer_class`
             # and extended to check for GET method
-            if self.request.method == "GET":
-                return BuildAdminUISerializer
-            return BuildAdminSerializer
-        return BuildSerializer
+            if self.request.action in ["list", "retrieve"]:
+                return BuildAdminReadOnlySerializer  # Staff read-onlyl
+            return BuildAdminSerializer  # Staff write-only
+        return BuildSerializer  # Non-staff
 
     @decorators.action(
         detail=False,


### PR DESCRIPTION
Continuation of the work done in
#9815 that didn't work as we
expected.

We weren't saving the commands properly when hitting the API since
`serializers.SerializerMethodField` is a read-only field. This commit fixes this
problem by using a different Serializer depending if it's a GET request or not,
and if it's made by an Admin or not.

It overrides the method `BuildViewSet.get_serializer_class` to manage these
different cases and return the proper serializer.

Done on top of #9827 to be sure the
tests for saving commands are passing.

Closes #9833 