### PR TITLE
Build: improve `concurent` queryset

### DIFF
--- a/readthedocs/builds/querysets.py
+++ b/readthedocs/builds/querysets.py
@@ -208,8 +208,6 @@ class BuildQuerySet(models.QuerySet):
         limit_reached = False
         query = Q(
             project=project,
-            # Limit builds to 5 hours ago to speed up the query
-            date__gt=timezone.now() - datetime.timedelta(hours=5),
         )
 
         if project.main_language_project:
@@ -226,6 +224,9 @@ class BuildQuerySet(models.QuerySet):
         organization = project.organizations.first()
         if organization:
             query |= Q(project__in=organization.projects.all())
+
+        # Limit builds to 5 hours ago to speed up the query
+        query &= Q(date__gt=timezone.now() - datetime.timedelta(hours=5))
 
         concurrent = (
             (


### PR DESCRIPTION
We weren't filtering by dat _all the conditions_, only together with the `project_id`. However, when translations where involved builds where not restricted to be the latest ones (starting 5hs ago).

I found this by taking a look at the raw SQL query in New Relic:

```sql
SELECT COUNT(*) FROM (

SELECT DISTINCT "builds_build"."id" AS Col1,
"builds_build"."project_id" AS Col2, "builds_build"."version_id" AS Col3,
"builds_build"."type" AS Col4, "builds_build"."state" AS Col5,
"builds_build"."status" AS Col6, "builds_build"."date" AS Col7,
"builds_build"."success" AS Col8, "builds_build"."setup" AS Col9,
"builds_build"."setup_error" AS Col10, "builds_build"."output" AS Col11,
"builds_build"."error" AS Col12, "builds_build"."exit_code" AS Col13,
"builds_build"."commit" AS Col14, "builds_build"."version_slug" AS Col15,
"builds_build"."version_name" AS Col16, "builds_build"."version_type" AS Col17,
"builds_build"."_config" AS Col18, "builds_build"."length" AS Col19,
"builds_build"."builder" AS Col20, "builds_build"."cold_storage" AS Col21,
"builds_build"."task_id" AS Col22 FROM "builds_build"

INNER JOIN "projects_project" ON ("builds_build"."project_id" = "projects_project"."id")
WHERE ((("builds_build"."date" > %s AND "builds_build"."project_id" = %s) OR
"projects_project"."main_language_project_id" = %s OR "projects_project"."slug"
= %s) AND NOT ("builds_build"."state" IN (%s, %s, %s)))) subquery
```

The initial 5 hours optimization was added in https://github.com/readthedocs/readthedocs.org/pull/7839