### PR TITLE
Build: use safe_open for security reasons

### DIFF
--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 from readthedocs.builds.constants import EXTERNAL
+from readthedocs.core.utils.filesystem import safe_open
 from readthedocs.doc_builder.config import load_yaml_config
 from readthedocs.doc_builder.exceptions import BuildUserError
 from readthedocs.doc_builder.loader import get_builder_class
@@ -643,7 +644,7 @@ class BuildDirector:
             return
 
         try:
-            with open(yaml_path, "r") as f:
+            with safe_open(yaml_path, "r") as f:
                 data = yaml.safe_load(f)
         except Exception:
             # NOTE: skip this work for now until we decide whether or not this

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -26,12 +26,9 @@ class ReadTheDocsConfigJson(CDNCacheControlMixin, View):
         unresolved_domain = request.unresolved_domain
         project = unresolved_domain.project
 
-        # TODO: why the UnresolvedURL object is not injected in the `request` by the middleware.
-        # Is is fine to calculate it here?
         unresolved_url = unresolver.unresolve_url(url)
         version = unresolved_url.version
 
-        # TODO: use Referrer header or GET arguments for Version / Build
         project.get_default_version()
         build = version.builds.last()
 


### PR DESCRIPTION
Use `safe_open` instead of global open for security reasons.

Referece: https://github.com/readthedocs/readthedocs.org/pull/10127#pullrequestreview-1348831191