### PR TITLE
Docs: Use "Sentence case" for titles

### DIFF
--- a/docs/dev/design.rst
+++ b/docs/dev/design.rst
@@ -12,7 +12,7 @@ to get a working copy of the Read the Docs repository locally.
 
 .. TODO: update to match the new ext-theme
 
-Style Catalog
+Style catalog
 -------------
 
 Once you have RTD running locally, you can open ``http://localhost:8000/style-catalog/``
@@ -24,7 +24,7 @@ This way you can quickly get started writing HTML -- or if you're
 modifying existing styles you can get a quick idea of how things
 will change site-wide.
 
-Readthedocs.org Changes
+Readthedocs.org changes
 -----------------------
 
 Styles for the primary RTD site are located in ``media/css`` directory.
@@ -44,7 +44,7 @@ There's not a hard browser range, but your design changes should work reasonably
 browsers, IE8+ -- that's not to say it needs to be pixel-perfect in older browsers! Just avoid
 making changes that render older browsers utterly unusable (or provide a sane fallback).
 
-Brand Guidelines
+Brand guidelines
 ----------------
 
 Find our branding guidelines in our guidelines documentation: https://read-the-docs-guidelines.readthedocs-hosted.com.

--- a/docs/dev/design/apiv3.rst
+++ b/docs/dev/design/apiv3.rst
@@ -1,5 +1,5 @@
 ======================
-API v3 Design Document
+API v3 design document
 ======================
 
 This document describes the design,

--- a/docs/dev/design/build-images.rst
+++ b/docs/dev/design/build-images.rst
@@ -1,4 +1,4 @@
-Build Images
+Build images
 ============
 
 This document describes how Read the Docs uses the `Docker Images`_ and how they are named.

--- a/docs/dev/design/future-builder.rst
+++ b/docs/dev/design/future-builder.rst
@@ -1,4 +1,4 @@
-Future Builder
+Future builder
 ==============
 
 .. contents::

--- a/docs/dev/design/in-doc-search-ui.rst
+++ b/docs/dev/design/in-doc-search-ui.rst
@@ -1,4 +1,4 @@
-In Doc Search UI
+In-doc search UI
 ================
 
 Giving readers the ability to easily search the information
@@ -24,11 +24,11 @@ The final result may look something like this:
     Short demo
 
 
-Goals And Non-Goals
+Goals And non-Goals
 -------------------
 
-Project Goals
-++++++++++++++
+Project goals
++++++++++++++
 
 * Support a search-as-you-type/autocomplete interface.
 * Support across all (or virtually all) Sphinx themes.
@@ -36,14 +36,14 @@ Project Goals
 * Project maintainers should have a way to opt-in/opt-out of this feature.
 * (Optional) Project maintainers should have the flexibility to change some of the styles using custom CSS and JS files.
 
-Non-Goals
-++++++++++
+Non-goals
++++++++++
 
 * For the initial release, we are targeting only Sphinx documentations
   as we don't index MkDocs documentations to our Elasticsearch index.
 
 
-Existing Search Implementation
+Existing search implementation
 ------------------------------
 
 We have a detailed documentation explaining the underlying architecture of our search backend
@@ -51,7 +51,7 @@ and how we index documents to our Elasticsearch index.
 You can read about it :doc:`here </server-side-search>`.
 
 
-Proposed Architecture for In-Doc Search UI
+Proposed architecture for in-doc search UI
 ------------------------------------------
 
 Frontend
@@ -69,7 +69,7 @@ This will provide us some advantages over using any third party library:
 * Performance benefits.
 
 
-Proposed Architecture
+Proposed architecture
 ~~~~~~~~~~~~~~~~~~~~~
 
 We plan to select the search bar, which is present in every theme,
@@ -125,7 +125,7 @@ Edge NGram Tokenizer
   * Requires greater disk space.
 
 
-Completion Suggester
+Completion suggester
 ~~~~~~~~~~~~~~~~~~~~
 
 * Pros
@@ -164,7 +164,7 @@ Milestones
 +-----------------------------------------------------------------------------------+------------------+
 
 
-Open Questions
+Open questions
 ++++++++++++++
 
 * Should we rely on jQuery, any third party library or pure vanilla JavaScript?

--- a/docs/dev/design/index.rst
+++ b/docs/dev/design/index.rst
@@ -1,4 +1,4 @@
-Design Documents
+Design documents
 ================
 
 This is where we outline the design of major parts of our project.
@@ -7,7 +7,7 @@ but we hope to write more of them over time.
 
 .. warning::
 
-   These documents may not match the final implementation, or may be out of date. 
+   These documents may not match the final implementation, or may be out of date.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/dev/design/pr-builder.rst
+++ b/docs/dev/design/pr-builder.rst
@@ -1,4 +1,4 @@
-Design of Pull Request Builder
+Design of pull request builder
 ==============================
 
 Background
@@ -25,7 +25,7 @@ Scope
 - Triggering Builds on new commits on a PR
 - Status reporting to Github
 
-Fetching Data from Pull Requests
+Fetching data from pull requests
 --------------------------------
 
 We already get Pull request events from Github webhooks.
@@ -34,7 +34,7 @@ when a ``pull_request`` event is triggered we can fetch the data of that pull re
 We can fetch the pull request by doing something similar to travis-ci.
 ie: ``git fetch origin +refs/pull/<pr_number>/merge:``
 
-Modeling Pull Requests as a Type of Version
+Modeling pull requests as a type of version
 -------------------------------------------
 
 Pull requests can be Treated as a Type of Temporary ``Version``.
@@ -52,19 +52,19 @@ We can then use ``Build.internal.all()`` to get all regular version builds,
 ``Build.external.all()`` to get all PR version builds.
 
 
-Excluding PR Versions from Elasticsearch Indexing
+Excluding PR versions from Elasticsearch indexing
 -------------------------------------------------
 
 We should exclude to PR Versions from being Indexed to Elasticsearch.
 We need to update the queryset to exclude PR Versions.
 
-Adding a PR Builds Tab in the Project Dashboard
+Adding a PR builds tab in the project dashboard
 -----------------------------------------------
 
 We can add a Tab in the project dashboard that will listout the PR Builds of that project.
 We can name it ``PR Builds``.
 
-Creating Versions for Pull Requests
+Creating versions for pull requests
 -----------------------------------
 
 If the Github webhook event is ``pull_request`` and action is ``opened``,
@@ -72,14 +72,14 @@ this means a pull request was opened in the projects repository.
 We can create a ``Version`` from the Payload data and trigger a initial build for the version.
 A version will be created whenever RTD receives an event like this.
 
-Triggering Build for New Commits in a Pull Request
+Triggering build for new commits in a pull request
 --------------------------------------------------
 
 We might want to trigger a new build for the PR version if there is a new commit on the PR.
 If the Github webhook event is ``pull_request`` and action is ``synchronize``,
 this means a new commit was added to the pull request.
 
-Status Reporting to Github
+Status reporting to GitHub
 --------------------------
 
 We could send build status reports to Github. We could send if the build was Successful or Failed.
@@ -101,13 +101,13 @@ Sending the status report would be something like this:
        "context": "continuous-documentation/read-the-docs"
    }
 
-Storing Pull Request Docs
+Storing pull request docs
 -------------------------
 
 We need to think about how and where to store data after a PR Version build is finished.
 We can store the data in a blob storage.
 
-Excluding PR Versions from Search Engines
+Excluding PR versions from search engines
 -----------------------------------------
 
 We should Exclude the PR Versions from Search Engines,
@@ -115,7 +115,7 @@ because it might cause problems for RTD users.
 As users might land to a pull request doc but not the original Project Docs.
 This will cause confusion for the users.
 
-Serving PR Docs
+Serving PR docs
 ---------------
 
 We need to think about how we want to serve the PR Docs.
@@ -136,13 +136,13 @@ We might want to have a way to show that if this is a PR Build on the Footer.
 - For regular project docs we should remove the PR Versions from the version list of the Footer.
 - We might want to send ``is_pr`` data with the Footer API response.
 
