### PR TITLE
 Filters: several bug fixes and some filter tuning

### DIFF
--- a/readthedocs/builds/filters.py
+++ b/readthedocs/builds/filters.py
@@ -18,36 +18,36 @@ class BuildListFilter(FilterSet):
 
     """Project build list dashboard filter."""
 
-    STATE_ACTIVE = 'active'
-    STATE_SUCCESS = 'succeeded'
-    STATE_FAILED = 'failed'
+    STATE_ACTIVE = "active"
+    STATE_SUCCESS = "succeeded"
+    STATE_FAILED = "failed"
 
     STATE_CHOICES = (
-        (STATE_ACTIVE, _('Active')),
-        (STATE_SUCCESS, _('Build successful')),
-        (STATE_FAILED, _('Build failed')),
+        (STATE_ACTIVE, _("Active")),
+        (STATE_SUCCESS, _("Build successful")),
+        (STATE_FAILED, _("Build failed")),
     )
 
     TYPE_NORMAL = "normal"
     TYPE_EXTERNAL = "external"
     TYPE_CHOICES = (
-        (TYPE_NORMAL, _('Normal')),
-        (TYPE_EXTERNAL, _('Pull/merge request')),
+        (TYPE_NORMAL, _("Normal")),
+        (TYPE_EXTERNAL, _("Pull/merge request")),
     )
 
     # Attribute filter fields
-    version = CharFilter(field_name='version__slug', widget=HiddenInput)
+    version = CharFilter(field_name="version__slug", widget=HiddenInput)
     state = ChoiceFilter(
-        label=_('State'),
+        label=_("State"),
         choices=STATE_CHOICES,
-        empty_label=_('Any'),
-        method='get_state',
+        empty_label=_("Any"),
+        method="get_state",
     )
     type = ChoiceFilter(
-        label=_('Type'),
+        label=_("Type"),
         choices=TYPE_CHOICES,
-        empty_label=_('Any'),
-        method='get_type',
+        empty_label=_("Any"),
+        method="get_type",
     )
 
     def get_state(self, queryset, *, value):

--- a/readthedocs/builds/filters.py
+++ b/readthedocs/builds/filters.py
@@ -1,14 +1,22 @@
+"""Filters used in project dashboard."""
+
 import structlog
 from django.forms.widgets import HiddenInput
 from django.utils.translation import gettext_lazy as _
 from django_filters import CharFilter, ChoiceFilter, FilterSet
 
-from readthedocs.builds.constants import BUILD_FINAL_STATES, BUILD_STATE_FINISHED
+from readthedocs.builds.constants import (
+    BUILD_FINAL_STATES,
+    BUILD_STATE_FINISHED,
+    EXTERNAL,
+)
 
 log = structlog.get_logger(__name__)
 
 
 class BuildListFilter(FilterSet):
+
+    """Project build list dashboard filter."""
 
     STATE_ACTIVE = 'active'
     STATE_SUCCESS = 'succeeded'
@@ -16,8 +24,15 @@ class BuildListFilter(FilterSet):
 
     STATE_CHOICES = (
         (STATE_ACTIVE, _('Active')),
-        (STATE_SUCCESS, _('Build finished')),
+        (STATE_SUCCESS, _('Build successful')),
         (STATE_FAILED, _('Build failed')),
+    )
+
+    TYPE_NORMAL = "normal"
+    TYPE_EXTERNAL = "external"
+    TYPE_CHOICES = (
+        (TYPE_NORMAL, _('Normal')),
+        (TYPE_EXTERNAL, _('Pull/merge request')),
     )
 
     # Attribute filter fields
@@ -28,10 +43,16 @@ class BuildListFilter(FilterSet):
         empty_label=_('Any'),
         method='get_state',
     )
+    type = ChoiceFilter(
+        label=_('Type'),
+        choices=TYPE_CHOICES,
+        empty_label=_('Any'),
+        method='get_type',
+    )
 
-    def get_state(self, queryset, name, value):
+    def get_state(self, queryset, *, value):
         if value == self.STATE_ACTIVE:
