### PR TITLE
Docs: correct Python console block type

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -119,9 +119,9 @@ You can use this approach to cancel builds that you don't want to complete based
    `the Unix implementation does this automatically <https://tldp.org/LDP/abs/html/exitcodes.html>`_
    for exit codes greater than 255.
 
-   .. code-block:: python
+   .. code-block:: pycon
 
-      >>> sum(list('skip'.encode('ascii')))
+      >>> sum(list("skip".encode("ascii")))
       439
       >>> 439 % 256
       183


### PR DESCRIPTION
Correct block type to avoid failing test such as in #9879:

```
blacken-docs.............................................................Failed
- hook id: blacken-docs
- exit code: 1

docs/user/build-customization.rst:122: code block parse error Cannot parse: 1:0: >>> sum(list('skip'.encode('ascii')))

pre-commit: exit 1 (27.71 seconds) /home/circleci/project> pre-commit run --from-ref main --to-ref HEAD pid=311
  pre-commit: FAIL code 1 (32.93=setup[5.22]+cmd[27.71] seconds)
  evaluation failed :( (33.28 seconds)

Exited with code exit status 1
```

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9880.org.readthedocs.build/en/9880/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9880.org.readthedocs.build/en/9880/

<!-- readthedocs-preview dev end -->