### PR TITLE
CORS: don't allow to pass credentials by default

### DIFF
--- a/readthedocs/rtd_tests/tests/test_middleware.py
+++ b/readthedocs/rtd_tests/tests/test_middleware.py
@@ -1,6 +1,10 @@
 from unittest import mock
 
-from corsheaders.middleware import CorsMiddleware
+from corsheaders.middleware import (
+    ACCESS_CONTROL_ALLOW_CREDENTIALS,
+    ACCESS_CONTROL_ALLOW_ORIGIN,
+    CorsMiddleware,
+)
 from django.conf import settings
 from django.http import HttpResponse
 from django.test import TestCase, override_settings
@@ -73,7 +77,8 @@ class TestCORSMiddleware(TestCase):
             HTTP_ORIGIN='http://my.valid.domain',
         )
         resp = self.middleware.process_response(request, {})
-        self.assertIn('Access-Control-Allow-Origin', resp)
+        self.assertIn(ACCESS_CONTROL_ALLOW_ORIGIN, resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_CREDENTIALS, resp)
 
     def test_dont_allow_linked_domain_from_private_version(self):
         self.version.privacy_level = PRIVATE
@@ -84,7 +89,8 @@ class TestCORSMiddleware(TestCase):
             HTTP_ORIGIN='http://my.valid.domain',
         )
         resp = self.middleware.process_response(request, {})
-        self.assertNotIn('Access-Control-Allow-Origin', resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_ORIGIN, resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_CREDENTIALS, resp)
 
     def test_allowed_api_public_version_from_another_domain(self):
         request = self.factory.get(
@@ -93,7 +99,8 @@ class TestCORSMiddleware(TestCase):
             HTTP_ORIGIN='http://docs.another.domain',
         )
         resp = self.middleware.process_response(request, {})
-        self.assertIn('Access-Control-Allow-Origin', resp)
+        self.assertIn(ACCESS_CONTROL_ALLOW_ORIGIN, resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_CREDENTIALS, resp)
 
         request = self.factory.get(
             self.url,
@@ -101,7 +108,8 @@ class TestCORSMiddleware(TestCase):
             HTTP_ORIGIN='http://another.valid.domain',
         )
         resp = self.middleware.process_response(request, {})
-        self.assertIn('Access-Control-Allow-Origin', resp)
+        self.assertIn(ACCESS_CONTROL_ALLOW_ORIGIN, resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_CREDENTIALS, resp)
 
     def test_not_allowed_api_private_version_from_another_domain(self):
         self.version.privacy_level = PRIVATE
@@ -112,7 +120,8 @@ class TestCORSMiddleware(TestCase):
             HTTP_ORIGIN='http://docs.another.domain',
         )
         resp = self.middleware.process_response(request, {})
-        self.assertNotIn('Access-Control-Allow-Origin', resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_ORIGIN, resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_CREDENTIALS, resp)
 
         request = self.factory.get(
             self.url,
@@ -120,7 +129,8 @@ class TestCORSMiddleware(TestCase):
             HTTP_ORIGIN='http://another.valid.domain',
         )
         resp = self.middleware.process_response(request, {})
-        self.assertNotIn('Access-Control-Allow-Origin', resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_ORIGIN, resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_CREDENTIALS, resp)
 
     def test_valid_subproject(self):
         self.assertTrue(
@@ -135,7 +145,8 @@ class TestCORSMiddleware(TestCase):
             HTTP_ORIGIN='http://my.valid.domain',
         )
         resp = self.middleware.process_response(request, {})
-        self.assertIn('Access-Control-Allow-Origin', resp)
+        self.assertIn(ACCESS_CONTROL_ALLOW_ORIGIN, resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_CREDENTIALS, resp)
 
     def test_embed_api_private_version_linked_domain(self):
         self.version.privacy_level = PRIVATE
@@ -146,7 +157,8 @@ class TestCORSMiddleware(TestCase):
             HTTP_ORIGIN='http://my.valid.domain',
         )
         resp = self.middleware.process_response(request, {})
-        self.assertNotIn('Access-Control-Allow-Origin', resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_ORIGIN, resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_CREDENTIALS, resp)
 
     def test_embed_api_external_url(self):
         request = self.factory.get(
@@ -174,7 +186,8 @@ class TestCORSMiddleware(TestCase):
             HTTP_ORIGIN='http://invalid.domain',
         )
         resp = self.middleware.process_response(request, {})
-        self.assertIn('Access-Control-Allow-Origin', resp)
+        self.assertIn(ACCESS_CONTROL_ALLOW_ORIGIN, resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_CREDENTIALS, resp)
 
         request = self.factory.get(
             '/api/v2/sustainability/',
@@ -182,7 +195,8 @@ class TestCORSMiddleware(TestCase):
             HTTP_ORIGIN='http://my.valid.domain',
         )
         resp = self.middleware.process_response(request, {})