-Adding Warning Banner to Docs
+Adding warning banner to Docs
 -----------------------------
 
 We need to add a warning banner to the PR Version Docs to let the users know that this is a Draft/PR version.
 We can use a sphinx extension that we will force to install on the PR Versions to add the warning banner.
 
-Related Issues
+Related issues
 --------------
 
 - `Autobuild Docs for Pull Requests`_

--- a/docs/dev/design/privacy-levels.rst
+++ b/docs/dev/design/privacy-levels.rst
@@ -1,4 +1,4 @@
-Privacy Levels
+Privacy levels
 ==============
 
 This document describes how to handle and unify privacy levels
@@ -156,7 +156,7 @@ Public project (community)
   Users didn't want to show this version to their users yet or they were testing something.
   This can be solved with the pull request builder feature and the ``hidden`` setting.
   We migrate those to public with the ``hidden`` setting.
-  If we are worried about leaking anything from the version, we can email users before doing the change. 
+  If we are worried about leaking anything from the version, we can email users before doing the change.
 
 Protected project (community)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/dev/design/refactor-remote-repository.rst
+++ b/docs/dev/design/refactor-remote-repository.rst
@@ -1,6 +1,6 @@
-======================================
- Refactor ``RemoteRepository`` object
-======================================
+====================================
+Refactor ``RemoteRepository`` object
+====================================
 
 
 This document describes the current usage of ``RemoteRepository`` objects and proposes a new normalized modeling.
@@ -18,7 +18,7 @@ Goals
 * Do not disconnect ``Project`` and ``RemoteRepository`` when a user delete/disconnects their account.
 
 
-Non-Goals
+Non-goals
 =========
 
 * Keep ``RemoteRepository`` in sync with GitHub repositories.
@@ -31,7 +31,7 @@ Non-Goals
    They are just outside the scope of this document.
 
 
-Current Implementation
+Current implementation
 ======================
 
 When a user connect their account to a social account, we create a
@@ -78,7 +78,7 @@ Where ``RemoteRepository`` is used?
 .. _Send build status: https://github.com/readthedocs/readthedocs.org/blob/56253cb786945c9fe53a034a4433f10672ae8a4f/readthedocs/projects/tasks.py#L1852-L1956
 
 
-New Normalized Implementation
+New normalized implementation
 =============================
 
 The ``ManyToMany`` relation ``RemoteRepository.users`` will be changed to be ``ManyToMany(through='RemoteRelation')``
@@ -109,7 +109,7 @@ We can get the list of ``Project`` where a user as access:
    Project.objects.filter(remote_repository__in=admin_remote_repositories)
 
 
-Rollout Plan
+Rollout plan
 ============
 
 Due the constraints we have in the ``RemoteRepository`` table and its size,

--- a/docs/dev/design/system-packages.rst
+++ b/docs/dev/design/system-packages.rst
@@ -1,4 +1,4 @@
-Allow Installation of System Packages
+Allow installation of system packages
 =====================================
 
 Currently we don't allow executing arbitrary commands in the build process.

--- a/docs/dev/design/telemetry.rst
+++ b/docs/dev/design/telemetry.rst
@@ -1,4 +1,4 @@
-Collect Data About Builds
+Collect data about builds
 =========================
 
 We may want to take some decisions in the future about deprecations and supported versions.

--- a/docs/dev/design/yaml-file.rst
+++ b/docs/dev/design/yaml-file.rst
@@ -1,4 +1,4 @@
-YAML Configuration File
+YAML configuration file
 =======================
 
 Background
@@ -16,14 +16,14 @@ Scope
 - Proper documentation for the end user
 - Allow to specify the spec's version used on the YAML file
 - Collect/show metadata about the YAML file and build configuration
-- Promote the adoption of the configuration file 
+- Promote the adoption of the configuration file
 
 RTD settings
 ------------
 
 No all the RTD settings are applicable to the YAML file,
 others are applicable for each build (or version),
-and others for the global project. 
+and others for the global project.
 
 Not applicable settings
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/dev/docs.rst
+++ b/docs/dev/docs.rst
@@ -1,4 +1,4 @@
-Building and Contributing to Documentation
+Building and contributing to documentation
 ==========================================
 
 As one might expect,

--- a/docs/dev/front-end.rst
+++ b/docs/dev/front-end.rst
@@ -1,4 +1,4 @@
-Front End Development
+Front-end development
 =====================
 
 Background
@@ -52,7 +52,7 @@ may change, so that assets are compiled before deployment, however as our front
 end assets are in a state of flux, it's easier to keep absolute sources checked
 in.
 
-Getting Started
+Getting started
 ---------------
 
 You will need to follow our :doc:`guide to install a development Read the Docs instance </install>` first.
@@ -72,7 +72,7 @@ make sure to check in both files under ``static`` and ``static-src``,
 and commit those.
 
 
-Making Changes
+Making changes
 --------------
 
 If you are creating a new library, or a new library entry point, make sure to
@@ -93,7 +93,7 @@ If merging several branches with JavaScript changes, it's important to do a
 final post-merge bundle. Follow the steps above to rebundle the libraries, and
 check in any changed libraries.
 
-JavaScript Bundles
+JavaScript bundles
 ------------------
 
 There are several components to our bundling scheme:

