### PR TITLE
Requirements: unpin `newrelic`

### DIFF
--- a/requirements/deploy.in
+++ b/requirements/deploy.in
@@ -8,9 +8,6 @@ psycopg2
 pillow
 
 structlog-sentry
-
-# We should unpin this dependency.
-# There is a new 8.x version, but I didn't find the changelog quickly.
-newrelic==7.4.0.172
+newrelic
 
 ipython

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -246,7 +246,7 @@ markupsafe==2.1.2
     #   jinja2
 matplotlib-inline==0.1.6
     # via ipython
-newrelic==7.4.0.172
+newrelic==8.6.0
     # via -r requirements/deploy.in
 oauthlib==3.2.2
     # via


### PR DESCRIPTION
I checked all the changelogs from 7.4.x and there is no breaking changes that affect us.

https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes/python-agent-80600/

Closes https://github.com/readthedocs/readthedocs-ops/issues/1290