### PR TITLE
Build: pass shell commands directly (`build.jobs` / `build.commands)`

### DIFF
--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -330,7 +330,7 @@ class BuildDirector:
 
         commands = getattr(self.data.config.build.jobs, job, [])
         for command in commands:
-            environment.run(*command.split(), escape_command=False, cwd=cwd)
+            environment.run(command, escape_command=False, cwd=cwd)
 
     def run_build_commands(self):
         reshim_commands = (
@@ -344,7 +344,7 @@ class BuildDirector:
         cwd = self.data.project.checkout_path(self.data.version.slug)
         environment = self.build_environment
         for command in self.data.config.build.commands:
-            environment.run(*command.split(), escape_command=False, cwd=cwd)
+            environment.run(command, escape_command=False, cwd=cwd)
 
             # Execute ``asdf reshim python`` if the user is installing a
             # package since the package may contain an executable

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -916,10 +916,11 @@ class TestBuildTask(BuildEnvironmentBase):
 
         self.mocker.mocks["environment.run"].assert_has_calls(
             [
-                mock.call(
-                    "git", "fetch", "--unshallow", escape_command=False, cwd=mock.ANY
-                ),
-                mock.call("echo", "`date`", escape_command=False, cwd=mock.ANY),
+                # NOTE: when running commands from `build.jobs` or
+                # `build.commands` they are not split to allow multi-line
+                # scripts
+                mock.call("git fetch --unshallow", escape_command=False, cwd=mock.ANY),
+                mock.call("echo `date`", escape_command=False, cwd=mock.ANY),
             ],
             any_order=True,
         )
@@ -1035,10 +1036,11 @@ class TestBuildTask(BuildEnvironmentBase):
                     "virtualenv",
                     "setuptools<58.3.0",
                 ),
+                # NOTE: when running commands from `build.jobs` or
+                # `build.commands` they are not split to allow multi-line
+                # scripts
                 mock.call(
-                    "pip",
-                    "install",
-                    "pelican[markdown]",
+                    "pip install pelican[markdown]",
                     escape_command=False,
                     cwd=mock.ANY,
                 ),
@@ -1051,12 +1053,7 @@ class TestBuildTask(BuildEnvironmentBase):
                     cwd=mock.ANY,
                 ),
                 mock.call(
-                    "pelican",
-                    "--settings",
-                    "docs/pelicanconf.py",
-                    "--output",
-                    "$READTHEDOCS_OUTPUT/html/",
-                    "docs/",
+                    "pelican --settings docs/pelicanconf.py --output $READTHEDOCS_OUTPUT/html/ docs/",
                     escape_command=False,
                     cwd=mock.ANY,
                 ),


### PR DESCRIPTION
I'm not sure about _why_ we split the commands before sending it out our executor. The command is finally wrapper properly before being executed.

I did some locally QA after removing the split of the command and it seems these scripts work fine. So, it seems safe to move forward with this, explanding the flexibility of our config file.

The example provided by the user works fine.

![Screenshot_2023-03-07_16-46-39](https://user-images.githubusercontent.com/244656/223473865-1a38f033-78ed-42fd-95de-6430ad6a3ed6.png)

> **Note**
> This example is interpreted just as a comment (since it's just _one line_ after the split) without this PR and nothing is executed. With this changes, the comment is ignored and the code is executed. However, the script is properly shown as multi-line in the UI as well.


Closes #10103