### PR TITLE
Docs: Relabel the "Science" page as Explanation

### DIFF
--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -82,6 +82,7 @@ to help you create fantastic documentation for your project.
    /custom-domains
    /pull-requests
    /downloadable-documentation
+   /science
 
 .. toctree::
    :maxdepth: 2
@@ -92,7 +93,6 @@ to help you create fantastic documentation for your project.
    /guides/authors
    /guides/administrators
    /guides/developers
-   /science
    /examples
 
 

--- a/docs/user/science.rst
+++ b/docs/user/science.rst
@@ -1,5 +1,9 @@
-Read the Docs for Science
-=========================
+Documentation in scientific and academic publishing
+===================================================
+
+On this page, we explore some of the many tools and practices that *software* documentation and *academic* writing share.
+If you are working within the field of science or academia,
+this page can be used as an introduction.
 
 .. 2022-08-10
 .. Notes about this section:
@@ -20,7 +24,6 @@ Documentation and technical writing are broad fields.
 Their tools and practices have grown relevant to most scientific activities.
 This includes building publications, books, educational resources, interactive data science, resources for data journalism and full-scale websites for research projects and courses.
 
-Let's explore the overlap of features for software documentation and academic writing.
 Here's a brief overview of some :doc:`features <features>` that people in science and academic writing love about Read the Docs:
 
 .. dropdown:: 🪄 Easy to use


### PR DESCRIPTION
Refs: https://github.com/readthedocs/readthedocs.org/issues/9746

This raises two questions:

1) Can we limit the amount of changes to this?
2) Are there any follow-up actions that we can already express or is it better to just plan for a revisit

(The reason that I wanted to minimize this effort, is in anticipation of some sort of separation between what lives on https://about.readthedocs.com/ and what lives in the documentation)

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9832.org.readthedocs.build/en/9832/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9832.org.readthedocs.build/en/9832/

<!-- readthedocs-preview dev end -->