### PR TITLE
EmbedAPI: decode filepath before open them from S3 storage

### DIFF
--- a/readthedocs/embed/v3/tests/test_internal_pages.py
+++ b/readthedocs/embed/v3/tests/test_internal_pages.py
@@ -78,3 +78,20 @@ class TestEmbedAPIv3InternalPages:
             'content': content,
             'external': False,
         }
+
+    @pytest.mark.sphinx("html", srcdir=srcdir, freshenv=False)
+    @mock.patch("readthedocs.embed.v3.views.build_media_storage.open")
+    @mock.patch("readthedocs.embed.v3.views.build_media_storage.exists")
+    def test_s3_storage_decoded_filename(
+        self, storage_exists, storage_open, app, client
+    ):
+        storage_exists.return_value = True
+        storage_open.side_effect = self._mock_open('<div id="section">content</div>')
+
+        params = {
+            "url": "https://project.readthedocs.io/en/latest/My%20Spaced%20File.html#section",
+        }
+        response = client.get(self.api_url, params)
+        assert response.status_code == 200
+
+        storage_open.assert_called_once_with("html/project/latest/My Spaced File.html")

--- a/readthedocs/embed/v3/views.py
+++ b/readthedocs/embed/v3/views.py
@@ -91,14 +91,15 @@ class EmbedAPIBase(EmbedAPIMixin, CDNCacheTagsMixin, APIView):
             include_file=False,
             version_type=version.type,
         )
+
+        # Decode encoded URLs (e.g. convert %20 into a whitespace)
+        filename = urllib.parse.unquote(filename)
+
         relative_filename = filename.lstrip("/")
         file_path = build_media_storage.join(
             storage_path,
             relative_filename,
         )
-
-        # Decode encoded URLs (e.g. convert %20 into a whitespace)
-        file_path = urllib.parse.unquote(file_path)
 
         try:
             with build_media_storage.open(file_path) as fd:  # pylint: disable=invalid-name

--- a/readthedocs/embed/v3/views.py
+++ b/readthedocs/embed/v3/views.py
@@ -1,6 +1,7 @@
 """Views for the EmbedAPI v3 app."""
 
 import re
+import urllib.parse
 from urllib.parse import urlparse
 
 import requests
@@ -95,6 +96,10 @@ class EmbedAPIBase(EmbedAPIMixin, CDNCacheTagsMixin, APIView):
             storage_path,
             relative_filename,
         )
+
+        # Decode encoded URLs (e.g. convert %20 into a whitespace)
+        file_path = urllib.parse.unquote(file_path)
+
         try:
             with build_media_storage.open(file_path) as fd:  # pylint: disable=invalid-name
                 return fd.read()

--- a/readthedocs/embed/views.py
+++ b/readthedocs/embed/views.py
@@ -2,7 +2,6 @@
 
 import json
 import re
-import urllib.parse
 
 import structlog
 from django.template.defaultfilters import slugify
@@ -205,8 +204,6 @@ def _get_doc_content(project, version, doc):
         storage_path,
         f'{doc}.fjson'.lstrip('/'),
     )
-    # Decode encoded URLs (e.g. convert %20 into a whitespace)
-    file_path = urllib.parse.unquote(file_path)
     try:
         with build_media_storage.open(file_path) as file:
             return json.load(file)

--- a/readthedocs/embed/views.py
+++ b/readthedocs/embed/views.py
@@ -2,6 +2,7 @@
 
 import json
 import re
+import urllib.parse
 
 import structlog
 from django.template.defaultfilters import slugify
@@ -204,6 +205,8 @@ def _get_doc_content(project, version, doc):
         storage_path,
         f'{doc}.fjson'.lstrip('/'),
     )
+    # Decode encoded URLs (e.g. convert %20 into a whitespace)
+    file_path = urllib.parse.unquote(file_path)
     try:
         with build_media_storage.open(file_path) as file:
             return json.load(file)


### PR DESCRIPTION
We can use encoded URLs (e.g. with %20 for white spaces) for external requests since they are valid URLs. However, when it's internal and we get it from the storage, we have to convert them to regular characters (white spaces, in this example).

We use `urllib.parse.unquote` for this before passing the filename to the S3 backend storage.

Closes #8301