### PR TITLE
Celery: bugfix when deleting pidbox keys

### DIFF
--- a/readthedocs/core/tasks.py
+++ b/readthedocs/core/tasks.py
@@ -85,6 +85,6 @@ def cleanup_pidbox_keys():
         total_memory += memory
 
         if idletime > (60 * 15):  # 15 minutes
-            client.delete([key])
+            client.delete(key)
 
     log.info("Redis pidbox objects.", memory=total_memory, keys=len(keys))


### PR DESCRIPTION
There was a typo here where we were passing a list instead of just the key, which is what the client expects.