-        self.assertIn('Access-Control-Allow-Origin', resp)
+        self.assertIn(ACCESS_CONTROL_ALLOW_ORIGIN, resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_CREDENTIALS, resp)
 
     @mock.patch('readthedocs.core.signals._has_donate_app')
     def test_sustainability_endpoint_no_ext(self, has_donate_app):
@@ -193,7 +207,8 @@ class TestCORSMiddleware(TestCase):
             HTTP_ORIGIN='http://invalid.domain',
         )
         resp = self.middleware.process_response(request, {})
-        self.assertNotIn('Access-Control-Allow-Origin', resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_ORIGIN, resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_CREDENTIALS, resp)
 
         request = self.factory.get(
             '/api/v2/sustainability/',
@@ -201,7 +216,8 @@ class TestCORSMiddleware(TestCase):
             HTTP_ORIGIN='http://my.valid.domain',
         )
         resp = self.middleware.process_response(request, {})
-        self.assertNotIn('Access-Control-Allow-Origin', resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_ORIGIN, resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_CREDENTIALS, resp)
 
     def test_apiv2_endpoint_not_allowed(self):
         request = self.factory.get(
@@ -210,7 +226,8 @@ class TestCORSMiddleware(TestCase):
             HTTP_ORIGIN='http://invalid.domain',
         )
         resp = self.middleware.process_response(request, {})
-        self.assertNotIn('Access-Control-Allow-Origin', resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_ORIGIN, resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_CREDENTIALS, resp)
 
         # This also doesn't work on registered domains.
         request = self.factory.get(
@@ -219,7 +236,8 @@ class TestCORSMiddleware(TestCase):
             HTTP_ORIGIN='http://my.valid.domain',
         )
         resp = self.middleware.process_response(request, {})
-        self.assertNotIn('Access-Control-Allow-Origin', resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_ORIGIN, resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_CREDENTIALS, resp)
 
         # Or from our public domain.
         request = self.factory.get(
@@ -228,7 +246,8 @@ class TestCORSMiddleware(TestCase):
             HTTP_ORIGIN='http://docs.readthedocs.io/',
         )
         resp = self.middleware.process_response(request, {})
-        self.assertNotIn('Access-Control-Allow-Origin', resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_ORIGIN, resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_CREDENTIALS, resp)
 
         # POST is not allowed
         request = self.factory.post(
@@ -237,7 +256,8 @@ class TestCORSMiddleware(TestCase):
             HTTP_ORIGIN='http://my.valid.domain',
         )
         resp = self.middleware.process_response(request, {})
-        self.assertNotIn('Access-Control-Allow-Origin', resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_ORIGIN, resp)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_CREDENTIALS, resp)
 
 
 class TestSessionMiddleware(TestCase):

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -728,8 +728,11 @@ class CommunityBaseSettings(Settings):
     }
 
     # CORS
-    # So cookies can be included in cross-domain requests where needed (eg. sustainability API).
-    CORS_ALLOW_CREDENTIALS = True
+    # Don't allow sending cookies in cross-domain requests, this is so we can
+    # relax our CORS headers for more views, but at the same time not opening
+    # users to CSRF attacks. The sustainability API is the only view that requires
+    # cookies to be send cross-site, we override that for that view only.
+    CORS_ALLOW_CREDENTIALS = False
     CORS_ALLOW_HEADERS = (
         'x-requested-with',
         'content-type',


### PR DESCRIPTION
Previously, we were allowing to pass cookies in cross-site requests (because our sustainability API required it), but due to this, we are doing some checks to guarantee that these requests weren't accessing to private resources.
These checks are getting a little complex (they are at the middleware level), since there are several things that influence if the resource is public or private.

This doesn't represent a breaking change since:

- The endpoints listed bellow allow to access public resources only.
- There is no need to pass cookies for accessing public resources.
- Cookies were only allowed to be passed in cross site requests on .org.
- For .com our session cookies are set to `Lax`, so they were never included in cross-site requests.

This could break if users were passing the `{'credentials': 'include'}` in their requests (browsers will reject those requests now), they just need to remove that from their code, or use the proxied APIs. If they were trying to access private resources, that wouldn't have worked anyway.

## Notes

I'm not changing the current list of allowed endpoints yet, wan to test that this works in production first,
but it worked locally. Once we are settled, we can remove all the custom logic from core/signals.py and just keep a list of URLs.

There is another PR on -ext to allow passing credentials to the sustainability API.

## Endpoints allowed in cross-site requests:

- /api/v2/footer_html
- /api/v2/search
- /api/v2/docsearch
- /api/v2/embed
- /api/v3/embed