### PR TITLE
Build: check for `_build/html` directory and fail if exists

### DIFF
--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -332,6 +332,30 @@ class BuildDirector:
         for command in commands:
             environment.run(command, escape_command=False, cwd=cwd)
 
+    def check_old_output_directory(self):
+        """
+        Check if there the directory '_build/html' exists and fail the build if so.
+
+        Read the Docs used to build artifacts into '_build/html' and there are
+        some projects with this path hardcoded in their files. Those builds are
+        having unexpected behavior since we are not using that path anymore.
+
+        In case we detect they are keep using that path, we fail the build
+        explaining this.
+        """
+        command = self.build_environment.run(
+            "test",
+            "-x",
+            "_build/html",
+            cwd=self.data.project.checkout_path(self.data.version.slug),
+            record=False,
+        )
+        if command.exit_code == 0:
+            log.warning(
+                "Directory '_build/html' exists. This may lead to unexpected behavior."
+            )
+            raise BuildUserError(BuildUserError.BUILD_OUTPUT_OLD_DIRECTORY_USED)
+
     def run_build_commands(self):
         reshim_commands = (
             {"pip", "install"},

--- a/readthedocs/doc_builder/exceptions.py
+++ b/readthedocs/doc_builder/exceptions.py
@@ -52,6 +52,13 @@ class BuildUserError(BuildBaseException):
         "and it is not currently supported. "
         'Please, remove all the files but the "{artifact_type}" your want to upload.'
     )
+    BUILD_OUTPUT_OLD_DIRECTORY_USED = gettext_noop(
+        "Your project is outputting files to an old directory ('_build/html') "
+        "when building the docs. "
+        "Note this directory is not used anymore and the result may be unexpected. "
+        "Please, check your build process looking for this directory and replace it by "
+        "the path '$READTHEDOCS_OUTPUT/html' instead."
+    )
     PDF_COMMAND_FAILED = gettext_noop(
         "PDF generation failed. "
         "The build log below contains information on what errors caused the failure."

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -754,6 +754,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
                     self.update_build(state=BUILD_STATE_BUILDING)
                     self.data.build_director.build()
             finally:
+                self.data.build_director.check_old_output_directory()
                 self.data.build_data = self.collect_build_data()
 
         # At this point, the user's build already succeeded.

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -782,6 +782,13 @@ class TestBuildTask(BuildEnvironmentBase):
                     cwd=mock.ANY,
                     record=False,
                 ),
+                mock.call(
+                    "test",
+                    "-x",
+                    "_build/html",
+                    record=False,
+                    cwd=mock.ANY,
+                ),
                 # FIXME: I think we are hitting this issue here:
                 # https://github.com/pytest-dev/pytest-mock/issues/234
                 mock.call("lsb_release", "--description", record=False, demux=True),
@@ -805,14 +812,6 @@ class TestBuildTask(BuildEnvironmentBase):
                     "json",
                     record=False,
                     demux=True,
-                ),
-                mock.call(
-                    "test",
-                    "-x",
-                    "_build/html",
-                    record=False,
-                    demux=True,
-                    cwd=mock.ANY,
                 ),
             ]
         )

--- a/readthedocs/telemetry/collectors.py
+++ b/readthedocs/telemetry/collectors.py
@@ -93,26 +93,7 @@ class BuildDataCollector:
         }
         data["doctool"] = self._get_doctool()
 
-        # NOTE: Check if there are files at `_build/html` (the old output directory)
-        # and log these projects so we can communicate with their maintainers
-        #
-        # This temporal and should be removed in the future once we have
-        # decided what to do with this collected data.
-        self._check_using_old_output_directory()
-
         return data
-
-    def _check_using_old_output_directory(self):
-        code, _, _ = self.run(
-            "test",
-            "-x",
-            "_build/html",
-            cwd=self.project.checkout_path(self.version.slug),
-        )
-        if code == 0:
-            log.warning(
-                "Directory '_build/html' exists. This may lead to unexpected behavior."
-            )
 
     def _get_doctool_name(self):
         if self.version.is_sphinx_type:


### PR DESCRIPTION
Example of a failed build:

![Screenshot_2023-03-08_10-32-09](https://user-images.githubusercontent.com/244656/223676022-263d204e-f004-425c-90bf-9e3762ddb5db.png)

Continuation of #10038
Closes #10036