--- a/docs/dev/guides/gvisor.rst
+++ b/docs/dev/guides/gvisor.rst
@@ -1,4 +1,4 @@
-gVisor Installation
+gVisor installation
 ===================
 
 You can mostly get by just following installation instructions in the `gVisor

--- a/docs/dev/guides/index.rst
+++ b/docs/dev/guides/index.rst
@@ -1,4 +1,4 @@
-Development Guides
+Development guides
 ==================
 
 These are guides to aid local development and common development procedures.

--- a/docs/dev/i18n.rst
+++ b/docs/dev/i18n.rst
@@ -16,7 +16,7 @@ For more information about the general ideas,
 look at this document: http://www.gnu.org/software/gettext/manual/html_node/Concepts.html
 
 
-Making Strings Localizable
+Making strings localizable
 --------------------------
 
 Making strings in templates localizable is exceptionally easy. Making strings
@@ -45,7 +45,7 @@ Python gives you a lot of ways to interpolate strings. The best way is to use
 Py3k formatting and kwargs. That's the clearest for localizers.
 
 
-Localization Comments
+Localization comments
 ^^^^^^^^^^^^^^^^^^^^^
 
 Sometimes, it can help localizers to describe where a string comes from,
@@ -70,7 +70,7 @@ Example::
     )
 
 
-Adding Context with msgctxt
+Adding context with msgctxt
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Strings may be the same in English, but different in other languages. English,
@@ -117,7 +117,7 @@ different phrases for, say 0, 1, 2-3, 4-10, >10. That's absolutely fine, and
 gettext makes it possible.
 
 
-Strings in Templates
+Strings in templates
 --------------------
 
 When putting new text into a template, all you need to do is wrap it in a
@@ -221,7 +221,7 @@ If you need to use plurals, import the
     msg = ungettext('Found {0} result', 'Found {0} results', n).format(n)
 
 
-Lazily Translated Strings
+Lazily translated strings
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can use :func:`~django.utils.translation.gettext` or
@@ -247,11 +247,11 @@ In case you want to provide context to a lazily-evaluated gettext string, you
 will need to use :func:`~django.utils.translation.pgettext_lazy`.
 
 
-Administrative Tasks
+Administrative tasks
 --------------------
 
 
-Updating Localization Files
+Updating localization files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To update the translation source files (eg if you changed or added translatable
@@ -284,7 +284,7 @@ it's silly and not worth it. They are ignored by ``.gitignore``, but please
 make sure you don't forcibly add them to the repository.
 
 
-Transifex Integration
+Transifex integration
 ^^^^^^^^^^^^^^^^^^^^^
 
 To push updated translation source files to Transifex, run ``tx

--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -1,4 +1,4 @@
-Development Installation
+Development installation
 ========================
 
 .. meta::

--- a/docs/dev/search-integration.rst
+++ b/docs/dev/search-integration.rst
@@ -1,4 +1,4 @@
-Server Side Search Integration
+Server side search integration
 ==============================
 
 Read the Docs provides :doc:`server side search (SSS) <rtd:server-side-search/index>`

--- a/docs/dev/server-side-search.rst
+++ b/docs/dev/server-side-search.rst
@@ -1,4 +1,4 @@
-Server Side Search
+Server side search
 ==================
 
 Read the Docs uses Elasticsearch_ instead of the built in Sphinx search for providing better search

--- a/docs/dev/settings.rst
+++ b/docs/dev/settings.rst
@@ -1,4 +1,4 @@
-Interesting Settings
+Interesting settings
 ====================
 
 DOCKER_LIMITS

--- a/docs/dev/style-guide.rst
+++ b/docs/dev/style-guide.rst
@@ -1,4 +1,4 @@
-Documentation Style Guide
+Documentation style guide
 =========================
 
 This document will serve as the canonical place to define how we write documentation at Read the Docs.
@@ -49,7 +49,7 @@ Content
   * ``:guilabel:`<your username>` dropdown``
 * Make sure that **all bullet list items end with a period**, and don't mix periods with no periods.
 
-Word List
+Word list
 ---------
 
 We have a specific way that we write common words:
@@ -197,7 +197,7 @@ Explanation
 * Consider adding an Examples section.
 * Can you add screenshots or diagrams?
 
-How-to Guides
+How-to guides
 ~~~~~~~~~~~~~
 
 * Title should begin with **“How to ...”**,

--- a/docs/user/advertising/ad-customization.rst
+++ b/docs/user/advertising/ad-customization.rst
@@ -1,6 +1,6 @@
 :orphan:
 
-Customizing Advertising
+Customizing advertising
 =======================
 
 .. warning::

--- a/docs/user/advertising/advertising-details.rst
+++ b/docs/user/advertising/advertising-details.rst
@@ -1,4 +1,4 @@
-Advertising Details
+Advertising details
 ===================
 
 .. NOTE: This document is linked from:

--- a/docs/user/advertising/ethical-advertising.rst
+++ b/docs/user/advertising/ethical-advertising.rst
@@ -40,7 +40,7 @@ or seeing paid ads if you want.
 You will still see :ref:`community ads <advertising/ethical-advertising:Community Ads>`,
 which we run for free that promote community projects.
 
-Our Worldview
+Our worldview
 -------------
 
 We're building the advertising model we want to exist:
@@ -153,7 +153,7 @@ Please `complete an application`_ to be considered for our Community Ads program
 .. _complete an application: https://www.ethicalads.io/community-ads/?ref=docs.readthedocs.io
 
 
-Opting Out
+Opting out
 ----------
 
 We have added multiple ways to opt out of the advertising on Read the Docs.

--- a/docs/user/analytics.rst
+++ b/docs/user/analytics.rst
@@ -29,7 +29,7 @@ You can also access to analytics data from :ref:`search results <server-side-sea
    * On the Commercial one, it goes from 30 to infinite storage
       (check out `the pricing page <https://readthedocs.com/pricing/>`_).
 
-Enabling Google Analytics on your Project
+Enabling Google Analytics on your project
 -----------------------------------------
 
 Read the Docs has native support for Google Analytics.

--- a/docs/user/api/v3.rst
+++ b/docs/user/api/v3.rst
@@ -1291,17 +1291,17 @@ Redirect delete
     :statuscode 204: Redirect deleted successfully
 
 
-Environment Variables
+Environment variables
 ~~~~~~~~~~~~~~~~~~~~~
 
-Environment Variables are variables that you can define for your project.
+Environment variables are variables that you can define for your project.
 These variables are used in the build process when building your documentation.
 They are for example useful to define secrets in a safe way that can be used by your documentation to build properly.
 Environment variables can also be made public, allowing for them to be used in PR builds.
 See :doc:`/environment-variables`.
 
 
-Environment Variable details
+Environment variable details
 ++++++++++++++++++++++++++++
 
 .. http:get:: /api/v3/projects/(str:project_slug)/environmentvariables/(int:environmentvariable_id)/
@@ -1342,7 +1342,7 @@ Environment Variable details
        "name": "ENVVAR"
        }
 
-Environment Variables listing
+Environment variables listing
 +++++++++++++++++++++++++++++
 
 .. http:get:: /api/v3/projects/(str:project_slug)/environmentvariables/
@@ -1377,7 +1377,7 @@ Environment Variables listing
             "results": ["ENVIRONMENTVARIABLE"]
         }
 
-Environment Variable create
+Environment variable create
 +++++++++++++++++++++++++++
 
 .. http:post:: /api/v3/projects/(str:project_slug)/environmentvariables/
@@ -1427,7 +1427,7 @@ Environment Variable create
     :statuscode 201: Environment variable created successfully
 
 
-Environment Variable delete
+Environment variable delete
 +++++++++++++++++++++++++++
 
 .. http:delete:: /api/v3/projects/(str:project_slug)/environmentvariables/(int:environmentvariable_id)/
@@ -1650,14 +1650,14 @@ Organization projects list
        }
 
 
-Remote Organizations
+Remote organizations
 ~~~~~~~~~~~~~~~~~~~~
 
-Remote Organizations are the VCS organizations connected via
+Remote organizations are the VCS organizations connected via
 ``GitHub``, ``GitLab`` and ``Bitbucket``.
 
 
-Remote Organization listing
+Remote organization listing
 +++++++++++++++++++++++++++
 
 
@@ -1713,14 +1713,14 @@ Remote Organization listing
     :requestheader Authorization: token to authenticate.
 
 
-Remote Repositories
+Remote repositories
 ~~~~~~~~~~~~~~~~~~~
 
-Remote Repositories are the importable repositories connected via
+Remote repositories are the importable repositories connected via
 ``GitHub``, ``GitLab`` and ``Bitbucket``.
 
 
-Remote Repository listing
+Remote repository listing
 +++++++++++++++++++++++++
 
 

--- a/docs/user/badges.rst
+++ b/docs/user/badges.rst
@@ -1,4 +1,4 @@
-Status Badges
+Status badges
 =============
 
 Status badges let you show the state of your documentation to your users.

--- a/docs/user/builds.rst
+++ b/docs/user/builds.rst
@@ -69,7 +69,7 @@ The build process includes the following jobs:
     If you require additional build steps or customization,
     it's possible to run user-defined commands and :doc:`customize the build process </build-customization>`.
 
-Cancelling Builds
+Cancelling builds
 -----------------
 
 There may be situations where you want to cancel a running build.

--- a/docs/user/changelog.rst
+++ b/docs/user/changelog.rst
@@ -18,7 +18,7 @@ July 23, 2015
 
 * Django 1.8 Support Merged
 
-Code Notes
+Code notes
 ``````````
 
 - Updated Django from `1.6.11` to `1.8.3`.
@@ -35,7 +35,7 @@ Code Notes
 - Added `django.setup()` to `conf.py` to load django properly for doc builds.
 - Added migrations for all apps with models in the `readthedocs/` directory
 
-Deployment Notes
+Deployment notes
 ````````````````
 
 After you have updated the code and installed the new dependencies, you need to run these commands on the server::
@@ -47,7 +47,7 @@ After you have updated the code and installed the new dependencies, you need to 
 Locally I had trouble in a test environment that pip did not update to the specified commit of tastypie. It might be required to use `pip install -U -r requirements/deploy.txt` during deployment.
 
 
-Development Update Notes
+Development update notes
 ````````````````````````
 
 The readthedocs developers need to execute these commands when switching to this branch (or when this got merged into ``main``):

--- a/docs/user/choosing-a-site.rst
+++ b/docs/user/choosing-a-site.rst
@@ -1,4 +1,4 @@
-Choosing Between Our Two Platforms
+Choosing between our two platforms
 ==================================
 
 Users often ask what the differences are between |org_brand| and |com_brand|.

--- a/docs/user/commercial/organizations.rst
+++ b/docs/user/commercial/organizations.rst
@@ -16,7 +16,7 @@ some who need full access and some who just need access to one project.
    :doc:`/guides/manage-read-the-docs-teams`
      A step-by-step guide to managing teams.
 
