### PR TITLE
Celery: limit `archive_builds_task` query to last 90 day ago

### DIFF
--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -200,7 +200,10 @@ def archive_builds_task(self, days=14, limit=200, delete=False):
         queryset = (
             Build.objects
             .exclude(cold_storage=True)
-            .filter(date__lt=max_date)
+            .filter(
+                date__lt=max_date,
+                date__gt=max_date - timezone.timedelta(days=90),
+            )
             .prefetch_related('commands')
             .only('date', 'cold_storage')
             [:limit]


### PR DESCRIPTION
This query is taking more than 30 seconds and it has been killed by our postgres config. I'm reducing the query to consider at most builds that are 90 days old. This should reduce the scope of the table and make the query to run fast.

Related to https://github.com/readthedocs/readthedocs-ops/issues/1291