### PR TITLE
Build: remove all `reshim` commands

### DIFF
--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -1,3 +1,5 @@
+"""Build process director."""
+
 import os
 import tarfile
 
@@ -357,33 +359,10 @@ class BuildDirector:
             raise BuildUserError(BuildUserError.BUILD_OUTPUT_OLD_DIRECTORY_USED)
 
     def run_build_commands(self):
-        reshim_commands = (
-            {"pip", "install"},
-            {"conda", "create"},
-            {"conda", "install"},
-            {"mamba", "create"},
-            {"mamba", "install"},
-            {"poetry", "install"},
-        )
         cwd = self.data.project.checkout_path(self.data.version.slug)
         environment = self.build_environment
         for command in self.data.config.build.commands:
             environment.run(command, escape_command=False, cwd=cwd)
-
-            # Execute ``asdf reshim python`` if the user is installing a
-            # package since the package may contain an executable
-            # See https://github.com/readthedocs/readthedocs.org/pull/9150#discussion_r882849790
-            for reshim_command in reshim_commands:
-                # Convert tuple/list into set to check reshim command is a
-                # subset of the command itself. This is to find ``pip install``
-                # but also ``pip -v install`` and ``python -m pip install``
-                if reshim_command.issubset(command.split()):
-                    environment.run(
-                        *["asdf", "reshim", "python"],
-                        escape_command=False,
-                        cwd=cwd,
-                        record=False,
-                    )
 
         html_output_path = os.path.join(cwd, BUILD_COMMANDS_OUTPUT_PATH_HTML)
         if not os.path.exists(html_output_path):

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -889,7 +889,6 @@ class TestBuildTask(BuildEnvironmentBase):
             [
                 mock.call("asdf", "install", "python", python_version),
                 mock.call("asdf", "global", "python", python_version),
-                mock.call("asdf", "reshim", "python", record=False),
                 mock.call(
                     "python",
                     "-mpip",
@@ -900,13 +899,10 @@ class TestBuildTask(BuildEnvironmentBase):
                 ),
                 mock.call("asdf", "install", "nodejs", nodejs_version),
                 mock.call("asdf", "global", "nodejs", nodejs_version),
-                mock.call("asdf", "reshim", "nodejs", record=False),
                 mock.call("asdf", "install", "rust", rust_version),
                 mock.call("asdf", "global", "rust", rust_version),
-                mock.call("asdf", "reshim", "rust", record=False),
                 mock.call("asdf", "install", "golang", golang_version),
                 mock.call("asdf", "global", "golang", golang_version),
-                mock.call("asdf", "reshim", "golang", record=False),
                 mock.ANY,
             ]
         )
@@ -988,7 +984,6 @@ class TestBuildTask(BuildEnvironmentBase):
                     record=False,
                 ),
                 mock.call("asdf", "global", "python", python_version),
-                mock.call("asdf", "reshim", "python", record=False),
                 mock.call(
                     "mv",
                     mock.ANY,
@@ -996,7 +991,6 @@ class TestBuildTask(BuildEnvironmentBase):
                     record=False,
                 ),
                 mock.call("asdf", "global", "nodejs", nodejs_version),
-                mock.call("asdf", "reshim", "nodejs", record=False),
                 mock.call(
                     "mv",
                     mock.ANY,
@@ -1004,7 +998,6 @@ class TestBuildTask(BuildEnvironmentBase):
                     record=False,
                 ),
                 mock.call("asdf", "global", "rust", rust_version),
-                mock.call("asdf", "reshim", "rust", record=False),
                 mock.call(
                     "mv",
                     mock.ANY,
@@ -1012,7 +1005,6 @@ class TestBuildTask(BuildEnvironmentBase):
                     record=False,
                 ),
                 mock.call("asdf", "global", "golang", golang_version),
-                mock.call("asdf", "reshim", "golang", record=False),
                 mock.ANY,
             ]
         )
@@ -1046,7 +1038,6 @@ class TestBuildTask(BuildEnvironmentBase):
             [
                 mock.call("asdf", "install", "python", python_version),
                 mock.call("asdf", "global", "python", python_version),
-                mock.call("asdf", "reshim", "python", record=False),
                 mock.call(
                     "python",
                     "-mpip",
@@ -1061,14 +1052,6 @@ class TestBuildTask(BuildEnvironmentBase):
                 mock.call(
                     "pip install pelican[markdown]",
                     escape_command=False,
-                    cwd=mock.ANY,
-                ),
-                mock.call(
-                    "asdf",
-                    "reshim",
-                    "python",
-                    escape_command=False,
-                    record=False,
                     cwd=mock.ANY,
                 ),
                 mock.call(
@@ -1194,7 +1177,6 @@ class TestBuildTask(BuildEnvironmentBase):
             [
                 mock.call("asdf", "install", "python", "mambaforge-4.10.3-10"),
                 mock.call("asdf", "global", "python", "mambaforge-4.10.3-10"),
-                mock.call("asdf", "reshim", "python", record=False),
                 mock.call(
                     "mamba",
                     "env",


### PR DESCRIPTION
They are not needed anymore because the `reshim` happens automatically inside each of the `asdf` plugins now.

The new version of the `asdf` and its plugin handle this in a better way than how we are handling it here.

Requires: https://github.com/readthedocs/readthedocs-docker-images/pull/189