### PR TITLE
Add new allauth templates

### DIFF
--- a/readthedocs/templates/account/email/account_already_exists_message.html
+++ b/readthedocs/templates/account/email/account_already_exists_message.html
@@ -1,0 +1,23 @@
+{% extends "core/email/common.html" %}
+
+{% block content %}
+<p>
+  You are receiving this email because you or someone else tried to signup for
+  an account using email address: {{ email}}.
+</p>
+
+<p>
+  However, an account using that email address already exists. In case you have
+  forgotten about this, please use the password forgotten procedure to recover
+  your account:
+</p>
+
+<p>
+  <a href="{{ password_reset_url }}">{{ password_reset_url }}</a>
+</p>
+
+<p>
+  If you did not sign up for an account with Read the Docs, you can disregard this email.
+</p>
+
+{% endblock %}

--- a/readthedocs/templates/account/email/account_already_exists_message.txt
+++ b/readthedocs/templates/account/email/account_already_exists_message.txt
@@ -1,0 +1,17 @@
+{% extends "core/email/common.txt" %}
+
+{% block content %}
+
+You are receiving this email because you or someone else tried to signup for
+an account using email address:
+
+{{ email }}
+
+However, an account using that email address already exists. In case you have
+forgotten about this, please use the password forgotten procedure to recover
+your account:
+
+{{ password_reset_url }
+
+If you did not sign up for an account with Read the Docs, you can disregard this email.
+{% endblock %}

--- a/readthedocs/templates/account/email/account_already_exists_subject.txt
+++ b/readthedocs/templates/account/email/account_already_exists_subject.txt
@@ -1,0 +1,1 @@
+Account Already Exists

--- a/readthedocs/templates/account/email/unknown_account_message.html
+++ b/readthedocs/templates/account/email/unknown_account_message.html
@@ -1,0 +1,21 @@
+{% extends "core/email/common.html" %}
+
+{% block content %}
+<p>
+  You are receiving this email because you or someone else has requested a
+  password for your user account. However, we do not have any record of a user
+  with email {{ email }} in our database.
+</p>
+
+<p>
+  This mail can be safely ignored if you did not request a password reset.
+</p>
+
+<p>
+  If it was you, you can sign up for an account using the link below.
+</p>
+
+<p>
+  <a href="{{ signup_url }}">{{ signup_url }}</a>
+</p>
+{% endblock %}

--- a/readthedocs/templates/account/email/unknown_account_message.txt
+++ b/readthedocs/templates/account/email/unknown_account_message.txt
@@ -1,0 +1,13 @@
+{% extends "core/email/common.txt" %}
+
+{% block content %}
+You are receiving this email because you or someone else has requested a
+password for your user account. However, we do not have any record of a user
+with email {{ email }} in our database.
+
+This mail can be safely ignored if you did not request a password reset.
+
+If it was you, you can sign up for an account using the link below.
+
+{{ signup_url }}
+{% endblock %}

--- a/readthedocs/templates/account/email/unknown_account_subject.txt
+++ b/readthedocs/templates/account/email/unknown_account_subject.txt
@@ -1,0 +1,1 @@
+Password Reset Email


### PR DESCRIPTION
This is so we are at pair with
https://github.com/pennersr/django-allauth/tree/master/allauth/templates/account/email.

And we are requiring html versions of these templates in our adapter https://github.com/readthedocs/readthedocs.org/blob/5252be35fb12c4222f56db356af6e92be2fd04c6/readthedocs/core/adapters.py#L50-L50

We should be safe to update django-allauth after this.