### PR TITLE
Project: only support Git as VCS for new projects

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -385,6 +385,7 @@ class UpdateProjectForm(
             # Basics
             'name',
             'repo',
+            "repo_type",
             # Extra
             'description',
             'language',

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -86,7 +86,7 @@ class ProjectBasicsForm(ProjectForm):
 
     class Meta:
         model = Project
-        fields = ('name', 'repo', 'repo_type', 'default_branch')
+        fields = ("name", "repo", "default_branch")
 
     remote_repository = forms.IntegerField(
         widget=forms.HiddenInput(),
@@ -385,7 +385,6 @@ class UpdateProjectForm(
             # Basics
             'name',
             'repo',
-            'repo_type',
             # Extra
             'description',
             'language',

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -144,6 +144,9 @@ class Project(models.Model):
         help_text=_('Hosted documentation repository URL'),
         db_index=True,
     )
+
+    # NOTE: this field is going to be completely removed soon.
+    # We only accept Git for new repositories
     repo_type = models.CharField(
         _('Repository type'),
         max_length=10,

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -177,7 +177,6 @@ class TestBasicsForm(WizardTestCase):
         self.step_data['basics'] = {'advanced': True}
         resp = self.post_step('basics')
         self.assertWizardFailure(resp, 'name')
-        self.assertWizardFailure(resp, 'repo_type')
 
 
 @mock.patch('readthedocs.projects.tasks.builds.update_docs_task', mock.MagicMock())


### PR DESCRIPTION
This is the continuation of a soft deprecation. We already remove mentions to other VCS different than Git from our documentation.

In this step, we remove the ability to import other repositories other than Git. However, we are keeping the code around to avoid existing projects to break when building. In the future, we will remove this support completely.

Continuation of #8840