### PR TITLE
Docs: add warning that pull requests only build HTML and not other formats

### DIFF
--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -144,6 +144,8 @@ Example:
    At the moment, only Sphinx supports additional formats.
    ``pdf``, ``epub``, and ``htmlzip`` output is not yet supported when using MkDocs.
 
+   With :doc:`builds from pull requests </pull-requests>`, only HTML formats are generated. Other formats are resource intensive and will be built after merging.
+
 python
 ~~~~~~
 


### PR DESCRIPTION
This adds a warning to the [Configuration File V2, Formats](https://docs.readthedocs.io/en/stable/config-file/v2.html#formats) section, to help users like myself to evaluate why the formats seemed to be ignored while building docs in pull requests.

Rewording suggestions or moving this to (e.g.) the "note" section is welcome.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9892.org.readthedocs.build/en/9892/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9892.org.readthedocs.build/en/9892/

<!-- readthedocs-preview dev end -->