### PR TITLE
CI: Add option `--show-diff-on-failure`  to pre-commit

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -77,7 +77,7 @@ deps =
 commands =
     # FIXME: use `github.event.pull_request.base.sha` in `--from-ref` because if
     # the base branch is different, this won't work as expected
-    pre-commit run --from-ref main --to-ref HEAD
+    pre-commit run --from-ref main --to-ref HEAD --show-diff-on-failure
 
 [testenv:eslint]
 allowlist_externals = npm


### PR DESCRIPTION
Referencing troubleshooting in https://github.com/readthedocs/readthedocs.org/pull/9411#issuecomment-1381366598, I think it would be really nice to see what pre-commit detects.

Docs: https://pre-commit.com/#pre-commit-run