-            queryset = queryset.exclude(state=BUILD_STATE_FINISHED)
+            queryset = queryset.exclude(state__in=BUILD_FINAL_STATES)
         elif value == self.STATE_SUCCESS:
             queryset = queryset.filter(state=BUILD_STATE_FINISHED, success=True)
         elif value == self.STATE_FAILED:
@@ -39,4 +60,11 @@ class BuildListFilter(FilterSet):
                 state__in=BUILD_FINAL_STATES,
                 success=False,
             )
+        return queryset
+
+    def get_type(self, queryset, *, value):
+        if value == self.TYPE_NORMAL:
+            queryset = queryset.exclude(type=EXTERNAL)
+        elif value == self.TYPE_EXTERNAL:
+            queryset = queryset.filter(type=EXTERNAL)
         return queryset

--- a/readthedocs/projects/filters.py
+++ b/readthedocs/projects/filters.py
@@ -1,3 +1,5 @@
+"""Filters used in project dashboard."""
+
 import structlog
 from django.db.models import Count, F, Max
 from django.forms.widgets import HiddenInput
@@ -23,38 +25,55 @@ class VersionSortOrderingFilter(OrderingFilter):
     filter, because result would be params like ``?sort=None``.
     """
 
+    SORT_BUILD_COUNT = "build_count"
+    SORT_BUILD_DATE = "build_date"
+    SORT_NAME = "name"
+
     def __init__(self, *args, **kwargs):
+        # The default filtering operation will be `-recent`, so we omit it
+        # from choices to avoid showing it on the list twice.
+        kwargs.setdefault("empty_label", _("Recently built"))
+        kwargs.setdefault(
+            "choices",
+            (
+                ("-" + self.SORT_BUILD_DATE, _("Least recently built")),
+                ("-" + self.SORT_BUILD_COUNT, _("Frequently built")),
+                (self.SORT_BUILD_COUNT, _("Least frequently built")),
+                (self.SORT_NAME, _("Name")),
+                ("-" + self.SORT_NAME, _("Name (descending)")),
+            ),
+        )
         super().__init__(*args, **kwargs)
-        self.extra['choices'] = [
-            ('name', _('Name')),
-            ('-name', _('Name (descending)')),
-            ('-recent', _('Most recently built')),
-            ('recent', _('Least recently built')),
-        ]
 
     def filter(self, qs, value):
         # This is where we use the None value for this custom filter. This
         # doesn't work with a standard model filter. Note: ``value`` is always
         # an iterable, but can be empty.
         if not value:
-            value = ['relevance']
+            value = [self.SORT_BUILD_DATE]
 
-        # Selectively add anotations as a small query optimization
-        annotations = {
-            # Default ordering is number of builds, but could be another proxy
-            # for version populatrity
-            'relevance': {'relevance': Count('builds')},
-            # Most recent build date, this appears inverted in the option value
-            'recent': {'recent': Max('builds__date')},
-            # Alias field name here, as ``OrderingFilter`` was having trouble
-            # doing this with it's native field mapping
-            'name': {'name': F('verbose_name')},
-        }
-        # And copy the negative sort lookups, ``value`` might be ``['-recent']``
-        annotations.update({f'-{key}': value for (key, value) in annotations.items()})
+        annotations = {}
+        order_bys = []
+        for field_ordered in value:
+            field = field_ordered.lstrip("-")
 
-        annotation = annotations.get(*value)
-        return qs.annotate(**annotation).order_by(*value)
+            if field == self.SORT_BUILD_DATE:
+                annotations[self.SORT_BUILD_DATE] = Max("builds__date")
+            elif field == self.SORT_BUILD_COUNT:
+                annotations[self.SORT_BUILD_COUNT] = Count("builds")
+            elif field == self.SORT_NAME:
+                # Alias field name here, as ``OrderingFilter`` was having trouble
+                # doing this with it's native field mapping
+                annotations[self.SORT_NAME] = F("verbose_name")
+
+            if field_ordered == self.SORT_BUILD_DATE:
+                order_bys.append(F(field).desc(nulls_last=True))
+            elif field_ordered == "-" + self.SORT_BUILD_DATE:
+                order_bys.append(F(field).asc(nulls_first=True))
+            else:
+                order_bys.append(field_ordered)
+
+        return qs.annotate(**annotations).order_by(*order_bys)
 
 
 class ProjectSortOrderingFilter(OrderingFilter):
@@ -68,33 +87,52 @@ class ProjectSortOrderingFilter(OrderingFilter):
     custom filter, instead of an automated model filter.
     """
 
