### PR TITLE
Logging: avoid logging `invalid_grant` error in Sentry

### DIFF
--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -519,7 +519,7 @@ class GitHubService(Service):
         except CustomOAuth2Error as e:
             if e.error != "invalid_grant":
                 raise
-            log.info("Invalid GitHub grant for user.")
+            log.info("Invalid GitHub grant for user.", exc_info=True)
 
         return False
 

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -8,6 +8,7 @@ from allauth.socialaccount.models import SocialToken
 from allauth.socialaccount.providers.github.views import GitHubOAuth2Adapter
 from django.conf import settings
 from django.urls import reverse
+from oauthlib.oauth2.rfc6749.errors import CustomOAuth2Error
 from requests.exceptions import RequestException
 
 from readthedocs.api.v2.client import api
@@ -515,6 +516,10 @@ class GitHubService(Service):
         # Catch exceptions with request or deserializing JSON
         except (RequestException, ValueError):
             log.exception('GitHub commit status creation failed for project.')
+        except CustomOAuth2Error as e:
+            if e.error != "invalid_grant":
+                raise
+            log.info("Invalid GitHub grant for user.")
 
         return False
 

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -8,6 +8,7 @@ import structlog
 from allauth.socialaccount.providers.gitlab.views import GitLabOAuth2Adapter
 from django.conf import settings
 from django.urls import reverse
+from oauthlib.oauth2.rfc6749.errors import CustomOAuth2Error
 from requests.exceptions import RequestException
 
 from readthedocs.builds import utils as build_utils
@@ -601,4 +602,9 @@ class GitLabService(Service):
                 'GitLab commit status creation failed.',
                 debug_data=debug_data,
             )
-            return False
+        except CustomOAuth2Error as e:
+            if e.error != "invalid_grant":
+                raise
+            log.info("Invalid GitLab grant for user.")
+
+        return False

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -605,6 +605,6 @@ class GitLabService(Service):
         except CustomOAuth2Error as e:
             if e.error != "invalid_grant":
                 raise
-            log.info("Invalid GitLab grant for user.")
+            log.info("Invalid GitLab grant for user.", exc_info=True)
 
         return False


### PR DESCRIPTION
This is a known error and it happens because the user revoked the our grant from GitHub/GitLab UI. This commit handles this error and avoids sending it to Sentry.