### PR TITLE
Build: fail PDF command (`latexmk`) if exit code != 0

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -579,14 +579,18 @@ class PdfBuilder(BaseSphinx):
             '-interaction=nonstopmode',
         ]
 
-        cmd_ret = self.run(
-            *cmd,
-            cwd=self.absolute_host_output_dir,
-        )
+        try:
+            cmd_ret = self.run(
+                *cmd,
+                cwd=self.absolute_host_output_dir,
+            )
+            self.pdf_file_name = f"{self.project.slug}.pdf"
+            return cmd_ret.successful
 
-        self.pdf_file_name = f'{self.project.slug}.pdf'
-
-        return cmd_ret.successful
+        # Catch the exception and re-raise it with a specific message
+        except BuildUserError:
+            raise BuildUserError(BuildUserError.PDF_COMMAND_FAILED)
+        return False
 
     def _post_build(self):
         """Internal post build to cleanup PDF output directory and leave only one .pdf file."""

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -26,8 +26,6 @@ from readthedocs.projects.models import Feature
 from readthedocs.projects.utils import safe_write
 
 from ..base import BaseBuilder
-from ..constants import PDF_RE
-from ..environments import BuildCommand, DockerBuildCommand
 from ..exceptions import BuildUserError
 from ..signals import finalize_sphinx_context_data
 
@@ -488,30 +486,6 @@ class EpubBuilder(BaseSphinx):
             )
 
 
-class LatexBuildCommand(BuildCommand):
-
-    """Ignore LaTeX exit code if there was file output."""
-
-    def run(self):
-        super().run()
-        # Force LaTeX exit code to be a little more optimistic. If LaTeX
-        # reports an output file, let's just assume we're fine.
-        if PDF_RE.search(self.output):
-            self.exit_code = 0
-
-
-class DockerLatexBuildCommand(DockerBuildCommand):
-
-    """Ignore LaTeX exit code if there was file output."""
-
-    def run(self):
-        super().run()
-        # Force LaTeX exit code to be a little more optimistic. If LaTeX
-        # reports an output file, let's just assume we're fine.
-        if PDF_RE.search(self.output):
-            self.exit_code = 0
-
-
 class PdfBuilder(BaseSphinx):
 
     """Builder to generate PDF documentation."""
@@ -589,11 +563,6 @@ class PdfBuilder(BaseSphinx):
             cwd=self.absolute_host_output_dir,
         )
 
-        if self.build_env.command_class == DockerBuildCommand:
-            latex_class = DockerLatexBuildCommand
-        else:
-            latex_class = LatexBuildCommand
-
         cmd = [
             'latexmk',
             '-r',
@@ -610,10 +579,8 @@ class PdfBuilder(BaseSphinx):
             '-interaction=nonstopmode',
         ]
 
-        cmd_ret = self.build_env.run_command_class(
-            cls=latex_class,
-            cmd=cmd,
-            warn_only=True,
+        cmd_ret = self.run(
+            *cmd,
             cwd=self.absolute_host_output_dir,
         )
 

--- a/readthedocs/doc_builder/constants.py
+++ b/readthedocs/doc_builder/constants.py
@@ -1,14 +1,11 @@
 
 """Doc build constants."""
 
-import re
 
 import structlog
 from django.conf import settings
 
 log = structlog.get_logger(__name__)
-
-PDF_RE = re.compile('Output written on (.*?)')
 
 # Docker
 DOCKER_SOCKET = settings.DOCKER_SOCKET

--- a/readthedocs/doc_builder/exceptions.py
+++ b/readthedocs/doc_builder/exceptions.py
@@ -54,10 +54,10 @@ class BuildUserError(BuildBaseException):
     )
     PDF_COMMAND_FAILED = gettext_noop(
         "PDF generation failed. "
-        "Please double check the command's output looking for errors and fix them. "
-        "Note it's possible the PDF has been always failing silently in your project, "
-        "but due to latest changes, "
-        "Read the Docs now makes it explicit and fail the whole build."
+        "The build log below contains information on what errors caused the failure." 
+        "Our code has recently changed to fail the entire build on PDF errors, "
+        "where we used to pass the build when a PDF was created."
+        "Please contact us if you need help understanding this error."
     )
 
 

