### PR TITLE
Build: export READTHEDOCS_CANONICAL_URL variable

### DIFF
--- a/docs/user/canonical-urls.rst
+++ b/docs/user/canonical-urls.rst
@@ -34,7 +34,7 @@ The canonical URL takes the following into account:
 
 * The default version of your project (usually "latest" or "stable").
 * The canonical :doc:`custom domain </custom-domains>` if you have one,
-  otherwise the default :ref:`subdomain <default_subdomain>` will be used.
+  otherwise the default :ref:`subdomain <default-subdomain>` will be used.
 
 For example, if you have a project named ``example-docs``
 with a custom domain ``https://docs.example.com``,

--- a/docs/user/custom-domains.rst
+++ b/docs/user/custom-domains.rst
@@ -5,7 +5,7 @@ You can serve your documentation project from your own domain,
 for instance ``docs.example.com``.
 This is great for maintaining a consistent brand for your product and its documentation.
 
-.. _default_subdomain:
+.. _default-subdomain:
 
 .. rubric:: Default subdomains
 

--- a/docs/user/reference/environment-variables.rst
+++ b/docs/user/reference/environment-variables.rst
@@ -52,6 +52,7 @@ All :doc:`build processes </builds>` have the following environment variables au
 
     :Example: ``https://docs.example.com/en/latest/``
     :Example: ``https://docs.readthedocs.io/ja/stable/``
+    :Example: ``https://example--17.org.readthedocs.build/fr/17/``
 
 .. seealso::
 

--- a/docs/user/reference/environment-variables.rst
+++ b/docs/user/reference/environment-variables.rst
@@ -46,9 +46,11 @@ All :doc:`build processes </builds>` have the following environment variables au
 
 .. envvar:: READTHEDOCS_CANONICAL_URL
 
-    Canonical URL for the version it's currently building.
+    Canonical base URL for the version that is built.
     If the project has configured a :doc:`custom domain </custom-domains>` (e.g. ``docs.example.com``) it will be used in the resulting canonical URL.
-    Otherwise, the default domain will be exposed (e.g. ``.readthedocs.io``)
+    Otherwise, your project's :ref:`default subdomain <custom-domains:default-subdomain>` will be used.
+    
+The path for the language and version is appended to the domain, so the final canonical base URLs can look like the following examples.
 
     :Example: ``https://docs.example.com/en/latest/``
     :Example: ``https://docs.readthedocs.io/ja/stable/``

--- a/docs/user/reference/environment-variables.rst
+++ b/docs/user/reference/environment-variables.rst
@@ -48,8 +48,8 @@ All :doc:`build processes </builds>` have the following environment variables au
 
     Canonical base URL for the version that is built.
     If the project has configured a :doc:`custom domain </custom-domains>` (e.g. ``docs.example.com``) it will be used in the resulting canonical URL.
-    Otherwise, your project's :ref:`default subdomain <custom-domains:default-subdomain>` will be used.
-    
+    Otherwise, your project's :ref:`default subdomain <default-subdomain>` will be used.
+
     The path for the language and version is appended to the domain, so the final canonical base URLs can look like the following examples:
 
     :Example: ``https://docs.example.com/en/latest/``

--- a/docs/user/reference/environment-variables.rst
+++ b/docs/user/reference/environment-variables.rst
@@ -50,7 +50,7 @@ All :doc:`build processes </builds>` have the following environment variables au
     If the project has configured a :doc:`custom domain </custom-domains>` (e.g. ``docs.example.com``) it will be used in the resulting canonical URL.
     Otherwise, your project's :ref:`default subdomain <custom-domains:default-subdomain>` will be used.
     
-The path for the language and version is appended to the domain, so the final canonical base URLs can look like the following examples.
+    The path for the language and version is appended to the domain, so the final canonical base URLs can look like the following examples:
 
     :Example: ``https://docs.example.com/en/latest/``
     :Example: ``https://docs.readthedocs.io/ja/stable/``

