### PR TITLE
Update some docs for the new dashboard templates

### DIFF
--- a/docs/dev/front-end.rst
+++ b/docs/dev/front-end.rst
@@ -6,10 +6,9 @@ Background
 
 .. note::
 
-    Consider this the canonical resource for contributing Javascript and CSS. We
-    are currently in the process of modernizing our front end development
-    procedures. You will see a lot of different styles around the code base for
-    front end JavaScript and CSS.
+   This information is for the current dashboard templates and JavaScript source
+   files and will soon be replaced by the new dashboard templates. This
+   information will soon be mostly out of date.
 
 Our modern front end development stack includes the following tools:
 

--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -98,6 +98,8 @@ save some work while typing docker compose commands. This section explains these
     * ``--no-reload`` makes all celery processes and django runserver
       to use no reload and do not watch for files changes
     * ``--ngrok`` is useful when it's required to access the local instance from outside (e.g. GitHub webhook)
+    * ``--ext-theme`` to use the new dashboard templates 
+    * ``--webpack`` to start the Webpack dev server for the new dashboard templates
 
 ``inv docker.shell``
     Opens a shell in a container (web by default).

--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -98,7 +98,7 @@ save some work while typing docker compose commands. This section explains these
     * ``--no-reload`` makes all celery processes and django runserver
       to use no reload and do not watch for files changes
     * ``--ngrok`` is useful when it's required to access the local instance from outside (e.g. GitHub webhook)
-    * ``--ext-theme`` to use the new dashboard templates 
+    * ``--ext-theme`` to use the new dashboard templates
     * ``--webpack`` to start the Webpack dev server for the new dashboard templates
 
 ``inv docker.shell``


### PR DESCRIPTION
Just some small changes for now. The library is still private for a
private beta period, but will be made public soonish.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10161.org.readthedocs.build/en/10161/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10161.org.readthedocs.build/en/10161/

<!-- readthedocs-preview dev end -->