### PR TITLE
Docs: Experiment with canonical url using READTHEDOCS_CANONICAL_URL

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,7 +70,7 @@ templates_path = ["_templates"]
 # This will ensure that we use the correctly set environment for canonical URLs
 # Old Read the Docs injections makes it point only to the default version,
 # for instance /en/stable/
-html_baseurl = os.environment.get("READTHEDOCS_CANONICAL_URL")
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
 
 master_doc = "index"
 copyright = "Read the Docs, Inc & contributors"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,6 +65,13 @@ ogp_description_length = 300
 
 templates_path = ["_templates"]
 
+# This may be elevated as a general issue for documentation and behavioral
+# change to the Sphinx build:
+# This will ensure that we use the correctly set environment for canonical URLs
+# Old Read the Docs injections makes it point only to the default version,
+# for instance /en/stable/
+html_baseurl = os.environment.get("READTHEDOCS_CANONICAL_URL")
+
 master_doc = "index"
 copyright = "Read the Docs, Inc & contributors"
 version = "9.10.0"


### PR DESCRIPTION
This is a quick experiment: I noticed that all the canonical  meta tags on [all versions of the Jupyter Notebook](https://jupyter-notebook.readthedocs.io/en/stable/) are almost definitely wrong.. they point to /stable meaning that you cannot generate accurate link previews.

Take for instance this build: https://readthedocs.org/projects/jupyter-notebook/builds/19683327/

The solution is to use our new environment variable :tada: 