### PR TITLE
Remove custom CORS logic

### DIFF
--- a/readthedocs/core/signals.py
+++ b/readthedocs/core/signals.py
@@ -3,7 +3,7 @@
 import requests
 import structlog
 from allauth.account.signals import email_confirmed
-from corsheaders import signals
+from corsheaders.signals import check_request_enabled
 from django.conf import settings
 from django.db.models.signals import pre_delete
 from django.dispatch import Signal, receiver
@@ -12,20 +12,19 @@ from simple_history.models import HistoricalRecords
 from simple_history.signals import pre_create_historical_record
 
 from readthedocs.analytics.utils import get_client_ip
-from readthedocs.builds.models import Version
 from readthedocs.core.models import UserProfile
-from readthedocs.core.unresolver import unresolve
 from readthedocs.organizations.models import Organization
 from readthedocs.projects.models import Project
 
 log = structlog.get_logger(__name__)
 
 ALLOWED_URLS = [
-    '/api/v2/footer_html',
-    '/api/v2/search',
-    '/api/v2/docsearch',
-    '/api/v2/embed',
-    '/api/v3/embed',
+    "/api/v2/footer_html",
+    "/api/v2/search",
+    "/api/v2/docsearch",
+    "/api/v2/embed",
+    "/api/v3/embed",
+    "/api/v2/sustainability",
 ]
 
 webhook_github = Signal()
@@ -86,15 +85,7 @@ def process_email_confirmed(request, email_address, **kwargs):
             log.exception("Unknown error subscribing user to newsletter.")
 
 
-def _has_donate_app():
-    """
-    Check if the current app has the sustainability API.
-
-    This is a separate function so it's easy to mock.
-    """
-    return 'readthedocsext.donate' in settings.INSTALLED_APPS
-
-
+@receiver(check_request_enabled)
 def decide_if_cors(sender, request, **kwargs):  # pylint: disable=unused-argument
     """
     Decide whether a request should be given CORS access.
@@ -103,64 +94,15 @@ def decide_if_cors(sender, request, **kwargs):  # pylint: disable=unused-argumen
 
     * It's a safe HTTP method
     * The origin is in ALLOWED_URLS
-    * The URL is owned by the project that they are requesting data from
-    * The version is public
-
-    .. note::
-
-       Requests from the sustainability API are always allowed
-       if the donate app is installed.
 
     :returns: `True` when a request should be given CORS access.
     """
     if 'HTTP_ORIGIN' not in request.META or request.method not in SAFE_METHODS:
         return False
 
-    # Always allow the sustainability API,
-    # it's used only on .org to check for ad-free users.
-    if _has_donate_app() and request.path_info.startswith('/api/v2/sustainability'):
-        return True
-
-    valid_url = None
     for url in ALLOWED_URLS:
         if request.path_info.startswith(url):
-            valid_url = url
-            break
-
-    if valid_url:
-        url = request.GET.get('url')
-        if url:
-            unresolved = unresolve(url)
-            if unresolved is None:
-                # NOTE: Embed APIv3 now supports external sites. In that case
-                # ``unresolve()`` will return None and we want to allow it
-                # since the target is a public project.
-                return True
-
-            project = unresolved.project
-            version_slug = unresolved.version.slug
-        else:
-            project_slug = request.GET.get('project', None)
-            version_slug = request.GET.get('version', None)
-            project = Project.objects.filter(slug=project_slug).first()
-
-        if project and version_slug:
-            # This is from IsAuthorizedToViewVersion,
-            # we should abstract is a bit perhaps?
-            is_public = (
-                Version.objects
-                .public(
-                    project=project,
-                    only_active=False,
-                )
-                .filter(slug=version_slug)
-                .exists()
-            )
-            # Allowing CORS on public versions,
-            # since they are already public.
-            if is_public:
-                return True
-
+            return True
     return False
 
 
@@ -196,6 +138,3 @@ def add_extra_historical_fields(sender, **kwargs):
     if request:
         history_instance.extra_history_ip = get_client_ip(request)
         history_instance.extra_history_browser = request.headers.get('User-Agent')
-
-
-signals.check_request_enabled.connect(decide_if_cors)

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -749,6 +749,7 @@ class CommunityBaseSettings(Settings):
         'HEAD',
     ]
 
+    # URLs to allow CORS to read from unauthed.
     CORS_URLS_ALLOW_ALL_REGEX = [
         r"^/api/v2/footer_html",
         r"^/api/v2/search",

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -749,6 +749,15 @@ class CommunityBaseSettings(Settings):
         'HEAD',
     ]
 
+    CORS_URLS_ALLOW_ALL_REGEX = [
+        r"^/api/v2/footer_html",
+        r"^/api/v2/search",
+        r"^/api/v2/docsearch",
+        r"^/api/v2/embed",
+        r"^/api/v3/embed",
+        r"^/api/v2/sustainability",
+    ]
+
     # RTD Settings
     ALLOW_PRIVATE_REPOS = False
     DEFAULT_PRIVACY_LEVEL = 'public'

--- a/readthedocs/settings/proxito/base.py
+++ b/readthedocs/settings/proxito/base.py
@@ -37,6 +37,7 @@ class CommunityProxitoSettingsMixin:
         classes.append('readthedocs.proxito.middleware.ProxitoMiddleware')
 
         middleware_to_remove = (
+            'corsheaders.middleware.CorsMiddleware',
             'csp.middleware.CSPMiddleware',
             'django.middleware.clickjacking.XFrameOptionsMiddleware',
         )

--- a/readthedocs/settings/proxito/base.py
+++ b/readthedocs/settings/proxito/base.py
@@ -20,6 +20,9 @@ class CommunityProxitoSettingsMixin:
     # As 'Lax' breaks when the page is embedded in an iframe.
     SESSION_COOKIE_SAMESITE = None
 
+    # We don't need or want to allow cross site requests in proxito.
+    CORS_URLS_ALLOW_ALL_REGEX = []
+
     @property
     def DATABASES(self):
         # This keeps connections to the DB alive,
@@ -37,6 +40,7 @@ class CommunityProxitoSettingsMixin:
         classes.append('readthedocs.proxito.middleware.ProxitoMiddleware')
 
         middleware_to_remove = (
+            # We don't need or want to allow cross site requests in proxito.
             'corsheaders.middleware.CorsMiddleware',
             'csp.middleware.CSPMiddleware',
             'django.middleware.clickjacking.XFrameOptionsMiddleware',


### PR DESCRIPTION
We don't need this logic anymore, we don't allow passing cookies, so just checking the list of allowed URLs is enough.