### PR TITLE
Proxito: use `django-cacheops` to cache some querysets

### DIFF
--- a/dockerfiles/settings/proxito.py
+++ b/dockerfiles/settings/proxito.py
@@ -6,6 +6,8 @@ from .docker_compose import DockerBaseSettings
 class ProxitoDevSettings(CommunityProxitoSettingsMixin, DockerBaseSettings):
     DONT_HIT_DB = False
 
+    CACHEOPS_ENABLED = True
+
     # El Proxito does not have django-debug-toolbar installed
     @property
     def DEBUG_TOOLBAR_CONFIG(self):

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -245,6 +245,7 @@ class CommunityBaseSettings(Settings):
             'allauth.socialaccount.providers.gitlab',
             'allauth.socialaccount.providers.bitbucket',
             'allauth.socialaccount.providers.bitbucket_oauth2',
+            'cacheops',
         ]
         if ext:
             apps.append('readthedocsext.cdn')
@@ -744,7 +745,7 @@ class CommunityBaseSettings(Settings):
 
     # Allow cross-site requests from any origin,
     # all information from our allowed endpoits is public.
-    # 
+    #
     # NOTE: We don't use `CORS_ALLOW_ALL_ORIGINS=True`,
     # since that will set the `Access-Control-Allow-Origin` header to `*`,
     # we won't be able to pass credentials fo the sustainability API with that value.
@@ -1024,3 +1025,29 @@ class CommunityBaseSettings(Settings):
     RTD_SPAM_THRESHOLD_DONT_SERVE_DOCS = 500
     RTD_SPAM_THRESHOLD_DELETE_PROJECT = 1000
     RTD_SPAM_MAX_SCORE = 9999
+
+    CACHEOPS_ENABLED = False
+    CACHEOPS_TIMEOUT = 60 * 60  # seconds
+    CACHEOPS_OPS = {'get', 'fetch'}
+    CACHEOPS_DEGRADE_ON_FAILURE = True
+    CACHEOPS = {
+        # readthedocs.projects.*
+        'projects.project': {
+            'ops': CACHEOPS_OPS,
+            'timeout': CACHEOPS_TIMEOUT,
+        },
+        'projects.projectrelationship': {
+            'ops': CACHEOPS_OPS,
+            'timeout': CACHEOPS_TIMEOUT,
+        },
+        'projects.domain': {
+            'ops': CACHEOPS_OPS,
+            'timeout': CACHEOPS_TIMEOUT,
+        },
+
+        # readthedocs.builds.*
+        'builds.version': {
+            'ops': CACHEOPS_OPS,
+            'timeout': CACHEOPS_TIMEOUT,
+        },
+    }

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -161,6 +161,7 @@ class DockerBaseSettings(CommunityBaseSettings):
         },
     }
 
+    CACHEOPS_REDIS = f"redis://:{CACHES['default']['OPTIONS']['PASSWORD']}@cache:6379/1"
     BROKER_URL = f"redis://:{CACHES['default']['OPTIONS']['PASSWORD']}@cache:6379/0"
 
     CELERY_ALWAYS_EAGER = False

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -108,6 +108,7 @@ django==3.2.18
     #   dj-stripe
     #   django-allauth
     #   django-annoying
+    #   django-cacheops
     #   django-cors-headers
     #   django-csp
     #   django-debug-toolbar
@@ -126,6 +127,8 @@ django-allauth==0.51.0
 django-annoying==0.10.6
     # via -r requirements/pip.txt
 django-autoslug==1.9.8
+    # via -r requirements/pip.txt
+django-cacheops==6.2
     # via -r requirements/pip.txt
 django-cors-headers==3.14.0
     # via -r requirements/pip.txt
@@ -197,6 +200,10 @@ filelock==3.9.0
     # via
     #   -r requirements/pip.txt
     #   virtualenv
+funcy==1.18
+    # via
+    #   -r requirements/pip.txt
+    #   django-cacheops
 gitdb==4.0.10
     # via
     #   -r requirements/pip.txt
@@ -319,6 +326,7 @@ pyyaml==5.4.1
 redis==4.5.1
     # via
     #   -r requirements/pip.txt
+    #   django-cacheops
     #   django-redis
 regex==2022.10.31
     # via -r requirements/pip.txt
@@ -352,6 +360,7 @@ six==1.16.0
     #   asttokens
     #   click-repl
     #   django-annoying
+    #   django-cacheops
     #   django-elasticsearch-dsl
     #   elasticsearch-dsl
     #   python-dateutil

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -117,6 +117,7 @@ django==3.2.18
     #   dj-stripe
     #   django-allauth
     #   django-annoying
+    #   django-cacheops
     #   django-cors-headers
     #   django-csp
     #   django-debug-toolbar
@@ -135,6 +136,8 @@ django-allauth==0.51.0
 django-annoying==0.10.6
     # via -r requirements/pip.txt
 django-autoslug==1.9.8
+    # via -r requirements/pip.txt
+django-cacheops==6.2
     # via -r requirements/pip.txt
 django-cors-headers==3.14.0
     # via -r requirements/pip.txt
@@ -209,6 +212,10 @@ filelock==3.9.0
     #   -r requirements/pip.txt
     #   tox
     #   virtualenv
+funcy==1.18
+    # via
+    #   -r requirements/pip.txt
+    #   django-cacheops
 gitdb==4.0.10
     # via
     #   -r requirements/pip.txt