-Member Types
+Member types
 ~~~~~~~~~~~~
 
 * **Owners** -- Get full access to both view and edit the Organization and all Projects
@@ -32,7 +32,7 @@ The best way to think about this relationship is:
    Owners, Members and Teams behave differently if you are using
    :ref:`SSO with VCS provider (GitHub, Bitbucket or GitLab) <commercial/single-sign-on:SSO with VCS provider (GitHub, Bitbucket or GitLab)>`
 
-Team Types
+Team types
 ~~~~~~~~~~
 
 You can create two types of Teams:

--- a/docs/user/commercial/privacy-level.rst
+++ b/docs/user/commercial/privacy-level.rst
@@ -1,4 +1,4 @@
-Project Privacy Level
+Project privacy level
 ---------------------
 
 .. include:: /shared/admonition-rtd-business.rst

--- a/docs/user/commercial/sharing.rst
+++ b/docs/user/commercial/sharing.rst
@@ -1,4 +1,4 @@
-Private Documentation Sharing
+Private documentation sharing
 =============================
 
 .. include:: /shared/admonition-rtd-business.rst
@@ -13,7 +13,7 @@ These methods will allow them to view specific projects or versions of a project
 Additionally, you can use a HTTP Authorization Header.
 This is useful to have access from a script.
 
-Enabling Sharing
+Enabling sharing
 ----------------
 
 * Go into your project's :guilabel:`Admin` page and click on :guilabel:`Sharing`.
@@ -37,10 +37,10 @@ Enabling Sharing
 
 Users can log out by using the :ref:`Log Out <versions:Logging out>` link in the RTD flyout menu.
 
-Sharing Methods
+Sharing methods
 ---------------
 
-Secret Link
+Secret link
 ***********
 
 Once the person you send the link to clicks the link,

--- a/docs/user/config-file/index.rst
+++ b/docs/user/config-file/index.rst
@@ -1,4 +1,4 @@
-Configuration File
+Configuration file
 ==================
 
 In addition to using the admin panel of your project to configure your project,

--- a/docs/user/config-file/v1.rst
+++ b/docs/user/config-file/v1.rst
@@ -1,6 +1,6 @@
 :orphan:
 
-Configuration File V1 (Deprecated)
+Configuration file v1 (Deprecated)
 ==================================
 
 Read the Docs has support for configuring builds with a YAML file.

--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -1,4 +1,4 @@
-Configuration File V2
+Configuration file v2
 =====================
 
 Read the Docs supports configuring your documentation builds with a YAML file.

--- a/docs/user/custom-domains.rst
+++ b/docs/user/custom-domains.rst
@@ -1,4 +1,4 @@
-Custom Domains
+Custom domains
 ==============
 
 You can serve your documentation project from your own domain,

--- a/docs/user/dmca/index.rst
+++ b/docs/user/dmca/index.rst
@@ -1,4 +1,4 @@
-DMCA Takedown Policy
+DMCA takedown policy
 ====================
 
 These are the guidelines that Read the Docs follows when handling DMCA takedown
@@ -19,7 +19,7 @@ the Docs user and project names.
 
 __ https://help.github.com/articles/dmca-takedown-policy/
 
-Takedown Process
+Takedown process
 ----------------
 
 Here are the steps the Read the Docs will follow in the takedown request process:
@@ -83,7 +83,7 @@ Copyright holder may file legal action
     holder does not respond to this request, is to re-enable the author's
     project.
 
-Submitting a Request
+Submitting a request
 ~~~~~~~~~~~~~~~~~~~~
 
 Your request must:
@@ -113,7 +113,7 @@ Include your signature
 
 Please complete this :download:`takedown request template <../_static/dmca/takedown-template.txt>` and send it to: support@readthedocs.com
 
-Submitting a Counter
+Submitting a counter
 ~~~~~~~~~~~~~~~~~~~~
 
 Your counter request must:
@@ -134,7 +134,7 @@ Include your signature
 
 Requests can be submitted to: support@readthedocs.com
 
-Request Archive
+Request archive
 ---------------
 
 For better transparency into copyright ownership and the DMCA takedown process,

--- a/docs/user/downloadable-documentation.rst
+++ b/docs/user/downloadable-documentation.rst
@@ -1,4 +1,4 @@
-Understanding Offline Formats
+Understanding offline formats
 =============================
 
 This page will provide an overview of a core Read the Docs feature: building docs in multiple formats.

--- a/docs/user/examples.rst
+++ b/docs/user/examples.rst
@@ -6,7 +6,7 @@ Example projects
 * Want to showcase your own solution?
 
 The following example projects show a rich variety of uses of Read the Docs.
-You can use them for inspiration, for learning and for recipies to start your own documentation projects.
+You can use them for inspiration, for learning and for recipes to start your own documentation projects.
 View the *rendered* version of each project and then head over to the Git source to see how it's done and reuse the code.
 
 Sphinx and MkDocs examples

--- a/docs/user/faq.rst
+++ b/docs/user/faq.rst
@@ -1,4 +1,4 @@
-Frequently Asked Questions
+Frequently asked questions
 ==========================
 
 .. contents::

--- a/docs/user/faq.rst
+++ b/docs/user/faq.rst
@@ -142,7 +142,7 @@ You can also set your project documentation to install your Python project itsel
      How to customize your builds, for example if you need to build with different tools from Sphinx or
      if you need to add additional packages for the Ubuntu-based builder.
 
-   :doc:`Configuration File <config-file/v2>`
+   :doc:`/config-file/v2`
      Reference for the main configuration file, `.readthedocs.yaml`
 
    :ref:`build.apt_packages <config-file/v2:build.apt_packages>`

--- a/docs/user/feature-flags.rst
+++ b/docs/user/feature-flags.rst
@@ -1,4 +1,4 @@
-Feature Flags
+Feature flags
 =============
 
 .. **Please don't add more stuff here**. We want to move user-facing options to the config file.
@@ -9,7 +9,7 @@ or reaching out to the administrator of your service.
 
 .. _contacting us through our support form: https://docs.readthedocs.io/en/stable/support.html
 
-Available Flags
+Available flags
 ---------------
 
 ``CONDA_APPEND_CORE_REQUIREMENTS``: Append Read the Docs core requirements to environment.yml file.

--- a/docs/user/flyout-menu.rst
+++ b/docs/user/flyout-menu.rst
@@ -1,4 +1,4 @@
-Flyout Menu
+Flyout menu
 ===========
 
 When you are using a Read the Docs site,

--- a/docs/user/gsoc.rst
+++ b/docs/user/gsoc.rst
@@ -32,7 +32,7 @@ We're happy to help you get up to speed,
 but the more you are able to demonstrate ability in advance,
 the more likely we are to choose your application!
 
-Getting Started
+Getting started
 ---------------
 
 The :doc:`rtd-dev:install` doc is probably the best place to get going.
@@ -60,7 +60,7 @@ Currently we have a few folks signed up:
 .. warning:: Please do not reach out directly to anyone about the Summer of Code.
              It will **not** increase your chances of being accepted!
 
-Project Ideas
+Project ideas
 -------------
 
 We have written our some loose ideas for projects to work on here.
@@ -71,7 +71,7 @@ We will consider the priority on our roadmap as a factor,
 along with the skill of the student,
 in our selection process.
 
-Collections of Projects
+Collections of projects
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 This project involves building a user interface for groups of projects in Read the Docs (`Collections`).
@@ -132,7 +132,7 @@ This project would include:
 .. _#4924: https://github.com/readthedocs/readthedocs.org/issues/4924
 .. _#1088: https://github.com/readthedocs/readthedocs.org/issues/1088
 
-Integrated Redirects
+Integrated redirects
 ~~~~~~~~~~~~~~~~~~~~
 
 Right now it's hard for users to rename files.
@@ -148,7 +148,7 @@ We should rebuild how we handle redirects across a number of cases:
 
 There will also be a good number of things that spawn from this, including version aliases and other related concepts, if this task doesn't take the whole summer.
 
