### PR TITLE
Analytics API: catch unresolver exceptions

### DIFF
--- a/readthedocs/analytics/proxied_api.py
+++ b/readthedocs/analytics/proxied_api.py
@@ -8,7 +8,7 @@ from rest_framework.views import APIView
 
 from readthedocs.analytics.models import PageView
 from readthedocs.api.v2.permissions import IsAuthorizedToViewVersion
-from readthedocs.core.unresolver import unresolve
+from readthedocs.core.unresolver import UnresolverError, unresolve
 from readthedocs.core.utils.extend import SettingsOverrideObject
 from readthedocs.projects.models import Project
 
@@ -59,8 +59,14 @@ class BaseAnalyticsView(APIView):
     # pylint: disable=no-self-use
     def increase_page_view_count(self, project, version, absolute_uri):
         """Increase the page view count for the given project."""
-        unresolved = unresolve(absolute_uri)
-        if not unresolved or not unresolved.filename:
+        try:
+            unresolved = unresolve(absolute_uri)
+        except UnresolverError:
+            # If we were unable to resolve the URL, it
+            # isn't pointing to a valid RTD project.
+            return
+
+        if not unresolved.filename:
             return
 
         path = unresolved.filename

--- a/readthedocs/analytics/tests.py
+++ b/readthedocs/analytics/tests.py
@@ -118,6 +118,16 @@ class AnalyticsPageViewsTests(TestCase):
         self.tomorrow = timezone.now() + timezone.timedelta(days=1)
         self.yesterday = timezone.now() - timezone.timedelta(days=1)
 
+    def test_invalid_uri(self):
+        assert PageView.objects.all().count() == 0
+        url = (
+            reverse("analytics_api")
+            + f"?project={self.project.slug}&version={self.version.slug}"
+            f"&absolute_uri=https://docs.example.com"
+        )
+        self.client.get(url, HTTP_HOST=self.host)
+        assert PageView.objects.all().count() == 0
+
     def test_increase_page_view_count(self):
         assert (
             PageView.objects.all().count() == 0


### PR DESCRIPTION
Currently we are returning 500.