### PR TITLE
Proxito: inject hosting integration header for `build.commands`

### DIFF
--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -281,9 +281,16 @@ class ProxitoMiddleware(MiddlewareMixin):
 
     def add_hosting_integrations_headers(self, request, response):
         project_slug = getattr(request, "path_project_slug", "")
+        version_slug = getattr(request, "path_version_slug", "")
+
         if project_slug:
             project = Project.objects.get(slug=project_slug)
             if project.has_feature(Feature.HOSTING_INTEGRATIONS):
+                response["X-RTD-Hosting-Integrations"] = "true"
+
+            # Inject the new integrations for versions using `build.commands`
+            version = project.versions.get(slug=version_slug)
+            if version.config.get("build", {}).get("commands", {}) != []:
                 response["X-RTD-Hosting-Integrations"] = "true"
 
     def process_response(self, request, response):  # noqa

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -290,7 +290,11 @@ class ProxitoMiddleware(MiddlewareMixin):
 
             # Inject the new integrations for versions using `build.commands`
             version = project.versions.filter(slug=version_slug).first()
-            if version and version.config.get("build", {}).get("commands", {}) != []:
+            if (
+                version
+                and version.config
+                and version.config.get("build", {}).get("commands", {}) != []
+            ):
                 response["X-RTD-Hosting-Integrations"] = "true"
 
     def process_response(self, request, response):  # noqa

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -289,8 +289,8 @@ class ProxitoMiddleware(MiddlewareMixin):
                 response["X-RTD-Hosting-Integrations"] = "true"
 
             # Inject the new integrations for versions using `build.commands`
-            version = project.versions.get(slug=version_slug)
-            if version.config.get("build", {}).get("commands", {}) != []:
+            version = project.versions.filter(slug=version_slug).first()
+            if version and version.config.get("build", {}).get("commands", {}) != []:
                 response["X-RTD-Hosting-Integrations"] = "true"
 
     def process_response(self, request, response):  # noqa


### PR DESCRIPTION
Versions using `build.commands` will start using the new Read the Docs JavaScript client.

This is still under beta testing, but we want to move forward slowly and start exposing these features to projects that don't have access currently.

Related https://github.com/readthedocs/readthedocs-client/issues/26