### PR TITLE
API: hosting integrations endpoint versioning/structure

### DIFF
--- a/readthedocs/proxito/tests/responses/v0.json
+++ b/readthedocs/proxito/tests/responses/v0.json
@@ -1,120 +1,118 @@
 {
-    "comment": "THIS RESPONSE IS IN ALPHA FOR TEST PURPOSES ONLY AND IT'S GOING TO CHANGE COMPLETELY -- DO NOT USE IT!",
-            "project": {
-                "created": "2019-04-29T10:00:00Z",
-                "default_branch": "master",
-                "default_version": "latest",
-                "id": 1,
-                "language": {
-                    "code": "en",
-                    "name": "English"
-                },
-                "modified": "2019-04-29T12:00:00Z",
-                "name": "project",
-                "programming_language": {
-                    "code": "words",
-                    "name": "Only Words"
-                },
-                "homepage": "http://project.com",
-                "repository": {
-                    "type": "git",
-                    "url": "https://github.com/readthedocs/project"
-                },
-                "slug": "project",
-                "subproject_of": null,
-                "tags": [
-                    "project",
-                    "tag",
-                    "test"
-                ],
-                "translation_of": null,
-                "users": [
-                    {
-                    "username": "testuser"
-                }
-                ]
-            },
-            "version": {
-                "active": true,
-                "hidden": false,
-                "built": true,
-                "downloads": {},
-                "id": 1,
-                "identifier": "a1b2c3",
-                "ref": null,
-                "slug": "latest",
-                "type": "tag",
-                "verbose_name": "latest"
-            },
-            "build": {
-                "commit": "a1b2c3",
-                "created": "2019-04-29T10:00:00Z",
-                "duration": 60,
-                "error": "",
-                "finished": "2019-04-29T10:01:00Z",
-                "id": 1,
-                "project": "project",
-                "state": {
-                    "code": "finished",
-                    "name": "Finished"
-                },
-                "success": true,
-                "version": "latest"
-            },
-            "domains": {
-                "dashboard": "readthedocs.org"
-            },
-            "readthedocs": {
-                "analytics": {
-                    "code": null
-                }
-            },
-            "features": {
-                "analytics": {
-                    "code": null
-                },
-                "external_version_warning": {
-                    "enabled": true,
-                    "query_selector": "[role=main]"
-                },
-                "non_latest_version_warning": {
-                    "enabled": true,
-                    "query_selector": "[role=main]",
-                    "versions": [
-                        "latest"
-                    ]
-                },
-                "doc_diff": {
-                    "enabled": true,
-                    "base_url": "https://project.dev.readthedocs.io/en/latest/index.html",
-                    "root_selector": "[role=main]",
-                    "inject_styles": true,
-                    "base_host": "",
-                    "base_page": ""
-                },
-                "flyout": {
-                    "translations": [],
-                    "versions": [
-                        {"slug": "latest", "url": "/en/latest/"}
-                    ],
-                    "downloads": [],
-                    "vcs": {
-                        "url": "https://github.com",
-                        "username": "readthedocs",
-                        "repository": "test-builds",
-                        "branch": "a1b2c3",
-                        "filepath": "/docs/index.rst"
-                    }
-                },
-                "search": {
-                    "api_endpoint": "/_/api/v3/search/",
-                    "default_filter": "subprojects:project/latest",
-                    "filters": [
-                        ["Search only in this project", "project:project/latest"],
-                        ["Search subprojects", "subprojects:project/latest"]
-                    ],
-                    "project": "project",
-                    "version": "latest"
-                }
-            }
+  "comment": "THIS RESPONSE IS IN ALPHA FOR TEST PURPOSES ONLY AND IT'S GOING TO CHANGE COMPLETELY -- DO NOT USE IT!",
+  "projects": {
+    "current": {
+      "created": "2019-04-29T10:00:00Z",
+      "default_branch": "master",
+      "default_version": "latest",
+      "id": 1,
+      "language": {
+        "code": "en",
+        "name": "English"
+      },
+      "modified": "2019-04-29T12:00:00Z",
+      "name": "project",
+      "programming_language": {
+        "code": "words",
+        "name": "Only Words"
+      },
+      "homepage": "http://project.com",
+      "repository": {
+        "type": "git",
+        "url": "https://github.com/readthedocs/project"
+      },
+      "slug": "project",
+      "subproject_of": null,
+      "tags": ["project", "tag", "test"],
+      "translation_of": null,
+      "users": [
+        {
+          "username": "testuser"
         }
+      ]
+    }
+  },
+  "versions": {
+    "current": {
+      "active": true,
+      "hidden": false,
+      "built": true,
+      "downloads": {},
+      "id": 1,
+      "identifier": "a1b2c3",
+      "ref": null,
+      "slug": "latest",
+      "type": "tag",
+      "verbose_name": "latest"
+    }
+  },
+  "builds": {
+    "current": {
+      "commit": "a1b2c3",
+      "created": "2019-04-29T10:00:00Z",
+      "duration": 60,
+      "error": "",
+      "finished": "2019-04-29T10:01:00Z",
+      "id": 1,
+      "project": "project",
+      "state": {
+        "code": "finished",
+        "name": "Finished"
+      },
+      "success": true,
+      "version": "latest"
+    }
+  },
+  "domains": {
+    "dashboard": "readthedocs.org"
+  },
+  "readthedocs": {
+    "analytics": {
+      "code": null
+    }
+  },
+  "features": {
+    "analytics": {
+      "code": null
+    },
+    "external_version_warning": {
+      "enabled": true,
+      "query_selector": "[role=main]"
+    },
+    "non_latest_version_warning": {
+      "enabled": true,
+      "query_selector": "[role=main]",
+      "versions": ["latest"]
+    },
+    "doc_diff": {
+      "enabled": true,
+      "base_url": "https://project.dev.readthedocs.io/en/latest/index.html",
+      "root_selector": "[role=main]",
+      "inject_styles": true,
+      "base_host": "",
+      "base_page": ""
+    },
+    "flyout": {
+      "translations": [],
+      "versions": [{ "slug": "latest", "url": "/en/latest/" }],
+      "downloads": [],
+      "vcs": {
+        "url": "https://github.com",
+        "username": "readthedocs",
+        "repository": "test-builds",
+        "branch": "a1b2c3",
+        "filepath": "/docs/index.rst"
+      }
+    },
+    "search": {
+      "api_endpoint": "/_/api/v3/search/",
+      "default_filter": "subprojects:project/latest",
+      "filters": [
+        ["Search only in this project", "project:project/latest"],
+        ["Search subprojects", "subprojects:project/latest"]
+      ],
+      "project": "project",
+      "version": "latest"
+    }
+  }
+}

