### PR TITLE
Subscriptions: allow users to create a new subs on `incomplete_expired`

### DIFF
--- a/readthedocs/subscriptions/constants.py
+++ b/readthedocs/subscriptions/constants.py
@@ -1,4 +1,13 @@
 """Constants for subscriptions."""
+from djstripe.enums import SubscriptionStatus
 
 # Days after the subscription has ended to disable the organization
 DISABLE_AFTER_DAYS = 30
+
+# These status are "terminal", meaning the subscription can't be updated.
+# Users need to create a new subscription to use our service.
+# https://stripe.com/docs/api/subscriptions/object#subscription_object-status.
+TERMINAL_STRIPE_STATUS = [
+    SubscriptionStatus.canceled,
+    SubscriptionStatus.incomplete_expired,
+]

--- a/readthedocs/subscriptions/templates/subscriptions/subscription_detail.html
+++ b/readthedocs/subscriptions/templates/subscriptions/subscription_detail.html
@@ -26,7 +26,7 @@
       </ul>
     {% endif %}
 
-    {% if stripe_subscription.status != 'canceled' %}
+    {% if stripe_subscription.status not in terminal_stripe_status %}
     <dl>
       <dt>{% trans "Plan" %}:</dt>
       <dd>

--- a/readthedocs/subscriptions/views.py
+++ b/readthedocs/subscriptions/views.py
@@ -14,6 +14,7 @@ from djstripe.enums import SubscriptionStatus
 from vanilla import DetailView, GenericView
 
 from readthedocs.organizations.views.base import OrganizationMixin
+from readthedocs.subscriptions.constants import TERMINAL_STRIPE_STATUS
 from readthedocs.subscriptions.forms import PlanForm
 from readthedocs.subscriptions.models import Plan
 from readthedocs.subscriptions.utils import get_or_create_stripe_customer
@@ -62,7 +63,7 @@ class DetailSubscription(OrganizationMixin, DetailView):
         stripe_subscription = self.get_object()
         if (
             not stripe_subscription
-            or stripe_subscription.status != SubscriptionStatus.canceled
+            or stripe_subscription.status not in TERMINAL_STRIPE_STATUS
         ):
             raise Http404()
 
@@ -113,6 +114,7 @@ class DetailSubscription(OrganizationMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context["terminal_stripe_status"] = TERMINAL_STRIPE_STATUS
         stripe_subscription = self.get_object()
         if stripe_subscription:
             context[


### PR DESCRIPTION
We have only 3 subs in this state, so nothing to worry about. I still want to check other places and status in our code...