### PR TITLE
Build: communicate uploading errors to users

### DIFF
--- a/readthedocs/builds/constants.py
+++ b/readthedocs/builds/constants.py
@@ -164,3 +164,11 @@ UNDELETABLE_ARTIFACT_TYPES = (
     "html",
     "json",
 )
+# Artifacts that expect one and only one file in the output directory.
+# NOTE: currently, this is a limitation that we are consider to remove
+# https://github.com/readthedocs/readthedocs.org/issues/9931#issuecomment-1403415757
+ARTIFACT_TYPES_WITHOUT_MULTIPLE_FILES_SUPPORT = (
+    "htmlzip",
+    "epub",
+    "pdf",
+)

--- a/readthedocs/doc_builder/exceptions.py
+++ b/readthedocs/doc_builder/exceptions.py
@@ -43,6 +43,10 @@ class BuildUserError(BuildBaseException):
     BUILD_OUTPUT_IS_NOT_A_DIRECTORY = gettext_noop(
         'Build output directory for format "{artifact_type}" is not a directory.'
     )
+    BUILD_OUTPUT_HAS_0_FILES = gettext_noop(
+        'Build output directory for format "{artifact_type}" does not contain any files. '
+        "It seems the build process created the directory but did not save any file to it."
+    )
     BUILD_OUTPUT_HAS_MULTIPLE_FILES = gettext_noop(
         'Build output directory for format "{artifact_type}" contains multiple files '
         "and it is not currently supported. "

--- a/readthedocs/doc_builder/exceptions.py
+++ b/readthedocs/doc_builder/exceptions.py
@@ -40,6 +40,9 @@ class BuildUserError(BuildBaseException):
     BUILD_COMMANDS_WITHOUT_OUTPUT = gettext_noop(
         f'No "{BUILD_COMMANDS_OUTPUT_PATH_HTML}" folder was created during this build.'
     )
+    BUILD_OUTPUT_IS_NOT_A_DIRECTORY = gettext_noop(
+        'Build output directory for format "{format}" is not a directory.',
+    )
 
 
 class BuildUserSkip(BuildUserError):

--- a/readthedocs/doc_builder/exceptions.py
+++ b/readthedocs/doc_builder/exceptions.py
@@ -41,7 +41,12 @@ class BuildUserError(BuildBaseException):
         f'No "{BUILD_COMMANDS_OUTPUT_PATH_HTML}" folder was created during this build.'
     )
     BUILD_OUTPUT_IS_NOT_A_DIRECTORY = gettext_noop(
-        'Build output directory for format "{format}" is not a directory.',
+        'Build output directory for format "{artifact_type}" is not a directory.'
+    )
+    BUILD_OUTPUT_HAS_MULTIPLE_FILES = gettext_noop(
+        'Build output directory for format "{artifact_type}" contains multiple files '
+        "and it is not currently supported. "
+        'Please, remove all the files but the "{artifact_type}" your want to upload.'
     )
 
 

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -19,6 +19,7 @@ from readthedocs.api.v2.client import api as api_v2
 from readthedocs.builds import tasks as build_tasks
 from readthedocs.builds.constants import (
     ARTIFACT_TYPES,
+    ARTIFACT_TYPES_WITHOUT_MULTIPLE_FILES_SUPPORT,
     BUILD_FINAL_STATES,
     BUILD_STATE_BUILDING,
     BUILD_STATE_CLONING,
@@ -550,7 +551,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
             # Check if there are multiple files on artifact directories.
             # These output format does not support multiple files yet.
             # In case multiple files are found, the upload for this format is not performed.
-            if artifact_type in ("htmlzip", "epub", "pdf"):
+            if artifact_type in ARTIFACT_TYPES_WITHOUT_MULTIPLE_FILES_SUPPORT:
                 artifact_format_files = len(os.listdir(artifact_directory))
                 if artifact_format_files > 1:
                     log.error(

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -796,12 +796,22 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         types_to_delete = []
 
         for artifact_type in ARTIFACT_TYPES:
-            if os.path.exists(
-                self.data.project.artifact_path(
-                    version=self.data.version.slug,
-                    type_=artifact_type,
+            artifact_directory = self.data.project.artifact_path(
+                version=self.data.version.slug,
+                type_=artifact_type,
+            )
+            if os.path.isdir(artifact_directory):
+                log.exception(
+                    "Multiple files are not supported for this format. "
+                    "Skipping this output format.",
+                    output_format=media_type,
                 )
-            ):
+                # TODO: we should raise an exception here, fail the build,
+                # and communicate the error to the user.
+                #
+                # raise BuildUserError(BuildUserError.BUILD_OUTPUT_IS_NOT_A_DIRECTORY.format(artifact_type))
+                continue
+            if os.path.exists(artifact_directory):
                 types_to_copy.append(artifact_type)
             # Never delete HTML nor JSON (search index)
             elif artifact_type not in UNDELETABLE_ARTIFACT_TYPES:

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -1,4 +1,5 @@
 import os
+import pathlib
 from unittest import mock
 
 import django_dynamic_fixture as fixture
@@ -200,8 +201,14 @@ class TestBuildTask(BuildEnvironmentBase):
         # Create the artifact paths, so that `store_build_artifacts`
         # properly runs: https://github.com/readthedocs/readthedocs.org/blob/faa611fad689675f81101ea643770a6b669bf529/readthedocs/projects/tasks/builds.py#L798-L804
         os.makedirs(self.project.artifact_path(version=self.version.slug, type_="html"))
-        os.makedirs(self.project.artifact_path(version=self.version.slug, type_="epub"))
-        os.makedirs(self.project.artifact_path(version=self.version.slug, type_="pdf"))
+        for f in ("epub", "pdf"):
+            os.makedirs(self.project.artifact_path(version=self.version.slug, type_=f))
+            pathlib.Path(
+                os.path.join(
+                    self.project.artifact_path(version=self.version.slug, type_=f),
+                    f"{self.project.slug}.{f}",
+                )
+            ).touch()
 
         self._trigger_update_docs_task()
 
@@ -322,11 +329,14 @@ class TestBuildTask(BuildEnvironmentBase):
         # Create the artifact paths, so it's detected by the builder
         os.makedirs(self.project.artifact_path(version=self.version.slug, type_="html"))
         os.makedirs(self.project.artifact_path(version=self.version.slug, type_="json"))
-        os.makedirs(
-            self.project.artifact_path(version=self.version.slug, type_="htmlzip")
-        )
-        os.makedirs(self.project.artifact_path(version=self.version.slug, type_="epub"))
-        os.makedirs(self.project.artifact_path(version=self.version.slug, type_="pdf"))
+        for f in ("htmlzip", "epub", "pdf"):
+            os.makedirs(self.project.artifact_path(version=self.version.slug, type_=f))
+            pathlib.Path(
+                os.path.join(
+                    self.project.artifact_path(version=self.version.slug, type_=f),
+                    f"{self.project.slug}.{f}",
+                )
+            ).touch()
 
         self._trigger_update_docs_task()
 


### PR DESCRIPTION
Running `store_build_artifacts` from inside `.execute()` method
instead of from `.on_sucess()` allow us to raise any exception and handle it
properly.

We can raise a `BuildUserError` to clearly communicate the specific error to the
user, or any other exception to show the generic message: "Try again or contact
us".

Besides, this allows us to *fail the build* instead of continuing silently
without the user noticing this:

- there are more than 1 file of formats that don't support multiple files
- the output path is not a directory
- there were errors uploading the artifacts to the storage

PR based in https://github.com/readthedocs/readthedocs.org/pull/9940
Related to https://github.com/readthedocs/readthedocs.org/issues/9931