### PR TITLE
Fix Tox configuration issue

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ commands =
 [testenv:migrations]
 description = check for missing migrations
 commands =
-    {base_python} manage.py makemigrations --check --dry-run
+    {basepython} manage.py makemigrations --check --dry-run
 
 [testenv:lint]
 description = run linter (prospector) to ensure the source code corresponds to our coding standards


### PR DESCRIPTION
I was getting errors from Tox about `base_path` replacement not
existing. This was using `inv docker.test`, so I don't think this is
limited to me.


```
inv docker.test -a "-e py310 -- -k ProjectsEndpointTests"             
Traceback (most recent call last):
  File "/usr/local/bin/tox", line 8, in <module>
    sys.exit(cmdline())
  File "/usr/local/lib/python3.10/dist-packages/tox/session/__init__.py", line 44, in cmdline
    main(args)
  File "/usr/local/lib/python3.10/dist-packages/tox/session/__init__.py", line 65, in main
    config = load_config(args)
  File "/usr/local/lib/python3.10/dist-packages/tox/session/__init__.py", line 81, in load_config
    config = parseconfig(args)
  File "/usr/local/lib/python3.10/dist-packages/tox/config/__init__.py", line 299, in parseconfig
    ParseIni(config, config_file, content)
  File "/usr/local/lib/python3.10/dist-packages/tox/config/__init__.py", line 1323, in __init__
    raise tox.exception.ConfigError(
tox.exception.ConfigError: ConfigError: migrations failed with ConfigError: substitution key 'base_python' not found at Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/tox/config/__init__.py", line 1299, in run
    results[name] = cur_self.make_envconfig(name, section, subs, config)
  File "/usr/local/lib/python3.10/dist-packages/tox/config/__init__.py", line 1475, in make_envconfig
    res = meth(env_attr.name, env_attr.default, replace=replace)
  File "/usr/local/lib/python3.10/dist-packages/tox/config/__init__.py", line 1772, in getargvlist
    return _ArgvlistReader.getargvlist(self, s, replace=replace, name=name)
  File "/usr/local/lib/python3.10/dist-packages/tox/config/__init__.py", line 2036, in getargvlist
    commands.append(cls.processcommand(reader, current_command, replace, name=name))
  File "/usr/local/lib/python3.10/dist-packages/tox/config/__init__.py", line 2062, in processcommand
    new_word = reader._replace(word, name=name)
  File "/usr/local/lib/python3.10/dist-packages/tox/config/__init__.py", line 1857, in _replace
    replaced = Replacer(self, crossonly=crossonly).do_replace(value)
  File "/usr/local/lib/python3.10/dist-packages/tox/config/__init__.py", line 1893, in do_replace
    expanded = substitute_once(value)
  File "/usr/local/lib/python3.10/dist-packages/tox/config/__init__.py", line 1891, in substitute_once
    return self.RE_ITEM_REF.sub(self._replace_match, x)
  File "/usr/local/lib/python3.10/dist-packages/tox/config/__init__.py", line 1964, in _replace_match
    return self._replace_substitution(sub_value)
  File "/usr/local/lib/python3.10/dist-packages/tox/config/__init__.py", line 1999, in _replace_substitution
    val = self._substitute_from_other_section(sub_key)
  File "/usr/local/lib/python3.10/dist-packages/tox/config/__init__.py", line 1994, in _substitute_from_other_section
    raise tox.exception.ConfigError("substitution key {!r} not found".format(key))
tox.exception.ConfigError: ConfigError: substitution key 'base_python' not found
```