### PR TITLE
Celery: cleanup `pidbox` keys

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -503,7 +503,12 @@ class CommunityBaseSettings(Settings):
             'task': 'readthedocs.domains.tasks.email_pending_custom_domains',
             'schedule': crontab(minute=0, hour=3),
             'options': {'queue': 'web'},
-        }
+        },
+        'every-15m-delete-pidbox-objects': {
+            'task': 'readthedocs.core.tasks.cleanup_pidbox_keys',
+            'schedule': crontab(minute='*/15'),
+            'options': {'queue': 'web'},
+        },
     }
 
     MULTIPLE_BUILD_SERVERS = [CELERY_DEFAULT_QUEUE]


### PR DESCRIPTION
Simple task to remove `pidbox` keys older than 15 minutes. This is a workaround to avoid Redis OOM for now.

We will need to find out a better solution here. There is an upstream issue opened that we should check in the near future and probably remove this
workaround: https://github.com/celery/celery/issues/6089

Related: https://github.com/readthedocs/readthedocs-ops/issues/1260