### PR TITLE
Proxito: test serving language like paths

### DIFF
--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -375,6 +375,28 @@ class ProxitoV2TestFullDocServing(TestFullDocServing):
             future_default_true=True,
         )
 
+    def test_single_version_serving_language_like_subdir(self):
+        self.project.single_version = True
+        self.project.save()
+        url = "/en/api/awesome.html"
+        host = "project.dev.readthedocs.io"
+        resp = self.client.get(url, HTTP_HOST=host)
+        self.assertEqual(
+            resp["x-accel-redirect"],
+            "/proxito/media/html/project/latest/en/api/awesome.html",
+        )
+
+    def test_single_version_serving_language_like_dir(self):
+        self.project.single_version = True
+        self.project.save()
+        url = "/en/awesome.html"
+        host = "project.dev.readthedocs.io"
+        resp = self.client.get(url, HTTP_HOST=host)
+        self.assertEqual(
+            resp["x-accel-redirect"],
+            "/proxito/media/html/project/latest/en/api/awesome.html",
+        )
+
 
 @override_settings(
     PUBLIC_DOMAIN="dev.readthedocs.io",


### PR DESCRIPTION
This will work once we remove this

https://github.com/readthedocs/readthedocs.org/blob/eadf6ac6dc6abc760a91e1cb147cc3c5f37d1ea8/readthedocs/proxito/urls.py#L163-L171

and make the new implementation the default.

Closes https://github.com/readthedocs/readthedocs.org/issues/8399