### PR TITLE
Redis: use `django-redis` and add password

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -27,9 +27,6 @@ services:
         GITHUB_USER: ${GITHUB_USER:-}
         GITHUB_TOKEN: ${GITHUB_TOKEN:-}
 
-  cache:
-    image: redis:6.0.5
-
   nginx:
     networks:
       readthedocs:

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -152,14 +152,17 @@ class DockerBaseSettings(CommunityBaseSettings):
     SESSION_COOKIE_DOMAIN = None
     CACHES = {
         'default': {
-            'BACKEND': 'redis_cache.RedisCache',
-            'LOCATION': 'cache:6379',
-        }
+            "BACKEND": "django_redis.cache.RedisCache",
+            'LOCATION': 'redis://cache:6379',
+            "OPTIONS": {
+                "CLIENT_CLASS": "django_redis.client.DefaultClient",
+                "PASSWORD": "redispassword",
+            },
+        },
     }
 
-    BROKER_URL = "redis://cache:6379/0"
-    CELERY_RESULT_BACKEND = "redis://cache:6379/0"
-    CELERY_RESULT_SERIALIZER = "json"
+    BROKER_URL = f"redis://:{CACHES['default']['OPTIONS']['PASSWORD']}@cache:6379/0"
+
     CELERY_ALWAYS_EAGER = False
 
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"

--- a/requirements/deploy.in
+++ b/requirements/deploy.in
@@ -3,7 +3,6 @@
 -r pip.txt
 
 psycopg2
-django-redis-cache
 
 # For resizing images
 pillow

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -18,6 +18,10 @@ asgiref==3.6.0
     #   django
 asttokens==2.2.1
     # via stack-data
+async-timeout==4.0.2
+    # via
+    #   -r requirements/pip.txt
+    #   redis
 babel==2.11.0
     # via
     #   -r requirements/pip.txt
@@ -150,8 +154,6 @@ django-polymorphic==3.1.0
     # via -r requirements/pip.txt
 django-redis==5.2.0
     # via -r requirements/pip.txt
-django-redis-cache==3.0.1
-    # via -r requirements/deploy.in
 django-simple-history==3.0.0
     # via -r requirements/pip.txt
 django-storages[boto3]==1.13.2
@@ -313,11 +315,10 @@ pytz==2022.7.1
     #   djangorestframework
 pyyaml==5.4.1
     # via -r requirements/pip.txt
-redis==3.5.3
+redis==4.5.1
     # via
     #   -r requirements/pip.txt
     #   django-redis
-    #   django-redis-cache
 regex==2022.10.31
     # via -r requirements/pip.txt
 requests==2.28.2

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -110,6 +110,7 @@ django==3.2.17
     #   django-filter
     #   django-formtools
     #   django-polymorphic
+    #   django-redis
     #   django-storages
     #   django-structlog
     #   django-taggit
@@ -146,6 +147,8 @@ django-ipware==4.0.2
 django-messages-extends==0.6.3
     # via -r requirements/pip.txt
 django-polymorphic==3.1.0
+    # via -r requirements/pip.txt
+django-redis==5.2.0
     # via -r requirements/pip.txt
 django-redis-cache==3.0.1
     # via -r requirements/deploy.in
@@ -313,6 +316,7 @@ pyyaml==5.4.1
 redis==3.5.3
     # via
     #   -r requirements/pip.txt
+    #   django-redis
     #   django-redis-cache
 regex==2022.10.31
     # via -r requirements/pip.txt

--- a/requirements/docker.in
+++ b/requirements/docker.in
@@ -5,8 +5,6 @@
 # https://www.psycopg.org/docs/install.html#psycopg-vs-psycopg-binary
 psycopg2-binary
 
-django-redis-cache
-
 # For resizing images
 pillow
 
@@ -15,7 +13,6 @@ tox
 
 # Used together with structlog to have nicer logs locally
 rich
-
 
 # Useful tools during a debug session.
 datadiff

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -18,6 +18,10 @@ asgiref==3.6.0
     #   django
 asttokens==2.2.1
     # via stack-data
+async-timeout==4.0.2
+    # via
+    #   -r requirements/pip.txt
+    #   redis
 babel==2.11.0
     # via
     #   -r requirements/pip.txt
@@ -340,7 +344,7 @@ pytz==2022.7.1
     #   djangorestframework
 pyyaml==5.4.1
     # via -r requirements/pip.txt
-redis==3.5.3
+redis==4.5.1
     # via
     #   -r requirements/pip.txt
     #   django-redis

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -119,6 +119,7 @@ django==3.2.17
     #   django-filter
     #   django-formtools
     #   django-polymorphic
+    #   django-redis
     #   django-storages
     #   django-structlog
     #   django-taggit
@@ -156,8 +157,8 @@ django-messages-extends==0.6.3
     # via -r requirements/pip.txt
 django-polymorphic==3.1.0
     # via -r requirements/pip.txt
-django-redis-cache==3.0.1
-    # via -r requirements/docker.in
+django-redis==5.2.0
+    # via -r requirements/pip.txt
 django-simple-history==3.0.0
     # via -r requirements/pip.txt
 django-storages[boto3]==1.13.2
@@ -342,7 +343,7 @@ pyyaml==5.4.1
 redis==3.5.3
     # via
     #   -r requirements/pip.txt
