### PR TITLE
rm mention of docs/requirements.txt from tutorial

### DIFF
--- a/docs/user/tutorial/index.rst
+++ b/docs/user/tutorial/index.rst
@@ -50,8 +50,7 @@ and it contains the following files:
 
 ``docs/``
   Directory holding all the Sphinx documentation sources,
-  including some required dependencies in ``docs/requirements.txt``,
-  the Sphinx configuration ``docs/source/conf.py``,
+  including the Sphinx configuration ``docs/source/conf.py``
   and the root document ``docs/source/index.rst`` written in reStructuredText.
 
 .. figure:: /_static/images/tutorial/github-template.png


### PR DESCRIPTION
Per @humitos instructions I have removed the mention "of some required dependencies in docs/requirements.txt" from the getting started tutorial.
The reason being "it's too deep (and advanced) topic than the tutorial was thought for"
fixes #9873

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9902.org.readthedocs.build/en/9902/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9902.org.readthedocs.build/en/9902/

<!-- readthedocs-preview dev end -->