### PR TITLE
Build: expose `READTHEDOCS_VIRTUALENV_PATH` variable

### DIFF
--- a/docs/user/environment-variables.rst
+++ b/docs/user/environment-variables.rst
@@ -50,6 +50,12 @@ Read the Docs builders set the following environment variables automatically for
 
     :Examples: ``en``, ``it``, ``de_AT``, ``es``, ``pt_BR``
 
+.. envvar:: READTHEDOCS_VIRTUALENV_PATH
+
+    Path where Read the Docs created the virtualenv for this build.
+
+    :Example: ``/home/docs/checkouts/readthedocs.org/user_builds/project/envs/version``
+
 User-defined environment variables
 ----------------------------------
 

--- a/docs/user/environment-variables.rst
+++ b/docs/user/environment-variables.rst
@@ -52,7 +52,8 @@ Read the Docs builders set the following environment variables automatically for
 
 .. envvar:: READTHEDOCS_VIRTUALENV_PATH
 
-    Path where Read the Docs created the virtualenv for this build.
+    Path for the :ref:`virtualenv that was created for this build <builds:Understanding what's going on>`.
+    Only exists for builds using Virtualenv and not Conda.
 
     :Example: ``/home/docs/checkouts/readthedocs.org/user_builds/project/envs/version``
 

--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -172,6 +172,9 @@ class BuildCommandReadOnlySerializer(BuildCommandSerializer):
 
         regex = f"{docroot}{container_hash}{project_slug}/envs/{version_slug}(/bin/)?"
         command = re.sub(regex, "", obj.command, count=1)
+
+        regex = f"^\\$READTHEDOCS_VIRTUALENV_PATH/bin/"
+        command = re.sub(regex, "", obj.command, count=1)
         return command
 
 

--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -173,7 +173,10 @@ class BuildCommandReadOnlySerializer(BuildCommandSerializer):
         regex = f"{docroot}{container_hash}{project_slug}/envs/{version_slug}(/bin/)?"
         command = re.sub(regex, "", obj.command, count=1)
 
-        regex = f"^\\$READTHEDOCS_VIRTUALENV_PATH/bin/"
+        regex = "^\\$READTHEDOCS_VIRTUALENV_PATH/bin/"
+        command = re.sub(regex, "", obj.command, count=1)
+
+        regex = "^\\$CONDA_ENVS_PATH/\\$CONDA_DEFAULT_ENV/bin/"
         command = re.sub(regex, "", obj.command, count=1)
         return command
 

--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -170,14 +170,15 @@ class BuildCommandReadOnlySerializer(BuildCommandSerializer):
             docroot = re.sub("/[0-9a-z]+/?$", "", settings.DOCROOT, count=1)
             container_hash = "/([0-9a-z]+/)?"
 
+        command = obj.command
         regex = f"{docroot}{container_hash}{project_slug}/envs/{version_slug}(/bin/)?"
-        command = re.sub(regex, "", obj.command, count=1)
+        command = re.sub(regex, "", command, count=1)
 
-        regex = "^\\$READTHEDOCS_VIRTUALENV_PATH/bin/"
-        command = re.sub(regex, "", obj.command, count=1)
+        regex = r"^\$READTHEDOCS_VIRTUALENV_PATH/bin/"
+        command = re.sub(regex, "", command, count=1)
 
-        regex = "^\\$CONDA_ENVS_PATH/\\$CONDA_DEFAULT_ENV/bin/"
-        command = re.sub(regex, "", obj.command, count=1)
+        regex = r"^\$CONDA_ENVS_PATH/\\$CONDA_DEFAULT_ENV/bin/"
+        command = re.sub(regex, "", command, count=1)
         return command
 
 

--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -175,7 +175,7 @@ class BuildCommandReadOnlySerializer(BuildCommandSerializer):
         command = re.sub(regex, "", command, count=1)
 
         # Remove explicit variable names we use to run commands,
-        # since users don't care about these. 
+        # since users don't care about these.
         regex = r"^\$READTHEDOCS_VIRTUALENV_PATH/bin/"
         command = re.sub(regex, "", command, count=1)
 

--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -174,6 +174,8 @@ class BuildCommandReadOnlySerializer(BuildCommandSerializer):
         regex = f"{docroot}{container_hash}{project_slug}/envs/{version_slug}(/bin/)?"
         command = re.sub(regex, "", command, count=1)
 
+        # Remove explicit variable names we use to run commands,
+        # since users don't care about these. 
         regex = r"^\$READTHEDOCS_VIRTUALENV_PATH/bin/"
         command = re.sub(regex, "", command, count=1)
 