@@ -348,6 +355,7 @@ pyyaml==5.4.1
 redis==4.5.1
     # via
     #   -r requirements/pip.txt
+    #   django-cacheops
     #   django-redis
 regex==2022.10.31
     # via -r requirements/pip.txt
@@ -381,6 +389,7 @@ six==1.16.0
     #   asttokens
     #   click-repl
     #   django-annoying
+    #   django-cacheops
     #   django-elasticsearch-dsl
     #   elasticsearch-dsl
     #   python-dateutil

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -108,6 +108,7 @@ django==3.2.18
     #   dj-stripe
     #   django-allauth
     #   django-annoying
+    #   django-cacheops
     #   django-cors-headers
     #   django-csp
     #   django-debug-toolbar
@@ -126,6 +127,8 @@ django-allauth==0.51.0
 django-annoying==0.10.6
     # via -r requirements/pip.txt
 django-autoslug==1.9.8
+    # via -r requirements/pip.txt
+django-cacheops==6.2
     # via -r requirements/pip.txt
 django-cors-headers==3.14.0
     # via -r requirements/pip.txt
@@ -203,6 +206,10 @@ flake8==3.8.4
     #   flake8-polyfill
 flake8-polyfill==1.0.2
     # via pep8-naming
+funcy==1.18
+    # via
+    #   -r requirements/pip.txt
+    #   django-cacheops
 gitdb==4.0.10
     # via
     #   -r requirements/pip.txt
@@ -348,6 +355,7 @@ pyyaml==5.4.1
 redis==4.5.1
     # via
     #   -r requirements/pip.txt
+    #   django-cacheops
     #   django-redis
 regex==2022.10.31
     # via -r requirements/pip.txt
@@ -383,6 +391,7 @@ six==1.16.0
     #   astroid
     #   click-repl
     #   django-annoying
+    #   django-cacheops
     #   django-elasticsearch-dsl
     #   elasticsearch-dsl
     #   python-dateutil

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -129,3 +129,5 @@ structlog
 dparse
 
 gunicorn
+
+django-cacheops

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -64,6 +64,7 @@ django==3.2.18
     #   dj-stripe
     #   django-allauth
     #   django-annoying
+    #   django-cacheops
     #   django-cors-headers
     #   django-csp
     #   django-debug-toolbar
@@ -82,6 +83,8 @@ django-allauth==0.51.0
 django-annoying==0.10.6
     # via -r requirements/pip.in
 django-autoslug==1.9.8
+    # via -r requirements/pip.in
+django-cacheops==6.2
     # via -r requirements/pip.in
 django-cors-headers==3.14.0
     # via -r requirements/pip.in
@@ -147,6 +150,8 @@ elasticsearch-dsl==7.4.0
     #   django-elasticsearch-dsl
 filelock==3.9.0
     # via virtualenv
+funcy==1.18
+    # via django-cacheops
 gitdb==4.0.10
     # via gitpython
 gitpython==3.1.31
@@ -216,7 +221,9 @@ pytz==2022.7.1
 pyyaml==5.4.1
     # via -r requirements/pip.in
 redis==4.5.1
-    # via django-redis
+    # via
+    #   django-cacheops
+    #   django-redis
 regex==2022.10.31
     # via -r requirements/pip.in
 requests==2.28.2
@@ -243,6 +250,7 @@ six==1.16.0
     # via
     #   click-repl
     #   django-annoying
+    #   django-cacheops
     #   django-elasticsearch-dsl
     #   elasticsearch-dsl
     #   python-dateutil

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -105,6 +105,7 @@ django==3.2.18
     #   dj-stripe
     #   django-allauth
     #   django-annoying
+    #   django-cacheops
     #   django-cors-headers
     #   django-csp
     #   django-debug-toolbar
@@ -123,6 +124,8 @@ django-allauth==0.51.0
 django-annoying==0.10.6
     # via -r requirements/pip.txt
 django-autoslug==1.9.8
+    # via -r requirements/pip.txt
+django-cacheops==6.2
     # via -r requirements/pip.txt
 django-cors-headers==3.14.0
     # via -r requirements/pip.txt
@@ -196,6 +199,10 @@ filelock==3.9.0
     # via
     #   -r requirements/pip.txt
     #   virtualenv
+funcy==1.18
+    # via
+    #   -r requirements/pip.txt
+    #   django-cacheops
 gitdb==4.0.10
     # via
     #   -r requirements/pip.txt
@@ -318,6 +325,7 @@ pyyaml==5.4.1
 redis==4.5.1
     # via
     #   -r requirements/pip.txt
+    #   django-cacheops
     #   django-redis
 regex==2022.10.31
     # via -r requirements/pip.txt
@@ -351,6 +359,7 @@ six==1.16.0
     #   -r requirements/pip.txt
     #   click-repl
     #   django-annoying
+    #   django-cacheops
     #   django-dynamic-fixture
     #   django-elasticsearch-dsl
     #   elasticsearch-dsl


### PR DESCRIPTION
First attempt to use `django-cacheops` on El Proxito to cache some frequenly used queryset when serving docs via El Proxito. Queries to these models,

- Project
- Version
- ProjectRelationship
- Domain

are done on every request, and we want to do a small test by caching them in Redis to take a look at the metrics and decide whether or not this is faster than Postgres when serving documentation.