-Improve Translation Workflow
+Improve translation workflow
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Currently we have our documentation & website translated on Transifex,
@@ -179,7 +179,7 @@ It would be great to have wrappers for the following as a start:
 The goal would also be to make it quite easy for users to contribute third party build steps for Read the Docs,
 so that other useful parts of the Sphinx ecosystem could be tightly integrated with Read the Docs.
 
-Additional Ideas
+Additional ideas
 ~~~~~~~~~~~~~~~~
 
 We have some medium sized projects sketched out in our issue tracker with the tag *Feature*.

--- a/docs/user/guides/adding-custom-css.rst
+++ b/docs/user/guides/adding-custom-css.rst
@@ -1,5 +1,5 @@
-Adding Custom CSS or JavaScript to Sphinx Documentation
-=======================================================
+How to add custom CSS or JavaScript to Sphinx documentation
+===========================================================
 
 .. meta::
    :description lang=en:

--- a/docs/user/guides/administrators.rst
+++ b/docs/user/guides/administrators.rst
@@ -12,24 +12,24 @@ have a look at our :doc:`/tutorial/index`.
 .. toctree::
    :maxdepth: 1
 
-   Connect your git repository <git-integrations>
-   /connected-accounts
-   Connect your Read the Docs account to your Git repository <connecting-git-account>
-   Manage Custom Domains <custom-domains>
-   Enable Canonical URLs <canonical-urls>
+   Connect your Read the Docs account to your Git provider <connecting-git-account>
+   Connect your Git repository automatically </connected-accounts>
+   Connect your Git repository manually <git-integrations>
+   Manage custom domains <custom-domains>
+   Enable canonical URLs <canonical-urls>
    Use traffic analytics </analytics>
-   manage-translations-sphinx
-   hiding-a-version
-   deprecating-content
-   pdf-non-ascii-languages
-   importing-private-repositories
-   Setup Build Notifications <build-notifications>
-   subprojects
-   Configure Pull Request Builds <pull-requests>
-   setup-single-sign-on-github-gitlab-bitbucket
-   setup-single-sign-on-google-email
-   manage-read-the-docs-teams
+   Manage translations for Sphinx projects <manage-translations-sphinx>
+   Hide a version and keep its documentation online <hiding-a-version>
+   Deprecate content <deprecating-content>
+   Support Unicode in Sphinx PDFs <pdf-non-ascii-languages>
+   Import private repositories <importing-private-repositories>
+   Setup build notifications and webhooks <build-notifications>
+   Manage subprojects <subprojects>
+   Configure pull request builds <pull-requests>
+   Setup Single Sign-On (SSO) with GitHub, GitLab, or Bitbucket <setup-single-sign-on-github-gitlab-bitbucket>
+   Setup Single Sign-On (SSO) with Google Workspace <setup-single-sign-on-google-email>
+   Manage Read the Docs teams <manage-read-the-docs-teams>
    Use custom environment variables <environment-variables>
-   automation-rules
-   redirects
-   Managing your Read the Docs for Business subscription </commercial/subscriptions>
+   Manage versions automatically <automation-rules>
+   Use custom URL redirects in documentation projects <redirects>
+   Manage your Read the Docs for Business subscription </commercial/subscriptions>

--- a/docs/user/guides/authors.rst
+++ b/docs/user/guides/authors.rst
@@ -13,12 +13,12 @@ and :doc:`/intro/getting-started-with-mkdocs`.
 .. toctree::
    :maxdepth: 1
 
-   cross-referencing-with-sphinx
-   Link to external projects (Intersphinx) <intersphinx>
-   jupyter
-   /guides/technical-docs-seo-guide
+   Cross-referencing with Sphinx <cross-referencing-with-sphinx>
+   Link to other projects with Intersphinx <intersphinx>
+   Use Jupyter notebooks in Sphinx <jupyter>
+   Search Engine Optimization (SEO) for documentation projects </guides/technical-docs-seo-guide>
    Migrate from rST to MyST <migrate-rest-myst>
-   enable-offline-formats
-   Using search analytics <search-analytics>
-   /automatic-redirects
+   Enable offline formats <enable-offline-formats>
+   Use search analytics <search-analytics>
+   Best practices for linking to your documentation </automatic-redirects>
    /science

--- a/docs/user/guides/build-notifications.rst
+++ b/docs/user/guides/build-notifications.rst
@@ -1,4 +1,4 @@
-How To Setup Build Notifications and Webhooks
+How to setup build notifications and webhooks
 =============================================
 
 In this guide, you can learn how to setup a number of build notification mechanisms.
@@ -33,7 +33,7 @@ Take these steps to enable build notifications using email:
 
 You should now get notified by email when your builds fail!
 
-Build Status Webhooks
+Build status webhooks
 ---------------------
 
 Read the Docs can also send webhooks when builds are triggered, successful or failed.

--- a/docs/user/guides/build-troubleshooting.rst
+++ b/docs/user/guides/build-troubleshooting.rst
@@ -1,5 +1,5 @@
-Troubleshooting build errors
-============================
+How to troubleshoote build errors
+=================================
 
 .. include:: /shared/contribute-to-troubleshooting.rst
 

--- a/docs/user/guides/canonical-urls.rst
+++ b/docs/user/guides/canonical-urls.rst
@@ -1,4 +1,4 @@
-How to Enable Canonical URLs
+How to enable canonical URLs
 ============================
 
 In this guide, we introduce relevant settings for enabling canonical URLs in popular documentation frameworks.

--- a/docs/user/guides/conda.rst
+++ b/docs/user/guides/conda.rst
@@ -1,4 +1,4 @@
-Conda Support
+Conda support
 =============
 
 Read the Docs supports Conda as an environment management tool,
@@ -10,7 +10,7 @@ This work was funded by `Clinical Graphics`_ -- many thanks for their support of
 
 .. _Clinical Graphics: https://www.clinicalgraphics.com/
 
-Activating Conda
+Activating conda
 ----------------
 
 Conda support is available using a :doc:`../config-file/index`, see :ref:`config-file/v2:conda`.

--- a/docs/user/guides/conda.rst
+++ b/docs/user/guides/conda.rst
@@ -1,5 +1,5 @@
-Conda support
-=============
+How to use Conda as your Python environment
+===========================================
 
 Read the Docs supports Conda as an environment management tool,
 along with Virtualenv.

--- a/docs/user/guides/custom-domains.rst
+++ b/docs/user/guides/custom-domains.rst
@@ -1,4 +1,4 @@
-How To Manage Custom Domains
+How to manage custom domains
 ============================
 
 This guide describes how to host your documentation using your own domain name, such as ``docs.example.com``.

--- a/docs/user/guides/deprecating-content.rst
+++ b/docs/user/guides/deprecating-content.rst
@@ -1,5 +1,5 @@
-Deprecating Content
-===================
+How to deprecate content
+========================
 
 When you deprecate a feature from your project,
 you may want to deprecate its docs as well,

--- a/docs/user/guides/developers.rst
+++ b/docs/user/guides/developers.rst
@@ -8,13 +8,11 @@ or customize the documentation appearance.
 .. toctree::
    :maxdepth: 1
 
-   private-python-packages
-   private-submodules
-   adding-custom-css
-   reproducible-builds
-   embedding-content
-   conda
-   remove-edit-buttons
-   edit-source-links-sphinx
-   Setup Build Notifications <build-notifications>
-   Use traffic analytics </analytics>
+   Install private python packages <private-python-packages>
+   Use private Git submodules <private-submodules>
+   Add custom CSS or JavaScript to Sphinx documentation <adding-custom-css>
+   Create reproducible builds <reproducible-builds>
+   Embed content from your documentation <embedding-content>
+   Use Conda as your Python environment <conda>
+   Remove "Edit on ..." buttons from documentation <remove-edit-buttons>
+   Add "Edit Source" links on your Sphinx theme <edit-source-links-sphinx>

