### PR TITLE
Docs: Relabel "Single version documentation" documentation from feature to explanation (Diátaxis)

### DIFF
--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -82,6 +82,7 @@ to help you create fantastic documentation for your project.
    /custom-domains
    /pull-requests
    /downloadable-documentation
+   /single_version
 
 .. toctree::
    :maxdepth: 2
@@ -232,7 +233,6 @@ out of your documentation and Read the Docs.
    :caption: Advanced features
 
    subprojects
-   single_version
    flyout-menu
    feature-flags
 

--- a/docs/user/single_version.rst
+++ b/docs/user/single_version.rst
@@ -5,7 +5,7 @@ Single version documentation
 for example ``https://docs.example.com/`` or ``https://example.readthedocs.io/``.
 
 By default, all documentation served by Read the Docs has a standard path of ``/<language>/<version>/``.
-Documentation can be served at ``/`` if you enable the *single version* option for a project. 
+Documentation can be served at ``/`` if you enable the *single version* option for a project.
 
 .. warning:: This means you can't have translations or multiple versions for your documentation.
 
@@ -13,7 +13,7 @@ Having a single version of a documentation project can be considered the better 
 in cases where there should only always exist one unambiguous copy of your project.
 
 For example, a research project may wish to *only* expose readers to their latest list of publications and research data.
-Similarly, a :abbr:`SaaS (Software as a Service)` application might only ever have one version live. 
+Similarly, a :abbr:`SaaS (Software as a Service)` application might only ever have one version live.
 
 You can see a live example of this at http://www.contribution-guide.org
 

--- a/docs/user/single_version.rst
+++ b/docs/user/single_version.rst
@@ -1,18 +1,24 @@
-Single Version Documentation
+Single version documentation
 ----------------------------
 
-Single Version Documentation lets you serve your docs at a root domain.
+*Single version* documentation lets you serve your documentation direct from ``https://docs.example.com`` or ``https://example.readthedocs.io``.
+
 By default, all documentation served by Read the Docs has a root of ``/<language>/<version>/``.
-But, if you enable the "Single Version" option for a project, its documentation will instead be served at ``/``.
+But, if you enable the *single version* option for a project, its documentation will instead be served at ``/``.
 
 .. warning:: This means you can't have translations or multiple versions for your documentation.
+
+Having a single version of a documentation project can be considered the better choice
+in cases where there should only always exist one unambiguous copy of your project.
+
+For example, a research project may wish to *only* expose readers to their latest list of publications and research data.
 
 You can see a live example of this at http://www.contribution-guide.org
 
 Enabling
 ~~~~~~~~
 
-You can toggle the "Single Version" option on or off for your project in the Project Admin page.
+In your project's :guilabel:`Admin` page, you can toggle the :guilabel:`Single version` option on or off for your project .
 Check your :term:`dashboard` for a list of your projects.
 
 Effects

--- a/docs/user/single_version.rst
+++ b/docs/user/single_version.rst
@@ -1,10 +1,11 @@
 Single version documentation
 ----------------------------
 
-*Single version* documentation lets you serve your documentation direct from ``https://docs.example.com`` or ``https://example.readthedocs.io``.
+*Single version* documentation lets you serve your documentation at the top level of your domain,
+for example ``https://docs.example.com/`` or ``https://example.readthedocs.io/``.
 
-By default, all documentation served by Read the Docs has a root of ``/<language>/<version>/``.
-But, if you enable the *single version* option for a project, its documentation will instead be served at ``/``.
+By default, all documentation served by Read the Docs has a standard path of ``/<language>/<version>/``.
+Documentation can be served at ``/`` if you enable the *single version* option for a project. 
 
 .. warning:: This means you can't have translations or multiple versions for your documentation.
 
@@ -12,6 +13,7 @@ Having a single version of a documentation project can be considered the better 
 in cases where there should only always exist one unambiguous copy of your project.
 
 For example, a research project may wish to *only* expose readers to their latest list of publications and research data.
+Similarly, a :abbr:`SaaS (Software as a Service)` application might only ever have one version live. 
 
 You can see a live example of this at http://www.contribution-guide.org
 


### PR DESCRIPTION
This ~is~ was a WIP.

Refs: https://github.com/readthedocs/readthedocs.org/issues/9746

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9835.org.readthedocs.build/en/9835/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9835.org.readthedocs.build/en/9835/

<!-- readthedocs-preview dev end -->