### PR TITLE
Fix code block indentation in Jupyter user guide

### DIFF
--- a/docs/user/guides/jupyter.rst
+++ b/docs/user/guides/jupyter.rst
@@ -175,15 +175,15 @@ For example, this is how a simple notebook looks like in MyST Markdown format:
 
    ---
    jupytext:
-   text_representation:
-      extension: .md
-      format_name: myst
-      format_version: 0.13
-      jupytext_version: 1.10.3
+     text_representation:
+       extension: .md
+       format_name: myst
+       format_version: 0.13
+       jupytext_version: 1.10.3
    kernelspec:
-   display_name: Python 3
-   language: python
-   name: python3
+     display_name: Python 3
+     language: python
+     name: python3
    ---
 
    # Plain-text notebook formats


### PR DESCRIPTION
This Pull Request fixes indentation in [Jupyter user guide](https://docs.readthedocs.io/en/latest/guides/jupyter.html#id7) markdown code block.

It avoids users who replicate the MyST-NB example to get trough this uninformative error

```log
Exception occurred:
  File ".../site-packages/myst_nb/core/read.py", line 140, in is_myst_markdown_notebook
    metadata.get("jupytext", {})
AttributeError: 'NoneType' object has no attribute 'get'
```

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10008.org.readthedocs.build/en/10008/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10008.org.readthedocs.build/en/10008/

<!-- readthedocs-preview dev end -->