### PR TITLE
Use the pycon lexer and avoid blacken-docs syntax error

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -119,9 +119,9 @@ You can use this approach to cancel builds that you don't want to complete based
    `the Unix implementation does this automatically <https://tldp.org/LDP/abs/html/exitcodes.html>`_
    for exit codes greater than 255.
 
-   .. code-block:: python
+   .. code-block:: pycon
 
-      >>> sum(list('skip'.encode('ascii')))
+      >>> sum(list("skip".encode("ascii")))
       439
       >>> 439 % 256
       183


### PR DESCRIPTION
Fix a blacken-docs linting error seen in #9879 

`pycon` is a valid highligter :)

See: https://pygments.org/docs/lexers/#pygments.lexers.python.PythonConsoleLexer

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9884.org.readthedocs.build/en/9884/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9884.org.readthedocs.build/en/9884/

<!-- readthedocs-preview dev end -->