### PR TITLE
Requirements: remove `django-kombu`

### DIFF
--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -143,8 +143,6 @@ django-ipware==4.0.2
     # via
     #   -r requirements/pip.txt
     #   django-structlog
-django-kombu==0.9.4
-    # via -r requirements/pip.txt
 django-messages-extends==0.6.3
     # via -r requirements/pip.txt
 django-polymorphic==3.1.0

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -152,8 +152,6 @@ django-ipware==4.0.2
     # via
     #   -r requirements/pip.txt
     #   django-structlog
-django-kombu==0.9.4
-    # via -r requirements/pip.txt
 django-messages-extends==0.6.3
     # via -r requirements/pip.txt
 django-polymorphic==3.1.0

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -143,8 +143,6 @@ django-ipware==4.0.2
     # via
     #   -r requirements/pip.txt
     #   django-structlog
-django-kombu==0.9.4
-    # via -r requirements/pip.txt
 django-messages-extends==0.6.3
     # via -r requirements/pip.txt
 django-polymorphic==3.1.0

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -70,7 +70,6 @@ orjson
 # Utils
 django-gravatar2
 pytz
-django-kombu
 
 # We cannot upgrade it until dj-stripe fixes this issue
 # https://github.com/dj-stripe/dj-stripe/issues/1842

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -99,8 +99,6 @@ django-gravatar2==1.4.4
     # via -r requirements/pip.in
 django-ipware==4.0.2
     # via django-structlog
-django-kombu==0.9.4
-    # via -r requirements/pip.in
 django-messages-extends==0.6.3
     # via -r requirements/pip.in
 django-polymorphic==3.1.0

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -142,8 +142,6 @@ django-ipware==4.0.2
     # via
     #   -r requirements/pip.txt
     #   django-structlog
-django-kombu==0.9.4
-    # via -r requirements/pip.txt
 django-messages-extends==0.6.3
     # via -r requirements/pip.txt
 django-polymorphic==3.1.0


### PR DESCRIPTION
It's deprecated and it was included in `kombu` directly.

> django-kombu has now moved into Kombu core, so this repository is no longer in
use.

(from https://pypi.org/project/django-kombu/)

We are not using it directly, but as a dependency required by Celery itself.