### PR TITLE
Proxito: add another model to cacheops

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -1041,6 +1041,10 @@ class CommunityBaseSettings(Settings):
             'ops': CACHEOPS_OPS,
             'timeout': CACHEOPS_TIMEOUT,
         },
+        'projects.feature': {
+            'ops': CACHEOPS_OPS,
+            'timeout': CACHEOPS_TIMEOUT,
+        },
         'projects.projectrelationship': {
             'ops': CACHEOPS_OPS,
             'timeout': CACHEOPS_TIMEOUT,


### PR DESCRIPTION
We are hitting `projects_feature` table now. So, I'm adding this one to be cached as well.