### PR TITLE
Development: allow to define the logging level via an env variable

### DIFF
--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -88,7 +88,7 @@ class DockerBaseSettings(CommunityBaseSettings):
     def LOGGING(self):
         logging = super().LOGGING
 
-        logging['handlers']['console']['level'] = 'DEBUG'
+        logging['handlers']['console']['level'] = os.environ.get("RTD_LOGGING_LEVEL", 'INFO')
         logging['formatters']['default']['format'] = '[%(asctime)s] ' + self.LOG_FORMAT
         # Allow Sphinx and other tools to create loggers
         logging['disable_existing_loggers'] = False


### PR DESCRIPTION
Use an environment variable defined by `invoke` command to set the logging level of our Django application.

Requires: https://github.com/readthedocs/common/pull/167