### PR TITLE
Docs: Make the GSOC page orphaned (Diátaxis)

### DIFF
--- a/docs/user/gsoc.rst
+++ b/docs/user/gsoc.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Google Summer of Code
 =====================
 

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -298,7 +298,6 @@ of Read the Docs and the larger software documentation ecosystem.
 
 * **Getting involved with Read the Docs**:
   :doc:`/glossary` |
-  :doc:`/gsoc` |
   :doc:`Developer Documentation <rtd-dev:index>`
 
 
@@ -325,4 +324,3 @@ of Read the Docs and the larger software documentation ecosystem.
 
    Developer Documentation <https://dev.readthedocs.io>
    glossary
-   gsoc


### PR DESCRIPTION
We can also remove it completely, but this also works.

Refs: #9746 

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9949.org.readthedocs.build/en/9949/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9949.org.readthedocs.build/en/9949/

<!-- readthedocs-preview dev end -->