### PR TITLE
Add documentation page on Commercial subscriptions

### DIFF
--- a/docs/user/commercial/subscriptions.rst
+++ b/docs/user/commercial/subscriptions.rst
@@ -3,7 +3,7 @@ Read the Docs for Business subscription management
 
 We want to make it easy to manage your billing information.
 All :doc:`organization owners </commercial/subscriptions>` can manage the subscription for that organization.
-It's easy in this dashboard to achieve a number of common tasks:
+It's easy to achieve a number of common tasks in this dashboard:
 
 * Update your credit card information.
 * Upgrade, downgrade, or cancel your plan.
@@ -31,11 +31,11 @@ This action will take you to the Stripe billing portal where you can manage your
 Cancelling your subscription
 ----------------------------
 
-Cancelling your subscription can be done in the same way as the above instructions.
-You will be billed for the remainder of the current billing period,
-and then not charged again.
+Cancelling your subscription can be done following the instructions in `Managing your subscription`_.
+Your subscription will remain active for the remainder of the current billing period,
+and will not renew for the next billing period.
 
-**We can not cancel subscriptions just by sending us an email,
+**We can not cancel subscriptions through an email request,
 as email is an insecure method of verifying a user's identity.**
 If you email us about this,
 we require you to verify your identity by logging into your Read the Docs account and submitting an official support request there.
@@ -45,22 +45,22 @@ Billing information
 
 We provide both monthly and annual subscriptions for all plans.
 Annual plans are given a 2 month discount compared to monthly billing.
-We only support credit card billing for our Basic & Advanced plans.
-For our Pro & Enterprise users, we support invoice-based and PO billing.
+We only support credit card billing for our Basic and Advanced plans.
+For our Pro and Enterprise users, we support invoice-based and PO billing.
 
 .. tip::
     We recommend paying by credit card for all users,
     as this greatly simplifies the billing process.
 
-Discounts & Credits
--------------------
+Discounts and credits
+---------------------
 
 We do not generally discount our software.
-We provide a ad-supported service to the community with |org_brand|,
+We provide an ad-supported service to the community with |org_brand|,
 but we do have one standard discount that we offer.
 
-Non-profit & Academic Organizations
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Non-profit and academic organizations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Our community hosting,
 provided for free and open source projects,

--- a/docs/user/commercial/subscriptions.rst
+++ b/docs/user/commercial/subscriptions.rst
@@ -2,7 +2,15 @@ Read the Docs for Business subscription management
 ==================================================
 
 We want to make it easy to manage your billing information.
-You can manage or cancel subscriptions from the :guilabel:`Settings > Subscriptions` page of the :term:`dashboard`.
+All :doc:`organization owners </commercial/subscriptions>` can manage the subscription for that organization.
+It's easy in this dashboard to achieve a number of common tasks:
+
+* Update your credit card information.
+* Upgrade, downgrade, or cancel your plan.
+* View, download, and pay invoices.
+* Add additional tax (VAT/EIN) or contact email addresses on your invoices.
+
+You can always find our most up to date pricing information on our `pricing page <https://about.readthedocs.com/pricing/>`_.
 
 Managing your subscription
 --------------------------
@@ -31,6 +39,18 @@ and then not charged again.
 as email is an insecure method of verifying a user's identity.**
 If you email us about this,
 we require you to verify your identity by logging into your Read the Docs account and submitting an official support request there.
+
+Billing information
+-------------------
+
+We provide both monthly and annual subscriptions for all plans.
+Annual plans are given a 2 month discount compared to monthly billing.
+We only support credit card billing for our Basic & Advanced plans.
+For our Pro & Enterprise users, we support invoice-based and PO billing.
+
+.. tip::
+    We recommend paying by credit card for all users,
+    as this greatly simplifies the billing process.
 
 Discounts & Credits
 -------------------

--- a/docs/user/commercial/subscriptions.rst
+++ b/docs/user/commercial/subscriptions.rst
@@ -1,5 +1,5 @@
-Read the Docs for Business subscription management
-==================================================
+How to manage your Read the Docs for Business subscription
+==========================================================
 
 We want to make it easy to manage your billing information.
 All :doc:`organization owners </commercial/subscriptions>` can manage the subscription for that organization.

--- a/docs/user/commercial/subscriptions.rst
+++ b/docs/user/commercial/subscriptions.rst
@@ -1,0 +1,52 @@
+Read the Docs for Business subscription management
+==================================================
+
+We want to make it easy to manage your billing information.
+You can manage or cancel subscriptions from the :guilabel:`Settings > Subscriptions` page of the :term:`dashboard`.
+
+Managing your subscription
+--------------------------
+
+* Go to https://readthedocs.com/organizations/.
+* Select your organization from this list.
+* Select :guilabel:`Settings` at the top of the page.
+* Select the :guilabel:`Subscription` tab on the left.
+* Click :guilabel:`Manage Subscription`.
+
+This action will take you to the Stripe billing portal where you can manage your subscription.
+
+.. note::
+    You will need to be an organization owner to view subscription information.
+    If you do not have permission,
+    you can ask one of your existing organization owners to make any required changes.
+
+Cancelling your subscription
+----------------------------
+
+Cancelling your subscription can be done in the same way as the above instructions.
+You will be billed for the remainder of the current billing period,
+and then not charged again.
+
+**We can not cancel subscriptions just by sending us an email,
+as email is an insecure method of verifying a user's identity.**
+If you email us about this,
+we require you to verify your identity by logging into your Read the Docs account and submitting an official support request there.
+
+Discounts & Credits
+-------------------
+
+We do not generally discount our software.
+We provide a ad-supported service to the community with |org_brand|,
+but we do have one standard discount that we offer.
+
+Non-profit & Academic Organizations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Our community hosting,
+provided for free and open source projects,
+is generally where we recommend most academic projects to host their projects.
+If you have constraints on how public your documentation can be,
+our commercial hosting is probably a better fit.
+
+We offer a 50% discount on our all of our commercial plans to certified academic and non-profit organizations.
+Please contact :doc:`/support` to request this discount.


### PR DESCRIPTION
This basically just shows people how to manage and cancel their subscription,
so hopefully they don't have to email us for this.

I did this outside of the `diataxis` branch because I want to get it merged & shipped here soon if possible. I would like to add a screenshot, but didn't have a test accnt handy for it. 

Fixes https://github.com/readthedocs/readthedocs.org/issues/9520

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9963.org.readthedocs.build/en/9963/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9963.org.readthedocs.build/en/9963/

<!-- readthedocs-preview dev end -->