### PR TITLE
Celery: ignore task results

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -434,6 +434,7 @@ class CommunityBaseSettings(Settings):
     CELERY_ALWAYS_EAGER = True
     CELERYD_TASK_TIME_LIMIT = 60 * 60  # 60 minutes
     CELERY_SEND_TASK_ERROR_EMAILS = False
+    CELERY_IGNORE_RESULT = True
     CELERYD_HIJACK_ROOT_LOGGER = False
     # This stops us from pre-fetching a task that then sits around on the builder
     CELERY_ACKS_LATE = True

--- a/readthedocs/settings/dev.py
+++ b/readthedocs/settings/dev.py
@@ -40,7 +40,6 @@ class CommunityDevSettings(CommunityBaseSettings):
     CELERY_RESULT_BACKEND = 'redis://localhost:6379/0'
     CELERY_RESULT_SERIALIZER = 'json'
     CELERY_ALWAYS_EAGER = True
-    CELERY_TASK_IGNORE_RESULT = False
 
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -152,7 +152,6 @@ class DockerBaseSettings(CommunityDevSettings):
     CELERY_RESULT_BACKEND = "redis://cache:6379/0"
     CELERY_RESULT_SERIALIZER = "json"
     CELERY_ALWAYS_EAGER = False
-    CELERY_TASK_IGNORE_RESULT = False
 
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 


### PR DESCRIPTION
We are not using them for anything,
so we are just ignoring them and not saving them.

This could help to debug the OOM received by Redis due to a bunch of: `b'5d9d02c5-02bd-3fdf-944a-7b279b8ed2cf.reply.celery.pidbox'` keys.

Related to https://github.com/readthedocs/readthedocs.org/issues/8941