### PR TITLE
Docs: Relabel Server Side Search

### DIFF
--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -87,6 +87,7 @@ to help you create fantastic documentation for your project.
    /single_version
    /science
    /commercial/organizations
+   /server-side-search/index
 
 .. toctree::
    :maxdepth: 2
@@ -106,8 +107,10 @@ to help you create fantastic documentation for your project.
    :caption: Reference
    :glob:
 
-   api/index
-   reference/features
+   /api/index
+   /server-side-search/api
+   /reference/features
+   /server-side-search/syntax
 
 
 Read the Docs feature overview
@@ -153,7 +156,6 @@ and some of the core features of Read the Docs.
    /integrations
    /versions
    /hosting
-   /server-side-search/index
    /security-log
 
    /builds

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -87,7 +87,6 @@ to help you create fantastic documentation for your project.
    /single_version
    /science
    /commercial/organizations
-   /server-side-search/index
 
 .. toctree::
    :maxdepth: 2

--- a/docs/user/reference/features.rst
+++ b/docs/user/reference/features.rst
@@ -7,3 +7,4 @@ Features
    :maxdepth: 1
 
    analytics
+   /server-side-search/index

--- a/docs/user/server-side-search/api.rst
+++ b/docs/user/server-side-search/api.rst
@@ -7,11 +7,6 @@ If you are using :doc:`/commercial/index` you will need to replace
 https://readthedocs.org/ with https://readthedocs.com/ in all the URLs used in the following examples.
 Check :ref:`server-side-search/api:authentication and authorization` if you are using private versions.
 
-.. contents:: Table of contents
-   :local:
-   :backlinks: none
-   :depth: 3
-
 API V3
 ------
 

--- a/docs/user/server-side-search/index.rst
+++ b/docs/user/server-side-search/index.rst
@@ -6,22 +6,17 @@ this is powered by Elasticsearch_.
 You can search all projects at https://readthedocs.org/search/,
 or search only on your project from the :guilabel:`Search` tab of your project.
 
-.. contents:: Table of contents
-   :local:
-   :backlinks: none
-   :depth: 3
+.. seealso::
 
-.. toctree::
-   :maxdepth: 2
-   :glob:
-   :hidden:
-
-   *
+   :doc:`/server-side-search/syntax`
+     Syntax options for searching Read the Docs projects
+   :doc:`/server-side-search/api`
+     Reference to the Server Side Search API
 
 Search features
 ---------------
 
-We offer a number of benefits compared to other documentation hosts:
+Read the Docs has the following search features:
 
 Search across :doc:`subprojects </subprojects>`
    Subprojects allow you to host multiple discrete projects on a single domain.

--- a/docs/user/server-side-search/syntax.rst
+++ b/docs/user/server-side-search/syntax.rst
@@ -1,14 +1,9 @@
 Search Query Syntax
 ===================
 
-When searching on Read the Docs, you can use some parameters in your
-query in order to search on given projects, versions,
-or to get more accurate results.
-
-.. contents:: Table of contents
-   :local:
-   :backlinks: none
-   :depth: 3
+When searching on Read the Docs with :doc:`Server Side Search </server-side-search/index>`,
+you can use some parameters in your query
+in order to search on given projects, versions, or to get more accurate results.
 
 Parameters
 ----------


### PR DESCRIPTION
Relabling these articles. We should separate references and explanations and not gather them under domain-specific subtopics.

Aside from that, I kept changes minimal here as the articles went under a recent review.

Open question: Is "Server Side Search" to be understood as a proper noun? Or should we just say "server-side search"?

I removed the local TOCs as we haven been using that in many other places.

Refs: #9746 

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9897.org.readthedocs.build/en/9897/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9897.org.readthedocs.build/en/9897/

<!-- readthedocs-preview dev end -->