### PR TITLE
Proxito: always check `404/index.hmtml`

### DIFF
--- a/docs/user/hosting.rst
+++ b/docs/user/hosting.rst
@@ -74,18 +74,18 @@ Custom Not Found (404) Pages
 ----------------------------
 
 If you want your project to use a custom page for not found pages instead of the "Maze Found" default,
-you can put a ``404.html`` at the top level of your project's HTML output.
+you can put a ``404.html`` or ``404/index.html`` in your project's HTML output.
 
 When a 404 is returned,
-Read the Docs checks if there is a ``404.html`` in the root of your project's output
+Read the Docs checks if there is a ``404.html`` or ``404/index.html`` in your project's output
 corresponding to the *current* version
 and uses it if it exists.
-Otherwise, it tries to fall back to the ``404.html`` page
+Otherwise, it tries to fall back to the ``404.html`` or ``404/index.html`` page
 corresponding to the *default* version of the project.
 
 We recommend the `sphinx-notfound-page`_ extension,
 which Read the Docs maintains.
-It automatically creates a ``404.html`` page for your documentation,
+It automatically creates a the 404 page for your documentation,
 matching the theme of your project.
 See its documentation_ for how to install and customize it.
 

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -819,8 +819,10 @@ class TestAdditionalDocViews(BaseDocServing):
         )
         storage_exists.assert_has_calls(
             [
-                mock.call('html/project/fancy-version/404.html'),
-                mock.call('html/project/latest/404.html'),
+                mock.call("html/project/fancy-version/404.html"),
+                mock.call("html/project/fancy-version/404/index.html"),
+                mock.call("html/project/latest/404.html"),
+                mock.call("html/project/latest/404/index.html"),
             ]
         )
 
@@ -848,8 +850,10 @@ class TestAdditionalDocViews(BaseDocServing):
         )
         storage_exists.assert_has_calls(
             [
-                mock.call('html/project/fancy-version/404.html'),
-                mock.call('html/project/latest/404.html'),
+                mock.call("html/project/fancy-version/404.html"),
+                mock.call("html/project/fancy-version/404/index.html"),
+                mock.call("html/project/latest/404.html"),
+                mock.call("html/project/latest/404/index.html"),
             ]
         )
 
@@ -908,10 +912,12 @@ class TestAdditionalDocViews(BaseDocServing):
         )
         storage_exists.assert_has_calls(
             [
-                mock.call('html/project/fancy-version/not-found/index.html'),
-                mock.call('html/project/fancy-version/not-found/README.html'),
-                mock.call('html/project/fancy-version/404.html'),
-                mock.call('html/project/latest/404.html')
+                mock.call("html/project/fancy-version/not-found/index.html"),
+                mock.call("html/project/fancy-version/not-found/README.html"),
+                mock.call("html/project/fancy-version/404.html"),
+                mock.call("html/project/fancy-version/404/index.html"),
+                mock.call("html/project/latest/404.html"),
+                mock.call("html/project/latest/404/index.html"),
             ]
         )
 
@@ -938,11 +944,12 @@ class TestAdditionalDocViews(BaseDocServing):
         )
         storage_exists.assert_has_calls(
             [
-                mock.call('html/project/fancy-version/not-found/index.html'),
-                mock.call('html/project/fancy-version/not-found/README.html'),
-                mock.call('html/project/fancy-version/404.html'),
-                mock.call('html/project/latest/404.html'),
-                mock.call('html/project/latest/404/index.html'),
+                mock.call("html/project/fancy-version/not-found/index.html"),
+                mock.call("html/project/fancy-version/not-found/README.html"),
+                mock.call("html/project/fancy-version/404.html"),
+                mock.call("html/project/fancy-version/404/index.html"),
+                mock.call("html/project/latest/404.html"),
+                mock.call("html/project/latest/404/index.html"),
             ]
         )
 

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -376,7 +376,7 @@ class ServeError404Base(ServeRedirectMixin, ServeDocsMixin, View):
                     resp.status_code = 404
                     self._register_broken_link(
                         project=final_project,
-                        version=version,
+                        version_slug=version_slug_404,
                         path=filename,
                         full_path=proxito_path,
                     )
@@ -384,16 +384,18 @@ class ServeError404Base(ServeRedirectMixin, ServeDocsMixin, View):
 
         self._register_broken_link(
             project=final_project,
-            version=version,
+            version_slug=version_slug,
             path=filename,
             full_path=proxito_path,
         )
         raise Http404('No custom 404 page found.')
 
-    def _register_broken_link(self, project, version, path, full_path):
+    def _register_broken_link(self, project, version_slug, path, full_path):
         try:
             if not project.has_feature(Feature.RECORD_404_PAGE_VIEWS):
                 return
+
+            version = project.versions.get(slug=version_slug)
 
             # This header is set from Cloudflare,
             # it goes from 0 to 100, 0 being low risk,

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -347,7 +347,8 @@ class ServeError404Base(ServeRedirectMixin, ServeDocsMixin, View):
             project=final_project, slug=version_slug
         ).first()
 
-        # If there are no redirect, try to serve the custom 404 of the current version (version_slug)
+        # If there are no redirect,
+        # try to serve the custom 404 of the current version (version_slug)
         # Then, try to serve the custom 404 page for the default version
         # (project.get_default_version())
         versions = []

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -305,7 +305,7 @@ class ServeError404Base(ServeRedirectMixin, ServeDocsMixin, View):
                 )
                 log.debug("Trying index filename.")
                 if build_media_storage.exists(storage_filename_path):
-                    log.info("Redirecting to index file.")
+                    log.info("Redirecting to index file.", tryfile=tryfile)
                     # Use urlparse so that we maintain GET args in our redirect
                     parts = urlparse(proxito_path)
                     if tryfile == "README.html":

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -395,8 +395,6 @@ class ServeError404Base(ServeRedirectMixin, ServeDocsMixin, View):
             if not project.has_feature(Feature.RECORD_404_PAGE_VIEWS):
                 return
 
-            version = project.versions.get(slug=version_slug)
-
             # This header is set from Cloudflare,
             # it goes from 0 to 100, 0 being low risk,
             # and values above 10 are bots/spammers.
@@ -409,6 +407,7 @@ class ServeError404Base(ServeRedirectMixin, ServeDocsMixin, View):
                 )
                 return
 
+            version = project.versions.filter(slug=version_slug).first()
             # If the path isn't attached to a version
             # it should be the same as the full_path,
             # otherwise it would be empty.


### PR DESCRIPTION
With the introduction of `build.commands` we cannot use `version.documentation_type` anymore since those versions will be `generic` and we can't skip checking for this file location.

Note this commit may add and extra call to S3 API for all the 404 pages where our regular Maze will be shown. However, it removes 2 databsae calls from all the 404 requests.

We could only add this extra check on S3 for
`version.documentation_type='generic'`, but that would make the code a little more complex and we won't be removing these 2 db queries.

Reference: https://github.com/readthedocs/sphinx-notfound-page/issues/215#issuecomment-1415771549