-    SORT_NAME = 'name'
-    SORT_MODIFIED_DATE = 'modified_date'
-    SORT_BUILD_DATE = 'built_last'
-    SORT_BUILD_COUNT = 'build_count'
+    SORT_NAME = "name"
+    SORT_MODIFIED_DATE = "modified_date"
+    SORT_BUILD_DATE = "build_date"
+    SORT_BUILD_COUNT = "build_count"
 
     def __init__(self, *args, **kwargs):
+        # The default filtering operation will be `name`, so we omit it
+        # from choices to avoid showing it on the list twice.
+        kwargs.setdefault("empty_label", _("Recently built"))
+        kwargs.setdefault(
+            "choices",
+            (
+                ("-" + self.SORT_BUILD_DATE, _("Least recently built")),
+                ("-" + self.SORT_BUILD_COUNT, _("Frequently built")),
+                (self.SORT_BUILD_COUNT, _("Least frequently built")),
+                ("-" + self.SORT_MODIFIED_DATE, _("Recently modified")),
+                (self.SORT_MODIFIED_DATE, _("Least recently modified")),
+                (self.SORT_NAME, _("Name")),
+                ("-" + self.SORT_NAME, _("Name (descending)")),
+            ),
+        )
         super().__init__(*args, **kwargs)
-        self.extra["choices"] = [
-            (f"-{self.SORT_NAME}", _("Name (descending)")),
-            (f"-{self.SORT_MODIFIED_DATE}", _("Most recently modified")),
-            (self.SORT_MODIFIED_DATE, _("Least recently modified")),
-            (f"-{self.SORT_BUILD_DATE}", _("Most recently built")),
-            (self.SORT_BUILD_DATE, _("Least recently built")),
-            (f"-{self.SORT_BUILD_COUNT}", _("Most frequently built")),
-            (self.SORT_BUILD_COUNT, _("Least frequently built")),
-        ]
 
     def filter(self, qs, value):
         # This is where we use the None value from the custom filter
-        if value is None:
-            value = [self.SORT_NAME]
-        return qs.annotate(
-            **{
-                self.SORT_BUILD_DATE: Max('versions__builds__date'),
-                self.SORT_BUILD_COUNT: Count('versions__builds'),
-            }
-        ).order_by(*value)
+        if not value:
+            value = [self.SORT_BUILD_DATE]
+
+        annotations = {}
+        order_bys = []
+        for field_ordered in value:
+            field = field_ordered.lstrip("-")
+
+            if field == self.SORT_BUILD_DATE:
+                annotations[self.SORT_BUILD_DATE] = Max("builds__date")
+            elif field == self.SORT_BUILD_COUNT:
+                annotations[self.SORT_BUILD_COUNT] = Count("builds")
+
+            if field_ordered == self.SORT_BUILD_DATE:
+                order_bys.append(F(field).desc(nulls_last=True))
+            elif field_ordered == "-" + self.SORT_BUILD_DATE:
+                order_bys.append(F(field).asc(nulls_first=True))
+            else:
+                order_bys.append(field_ordered)
+
+        return qs.annotate(**annotations).order_by(*order_bys)
 
 
 class ProjectListFilterSet(FilterSet):
@@ -110,7 +148,6 @@ class ProjectListFilterSet(FilterSet):
     sort = ProjectSortOrderingFilter(
         field_name='sort',
         label=_('Sort by'),
-        empty_label=_('Name'),
     )
 
 
