### PR TITLE
Subscriptions: match stripe customer description with org name

### DIFF
--- a/readthedocs/subscriptions/signals.py
+++ b/readthedocs/subscriptions/signals.py
@@ -51,6 +51,9 @@ def update_stripe_customer(sender, instance, created, **kwargs):
     if organization.email != stripe_customer.email:
         fields_to_update["email"] = organization.email
 
+    if organization.name != stripe_customer.description:
+        fields_to_update["description"] = organization.name
+
     org_metadata = organization.get_stripe_metadata()
     current_metadata = stripe_customer.metadata or {}
     for key, value in org_metadata.items():

--- a/readthedocs/subscriptions/tests/test_signals.py
+++ b/readthedocs/subscriptions/tests/test_signals.py
@@ -19,11 +19,13 @@ class TestSignals(TestCase):
         self.organization = get(
             Organization,
             slug="org",
+            name="org",
             owners=[self.user],
             email=email,
             stripe_customer=self.stripe_customer,
         )
         self.stripe_customer.metadata = self.organization.get_stripe_metadata()
+        self.stripe_customer.description = self.organization.name
         self.stripe_customer.save()
 
     @mock.patch("readthedocs.subscriptions.signals.stripe.Customer")
@@ -34,6 +36,16 @@ class TestSignals(TestCase):
         customer.modify.assert_called_once_with(
             self.stripe_customer.id,
             email=new_email,
+        )
+
+    @mock.patch("readthedocs.subscriptions.signals.stripe.Customer")
+    def test_update_organization_name(self, customer):
+        new_name = "New organization"
+        self.organization.name = new_name
+        self.organization.save()
+        customer.modify.assert_called_once_with(
+            self.stripe_customer.id,
+            description=new_name,
         )
 
     @mock.patch("readthedocs.subscriptions.signals.stripe.Customer")


### PR DESCRIPTION
After creation we aren't updating this, and it can't be updated from the stripe portal