### PR TITLE
Docs: Remove html_theme_path from conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,6 @@ for more information read https://sphinx-multiproject.readthedocs.io/.
 import os
 import sys
 
-import sphinx_rtd_theme
 from multiproject.utils import get_project
 
 sys.path.insert(0, os.path.abspath(".."))
@@ -143,7 +142,7 @@ html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static", f"{docset}/_static"]
 html_css_files = ["css/custom.css", "css/sphinx_prompt_css.css"]
 html_js_files = ["js/expand_tabs.js"]
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
 html_logo = "img/logo.svg"
 html_theme_options = {
     "logo_only": True,


### PR DESCRIPTION
`html_theme_path` should NOT be defined and is hereby removed. tl;dr https://github.com/readthedocs/readthedocs.org/pull/9654

A really quick shortcut to see if `setup(app)` was called is to check the anchor link next to each headline. If it's a pilcrow (¶), then something is wrong! We want a " :link: "

https://github.com/readthedocs/sphinx_rtd_theme/blob/6444ca893043d8a0ca704474f7cf7d5a148f6767/sphinx_rtd_theme/__init__.py#L72-L76

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9923.org.readthedocs.build/en/9923/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9923.org.readthedocs.build/en/9923/

<!-- readthedocs-preview dev end -->