### PR TITLE
Docs: Disable ePub as a temporary work-around

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,9 @@
 version: 2
 
-formats: all
+# Disabled until we can ignore warnings in ePub
+# https://github.com/readthedocs/readthedocs.org/issues/9816
+formats:
+  - pdf
 
 sphinx:
   configuration: docs/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,7 @@ version: 2
 # https://github.com/readthedocs/readthedocs.org/issues/9816
 formats:
   - pdf
+  - htmlzip
 
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
Work-around for #9816

Will merge into `diataxis/main` after.