--- a/docs/user/guides/embedding-content.rst
+++ b/docs/user/guides/embedding-content.rst
@@ -1,5 +1,5 @@
-Embedding Content From Your Documentation
-=========================================
+How to embed content from your documentation
+============================================
 
 Read the Docs allows you to embed content from any of the projects we host and specific allowed external domains
 (currently, ``docs.python.org``, ``docs.scipy.org``, ``docs.sympy.org``, ``numpy.org``)

--- a/docs/user/guides/hiding-a-version.rst
+++ b/docs/user/guides/hiding-a-version.rst
@@ -1,5 +1,5 @@
-Hide a Version and Keep its Docs Online
-=======================================
+How to hide a version and keep its documentation online
+=======================================================
 
 If you manage a project with a lot of versions,
 the version (flyout) menu of your docs can be easily overwhelmed and hard to navigate.

--- a/docs/user/guides/importing-private-repositories.rst
+++ b/docs/user/guides/importing-private-repositories.rst
@@ -1,5 +1,5 @@
-Manually Importing Private Repositories
-=======================================
+How to import private repositories
+==================================
 
 .. warning::
 

--- a/docs/user/guides/intersphinx.rst
+++ b/docs/user/guides/intersphinx.rst
@@ -1,4 +1,4 @@
-How to Link to Other Documentation Projects With Intersphinx
+How to link to other documentation projects with Intersphinx
 ============================================================
 
 This section shows you how to maintain references to named sections of other external Sphinx projects.

--- a/docs/user/guides/manage-translations-sphinx.rst
+++ b/docs/user/guides/manage-translations-sphinx.rst
@@ -1,5 +1,5 @@
-Manage Translations for Sphinx projects
-=======================================
+How to manage translations for Sphinx projects
+==============================================
 
 This guide walks through the process needed to manage translations of your documentation.
 Once this work is done, you can setup your project under Read the Docs to build each language of your documentation by reading :doc:`/localization`.
@@ -187,9 +187,9 @@ Finally, to build our documentation in Spanish(Argentina) we need to tell Sphinx
 
 .. note::
 
-   There is no need to create a new ``conf.py`` to redefine the ``language`` for the Spanish version of this documentation, 
+   There is no need to create a new ``conf.py`` to redefine the ``language`` for the Spanish version of this documentation,
    but you need to set locale_dirs_ to ``["locale"]`` for Sphinx to find the translated content.
-   
+
    .. _locale_dirs: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-locale_dirs
 
 After running this command, the Spanish(Argentina) version of your documentation will be under ``_build/html/es_AR``.

--- a/docs/user/guides/pdf-non-ascii-languages.rst
+++ b/docs/user/guides/pdf-non-ascii-languages.rst
@@ -1,5 +1,5 @@
-Sphinx PDFs with Unicode
-========================
+How to support Unicode in Sphinx PDFs
+=====================================
 
 Sphinx offers different `LaTeX engines`_ that have better support for Unicode characters
 and non-European languages like Japanese or Chinese.

--- a/docs/user/guides/private-python-packages.rst
+++ b/docs/user/guides/private-python-packages.rst
@@ -1,5 +1,5 @@
-Installing Private Python Packages
-==================================
+How to install private python packages
+======================================
 
 .. warning::
 

--- a/docs/user/guides/private-submodules.rst
+++ b/docs/user/guides/private-submodules.rst
@@ -1,5 +1,5 @@
-Using Private Git Submodules
-============================
+How to use private Git submodules
+=================================
 
 .. warning::
 

--- a/docs/user/guides/pull-requests.rst
+++ b/docs/user/guides/pull-requests.rst
@@ -1,10 +1,10 @@
 How to configure pull request builds
 ====================================
 
-In this section, you can learn how to configure :doc:`Pull Request builds </pull-requests>`.
+In this section, you can learn how to configure :doc:`pull request builds </pull-requests>`.
 
-To enable Pull Request Builds for your project,
-your Read the Docs account needs to be connected to an account with a supported VCS provider.
+To enable pull request builds for your project,
+your Read the Docs account needs to be connected to an account with a supported Git provider.
 See `Limitations`_ for more information.
 
 If your account is already connected:
@@ -36,7 +36,7 @@ Limitations
 
 - Only available for **GitHub** and **GitLab** currently. Bitbucket is not yet supported.
 - To enable this feature, your Read the Docs account needs to be connected to an
-  account with your VCS provider.
+  account with your Git provider.
 - Builds from pull requests have the same memory and time limitations
   :doc:`as regular builds </builds>`.
 - Additional formats like PDF and EPUB aren't built, to reduce build time.
@@ -59,19 +59,19 @@ No new builds are started when I open a pull request
    webhook integration.
 
    You may also notice this behavior if your Read the Docs account is not
-   connected to your VCS provider account, or if it needs to be reconnected.
+   connected to your Git provider account, or if it needs to be reconnected.
    You can (re)connect your account by going to your :guilabel:`<Username dropdown>`,
    :guilabel:`Settings`, then to :guilabel:`Connected Services`.
 
 
-Build status is not being reported to your VCS provider
+Build status is not being reported to your Git provider
    If opening a pull request does start a new build, but the build status is not
-   being updated with your VCS provider, then your connected account may have out
+   being updated with your Git provider, then your connected account may have out
    dated or insufficient permisisons.
 
    Make sure that you have granted access to the Read the Docs `OAuth App`_ for
    your personal or organization GitHub account. You can also try reconnecting
-   your account with your VCS provider.
+   your account with your Git provider.
 
 .. seealso::
    - :ref:`guides/git-integrations:Debugging webhooks`

--- a/docs/user/guides/pull-requests.rst
+++ b/docs/user/guides/pull-requests.rst
@@ -1,4 +1,4 @@
-How To Configure Pull Request Builds
+How to configure pull request builds
 ====================================
 
 In this section, you can learn how to configure :doc:`Pull Request builds </pull-requests>`.

--- a/docs/user/guides/remove-edit-buttons.rst
+++ b/docs/user/guides/remove-edit-buttons.rst
@@ -1,5 +1,5 @@
-Removing "Edit on ..." Buttons from Documentation
-=================================================
+How to remove "Edit on ..." buttons from documentation
+======================================================
 
 When building your documentation, Read the Docs automatically adds buttons at
 the top of your documentation and in the versions menu that point readers to your repository to make

--- a/docs/user/guides/reproducible-builds.rst
+++ b/docs/user/guides/reproducible-builds.rst
@@ -1,5 +1,5 @@
-Reproducible builds
-===================
+How to create reproducible builds
+=================================
 
 Your documentation depends on a number of dependencies to be built.
 If your docs don't have reproducible builds,

--- a/docs/user/guides/reproducible-builds.rst
+++ b/docs/user/guides/reproducible-builds.rst
@@ -1,4 +1,4 @@
-Reproducible Builds
+Reproducible builds
 ===================
 
 Your documentation depends on a number of dependencies to be built.

--- a/docs/user/guides/technical-docs-seo-guide.rst
+++ b/docs/user/guides/technical-docs-seo-guide.rst
@@ -1,5 +1,5 @@
-Search Engine Optimization (SEO) for documentation projects
-===========================================================
+How to do Search Engine Optimization (SEO) for documentation projects
+=====================================================================
 
 .. meta::
     :description lang=en:

--- a/docs/user/guides/technical-docs-seo-guide.rst
+++ b/docs/user/guides/technical-docs-seo-guide.rst
@@ -26,7 +26,7 @@ they can get the answers from your documentation in the search results.
    :ref:`external resources <guides/technical-docs-seo-guide:External resources>` section.
 
 
-SEO Basics
+SEO basics
 ----------
 
 Search engines like Google and Bing crawl through the internet

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -153,13 +153,13 @@ and how to write successful documentation.
   :doc:`More guides for authors </guides/authors>`
 
 * **For project administrators**:
-  :doc:`Connect Your Git Repository </guides/git-integrations>` |
-  :doc:`Manage Custom Domains </guides/custom-domains>` |
+  :doc:`/guides/git-integrations` |
+  :doc:`/guides/custom-domains` |
   :doc:`/guides/technical-docs-seo-guide` |
   :doc:`/guides/manage-translations-sphinx` |
   :doc:`/guides/private-submodules` |
