### PR TITLE
Docs: Removal of implicit Intersphinx reference labels to MyST-based documentation

### DIFF
--- a/docs/user/guides/jupyter.rst
+++ b/docs/user/guides/jupyter.rst
@@ -114,8 +114,8 @@ Each editor has a different way of doing it:
 
 - The classical Jupyter Notebook interface
   provides a "Save Notebook Widget State" action in the "Widgets" menu,
-  :ref:`as explained in the ipywidgets
-  documentation <ipywidgets:/embedding.md#embedding-widgets-in-html-web-pages>`.
+  :doc:`as explained in the ipywidgets
+  documentation <ipywidgets:embedding>`.
   You need to click it before exporting your notebook to HTML.
 - JupyterLab provides a "Save Widget State Automatically" option in the "Settings" menu.
   You need to leave it checked so that widget state is automatically saved.
@@ -131,7 +131,7 @@ Each editor has a different way of doing it:
    JupyterLab option to save the interactive widget state automatically
 
 For example, if you create a notebook with a simple
-:ref:`ipywidgets:/examples/widget list.ipynb#intslider`
+`IntSlider <https://ipywidgets.readthedocs.io/en/stable/examples/Widget%20List.html#intslider>`__
 widget from ipywidgets and save the widget state,
 the slider will render correctly in Sphinx.
 


### PR DESCRIPTION
This is currently breaking the docs.

Related: https://github.com/executablebooks/MyST-Parser/issues/731

We can also remove the Intersphinx mapping. There are 2 references in use.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10176.org.readthedocs.build/en/10176/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10176.org.readthedocs.build/en/10176/

<!-- readthedocs-preview dev end -->