### PR TITLE
MkDocs builder: use proper relative path for `--site-dir`

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -295,10 +295,19 @@ class BaseMkdocs(BaseBuilder):
             '-m',
             'mkdocs',
             self.builder,
-            '--clean',
-            '--site-dir',
-            self.build_dir,
-            '--config-file',
+            "--clean",
+            # ``site_dir`` is relative to where the mkdocs.yaml file is
+            # https://www.mkdocs.org/user-guide/configuration/#site_dir
+            # Example:
+            #
+            #  when ``--config-file=docs/mkdocs.yml``,
+            # it must be ``--site-dir=../_readthedocs/html``
+            "--site-dir",
+            os.path.join(
+                os.path.relpath(self.project_path, os.path.dirname(self.yaml_file)),
+                self.build_dir,
+            ),
+            "--config-file",
             os.path.relpath(self.yaml_file, self.project_path),
         ]
         if self.config.mkdocs.fail_on_warning:

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -1257,7 +1257,7 @@ class TestBuildTask(BuildEnvironmentBase):
                     "build",
                     "--clean",
                     "--site-dir",
-                    "_readthedocs/html",
+                    "../_readthedocs/html",
                     "--config-file",
                     "docs/mkdocs.yaml",
                     "--strict",  # fail on warning flag


### PR DESCRIPTION
After performing the standardization of output directories, we broke MkDocs builders for those projects that don't have the config file in the root of the repository.

This happens because MkDocs consider the output directory relative to where the `mkdocs.yml` file is, instead from where the command is executed.

This commit solves this problem by calculating the `--site-dir` relative to where `--config-file` is.

Closes #9935