### PR TITLE
Build: pass `PATH` environment variable to Docker container

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -10,13 +10,13 @@ from datetime import datetime
 import structlog
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
+from docker import APIClient
 from docker.errors import APIError as DockerAPIError
 from docker.errors import DockerException
 from docker.errors import NotFound as DockerNotFoundError
 from requests.exceptions import ConnectionError, ReadTimeout  # noqa
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 
-from docker import APIClient
 from readthedocs.api.v2.client import api as api_v2
 from readthedocs.builds.models import BuildCommandResultMixin
 from readthedocs.core.utils import slugify

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -310,8 +310,8 @@ class DockerBuildCommand(BuildCommand):
         ] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
         # Add asdf extra paths
         environment["PATH"] += (
-            ":/home/{settings.RTD_DOCKER_USER}/.asdf/shims"
-            ":/home/{settings.RTD_DOCKER_USER}/.asdf/bin"
+            f":/home/{settings.RTD_DOCKER_USER}/.asdf/shims"
+            f":/home/{settings.RTD_DOCKER_USER}/.asdf/bin"
         )
 
         if settings.RTD_DOCKER_COMPOSE:

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -10,13 +10,13 @@ from datetime import datetime
 import structlog
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
-from docker import APIClient
 from docker.errors import APIError as DockerAPIError
 from docker.errors import DockerException
 from docker.errors import NotFound as DockerNotFoundError
-from requests.exceptions import ConnectionError, ReadTimeout
+from requests.exceptions import ConnectionError, ReadTimeout  # noqa
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 
+from docker import APIClient
 from readthedocs.api.v2.client import api as api_v2
 from readthedocs.builds.models import BuildCommandResultMixin
 from readthedocs.core.utils import slugify
@@ -73,7 +73,7 @@ class BuildCommand(BuildCommandResultMixin):
         bin_path=None,
         record_as_success=False,
         demux=False,
-        **kwargs,
+        **kwargs,  # pylint: disable=unused-argument
     ):
         self.command = command
         self.shell = shell
@@ -252,8 +252,8 @@ class BuildCommand(BuildCommandResultMixin):
                 {key: str(value) for key, value in data.items()}
             )
             resource = api_v2.command
-            resp = resource._store['session'].post(
-                resource._store['base_url'] + '/',
+            resp = resource._store["session"].post(  # pylint: disable=protected-access
+                resource._store["base_url"] + "/",  # pylint: disable=protected-access
                 data=encoder,
                 headers={
                     'Content-Type': encoder.content_type,
@@ -301,11 +301,35 @@ class DockerBuildCommand(BuildCommand):
 
         self.start_time = datetime.utcnow()
         client = self.build_env.get_client()
+
+        # Create a copy of the environment to update PATH variable
+        environment = self._environment.copy()
+        # Default PATH variable
+        environment[
+            "PATH"
+        ] = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        # Add asdf extra paths
+        environment["PATH"] += (
+            ":/home/{settings.RTD_DOCKER_USER}/.asdf/shims"
+            ":/home/{settings.RTD_DOCKER_USER}/.asdf/bin"
+        )
+
+        if settings.RTD_DOCKER_COMPOSE:
+            environment["PATH"] += ":/root/.asdf/shims:/root/.asdf/bin"
+
+        # Prepend the BIN_PATH if it's defined
+        if self.bin_path:
+            path = environment.get("PATH")
+            bin_path = self._escape_command(self.bin_path)
+            environment["PATH"] = bin_path
+            if path:
+                environment["PATH"] += f":{path}"
+
         try:
             exec_cmd = client.exec_create(
                 container=self.build_env.container_id,
                 cmd=self.get_wrapped_command(),
-                environment=self._environment,
+                environment=environment,
                 user=self.user,
                 workdir=self.cwd,
                 stdout=True,
@@ -357,31 +381,18 @@ class DockerBuildCommand(BuildCommand):
         """
         Wrap command in a shell and optionally escape special bash characters.
 
-        In order to set the current working path inside a docker container, we
-        need to wrap the command in a shell call manually.
-
         Some characters will be interpreted as shell characters without
         escaping, such as: ``pip install requests<0.8``. When passing
         ``escape_command=True`` in the init method this escapes a good majority
         of those characters.
         """
-        prefix = ''
-        if self.bin_path:
-            bin_path = self._escape_command(self.bin_path)
-            prefix += f'PATH={bin_path}:$PATH '
-
         command = (
             ' '.join(
                 self._escape_command(part) if self.escape_command else part
                 for part in self.command
             )
         )
-        return (
-            "/bin/sh -c '{prefix}{cmd}'".format(
-                prefix=prefix,
-                cmd=command,
-            )
-        )
+        return f"/bin/bash -c '{command}'"
 
     def _escape_command(self, cmd):
         r"""Escape the command by prefixing suspicious chars with `\`."""
@@ -524,14 +535,14 @@ class BuildEnvironment(BaseEnvironment):
     """
 
     def __init__(
-            self,
-            project=None,
-            version=None,
-            build=None,
-            config=None,
-            environment=None,
-            record=True,
-            **kwargs,
+        self,
+        project=None,
+        version=None,
+        build=None,
+        config=None,
+        environment=None,
+        record=True,
+        **kwargs,  # pylint: disable=unused-argument
     ):
         super().__init__(project, environment)
         self.version = version
@@ -557,7 +568,7 @@ class BuildEnvironment(BaseEnvironment):
         })
         return super().run(*cmd, **kwargs)
 
-    def run_command_class(self, *cmd, **kwargs):  # pylint: disable=arguments-differ
+    def run_command_class(self, *cmd, **kwargs):  # pylint: disable=signature-differs
         kwargs.update({
             'build_env': self,
         })

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -309,7 +309,8 @@ class DockerBuildCommand(BuildCommand):
         #
         # $ docker run --user docs -it --rm readthedocs/build:ubuntu-22.04 /bin/bash
         # docs@bfe702e31cdd:~$ echo $PATH
-        # /home/docs/.asdf/shims:/home/docs/.asdf/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+        # /home/docs/.asdf/shims:/home/docs/.asdf/bin
+        #  :/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
         # docs@bfe702e31cdd:~$
         asdf_paths = (
             f"/home/{settings.RTD_DOCKER_USER}/.asdf/shims"


### PR DESCRIPTION
Instead of prepending all the commands with the `PATH=` variable, we pass the environment variable directly to the Docker container.

This allow us to run multi-line shell script without failing with weird syntax errors. Besides, the implementation is cleaner since all the environment variables are passed to the commands in the same way.

I added some _default paths_ that I found by checking the local Docker container. I'm also passing the users' path, depending if we are working locally as root or in production.

This is not 100% complete and there may be some other issues that I'm not seeing yet, but I think it's a first step to behave in a way our users are expecting.

![Screenshot_2023-03-09_12-01-03](https://user-images.githubusercontent.com/244656/224004468-e7a2919f-0ea6-46c8-9187-d3d71a49c4ff.png)


Closes #10103