### PR TITLE
Account: organize allauth settings

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -701,11 +701,16 @@ class CommunityBaseSettings(Settings):
     # All auth
     ACCOUNT_ADAPTER = 'readthedocs.core.adapters.AccountAdapter'
     ACCOUNT_EMAIL_REQUIRED = True
+
+    # Make email verification mandatory.
+    # Users won't be able to login until they verify the email address.
     ACCOUNT_EMAIL_VERIFICATION = 'mandatory'
+
     ACCOUNT_AUTHENTICATION_METHOD = 'username_email'
-    ACCOUNT_ACTIVATION_DAYS = 7
+    ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS = 7
     SOCIALACCOUNT_AUTO_SIGNUP = False
     SOCIALACCOUNT_STORE_TOKENS = True
+
     SOCIALACCOUNT_PROVIDERS = {
         'github': {
             'SCOPE': [


### PR DESCRIPTION
- make email verification `mandatory`: users without a verified email will be asked to verify their address before being able to login
- rename `ACCOUNT_ACTIVATION_DAYS` since it was a setting from a Django app we don't use anymore. It's called `ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS` in Django Allauth.
- email verification is not required for development instance

This PR **requires other PRs** to work as intended:
* https://github.com/readthedocs/readthedocs-ops/pull/1271
* https://github.com/readthedocs/readthedocs-corporate/pull/1529

> NOTE that I review all the settings from https://django-allauth.readthedocs.io/en/latest/configuration.html and I think we are fine moving forward with this combination.

Context: https://github.com/readthedocs/meta/discussions/103
Closes: https://github.com/readthedocs/meta/issues/104