### PR TITLE
Docs: update build customization Poetry example

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -330,6 +330,7 @@ Take a look at the following example:
          - pip install poetry
          # Tell poetry to not use a virtual environment
          - poetry config virtualenvs.create false
+       post_install:
          # Install dependencies with 'docs' dependency group
          # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
          - poetry install --with docs


### PR DESCRIPTION
Move `poetry install` from `post_create_environment` to `post_install`.

This ensures the Sphinx version installed from `poetry.lock` is used to build the docs, rather than the default version of Sphinx.

Closes: #9869

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9879.org.readthedocs.build/en/9879/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9879.org.readthedocs.build/en/9879/

<!-- readthedocs-preview dev end -->