### PR TITLE
Invitations: fix model name (object_type)

### DIFF
--- a/readthedocs/invitations/models.py
+++ b/readthedocs/invitations/models.py
@@ -207,7 +207,7 @@ class Invitation(TimeStampedModel):
 
     @property
     def object_type(self):
-        return self.content_type.name
+        return self.content_type.model
 
     @property
     def object_name(self):


### PR DESCRIPTION
ContentType.name is the human-readable name,
this is taken from the label, which in some models is a translatable string (https://github.com/readthedocs/readthedocs.org/blob/a00eff14643eeb1f114f6bcc6d71510e5c3d51fd/readthedocs/projects/models.py#L468-L468).

What we actually want is ContentType.model
https://docs.djangoproject.com/en/4.1/ref/contrib/contenttypes/#django.contrib.contenttypes.models.ContentType, that is the plain model name in lowercase.