### PR TITLE
Update security docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,11 @@ Version 9.3.0
 Version 9.2.0
 -------------
 
+**This release contains two security fixes. For more information, see our GitHub advisories:**
+
+- `GHSA-7fcx-wwr3-99jv <https://github.com/readthedocs/readthedocs.org/security/advisories/GHSA-7fcx-wwr3-99jv>`__
+- `GHSA-hqwg-gjqw-h5wg <https://github.com/readthedocs/readthedocs.org/security/advisories/GHSA-hqwg-gjqw-h5wg>`__
+
 :Date: January 16, 2023
 
 * `@github-actions[bot] <https://github.com/github-actions[bot]>`__: Dependencies: all packages updated via pip-tools (`#9898 <https://github.com/readthedocs/readthedocs.org/pull/9898>`__)

--- a/docs/user/security.rst
+++ b/docs/user/security.rst
@@ -49,7 +49,8 @@ You can expect:
 * We will respond acknowledging your email typically within one business day.
 * We will follow up if and when we have confirmed the issue with a timetable for the fix.
 * We will notify you when the issue is fixed.
-* We will create a `GitHub advisory`_ and publish it when the issue has been fixed.
+* We will create a `GitHub advisory`_ and publish it when the issue has been fixed
+  and deployed in our platforms.
 
 .. _GitHub advisory: https://github.com/readthedocs/readthedocs.org/security/advisories
 

--- a/docs/user/security.rst
+++ b/docs/user/security.rst
@@ -49,8 +49,9 @@ You can expect:
 * We will respond acknowledging your email typically within one business day.
 * We will follow up if and when we have confirmed the issue with a timetable for the fix.
 * We will notify you when the issue is fixed.
-* We will add the issue to our :ref:`security issue archive <security:Security issue archive>`.
+* We will create a `GitHub advisory`_ and publish it when the issue has been fixed.
 
+.. _GitHub advisory: https://github.com/readthedocs/readthedocs.org/security/advisories
 
 PGP key
 -------


### PR DESCRIPTION
We missed to mention the latest security discoveries in our changelog as we have been doing.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--9973.org.readthedocs.build/en/9973/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--9973.org.readthedocs.build/en/9973/

<!-- readthedocs-preview dev end -->