### PR TITLE
API: add project name/slug filters

### DIFF
--- a/docs/user/api/v3.rst
+++ b/docs/user/api/v3.rst
@@ -186,6 +186,8 @@ Projects list
             }]
         }
 
+    :query string name: return projects with matching name
+    :query string slug: return projects with matching slug
     :query string language: language code as ``en``, ``es``, ``ru``, etc.
     :query string programming_language: programming language code as ``py``, ``js``, etc.
 

--- a/readthedocs/api/v3/filters.py
+++ b/readthedocs/api/v3/filters.py
@@ -7,16 +7,16 @@ from readthedocs.projects.models import Project
 
 
 class ProjectFilter(filters.FilterSet):
-    name = filters.CharFilter(lookup_expr='icontains')
-    slug = filters.CharFilter(lookup_expr='icontains')
+    name = filters.CharFilter(lookup_expr="icontains")
+    slug = filters.CharFilter(lookup_expr="icontains")
 
     class Meta:
         model = Project
         fields = [
-            'name',
-            'slug',
-            'language',
-            'programming_language',
+            "name",
+            "slug",
+            "language",
+            "programming_language",
         ]
 
 

--- a/readthedocs/api/v3/filters.py
+++ b/readthedocs/api/v3/filters.py
@@ -7,10 +7,14 @@ from readthedocs.projects.models import Project
 
 
 class ProjectFilter(filters.FilterSet):
+    name = filters.CharFilter(lookup_expr='icontains')
+    slug = filters.CharFilter(lookup_expr='icontains')
 
     class Meta:
         model = Project
         fields = [
+            'name',
+            'slug',
             'language',
             'programming_language',
         ]

--- a/readthedocs/api/v3/filters.py
+++ b/readthedocs/api/v3/filters.py
@@ -7,6 +7,11 @@ from readthedocs.projects.models import Project
 
 
 class ProjectFilter(filters.FilterSet):
+
+    # TODO this is copying the patterns from other filter sets, where the fields
+    # are all ``icontains`` lookups by default. We discussed reversing this
+    # pattern in the future though, see:
+    # https://github.com/readthedocs/readthedocs.org/issues/9862
     name = filters.CharFilter(lookup_expr="icontains")
     slug = filters.CharFilter(lookup_expr="icontains")
 

--- a/readthedocs/api/v3/tests/responses/projects-list-empty.json
+++ b/readthedocs/api/v3/tests/responses/projects-list-empty.json
@@ -1,0 +1,6 @@
+{
+    "count": 0,
+    "next": null,
+    "previous": null,
+    "results": []
+}

--- a/readthedocs/api/v3/tests/test_projects.py
+++ b/readthedocs/api/v3/tests/test_projects.py
@@ -24,46 +24,46 @@ class ProjectsEndpointTests(APIEndpointMixin):
         )
 
     def test_projects_list_filter_full_hit(self):
-        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
         response = self.client.get(
-            reverse('projects-list'),
+            reverse("projects-list"),
             data={
-                'name': self.project.name,
+                "name": self.project.name,
             },
         )
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(
             response.json(),
-            self._get_response_dict('projects-list'),
+            self._get_response_dict("projects-list"),
         )
 
     def test_projects_list_filter_partial_hit(self):
-        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
         response = self.client.get(
-            reverse('projects-list'),
+            reverse("projects-list"),
             data={
-                'name': self.project.name[0:3],
+                "name": self.project.name[0:3],
             },
         )
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(
             response.json(),
-            self._get_response_dict('projects-list'),
+            self._get_response_dict("projects-list"),
         )
 
     def test_projects_list_filter_miss(self):
-        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
         response = self.client.get(
-            reverse('projects-list'),
+            reverse("projects-list"),
             data={
-                'name': "63dadecd5323d789cafe09f01cda85fd",
+                "name": "63dadecd5323d789cafe09f01cda85fd",
             },
         )
         print(response.request)
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(
             response.json(),
-            self._get_response_dict('projects-list-empty'),
+            self._get_response_dict("projects-list-empty"),
         )
 
     def test_own_projects_detail(self):

--- a/readthedocs/api/v3/tests/test_projects.py
+++ b/readthedocs/api/v3/tests/test_projects.py
@@ -23,6 +23,49 @@ class ProjectsEndpointTests(APIEndpointMixin):
             self._get_response_dict('projects-list'),
         )
 
+    def test_projects_list_filter_full_hit(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
+        response = self.client.get(
+            reverse('projects-list'),
+            data={
+                'name': self.project.name,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(
+            response.json(),
+            self._get_response_dict('projects-list'),
+        )
+
+    def test_projects_list_filter_partial_hit(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
+        response = self.client.get(
+            reverse('projects-list'),
+            data={
+                'name': self.project.name[0:3],
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(
+            response.json(),
+            self._get_response_dict('projects-list'),
+        )
+
+    def test_projects_list_filter_miss(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
+        response = self.client.get(
+            reverse('projects-list'),
+            data={
+                'name': "63dadecd5323d789cafe09f01cda85fd",
+            },
+        )
+        print(response.request)
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(
+            response.json(),
+            self._get_response_dict('projects-list-empty'),
+        )
+
     def test_own_projects_detail(self):
         self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
         response = self.client.get(

--- a/readthedocs/api/v3/tests/test_projects.py
+++ b/readthedocs/api/v3/tests/test_projects.py
@@ -59,7 +59,6 @@ class ProjectsEndpointTests(APIEndpointMixin):
                 "name": "63dadecd5323d789cafe09f01cda85fd",
             },
         )
-        print(response.request)
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(
             response.json(),


### PR DESCRIPTION
I am trying to use the project API for some search and dropdown filters,
and while I can filter the local results, it's much nicer to use the API
filter for this.

This adds an icontains filter field for project name and slug, and
hopefully some accurate tests.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9843.org.readthedocs.build/en/9843/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9843.org.readthedocs.build/en/9843/

<!-- readthedocs-preview dev end -->