-    #   django-redis-cache
+    #   django-redis
 regex==2022.10.31
     # via -r requirements/pip.txt
 requests==2.28.2

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -23,6 +23,10 @@ astroid==2.4.1
     #   pylint-celery
     #   pylint-flask
     #   requirements-detector
+async-timeout==4.0.2
+    # via
+    #   -r requirements/pip.txt
+    #   redis
 babel==2.11.0
     # via
     #   -r requirements/pip.txt
@@ -337,7 +341,7 @@ pyyaml==5.4.1
     # via
     #   -r requirements/pip.txt
     #   prospector
-redis==3.5.3
+redis==4.5.1
     # via
     #   -r requirements/pip.txt
     #   django-redis

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -110,6 +110,7 @@ django==3.2.17
     #   django-filter
     #   django-formtools
     #   django-polymorphic
+    #   django-redis
     #   django-storages
     #   django-structlog
     #   django-taggit
@@ -146,6 +147,8 @@ django-ipware==4.0.2
 django-messages-extends==0.6.3
     # via -r requirements/pip.txt
 django-polymorphic==3.1.0
+    # via -r requirements/pip.txt
+django-redis==5.2.0
     # via -r requirements/pip.txt
 django-simple-history==3.0.0
     # via -r requirements/pip.txt
@@ -335,7 +338,9 @@ pyyaml==5.4.1
     #   -r requirements/pip.txt
     #   prospector
 redis==3.5.3
-    # via -r requirements/pip.txt
+    # via
+    #   -r requirements/pip.txt
+    #   django-redis
 regex==2022.10.31
     # via -r requirements/pip.txt
 requests==2.28.2

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -38,10 +38,7 @@ slumber
 pyyaml==5.4.1
 Pygments
 
-# Downgrade redis to 3.5.3 (latest 3.x release) because pip raises this error:
-# django-redis-cache 2.1.3 depends on redis<4.0
-redis==3.5.3
-
+django-redis
 celery
 
 # 0.52.0 requires creating a new email template:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,6 +10,8 @@ amqp==5.1.1
     # via kombu
 asgiref==3.6.0
     # via django
+async-timeout==4.0.2
+    # via redis
 babel==2.11.0
     # via sphinx
 billiard==3.6.4.0

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -212,7 +212,7 @@ pytz==2022.7.1
     #   djangorestframework
 pyyaml==5.4.1
     # via -r requirements/pip.in
-redis==3.5.3
+redis==4.5.1
     # via django-redis
 regex==2022.10.31
     # via -r requirements/pip.in

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -68,6 +68,7 @@ django==3.2.17
     #   django-filter
     #   django-formtools
     #   django-polymorphic
+    #   django-redis
     #   django-storages
     #   django-structlog
     #   django-taggit
@@ -102,6 +103,8 @@ django-ipware==4.0.2
 django-messages-extends==0.6.3
     # via -r requirements/pip.in
 django-polymorphic==3.1.0
+    # via -r requirements/pip.in
+django-redis==5.2.0
     # via -r requirements/pip.in
 django-simple-history==3.0.0
     # via -r requirements/pip.in
@@ -210,7 +213,7 @@ pytz==2022.7.1
 pyyaml==5.4.1
     # via -r requirements/pip.in
 redis==3.5.3
-    # via -r requirements/pip.in
+    # via django-redis
 regex==2022.10.31
     # via -r requirements/pip.in
 requests==2.28.2

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -107,6 +107,7 @@ django==3.2.17
     #   django-filter
     #   django-formtools
     #   django-polymorphic
+    #   django-redis
     #   django-storages
     #   django-structlog
     #   django-taggit
@@ -145,6 +146,8 @@ django-ipware==4.0.2
 django-messages-extends==0.6.3
     # via -r requirements/pip.txt
 django-polymorphic==3.1.0
+    # via -r requirements/pip.txt
+django-redis==5.2.0
     # via -r requirements/pip.txt
 django-simple-history==3.0.0
     # via -r requirements/pip.txt
@@ -308,7 +311,9 @@ pyyaml==5.4.1
     #   -r requirements/pip.txt
     #   yamale
 redis==3.5.3
-    # via -r requirements/pip.txt
+    # via
+    #   -r requirements/pip.txt
+    #   django-redis
 regex==2022.10.31
     # via -r requirements/pip.txt
 requests==2.28.2

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -16,6 +16,10 @@ asgiref==3.6.0
     # via
     #   -r requirements/pip.txt
     #   django
+async-timeout==4.0.2
+    # via
+    #   -r requirements/pip.txt
+    #   redis
 attrs==22.2.0
     # via pytest
 babel==2.11.0
@@ -310,7 +314,7 @@ pyyaml==5.4.1
     # via
     #   -r requirements/pip.txt
     #   yamale
-redis==3.5.3
+redis==4.5.1
     # via
     #   -r requirements/pip.txt
     #   django-redis


### PR DESCRIPTION
Use `django-redis` instead of `django-redis-cache` and connect to Redis via password. `django-redis` allows also to connect to Redis via SSL.

Celery instances also connect to Redis using the user/password authentication method.

Requires: https://github.com/readthedocs/common/pull/164
Requires: https://github.com/readthedocs/readthedocs-ops/pull/1293
Requires: https://github.com/readthedocs/readthedocs-corporate-ops/pull/824