--- a/readthedocs/proxito/tests/responses/v0.json
+++ b/readthedocs/proxito/tests/responses/v0.json
@@ -1,0 +1,120 @@
+{
+    "comment": "THIS RESPONSE IS IN ALPHA FOR TEST PURPOSES ONLY AND IT'S GOING TO CHANGE COMPLETELY -- DO NOT USE IT!",
+            "project": {
+                "created": "2019-04-29T10:00:00Z",
+                "default_branch": "master",
+                "default_version": "latest",
+                "id": 1,
+                "language": {
+                    "code": "en",
+                    "name": "English"
+                },
+                "modified": "2019-04-29T12:00:00Z",
+                "name": "project",
+                "programming_language": {
+                    "code": "words",
+                    "name": "Only Words"
+                },
+                "homepage": "http://project.com",
+                "repository": {
+                    "type": "git",
+                    "url": "https://github.com/readthedocs/project"
+                },
+                "slug": "project",
+                "subproject_of": null,
+                "tags": [
+                    "project",
+                    "tag",
+                    "test"
+                ],
+                "translation_of": null,
+                "users": [
+                    {
+                    "username": "testuser"
+                }
+                ]
+            },
+            "version": {
+                "active": true,
+                "hidden": false,
+                "built": true,
+                "downloads": {},
+                "id": 1,
+                "identifier": "a1b2c3",
+                "ref": null,
+                "slug": "latest",
+                "type": "tag",
+                "verbose_name": "latest"
+            },
+            "build": {
+                "commit": "a1b2c3",
+                "created": "2019-04-29T10:00:00Z",
+                "duration": 60,
+                "error": "",
+                "finished": "2019-04-29T10:01:00Z",
+                "id": 1,
+                "project": "project",
+                "state": {
+                    "code": "finished",
+                    "name": "Finished"
+                },
+                "success": true,
+                "version": "latest"
+            },
+            "domains": {
+                "dashboard": "readthedocs.org"
+            },
+            "readthedocs": {
+                "analytics": {
+                    "code": null
+                }
+            },
+            "features": {
+                "analytics": {
+                    "code": null
+                },
+                "external_version_warning": {
+                    "enabled": true,
+                    "query_selector": "[role=main]"
+                },
+                "non_latest_version_warning": {
+                    "enabled": true,
+                    "query_selector": "[role=main]",
+                    "versions": [
+                        "latest"
+                    ]
+                },
+                "doc_diff": {
+                    "enabled": true,
+                    "base_url": "https://project.dev.readthedocs.io/en/latest/index.html",
+                    "root_selector": "[role=main]",
+                    "inject_styles": true,
+                    "base_host": "",
+                    "base_page": ""
+                },
+                "flyout": {
+                    "translations": [],
+                    "versions": [
+                        {"slug": "latest", "url": "/en/latest/"}
+                    ],
+                    "downloads": [],
+                    "vcs": {
+                        "url": "https://github.com",
+                        "username": "readthedocs",
+                        "repository": "test-builds",
+                        "branch": "a1b2c3",
+                        "filepath": "/docs/index.rst"
+                    }
+                },
+                "search": {
+                    "api_endpoint": "/_/api/v3/search/",
+                    "default_filter": "subprojects:project/latest",
+                    "filters": [
+                        ["Search only in this project", "project:project/latest"],
+                        ["Search subprojects", "subprojects:project/latest"]
+                    ],
+                    "project": "project",
+                    "version": "latest"
+                }
+            }
+        }

