### PR TITLE
Search API: `@this` alias support

### DIFF
--- a/docs/user/server-side-search/api.rst
+++ b/docs/user/server-side-search/api.rst
@@ -18,6 +18,9 @@ API v3
    .. Request
 
    :query q: Search query (see :doc:`/server-side-search/syntax`)
+   :query project: Project slug to be used when a query includes the ``@this`` alias.
+   :query version: Version slug to be used when a query includes the ``@this`` alias,
+    If only the project is given, ``@this`` will use the default version of the project.
    :query page: Jump to a specific page
    :query page_size: Limits the results per page, default is 50
 

--- a/docs/user/server-side-search/syntax.rst
+++ b/docs/user/server-side-search/syntax.rst
@@ -59,6 +59,31 @@ user
 
    - ``user:@me test``
 
+Aliases
+~~~~~~~
+
+Some parameters support aliases as their values,
+aliases start with `@`.
+
+Depending on the context of the query, some aliases are available:
+
+@me
+   The current user.
+   This is only available when using the search API while authenticated.
+
+   Examples:
+
+   -  ``user:@me test``
+
+@this
+   The project and version of the current page.
+   This is only available when the current version and project are included in the API call.
+
+   Examples:
+
+   -  ``project:@this test``
+   -  ``subprojects:@this test``
+
 Permissions
 ~~~~~~~~~~~
 

--- a/readthedocs/rtd_tests/tests/test_middleware.py
+++ b/readthedocs/rtd_tests/tests/test_middleware.py
@@ -215,6 +215,15 @@ class TestCORSMiddleware(TestCase):
         self.assertNotIn(ACCESS_CONTROL_ALLOW_ORIGIN, resp.headers)
         self.assertNotIn(ACCESS_CONTROL_ALLOW_CREDENTIALS, resp.headers)
 
+    def test_search_api_v3(self):
+        resp = self.client.get(
+            "/api/v3/search/",
+            {"q": "project:docs test"},
+            HTTP_ORIGIN="http://my.valid.domain",
+        )
+        self.assertIn(ACCESS_CONTROL_ALLOW_ORIGIN, resp.headers)
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_CREDENTIALS, resp.headers)
+
 
 class TestSessionMiddleware(TestCase):
 

--- a/readthedocs/search/api/v3/views.py
+++ b/readthedocs/search/api/v3/views.py
@@ -1,3 +1,4 @@
+"""View for the search API v3."""
 from functools import cached_property
 
 import structlog
@@ -44,9 +45,15 @@ class SearchAPI(APIv3Settings, GenericAPIView):
     Required query parameters:
 
     - **q**: [Search term](https://docs.readthedocs.io/page/server-side-search/syntax.html).
+    - **project**: Project slug to be used when a query includes the `@this` alias.
+    - **version**: Version slug to be used when a query includes the `@this` alias.
+      If only the project is given, `@this` will use the default version of the project.
 
-    Check our [docs](https://docs.readthedocs.io/page/server-side-search/api.html) for more information.
-    """  # noqa
+    Check our [docs](https://docs.readthedocs.io/page/server-side-search/api.html)
+    for more information.
+    """
+
+    # pylint: enable=line-too-long
 
     http_method_names = ["get"]
     pagination_class = SearchPagination
@@ -84,6 +91,8 @@ class SearchAPI(APIv3Settings, GenericAPIView):
         search_executor = self.search_executor_class(
             request=self.request,
             query=self.request.GET["q"],
+            current_project_slug=self.request.GET.get("project"),
+            current_version_slug=self.request.GET.get("version"),
         )
         return search_executor
 
@@ -113,6 +122,7 @@ class SearchAPI(APIv3Settings, GenericAPIView):
 
         return search
 
+    # pylint: disable=unused-argument
     def get(self, request, *args, **kwargs):
         self._validate_query_params()
         result = self.list()

--- a/readthedocs/search/views.py
+++ b/readthedocs/search/views.py
@@ -77,12 +77,12 @@ class GlobalSearchView(TemplateView):
             language=self.request.GET.get("language"),
         )
         if user_input.type == "file":
-            context.update(self._searh_files())
+            context.update(self._search_files())
         else:
             context.update(self._search_projects(user_input, self.request))
         return context
 
-    def _searh_files(self):
+    def _search_files(self):
         results, facets = [], {}
         search_query = ""
         total_count = 0

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -774,6 +774,7 @@ class CommunityBaseSettings(Settings):
             |/api/v2/docsearch
             |/api/v2/embed
             |/api/v3/embed
+            |/api/v3/search
             |/api/v2/sustainability
         )
         """,


### PR DESCRIPTION
In order to make it easy to search on
projects without having to know the current slug of the project, I'm adding support for the `@this` alias.
This is done by allowing users to optional pass the current project and version in the request, then users will be able to use the `@this`  value when searching for projects, e.g `project:@this test` or `subprojects:@this test`.

I'm also allowing cross site requests to this API, since it can be useful (and makes it easier to test the search extension locally :D).

Other implementations I took into consideration:
- Get the current project/version from the `Referer` header. This would be using the unresolver, but it felt a little hidden.
- A separate `@this` for project and version, e.g `project:@this/@this`. Apart from ugly, don't think it was useful to search for a different version from the default. But we can support `project:@this/v2` in the future if needed.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10137.org.readthedocs.build/en/10137/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10137.org.readthedocs.build/en/10137/

<!-- readthedocs-preview dev end -->