--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -577,6 +577,9 @@ class BuildDirector:
                         self.data.version.slug,
                         "bin",
                     ),
+                    "READTHEDOCS_VIRTUALENV_PATH": os.path.join(
+                        self.data.project.doc_path, "envs", self.data.version.slug
+                    ),
                 }
             )
 

--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -556,6 +556,7 @@ class BuildDirector:
         if self.data.config.conda is not None:
             env.update(
                 {
+                    # NOTE: should these be prefixed with "READTHEDOCS_"?
                     "CONDA_ENVS_PATH": os.path.join(
                         self.data.project.doc_path, "conda"
                     ),

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -380,7 +380,15 @@ class DockerBuildCommand(BuildCommand):
 
     def _escape_command(self, cmd):
         r"""Escape the command by prefixing suspicious chars with `\`."""
-        return self.bash_escape_re.sub(r'\\\1', cmd)
+        command = self.bash_escape_re.sub(r"\\\1", cmd)
+
+        # HACK: avoid escaping `$READTHEDOCS_OUTPUT` variable
+        command = command.replace("\\$READTHEDOCS_OUTPUT", "$READTHEDOCS_OUTPUT")
+        # HACK: avoid escaping `$READTHEDOCS_VIRTUALENV_PATH` variable
+        command = command.replace(
+            "\\$READTHEDOCS_VIRTUALENV_PATH", "$READTHEDOCS_VIRTUALENV_PATH"
+        )
+        return command
 
 
 class BaseEnvironment:

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -382,12 +382,15 @@ class DockerBuildCommand(BuildCommand):
         r"""Escape the command by prefixing suspicious chars with `\`."""
         command = self.bash_escape_re.sub(r"\\\1", cmd)
 
-        # HACK: avoid escaping `$READTHEDOCS_OUTPUT` variable
-        command = command.replace("\\$READTHEDOCS_OUTPUT", "$READTHEDOCS_OUTPUT")
-        # HACK: avoid escaping `$READTHEDOCS_VIRTUALENV_PATH` variable
-        command = command.replace(
-            "\\$READTHEDOCS_VIRTUALENV_PATH", "$READTHEDOCS_VIRTUALENV_PATH"
+        # HACK: avoid escaping variables that we need to use in the commands
+        not_escape_variables = (
+            "READTHEDOCS_OUTPUT",
+            "READTHEDOCS_VIRTUALENV_PATH",
+            "CONDA_ENVS_PATH",
+            "CONDA_DEFAULT_ENV",
         )
+        for variable in not_escape_variables:
+            command = command.replace(f"\\${variable}", f"${variable}")
         return command
 
 

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -318,7 +318,7 @@ class Conda(PythonEnvironment):
     .. _Conda: https://conda.io/docs/
     """
 
-    # pylint disable=arguments-differ
+    # pylint: disable=arguments-differ
     def venv_bin(self, filename=None):
         return super().venv_bin(filename=filename, conda=True)
 

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -96,7 +96,7 @@ class PythonEnvironment:
         :param filename: If specified, add this filename to the path return
         :returns: Path to virtualenv bin or filename in virtualenv bin
         """
-        parts = [self.venv_path(), 'bin']
+        parts = ["$READTHEDOCS_VIRTUALENV_PATH", "bin"]
         if filename is not None:
             parts.append(filename)
         return os.path.join(*parts)
@@ -109,9 +109,6 @@ class Virtualenv(PythonEnvironment):
 
     .. _virtualenv: https://virtualenv.pypa.io/
     """
-
-    def venv_path(self):
-        return os.path.join(self.project.doc_path, 'envs', self.version.slug)
 
     def setup_base(self):
         """
@@ -133,9 +130,7 @@ class Virtualenv(PythonEnvironment):
             cli_args.append('--system-site-packages')
 
         # Append the positional destination argument
-        cli_args.append(
-            self.venv_path(),
-        )
+        cli_args.append("$READTHEDOCS_VIRTUALENV_PATH")
 
         self.build_env.run(
             self.config.python_interpreter,
@@ -167,7 +162,9 @@ class Virtualenv(PythonEnvironment):
         )
         cmd = pip_install_cmd + [pip_version, 'setuptools<58.3.0']
         self.build_env.run(
-            *cmd, bin_path=self.venv_bin(), cwd=self.checkout_path
+            *cmd,
+            bin_path=self.venv_bin(),
+            cwd=self.checkout_path,
         )
 
         requirements = []
@@ -318,9 +315,6 @@ class Conda(PythonEnvironment):
     .. _Conda: https://conda.io/docs/
     """
 
-    def venv_path(self):
-        return os.path.join(self.project.doc_path, 'conda', self.version.slug)
-
     def conda_bin_name(self):
         """
         Decide whether use ``mamba`` or ``conda`` to create the environment.
@@ -354,9 +348,6 @@ class Conda(PythonEnvironment):
         )
 
     def setup_base(self):
-        conda_env_path = os.path.join(self.project.doc_path, 'conda')
-        os.path.join(conda_env_path, self.version.slug)
-
         if self.project.has_feature(Feature.UPDATE_CONDA_STARTUP):
             self._update_conda_startup()
 

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -113,7 +113,7 @@ class Virtualenv(PythonEnvironment):
     # pylint: disable=arguments-differ
     def venv_bin(self, filename=None):
         prefixes = ["$READTHEDOCS_VIRTUALENV_PATH", "bin"]
-        super().venv_bin(prefixes, filename=filename)
+        return super().venv_bin(prefixes, filename=filename)
 
     def setup_base(self):
         """

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -318,7 +318,7 @@ class Conda(PythonEnvironment):
     .. _Conda: https://conda.io/docs/
     """
 
-    def venv_bin(self, filename=None):
+    def venv_bin(self, filename=None):  # pylint disable=arguments-differ
         return super().venv_bin(filename=filename, conda=True)
 
     def conda_bin_name(self):

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -318,7 +318,8 @@ class Conda(PythonEnvironment):
     .. _Conda: https://conda.io/docs/
     """
 
-    def venv_bin(self, filename=None):  # pylint disable=arguments-differ
+    # pylint disable=arguments-differ
+    def venv_bin(self, filename=None):
         return super().venv_bin(filename=filename, conda=True)
 
     def conda_bin_name(self):

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -53,6 +53,12 @@ class PythonEnvironment:
         :param install: A install object from the config module.
         :type install: readthedocs.config.models.PythonInstall
         """
+        # NOTE: `venv_bin` requires `prefixes`.
+        # However, it's overwritten in the subclasses and
+        # it forces passing the `prefixes=` attribute.
+        # I'm not sure how to solve this, so I'm skipping this check for now.
+        # pylint: disable=no-value-for-parameter
+
         if install.method == PIP:
             # Prefix ./ so pip installs from a local path rather than pypi
             local_path = (
@@ -94,7 +100,7 @@ class PythonEnvironment:
         Return path to the virtualenv bin path, or a specific binary.
 
         :param filename: If specified, add this filename to the path return
-        :param prefix: List of path prefixes to include in the resulting path
+        :param prefixes: List of path prefixes to include in the resulting path
         :returns: Path to virtualenv bin or filename in virtualenv bin
         """
         if filename is not None:

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -89,20 +89,17 @@ class PythonEnvironment:
                 bin_path=self.venv_bin(),
             )
 
-    def venv_bin(self, filename=None, conda=False):
+    def venv_bin(self, prefixes, filename=None):
         """
         Return path to the virtualenv bin path, or a specific binary.
 
         :param filename: If specified, add this filename to the path return
+        :param prefix: List of path prefixes to include in the resulting path
         :returns: Path to virtualenv bin or filename in virtualenv bin
         """
-        parts = ["$READTHEDOCS_VIRTUALENV_PATH", "bin"]
-        if conda:
-            parts = ["$CONDA_ENVS_PATH", "$CONDA_DEFAULT_ENV", "bin"]
-
         if filename is not None:
-            parts.append(filename)
-        return os.path.join(*parts)
+            prefixes.append(filename)
+        return os.path.join(*prefixes)
 
 
 class Virtualenv(PythonEnvironment):
@@ -112,6 +109,11 @@ class Virtualenv(PythonEnvironment):
 
     .. _virtualenv: https://virtualenv.pypa.io/
     """
+
+    # pylint: disable=arguments-differ
+    def venv_bin(self, filename=None):
+        prefixes = ["$READTHEDOCS_VIRTUALENV_PATH", "bin"]
+        super().venv_bin(prefixes, filename=filename)
 
     def setup_base(self):
         """
@@ -320,7 +322,8 @@ class Conda(PythonEnvironment):
 
     # pylint: disable=arguments-differ
     def venv_bin(self, filename=None):
-        return super().venv_bin(filename=filename, conda=True)
+        prefixes = ["$CONDA_ENVS_PATH", "$CONDA_DEFAULT_ENV", "bin"]
+        return super().venv_bin(prefixes, filename=filename)
 
     def conda_bin_name(self):
         """

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -89,7 +89,7 @@ class PythonEnvironment:
                 bin_path=self.venv_bin(),
             )
 
-    def venv_bin(self, filename=None):
+    def venv_bin(self, filename=None, conda=False):
         """
         Return path to the virtualenv bin path, or a specific binary.
 
@@ -97,6 +97,9 @@ class PythonEnvironment:
         :returns: Path to virtualenv bin or filename in virtualenv bin
         """
         parts = ["$READTHEDOCS_VIRTUALENV_PATH", "bin"]
+        if conda:
+            parts = ["$CONDA_ENVS_PATH", "$CONDA_DEFAULT_ENV", "bin"]
+
         if filename is not None:
             parts.append(filename)
         return os.path.join(*parts)
@@ -314,6 +317,9 @@ class Conda(PythonEnvironment):
 
     .. _Conda: https://conda.io/docs/
     """
+
+    def venv_bin(self, filename=None):
+        return super().venv_bin(filename=filename, conda=True)
 
     def conda_bin_name(self):
         """

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -275,6 +275,7 @@ class TestBuildTask(BuildEnvironmentBase):
             "READTHEDOCS_VERSION_NAME": self.version.verbose_name,
             "READTHEDOCS_PROJECT": self.project.slug,
             "READTHEDOCS_LANGUAGE": self.project.language,
+            "READTHEDOCS_VIRTUALENV_PATH": "/usr/src/app/checkouts/readthedocs.org/user_builds/project/envs/latest",
         }
 
         self._trigger_update_docs_task()

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -275,7 +275,6 @@ class TestBuildTask(BuildEnvironmentBase):
             "READTHEDOCS_VERSION_NAME": self.version.verbose_name,
             "READTHEDOCS_PROJECT": self.project.slug,
             "READTHEDOCS_LANGUAGE": self.project.language,
-            "READTHEDOCS_VIRTUALENV_PATH": "/usr/src/app/checkouts/readthedocs.org/user_builds/project/envs/latest",
         }
 
         self._trigger_update_docs_task()