--- a/readthedocs/doc_builder/exceptions.py
+++ b/readthedocs/doc_builder/exceptions.py
@@ -54,7 +54,7 @@ class BuildUserError(BuildBaseException):
     )
     PDF_COMMAND_FAILED = gettext_noop(
         "PDF generation failed. "
-        "The build log below contains information on what errors caused the failure." 
+        "The build log below contains information on what errors caused the failure."
         "Our code has recently changed to fail the entire build on PDF errors, "
         "where we used to pass the build when a PDF was created."
         "Please contact us if you need help understanding this error."

--- a/readthedocs/doc_builder/exceptions.py
+++ b/readthedocs/doc_builder/exceptions.py
@@ -52,6 +52,13 @@ class BuildUserError(BuildBaseException):
         "and it is not currently supported. "
         'Please, remove all the files but the "{artifact_type}" your want to upload.'
     )
+    PDF_COMMAND_FAILED = gettext_noop(
+        "PDF generation failed. "
+        "Please double check the command's output looking for errors and fix them. "
+        "Note it's possible the PDF has been always failing silently in your project, "
+        "but due to latest changes, "
+        "Read the Docs now makes it explicit and fail the whole build."
+    )
 
 
 class BuildUserSkip(BuildUserError):

--- a/readthedocs/projects/tests/mockers.py
+++ b/readthedocs/projects/tests/mockers.py
@@ -58,13 +58,6 @@ class BuildEnvironmentMocker:
             "project-slug.pdf",
         )
 
-        self.patches['builder.pdf.LatexBuildCommand.run'] = mock.patch(
-            'readthedocs.doc_builder.backends.sphinx.LatexBuildCommand.run',
-            return_value=mock.MagicMock(output='stdout', successful=True)
-        )
-        # self.patches['builder.pdf.LatexBuildCommand.output'] = mock.patch(
-        #     'readthedocs.doc_builder.backends.sphinx.LatexBuildCommand.output',
-        # )
         self.patches['builder.pdf.glob'] = mock.patch(
             'readthedocs.doc_builder.backends.sphinx.glob',
             return_value=['output.file'],

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -723,6 +723,18 @@ class TestBuildTask(BuildEnvironmentBase):
                     bin_path=mock.ANY,
                 ),
                 mock.call("cat", "latexmkrc", cwd=mock.ANY),
+                mock.call(
+                    "latexmk",
+                    "-r",
+                    "latexmkrc",
+                    "-pdf",
+                    "-f",
+                    "-dvi-",
+                    "-ps-",
+                    "-jobname=project",
+                    "-interaction=nonstopmode",
+                    cwd=mock.ANY,
+                ),
                 # NOTE: pdf `mv` commands and others are not here because the
                 # PDF resulting file is not found in the process (`_post_build`)
                 mock.call(
@@ -793,6 +805,14 @@ class TestBuildTask(BuildEnvironmentBase):
                     "json",
                     record=False,
                     demux=True,
+                ),
+                mock.call(
+                    "test",
+                    "-x",
+                    "_build/html",
+                    record=False,
+                    demux=True,
+                    cwd=mock.ANY,
                 ),
             ]
         )


### PR DESCRIPTION
We were forcing `exit_code=0` if we detected that `Output written on (.*?)` was found in the standard output of the `latexmk` command. This was producing confusions to our users because the PDF generation failed but we were considering it successful.

Now, we are relying on the exit code itself as we do for all the other commands making sure the command succeeded before proceding with the build. Now, if the PDF command fails, we fail the build completely.

Closes #10015 