### PR TITLE
Explicitly set JQuery globals on main site

### DIFF
--- a/readthedocs/templates/base.html
+++ b/readthedocs/templates/base.html
@@ -67,7 +67,9 @@
   <script src="{% static 'vendor/jquery-migrate.js' %}"></script>
   <script src="{% static 'vendor/jquery-ui.js' %}"></script>
   <script >
-    require('jquery');
+    // Set jQuery to its expected globals.
+    window.$ = require('jquery');
+    window.jQuery = window.$;
   </script>
 
   <script src="{% static 'javascript/base.js' %}"></script>


### PR DESCRIPTION
I guess this is related to the jquery update from #9861, or maybe this line wasn't working and we were relying in something else?

Not sure why I didn't notice this before,
maybe my browser cache :(

Ref https://github.com/readthedocs/readthedocs.org/pull/9861