@@ -295,6 +294,7 @@ class TestBuildTask(BuildEnvironmentBase):
                 "bin",
             ),
             PUBLIC_TOKEN="a1b2c3",
+            READTHEDOCS_VIRTUALENV_PATH=f"/usr/src/app/checkouts/readthedocs.org/user_builds/{self.project.slug}/envs/{self.version.slug}",
         )
         if not external:
             expected_build_env_vars["PRIVATE_TOKEN"] = "a1b2c3"

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -294,7 +294,9 @@ class TestBuildTask(BuildEnvironmentBase):
                 "bin",
             ),
             PUBLIC_TOKEN="a1b2c3",
-            READTHEDOCS_VIRTUALENV_PATH=f"/usr/src/app/checkouts/readthedocs.org/user_builds/{self.project.slug}/envs/{self.version.slug}",
+            # Local and Circle are different values.
+            # We only check it's present, but not its value.
+            READTHEDOCS_VIRTUALENV_PATH=mock.ANY,
         )
         if not external:
             expected_build_env_vars["PRIVATE_TOKEN"] = "a1b2c3"

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -334,7 +334,7 @@ class APIBuildTests(TestCase):
         buildcommandresult = get(
             BuildCommandResult,
             build=build,
-            command="/home/docs/checkouts/readthedocs.org/user_builds/myproject/envs/myversion/bin/python -m pip install --upgrade --no-cache-dir pip setuptools<58.3.0",
+            command="python -m pip install --upgrade --no-cache-dir pip setuptools<58.3.0",
             exit_code=0,
         )
         resp = client.get('/api/v2/build/{build}/'.format(build=build.pk))


### PR DESCRIPTION
The variable `$READTHEDOCS_VIRTUALENV_PATH` points to where Read the Docs created the virtualenv.

While working on this I found that we can use this variable to run our own commands. This way, we will be avoiding mistakes and potentially having differences path between "the real path" and the content of this variable. I changed our code to use this variable when running `/bin/python` and others.

Besides, I did the same for Conda environments and the variables `CONDA_ENV_PATHS` and `CONDA_DEFAULT_ENV` that were already defined.

This makes the code cleaner and simpler, while more standardized as well. Users can use these variables in the same way Read the Docs does and be sure the content they are expecting is going to be there.

Closes #9629

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9971.org.readthedocs.build/en/9971/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9971.org.readthedocs.build/en/9971/

<!-- readthedocs-preview dev end -->