### PR TITLE
Metrics: update URL for latency metric

### DIFF
--- a/readthedocs/metrics/tasks.py
+++ b/readthedocs/metrics/tasks.py
@@ -12,12 +12,9 @@ from readthedocsext.monitoring.metrics.database import (
     ConcurrencyLimitedBuildsMetric,
     RunningBuildsMetric,
 )
-from readthedocsext.monitoring.metrics.redislen import RedislenMetric
 from readthedocsext.monitoring.metrics.latency import BuildLatencyMetric
-from readthedocsext.monitoring.metrics.tasks import (
-    Metrics1mTaskBase,
-    Metrics5mTaskBase,
-)
+from readthedocsext.monitoring.metrics.redislen import RedislenMetric
+from readthedocsext.monitoring.metrics.tasks import Metrics1mTaskBase, Metrics5mTaskBase
 
 
 class CommunityMetrics1mTask(Metrics1mTaskBase):
@@ -47,7 +44,6 @@ class CommunityMetrics5mTask(Metrics5mTaskBase):
             doc='index',
             section='Time',
             doc_url=None,
-            api_host='https://readthedocs.org',
-            webhook_url='https://readthedocs.org/api/v2/webhook/time-test/125903/',
+            webhook_url="{api_host}/api/v2/webhook/{project}/{webhook_id}/",
         ),
     ]


### PR DESCRIPTION
Required by https://github.com/readthedocs/readthedocs-ext/pull/534