### PR TITLE
Subscriptions: use getattr for getting related organization

### DIFF
--- a/readthedocs/subscriptions/event_handlers.py
+++ b/readthedocs/subscriptions/event_handlers.py
@@ -114,7 +114,7 @@ def subscription_canceled(event):
         log.info("Stripe subscription not found.")
         return
 
-    organization = stripe_subscription.customer.rtd_organization
+    organization = getattr(stripe_subscription.customer, "rtd_organization", None)
     if not organization:
         log.error("Subscription isn't attached to an organization")
         return

--- a/readthedocs/subscriptions/event_handlers.py
+++ b/readthedocs/subscriptions/event_handlers.py
@@ -114,6 +114,8 @@ def subscription_canceled(event):
         log.info("Stripe subscription not found.")
         return
 
+    # Using `getattr` to avoid the `RelatedObjectDoesNotExist` exception
+    # when the subscription doesn't have an organization attached to it.
     organization = getattr(stripe_subscription.customer, "rtd_organization", None)
     if not organization:
         log.error("Subscription isn't attached to an organization")

--- a/readthedocs/subscriptions/tests/test_event_handlers.py
+++ b/readthedocs/subscriptions/tests/test_event_handlers.py
@@ -358,6 +358,35 @@ class TestStripeEventHandlers(TestCase):
         event_handlers.subscription_canceled(event)
         notification_send.assert_called_once()
 
+    @mock.patch(
+        "readthedocs.subscriptions.event_handlers.SubscriptionEndedNotification.send"
+    )
+    def test_subscription_canceled_no_organization_attached(self, notification_send):
+        customer = get(djstripe.Customer)
+
+        start_date = timezone.now()
+        end_date = timezone.now() + timezone.timedelta(days=30)
+        stripe_subscription = get(
+            djstripe.Subscription,
+            id="sub_9LtsU02uvjO6Ed",
+            status=SubscriptionStatus.canceled,
+            current_period_start=start_date,
+            current_period_end=end_date,
+            trial_end=end_date,
+            customer=customer,
+        )
+        event = get(
+            djstripe.Event,
+            data={
+                "object": {
+                    "id": stripe_subscription.id,
+                    "object": "subscription",
+                }
+            },
+        )
+        event_handlers.subscription_canceled(event)
+        notification_send.assert_not_called()
+
     def test_register_events(self):
         def test_func():
             pass


### PR DESCRIPTION
Otherwise if the customer doesn't have a rtd-organization attached (when an organization is deleted), this will raise an exception.

ref https://read-the-docs.sentry.io/issues/3729261304/?project=161479&query=is%3Aunresolved&referrer=issue-stream