--- a/readthedocs/proxito/tests/responses/v0.json
+++ b/readthedocs/proxito/tests/responses/v0.json
@@ -73,6 +73,7 @@
   },
   "addons": {
     "analytics": {
+      "enabled": true,
       "code": null
     },
     "external_version_warning": {

--- a/readthedocs/proxito/tests/responses/v0.json
+++ b/readthedocs/proxito/tests/responses/v0.json
@@ -71,7 +71,7 @@
       "code": null
     }
   },
-  "features": {
+  "addons": {
     "analytics": {
       "code": null
     },

--- a/readthedocs/proxito/tests/responses/v0.json
+++ b/readthedocs/proxito/tests/responses/v0.json
@@ -105,6 +105,7 @@
       }
     },
     "search": {
+      "enabled": true,
       "api_endpoint": "/_/api/v3/search/",
       "default_filter": "subprojects:project/latest",
       "filters": [

--- a/readthedocs/proxito/tests/responses/v1.json
+++ b/readthedocs/proxito/tests/responses/v1.json
@@ -1,0 +1,3 @@
+{
+    "comment": "Undefined yet. Use v0 for now"
+}

--- a/readthedocs/proxito/tests/responses/v2.json
+++ b/readthedocs/proxito/tests/responses/v2.json
@@ -1,0 +1,3 @@
+{
+    "error": "The version specified in 'X-RTD-Hosting-Integrations-Version' is currently not supported"
+}

--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -69,10 +69,10 @@ class TestReadTheDocsConfigJson(TestCase):
         return json.load(open(filename))
 
     def _normalize_datetime_fields(self, obj):
-        obj["project"]["created"] = "2019-04-29T10:00:00Z"
-        obj["project"]["modified"] = "2019-04-29T12:00:00Z"
-        obj["build"]["created"] = "2019-04-29T10:00:00Z"
-        obj["build"]["finished"] = "2019-04-29T10:01:00Z"
+        obj["projects"]["current"]["created"] = "2019-04-29T10:00:00Z"
+        obj["projects"]["current"]["modified"] = "2019-04-29T12:00:00Z"
+        obj["builds"]["current"]["created"] = "2019-04-29T10:00:00Z"
+        obj["builds"]["current"]["finished"] = "2019-04-29T10:01:00Z"
         return obj
 
     def test_get_config_v0(self):

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -186,7 +186,7 @@ class AddonsResponse:
             # TODO: the ``features`` is not polished and we expect to change drastically.
             # Mainly, all the fields including a Project, Version or Build will use the exact same
             # serializer than the keys ``project``, ``version`` and ``build`` from the top level.
-            "features": {
+            "addons": {
                 "analytics": {
                     # TODO: consider adding this field into the ProjectSerializer itself.
                     "code": project.analytics_code,

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -164,9 +164,15 @@ class AddonsResponse:
                 "THIS RESPONSE IS IN ALPHA FOR TEST PURPOSES ONLY"
                 " AND IT'S GOING TO CHANGE COMPLETELY -- DO NOT USE IT!"
             ),
-            "project": ProjectSerializerNoLinks(project).data,
-            "version": VersionSerializerNoLinks(version).data,
-            "build": BuildSerializerNoLinks(build).data,
+            "projects": {
+                "current": ProjectSerializerNoLinks(project).data,
+            },
+            "versions": {
+                "current": VersionSerializerNoLinks(version).data,
+            },
+            "builds": {
+                "current": BuildSerializerNoLinks(build).data,
+            },
             # TODO: consider creating one serializer per field here.
             # The resulting JSON will be the same, but maybe it's easier/cleaner?
             "domains": {

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -188,6 +188,7 @@ class AddonsResponse:
             # serializer than the keys ``project``, ``version`` and ``build`` from the top level.
             "addons": {
                 "analytics": {
+                    "enabled": True,
                     # TODO: consider adding this field into the ProjectSerializer itself.
                     "code": project.analytics_code,
                 },

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -241,6 +241,7 @@ class AddonsResponse:
                     },
                 },
                 "search": {
+                    "enabled": True,
                     "project": project.slug,
                     "version": version.slug,
                     "api_endpoint": "/_/api/v3/search/",

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -177,6 +177,9 @@ class AddonsResponse:
                     "code": settings.GLOBAL_ANALYTICS_CODE,
                 },
             },
+            # TODO: the ``features`` is not polished and we expect to change drastically.
+            # Mainly, all the fields including a Project, Version or Build will use the exact same
+            # serializer than the keys ``project``, ``version`` and ``build`` from the top level.
             "features": {
                 "analytics": {
                     # TODO: consider adding this field into the ProjectSerializer itself.

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -18,7 +18,7 @@ from readthedocs.core.unresolver import unresolver
 log = structlog.get_logger(__name__)  # noqa
 
 
-CLIENT_VERSIONS_SUPPORTED = (0, 1)
+ADDONS_VERSIONS_SUPPORTED = (0, 1)
 
 
 class ClientError(Exception):
@@ -55,8 +55,8 @@ class ReadTheDocsConfigJson(CDNCacheControlMixin, View):
                 status=400,
             )
 
-        client_version = request.headers.get("X-RTD-Hosting-Integrations-Version")
-        if not client_version:
+        addons_version = request.headers.get("X-RTD-Hosting-Integrations-Version")
+        if not addons_version:
             return JsonResponse(
                 {
                     "error": ClientError.VERSION_HEADER_MISSING,
@@ -64,8 +64,8 @@ class ReadTheDocsConfigJson(CDNCacheControlMixin, View):
                 status=400,
             )
         try:
-            client_version = packaging.version.parse(client_version)
-            if client_version.major not in CLIENT_VERSIONS_SUPPORTED:
+            addons_version = packaging.version.parse(addons_version)
+            if addons_version.major not in ADDONS_VERSIONS_SUPPORTED:
                 raise ClientError
         except packaging.version.InvalidVersion:
             return JsonResponse(
@@ -90,7 +90,7 @@ class ReadTheDocsConfigJson(CDNCacheControlMixin, View):
         project.get_default_version()
         build = version.builds.last()
 
-        data = ClientResponse().get(client_version, project, version, build, filename)
+        data = AddonsResponse().get(addons_version, project, version, build, filename)
         return JsonResponse(data, json_dumps_params=dict(indent=4))
 
 
@@ -132,18 +132,18 @@ class BuildSerializerNoLinks(NoLinksMixin, BuildSerializer):
     pass
 
 
-class ClientResponse:
-    def get(self, client_version, project, version, build, filename):
+class AddonsResponse:
+    def get(self, addons_version, project, version, build, filename):
         """
         Unique entry point to get the proper API response.
 
-        It will evaluate the ``client_version`` passed and decide which is the
+        It will evaluate the ``addons_version`` passed and decide which is the
         best JSON structure for that particular version.
         """
-        if client_version.major == 0:
+        if addons_version.major == 0:
             return self._v0(project, version, build, filename)
 
-        if client_version.major == 1:
+        if addons_version.major == 1:
             return self._v1(project, version, build, filename)
 
     def _v0(self, project, version, build, filename):


### PR DESCRIPTION
Review initial JSON response to keep consistency with APIv3 resources. It uses a small modified version of the APIv3 serializers for known resources, removing some URL fields that can't be resolved from El Proxito.

Sharing the same serializers that our APIv3 make our response a lot more consitent between the endpoints and allow us to expand the behavior by adding more fields in a structured way.

Besides, these changes include a minimal checking of the version coming from `X-RTD-Hosting-Integrations-Version` header to decide which JSON structure return, allowing us to support multiple version at the same time in case we require to do some breaking changes.

The JavaScript client is already sending this header in all of its requests. See https://github.com/readthedocs/readthedocs-client/issues/28

Closes #10211 