### PR TITLE
Fix intersphinx references to myst-parser (updated in myst-parser 0.19)

### DIFF
--- a/docs/user/guides/cross-referencing-with-sphinx.rst
+++ b/docs/user/guides/cross-referencing-with-sphinx.rst
@@ -29,7 +29,7 @@ with two markup options: reStructuredText and MyST (Markdown).
 - If you are not familiar with reStructuredText,
   check :doc:`sphinx:usage/restructuredtext/basics` for a quick introduction.
 - If you want to learn more about the MyST Markdown dialect,
-  check out :doc:`myst-parser:syntax/syntax`.
+  check out :doc:`myst-parser:syntax/reference`.
 
 .. contents:: Table of contents
    :local:

--- a/docs/user/guides/jupyter.rst
+++ b/docs/user/guides/jupyter.rst
@@ -331,7 +331,7 @@ However, there are some differences between them:
   whereas MyST-NB uses `MyST-Parser`_
   to directly convert the Markdown text to docutils AST.
   Therefore, nbsphinx assumes `pandoc flavored Markdown <https://pandoc.org/MANUAL.html#pandocs-markdown>`_,
-  whereas MyST-NB uses :doc:`MyST flavored Markdown <myst-parser:syntax/syntax>`.
+  whereas MyST-NB uses :doc:`MyST flavored Markdown <myst-parser:index>`.
   Both Markdown flavors are mostly equal,
   but they have some differences.
 - nbsphinx executes each notebook during the parsing phase,

--- a/docs/user/guides/migrate-rest-myst.md
+++ b/docs/user/guides/migrate-rest-myst.md
@@ -27,8 +27,8 @@ and some others in reStructuredText, for whatever reason.
 Luckily, Sphinx supports reading both types of markup at the same time without problems.
 
 To start using MyST in your existing Sphinx project,
-first {ref}``install the `myst-parser` Python package <myst-parser:intro.md#installation>``
-and then {ref}`enable it on your configuration <myst-parser:intro.md#enable-myst-in-sphinx>`:
+first [install the `myst-parser` Python package](https://myst-parser.readthedocs.io/en/stable/intro.html#installation)
+and then [enable it on your configuration](https://myst-parser.readthedocs.io/en/stable/intro.html#enable-myst-in-sphinx):
 
 ```{code-block} py
 :caption: conf.py


### PR DESCRIPTION
Issue regarding the replaced Intersphinx reference for `intro.md#installation` is reported here: https://github.com/executablebooks/MyST-Parser/issues/731

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10090.org.readthedocs.build/en/10090/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10090.org.readthedocs.build/en/10090/

<!-- readthedocs-preview dev end -->