### PR TITLE
Fix typo

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -2,7 +2,7 @@ Build process customization
 ===========================
 
 Read the Docs has a :doc:`well-defined build process </builds>` that works for many projects.
-We also allow customization of builds in primary ways:
+We also allow customization of builds in two ways:
 
 `Extend the build process`_
     Keep using the default build process,


### PR DESCRIPTION


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10130.org.readthedocs.build/en/10130/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10130.org.readthedocs.build/en/10130/

<!-- readthedocs-preview dev end -->