-  :doc:`Configure Pull Request Builds </guides/pull-requests>` |
-  :doc:`Use Traffic Analytics </analytics>` |
+  :doc:`/guides/pull-requests` |
+  :doc:`/analytics` |
   :doc:`/guides/build-notifications` |
   :doc:`More guides for administrators </guides/administrators>`
 
@@ -169,7 +169,7 @@ and how to write successful documentation.
   :doc:`/guides/reproducible-builds` |
   :doc:`/guides/embedding-content` |
   :doc:`/guides/conda` |
-  :doc:`Use Traffic Analytics </analytics>` |
+  :doc:`/analytics` |
   :doc:`/guides/build-notifications` |
   :doc:`More guides for developers and designers </guides/developers>`
 
@@ -211,8 +211,8 @@ Read the Docs has a commercial offering with improved support and additional fea
 
 * **Read the Docs for Business**:
   :doc:`Organizations <commercial/organizations>` |
-  :doc:`Single Sign On <commercial/single-sign-on>` |
-  :doc:`Project Privacy Level <commercial/privacy-level>` |
+  :doc:`Single sign on <commercial/single-sign-on>` |
+  :doc:`Project privacy level <commercial/privacy-level>` |
   :doc:`Sharing externally <commercial/sharing>`
 
 
@@ -232,7 +232,7 @@ of Read the Docs and the larger software documentation ecosystem.
 
 
 * **The people and philosophy behind Read the Docs**:
-  :doc:`About Us </about/index>` |
+  :doc:`About us </about/index>` |
   :doc:`Team <team>` |
   :doc:`Open source philosophy <open-source-philosophy>` |
   :doc:`Our story <story>`
@@ -248,4 +248,4 @@ of Read the Docs and the larger software documentation ecosystem.
 
 * **Getting involved with Read the Docs**:
   :doc:`/glossary` |
-  :doc:`Developer Documentation <rtd-dev:index>`
+  :doc:`Developer documentation <rtd-dev:index>`

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -1,4 +1,4 @@
-Read the Docs: Documentation Simplified
+Read the Docs: documentation simplified
 =======================================
 
 .. toctree::
@@ -139,7 +139,7 @@ and some of the core features of Read the Docs.
   :doc:`/faq`
 
 
-How-to Guides
+How-to guides
 -------------
 
 These guides will help you walk through specific use cases

--- a/docs/user/intro/getting-started-with-mkdocs.rst
+++ b/docs/user/intro/getting-started-with-mkdocs.rst
@@ -1,4 +1,4 @@
-Getting Started with MkDocs
+Getting started with MkDocs
 ===========================
 
 .. meta::

--- a/docs/user/intro/getting-started-with-sphinx.rst
+++ b/docs/user/intro/getting-started-with-sphinx.rst
@@ -1,4 +1,4 @@
-Getting Started with Sphinx
+Getting started with Sphinx
 ===========================
 
 .. meta::

--- a/docs/user/intro/import-guide.rst
+++ b/docs/user/intro/import-guide.rst
@@ -1,4 +1,4 @@
-Importing Your Documentation
+Importing your documentation
 ============================
 
 .. meta::

--- a/docs/user/legal/dpa/index.rst
+++ b/docs/user/legal/dpa/index.rst
@@ -1,5 +1,5 @@
-Data Processing Addendum
-========================
+Data Processing Addendum (DPA)
+==============================
 
 .. toctree::
     :hidden:
@@ -12,5 +12,5 @@ You can complete this by reviewing and accepting the following pre-signed agreem
 `Review the Read the Docs Data Processing Addendum <https://readthedocs.eversign.com/embedded/fa9e5a24917c4440a1770251102a044e>`_
 
 .. seealso::
-   :doc:`Read the Docs Sub-Processor List <subprocessors>`
+   :doc:`Read the Docs sub-processor list <subprocessors>`
       An up-to-date list of the sub-processors we use for hosting services.

--- a/docs/user/legal/dpa/subprocessors.rst
+++ b/docs/user/legal/dpa/subprocessors.rst
@@ -1,4 +1,4 @@
-Sub-Processor List
+Sub-processor list
 ==================
 
 :Effective: April 16, 2021

--- a/docs/user/legal/security-policy.rst
+++ b/docs/user/legal/security-policy.rst
@@ -58,7 +58,7 @@ Payment security
     stored with our payment provider, Stripe -- a PCI-certified level 1 payment
     provider.
 
-Engineering and Operational Practices
+Engineering and operational practices
 -------------------------------------
 
 Immutable infrastructure

--- a/docs/user/localization.rst
+++ b/docs/user/localization.rst
@@ -1,4 +1,4 @@
-Localization of Documentation
+Localization of documentation
 =============================
 
 In this article, we explain high-level approaches to internationalizing and localizing your documentation.

--- a/docs/user/open-source-philosophy.rst
+++ b/docs/user/open-source-philosophy.rst
@@ -1,5 +1,5 @@
-Read the Docs Open Source Philosophy
--------------------------------------
+Read the Docs open source philosophy
+------------------------------------
 
 Read the Docs is open source software.
 We have `licensed <https://github.com/readthedocs/readthedocs.org/blob/main/LICENSE>`_ the code base as MIT,
@@ -14,7 +14,7 @@ We also believe sharing the code openly is a valuable learning tool,
 especially for demonstrating how to collaborate and maintain an enormous website.
 
 
-Official Support
+Official support
 ~~~~~~~~~~~~~~~~
 
 The time of the core developers of Read the Docs is limited.

--- a/docs/user/privacy-policy.rst
+++ b/docs/user/privacy-policy.rst
@@ -1,10 +1,10 @@
 .. This is linked from the footer of readthedocs.org
 .. and from the version (flyout) menu on docs sites
 
-Privacy policy
+Privacy Policy
 ==============
 
-Effective date: **September  30, 2019**
+Effective date: **February 21, 2023**
 
 Welcome to Read the Docs.
 At Read the Docs, we believe in protecting the privacy of our
@@ -194,12 +194,11 @@ Analytics
 We go into detail on analytics in a
 :ref:`separate section specific to analytics <privacy-policy:Google Analytics>`.
 
-Support Desk
+Support desk
 ++++++++++++
 
-Read the Docs uses Intercom to manage support requests
-for documentation hosted through Read the Docs for Business.
-If you request support -- typically via email -- Intercom may process
+Read the Docs uses Front to manage support requests.
+If you request support -- typically via email -- Front may process
 your contact information.
 
 Email newsletter
@@ -214,7 +213,7 @@ You can manage your email subscription
 including unsubscribing and deleting your records with MailerLite.
 There is a link to do so in the footer of any newsletter you receive from us.
 
-Public Information on Read the Docs
+Public information on Read the Docs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Most of Read the Docs is public-facing including
@@ -342,7 +341,7 @@ In particular:
 * We also provide our users a method of recourse and enforcement.
 
 
-Resolving Complaints
+Resolving complaints
 --------------------
 
 If you have concerns about the way Read the Docs is handling your User Personal Information,

--- a/docs/user/pull-requests.rst
+++ b/docs/user/pull-requests.rst
@@ -1,4 +1,4 @@
-Preview Documentation from Pull Requests
+Preview documentation from pull requests
 ========================================
 
 Your project can be configured to build and host documentation for every new

--- a/docs/user/reference/analytics.rst
+++ b/docs/user/reference/analytics.rst
@@ -24,7 +24,7 @@ It's also possible to customize your documentation to include other analytics fr
 Learn more in :doc:`/analytics`.
 
 
-Search Analytics
+Search analytics
 ----------------
 
 When someone visits your documentation and uses the built-in :ref:`server-side search <server-side-search:Server Side Search>` feature,

--- a/docs/user/reference/cdn.rst
+++ b/docs/user/reference/cdn.rst
@@ -14,7 +14,7 @@ We support CDNs on both of our sites:
     the CDN is included as part of our all of our plans.
     We use `Cloudflare`_ for this as well.
 
