### PR TITLE
Put back template_name on proxito 404 view

### DIFF
--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -472,7 +472,8 @@ class ServeError404Base(CDNCacheControlMixin, ServeRedirectMixin, ServeDocsMixin
     This view is called by an internal nginx redirect when there is a 404.
     """
 
-    def get(self, request, proxito_path):
+    # pylint: disable=unused-argument
+    def get(self, request, proxito_path, template_name="404.html"):
         """
         Handler for 404 pages on subdomains.
 


### PR DESCRIPTION
We are overriding it on .com, it probably isn't necessary since we aren't using it in the view, but I'm adding it back just for the sake of deploy.