--- a/docs/user/reference/environment-variables.rst
+++ b/docs/user/reference/environment-variables.rst
@@ -44,6 +44,15 @@ All :doc:`build processes </builds>` have the following environment variables au
 
     :Example: ``/home/docs/checkouts/readthedocs.org/user_builds/project/envs/version``
 
+.. envvar:: READTHEDOCS_CANONICAL_URL
+
+    Canonical URL for the version it's currently building.
+    If the project has configured a :doc:`custom domain </custom-domains>` (e.g. ``docs.example.com``) it will be used in the resulting canonical URL.
+    Otherwise, the default domain will be exposed (e.g. ``.readthedocs.io``)
+
+    :Example: ``https://docs.example.com/en/latest/``
+    :Example: ``https://docs.readthedocs.io/ja/stable/``
+
 .. seealso::
 
    :doc:`/environment-variables`

--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -5,6 +5,7 @@ from allauth.socialaccount.models import SocialAccount
 from rest_framework import serializers
 
 from readthedocs.api.v2.utils import normalize_build_command
+from readthedocs.builds.constants import EXTERNAL
 from readthedocs.builds.models import Build, BuildCommandResult, Version
 from readthedocs.oauth.models import RemoteOrganization, RemoteRepository
 from readthedocs.projects.models import Domain, Project
@@ -124,11 +125,20 @@ class VersionAdminSerializer(VersionSerializer):
     """Version serializer that returns admin project data."""
 
     project = ProjectAdminSerializer()
+    canonical_url = serializers.SerializerMethodField()
     build_data = serializers.JSONField(required=False, write_only=True)
+
+    def get_canonical_url(self, obj):
+        return obj.project.get_docs_url(
+            lang_slug=obj.project.language,
+            version_slug=obj.slug,
+            external=obj.type == EXTERNAL,
+        )
 
     class Meta(VersionSerializer.Meta):
         fields = VersionSerializer.Meta.fields + [
             "build_data",
+            "canonical_url",
         ]
 
 

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -601,7 +601,8 @@ class APIVersion(Version):
         proxy = True
 
     def __init__(self, *args, **kwargs):
-        self.project = APIProject(**kwargs.pop('project', {}))
+        self.project = APIProject(**kwargs.pop("project", {}))
+        self.canonical_url = kwargs.pop("canonical_url", None)
         # These fields only exist on the API return, not on the model, so we'll
         # remove them to avoid throwing exceptions due to unexpected fields
         for key in ['resource_uri', 'absolute_url', 'downloads']:

--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -615,6 +615,12 @@ class BuildDirector:
                 }
             )
 
+        env.update(
+            {
+                "READTHEDOCS_CANONICAL_URL": self.data.version.canonical_url,
+            }
+        )
+
         # Update environment from Project's specific environment variables,
         # avoiding to expose private environment variables
         # if the version is external (i.e. a PR build).

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -301,6 +301,11 @@ class TestBuildTask(BuildEnvironmentBase):
             # Local and Circle are different values.
             # We only check it's present, but not its value.
             READTHEDOCS_VIRTUALENV_PATH=mock.ANY,
+            READTHEDOCS_CANONICAL_URL=self.project.get_docs_url(
+                lang_slug=self.project.language,
+                version_slug=self.version.slug,
+                external=external,
+            ),
         )
         if not external:
             expected_build_env_vars["PRIVATE_TOKEN"] = "a1b2c3"

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -2442,6 +2442,7 @@ class APIVersionTests(TestCase):
             "built": False,
             "id": 18,
             "active": True,
+            "canonical_url": "http://readthedocs.org/docs/pip/en/0.8/",
             "project": {
                 "analytics_code": None,
                 "analytics_disabled": False,


### PR DESCRIPTION
This variable communicates what's the canonical URL for the version it's running
the build. It will allow doctool/theme authors to implement the correct HTML tag
required:

```
<link rel="canonical" href="" />
```

Note the final `href` on each page will be `READTHEDOCS_CANONICAL_URL` + `page`.

Closes readthedocs/readthedocs-ops#1320
Closes #9781
Closes #8260
Closes #4820 

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10166.org.readthedocs.build/en/10166/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10166.org.readthedocs.build/en/10166/

<!-- readthedocs-preview dev end -->