-CDN Benefits
+CDN benefits
 ------------
 
 Having a CDN in front of your documentation has many benefits:

--- a/docs/user/science.rst
+++ b/docs/user/science.rst
@@ -133,7 +133,7 @@ Ready to get started?
 .. Note that this is a deliberate repitition of a previous segment. Should it repeat? Maybe not, but for now it's nice to be sure that people see it.
 
 * All new to this? Take the official :external+jupyterbook:doc:`Jupyter Book Tutorial » <start/your-first-book>`
-* Curious for practical code? See the list of :doc:`Example Projects » </examples>`
+* Curious for practical code? See the list of :doc:`example projects » </examples>`
 * Familiar with Sphinx? Read :doc:`How to use Jupyter notebooks in Sphinx » </guides/jupyter>`
 
 

--- a/docs/user/server-side-search/api.rst
+++ b/docs/user/server-side-search/api.rst
@@ -1,4 +1,4 @@
-Server Side Search API
+Server side search API
 ======================
 
 You can integrate our :doc:`server side search </server-side-search/index>` in your documentation by using our API.
@@ -7,7 +7,7 @@ If you are using :doc:`/commercial/index` you will need to replace
 https://readthedocs.org/ with https://readthedocs.com/ in all the URLs used in the following examples.
 Check :ref:`server-side-search/api:authentication and authorization` if you are using private versions.
 
-API V3
+API v3
 ------
 
 .. http:get:: /api/v3/search/
@@ -126,7 +126,7 @@ API V3
       }
 
 
-Migrating from API V2
+Migrating from API v2
 ~~~~~~~~~~~~~~~~~~~~~
 
 Instead of using query arguments to specify the project
@@ -166,7 +166,7 @@ To be able to use the user's current session you need to use the API from the do
 This is ``https://docs.readthedocs-hosted.com/_/api/v3/search/``
 for the ``https://docs.readthedocs-hosted.com/`` project, for example.
 
-API V2 (deprecated)
+API v2 (deprecated)
 -------------------
 
 .. note::

--- a/docs/user/server-side-search/index.rst
+++ b/docs/user/server-side-search/index.rst
@@ -1,4 +1,4 @@
-Server Side Search
+Server side search
 ==================
 
 Read the Docs provides full-text search across all of the pages of all projects,

--- a/docs/user/server-side-search/syntax.rst
+++ b/docs/user/server-side-search/syntax.rst
@@ -1,4 +1,4 @@
-Search Query Syntax
+Search query syntax
 ===================
 
 When searching on Read the Docs with :doc:`Server Side Search </server-side-search/index>`,

--- a/docs/user/server-side-search/syntax.rst
+++ b/docs/user/server-side-search/syntax.rst
@@ -1,7 +1,7 @@
 Search query syntax
 ===================
 
-When searching on Read the Docs with :doc:`Server Side Search </server-side-search/index>`,
+When searching on Read the Docs with :doc:`server side search </server-side-search/index>`,
 you can use some parameters in your query
 in order to search on given projects, versions, or to get more accurate results.
 

--- a/docs/user/sponsors.rst
+++ b/docs/user/sponsors.rst
@@ -41,14 +41,14 @@ Past sponsors
 .. _Chan Zuckerberg Initiative: https://chanzuckerberg.com/
 
 
-Sponsorship Information
+Sponsorship information
 -----------------------
 
 As part of increasing sustainability,
 Read the Docs is testing out promoting sponsors on documentation pages.
 We have more information about this in our `blog post <https://blog.readthedocs.com/ads-on-read-the-docs/>`_ about this effort.
 
-Sponsor Us
+Sponsor us
 ~~~~~~~~~~
 
 Contact us at rev@readthedocs.org for more information on sponsoring Read the Docs.

--- a/docs/user/story.rst
+++ b/docs/user/story.rst
@@ -1,7 +1,7 @@
-The Story of Read the Docs
+The story of Read the Docs
 ==========================
 
-Documenting projects is hard, hosting them shouldn’t be. Read the Docs was created to make hosting documentation simple. 
+Documenting projects is hard, hosting them shouldn’t be. Read the Docs was created to make hosting documentation simple.
 
 Read the Docs was `started`_ with a couple main goals in mind. The first goal was
 to encourage people to write documentation, by removing the barrier of entry to

--- a/docs/user/support.rst
+++ b/docs/user/support.rst
@@ -1,7 +1,7 @@
-Site Support
+Site support
 ============
 
-Usage Questions
+Usage questions
 ---------------
 
 If you have questions about how to use Read the Docs, or have an issue that
@@ -17,7 +17,7 @@ Good questions for Stack Overflow would be:
 You might also find the answers you are looking for in our :doc:`documentation guides </guides/index>`.
 These provide step-by-step solutions to common user requirements.
 
-User Support
+User support
 ------------
 
 If you need a specific request for your project or account,
@@ -35,7 +35,7 @@ like more resources, change of the project's slug or username.
         Please fill out the form at https://readthedocs.com/support/,
         and we will reply within 1 business day for most plans.
 
-Bug Reports
+Bug reports
 -----------
 
 If you have an issue with the actual functioning of the site,
@@ -43,7 +43,7 @@ you can file bug reports on our `GitHub issue tracker`_.
 You can also :doc:`contribute <rtd-dev:contribute>` to Read the Docs,
 as the code is open source.
 
-Priority Support
+Priority support
 ----------------
 
 We offer priority support with :doc:`Read the Docs for Business </commercial/index>`

--- a/docs/user/team.rst
+++ b/docs/user/team.rst
@@ -1,4 +1,4 @@
-Read the Docs Team
+Read the Docs team
 ==================
 
 readthedocs.org is the largest open source documentation hosting service.
@@ -89,7 +89,7 @@ Teams
 
 .. _major-contributors:
 
-Major Contributors
+Major contributors
 ------------------
 
 `The code that powers the Read the Docs platform <https://github.com/readthedocs/readthedocs.org/>`_,

--- a/docs/user/terms-of-service.rst
+++ b/docs/user/terms-of-service.rst
@@ -85,7 +85,7 @@ You alone are responsible for your Account and anything that happens while you a
 You are responsible for keeping your Account secure.*
 
 Account controls
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 Users
     Subject to these Terms, you retain ultimate administrative control over your User Account and the Content within it.

--- a/docs/user/tutorial/index.rst
+++ b/docs/user/tutorial/index.rst
@@ -580,7 +580,7 @@ how readers are using your documentation, addressing some common questions like:
 
 Read the Docs offers you some analytics tools to find out the answers.
 
-Browsing Traffic Analytics
+Browsing traffic analytics
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The :doc:`/analytics` view shows the top viewed documentation pages of the past 30 days,
@@ -621,7 +621,7 @@ and click on the :guilabel:`Download all data` button.
 That will prompt you to download a :abbr:`CSV (Comma-Separated Values)` file
 that you can process any way you want.
 
-Browsing Search Analytics
+Browsing search analytics
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Apart from traffic analytics, Read the Docs also offers the possibility

--- a/docs/user/versions.rst
+++ b/docs/user/versions.rst
@@ -1,4 +1,4 @@
-Versioned Documentation
+Versioned documentation
 =======================
 
 Read the Docs supports multiple versions of your repository.
@@ -45,7 +45,7 @@ which are branches that are maintained over time for a specific release number.
 
 .. _PEP 440: https://www.python.org/dev/peps/pep-0440/
 
-Version States
+Version states
 --------------
 
 States define the visibility of a version across the site.


### PR DESCRIPTION
@ericholscher This is supposed to be a 100% neutral change. No discussions of titles intended. Just want to get sentence case introduced and move on to creating new sub-levels in the next PR...

* [x] Go through all titles
* [x] Go through all "How to do x" titles
* [x] Navigation labels for all "How to do x" titles...
* [x] Go through all references like `:doc:` and `:ref:` that has a "Title Case" reference

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10055.org.readthedocs.build/en/10055/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10055.org.readthedocs.build/en/10055/

<!-- readthedocs-preview dev end -->