@@ -159,10 +196,9 @@ class ProjectVersionListFilterSet(FilterSet):
     sort = VersionSortOrderingFilter(
         field_name='sort',
         label=_('Sort by'),
-        empty_label=_('Relevance'),
     )
 
-    def get_visibility(self, queryset, name, value):
+    def get_visibility(self, queryset, *, value):
         if value == self.VISIBILITY_HIDDEN:
             return queryset.filter(hidden=True)
         if value == self.VISIBILITY_VISIBLE:

--- a/readthedocs/projects/filters.py
+++ b/readthedocs/projects/filters.py
@@ -144,10 +144,10 @@ class ProjectListFilterSet(FilterSet):
     provides search-as-you-type lookup filter as well.
     """
 
-    project = CharFilter(field_name='slug', widget=HiddenInput)
+    project = CharFilter(field_name="slug", widget=HiddenInput)
     sort = ProjectSortOrderingFilter(
-        field_name='sort',
-        label=_('Sort by'),
+        field_name="sort",
+        label=_("Sort by"),
     )
 
 
@@ -161,41 +161,41 @@ class ProjectVersionListFilterSet(FilterSet):
     with an included queryset, which provides user project authorization.
     """
 
-    VISIBILITY_HIDDEN = 'hidden'
-    VISIBILITY_VISIBLE = 'visible'
+    VISIBILITY_HIDDEN = "hidden"
+    VISIBILITY_VISIBLE = "visible"
 
     VISIBILITY_CHOICES = (
-        ('hidden', _('Hidden versions')),
-        ('visible', _('Visible versions')),
+        ("hidden", _("Hidden versions")),
+        ("visible", _("Visible versions")),
     )
 
     PRIVACY_CHOICES = (
-        ('public', _('Public versions')),
-        ('private', _('Private versions')),
+        ("public", _("Public versions")),
+        ("private", _("Private versions")),
     )
 
     # Attribute filter fields
-    version = CharFilter(field_name='slug', widget=HiddenInput)
+    version = CharFilter(field_name="slug", widget=HiddenInput)
     privacy = ChoiceFilter(
-        field_name='privacy_level',
-        label=_('Privacy'),
+        field_name="privacy_level",
+        label=_("Privacy"),
         choices=PRIVACY_CHOICES,
-        empty_label=_('Any'),
+        empty_label=_("Any"),
     )
     # This field looks better as ``visibility=hidden`` than it does
     # ``hidden=true``, otherwise we could use a BooleanFilter instance here
     # instead
     visibility = ChoiceFilter(
-        field_name='hidden',
-        label=_('Visibility'),
+        field_name="hidden",
+        label=_("Visibility"),
         choices=VISIBILITY_CHOICES,
-        method='get_visibility',
-        empty_label=_('Any'),
+        method="get_visibility",
+        empty_label=_("Any"),
     )
 
     sort = VersionSortOrderingFilter(
-        field_name='sort',
-        label=_('Sort by'),
+        field_name="sort",
+        label=_("Sort by"),
     )
 
     def get_visibility(self, queryset, *, value):


### PR DESCRIPTION
The changes here resolve a few bugs with these filters, mostly used in the new dashboard.

* Account for null values in date sorting. Null dates were presenting as ordering issues in listing displays.
* Always use filter annotations conditionally, depending on the sort parameter to the filter. The project list filter was always annotating the queryset, likely hurting performance.
* Reduce some of the words used in the filter text, for clarity.
* Add more filters to build and version filters, match project filters on the version filter
* Consolidate logic in the version/build filter around dates and null dates.

Linting is isolated in bfeb6f9eda67eabd5bb5a2ea37a2ceac2a8d2bce

* Closes https://github.com/readthedocs/ext-theme/issues/40
* Refs https://github.com/readthedocs/ext-theme/issues/128
* Closes https://github.com/readthedocs/ext-theme/issues/135
* Refs https://github.com/readthedocs/ext-theme/issues/116