### PR TITLE
Proxito: allow serving files under the projects dir

### DIFF
--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -375,6 +375,16 @@ class ProxitoV2TestFullDocServing(TestFullDocServing):
             future_default_true=True,
         )
 
+    def test_single_version_serving_projects_dir(self):
+        self.project.single_version = True
+        self.project.save()
+        url = '/projects/awesome.html'
+        host = 'project.dev.readthedocs.io'
+        resp = self.client.get(url, HTTP_HOST=host)
+        self.assertEqual(
+            resp['x-accel-redirect'], '/proxito/media/html/project/latest/projects/awesome.html',
+        )
+
 
 @override_settings(
     PUBLIC_DOMAIN="dev.readthedocs.io",


### PR DESCRIPTION
This is only available in the new implementation.

Closes https://github.com/readthedocs/readthedocs.org/issues/2292