### PR TITLE
Development: use `gunicorn` for `web` and `proxito`

### DIFF
--- a/readthedocs/wsgi.py
+++ b/readthedocs/wsgi.py
@@ -1,18 +1,11 @@
-# -*- coding: utf-8 -*-
-
 """WSGI application helper."""
-
-from __future__ import absolute_import
 import os
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'readthedocs.settings.dev')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "readthedocs.settings.docker_compose")
 
 # This application object is used by any WSGI server configured to use this
 # file. This includes Django's development server, if the WSGI_APPLICATION
 # setting points here.
 from django.core.wsgi import get_wsgi_application  # noqa
-application = get_wsgi_application()
 
-# Apply WSGI middleware here.
-# from helloworld.wsgi import HelloWorldApplication
-# application = HelloWorldApplication(application)
+application = get_wsgi_application()

--- a/requirements/deploy.in
+++ b/requirements/deploy.in
@@ -3,7 +3,6 @@
 -r pip.txt
 
 psycopg2
-gunicorn
 django-redis-cache
 
 # For resizing images

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -200,7 +200,7 @@ gitdb==4.0.10
 gitpython==3.1.30
     # via -r requirements/pip.txt
 gunicorn==20.1.0
-    # via -r requirements/deploy.in
+    # via -r requirements/pip.txt
 idna==3.4
     # via
     #   -r requirements/pip.txt

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -211,6 +211,8 @@ gitdb==4.0.10
     #   gitpython
 gitpython==3.1.30
     # via -r requirements/pip.txt
+gunicorn==20.1.0
+    # via -r requirements/pip.txt
 idna==3.4
     # via
     #   -r requirements/pip.txt

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -195,6 +195,8 @@ gitdb==4.0.10
     #   gitpython
 gitpython==3.1.30
     # via -r requirements/pip.txt
+gunicorn==20.1.0
+    # via -r requirements/pip.txt
 idna==3.4
     # via
     #   -r requirements/pip.txt

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -203,6 +203,8 @@ gitdb==4.0.10
     #   gitpython
 gitpython==3.1.30
     # via -r requirements/pip.txt
+gunicorn==20.1.0
+    # via -r requirements/pip.txt
 idna==3.4
     # via
     #   -r requirements/pip.txt

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -130,3 +130,5 @@ django-structlog==2.2.0
 
 structlog
 dparse
+
+gunicorn

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -147,6 +147,8 @@ gitdb==4.0.10
     # via gitpython
 gitpython==3.1.30
     # via -r requirements/pip.in
+gunicorn==20.1.0
+    # via -r requirements/pip.in
 idna==3.4
     # via requests
 imagesize==1.4.1

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -196,6 +196,8 @@ gitdb==4.0.10
     #   gitpython
 gitpython==3.1.30
     # via -r requirements/pip.txt
+gunicorn==20.1.0
+    # via -r requirements/pip.txt
 idna==3.4
     # via
     #   -r requirements/pip.txt


### PR DESCRIPTION
Match production environment by using `gunicorn` instead of the Django development server.

It uses a previous work that @agjohnson did to reload the `web` and `proxito` processes inside Docker using `nodemon`. It requires this "common" PR: https://github.com/readthedocs/common/pull/160

- it keeps the same functionality from `manage.py runserver` (auto reload --being able to turn it on/off)
- matches environment from production
- allows handling multiple requests in a nicer way locally
- site works faster locally (maybe it's my impression, but 🤷🏼 )