### PR TITLE
Proxito: cacheops right model

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -1061,7 +1061,9 @@ class CommunityBaseSettings(Settings):
             'ops': CACHEOPS_OPS,
             'timeout': CACHEOPS_TIMEOUT,
         },
-        'organizations.planfeature': {
+
+        # readthedocs.subscriptions.*
+        'subscriptions.planfeature': {
             'ops': CACHEOPS_OPS,
             'timeout': CACHEOPS_TIMEOUT,
         },


### PR DESCRIPTION
I got confused because we are mapping a different table name. `subscriptions.models.PlanFeature` maps to `organizations_planfeature` table.

Related https://github.com/readthedocs/readthedocs.org/pull/10106