### PR TITLE
Celery: delete Telemetry data that's at most 3 months older

### DIFF
--- a/readthedocs/telemetry/tasks.py
+++ b/readthedocs/telemetry/tasks.py
@@ -33,4 +33,7 @@ def delete_old_build_data():
     """
     retention_days = settings.RTD_TELEMETRY_DATA_RETENTION_DAYS
     days_ago = timezone.now().date() - timezone.timedelta(days=retention_days)
-    return BuildData.objects.filter(created__lt=days_ago).delete()
+    return BuildData.objects.filter(
+        created__lt=days_ago,
+        created__gt=days_ago - timezone.timezone(days=90),
+    ).delete()


### PR DESCRIPTION
Related https://github.com/readthedocs/readthedocs-ops/issues/1291