### PR TITLE
Refactor: remove `Version.documentation_type`

### DIFF
--- a/readthedocs/api/v2/views/footer_views.py
+++ b/readthedocs/api/v2/views/footer_views.py
@@ -155,6 +155,7 @@ class BaseFooterHTML(CDNCacheTagsMixin, APIView):
 
         page_slug = self.request.GET.get('page', '')
         path = ''
+        # TODO: review custom logic based con `documentation_type`
         if page_slug and page_slug != 'index':
             if version.documentation_type in {SPHINX_HTMLDIR, MKDOCS}:
                 path = re.sub('/index$', '', page_slug) + '/'

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1429,6 +1429,7 @@ class HTMLFile(ImportedFile):
     objects = HTMLFileManager()
 
     def get_processed_json(self):
+        # TODO: review custom logic based con `documentation_type`
         if (
             self.version.documentation_type == constants.GENERIC
             or self.project.has_feature(Feature.INDEX_FROM_HTML_FILES)

--- a/readthedocs/search/documents.py
+++ b/readthedocs/search/documents.py
@@ -74,6 +74,7 @@ class PageDocument(RTDDocTypeMixin, Document):
     # Metadata
     project = fields.KeywordField(attr='project.slug')
     version = fields.KeywordField(attr='version.slug')
+    # TODO: review custom logic based con `documentation_type`
     doctype = fields.KeywordField(attr='version.documentation_type')
     path = fields.KeywordField(attr='processed_json.path')
     full_path = fields.KeywordField(attr='path')


### PR DESCRIPTION
We are planning to suppose _any_ doctool and we want to get rid of the `documentation_type` attribute and make our logic more generic to work on most scenarios without specific logic per doctool.