### PR TITLE
Proxito: use cacheops for 2 more models

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -1055,4 +1055,14 @@ class CommunityBaseSettings(Settings):
             'ops': CACHEOPS_OPS,
             'timeout': CACHEOPS_TIMEOUT,
         },
+
+        # readthedocs.organizations.*
+        'organizations.organization': {
+            'ops': CACHEOPS_OPS,
+            'timeout': CACHEOPS_TIMEOUT,
+        },
+        'organizations.planfeature': {
+            'ops': CACHEOPS_OPS,
+            'timeout': CACHEOPS_TIMEOUT,
+        },
     }


### PR DESCRIPTION
`Organization` and `PlanFeature` weren't being cached by `cacheops` and they are used when serving documentation.

By caching these, we will be caching all the models used when serving documentation, reducing the db hits and a also a litte the response time.

With this change, we won't hit the db at all when serving documentation 👍🏼 . This has other benefits besides trying to reduce the response time.