### PR TITLE
Docs: minor changes to examples for consistency

### DIFF
--- a/docs/user/reference/environment-variables.rst
+++ b/docs/user/reference/environment-variables.rst
@@ -18,7 +18,11 @@ All :doc:`build processes </builds>` have the following environment variables au
     The locale name, or the identifier for the locale, for the project being built.
     This value comes from the project's configured language.
 
-    :Examples: ``en``, ``it``, ``de_AT``, ``es``, ``pt_BR``
+    :Example: ``en``
+    :Example: ``it``
+    :Example: ``de_AT``
+    :Example: ``es``
+    :Example: ``pt_BR``
 
 .. envvar:: READTHEDOCS_VERSION
 
@@ -35,7 +39,10 @@ All :doc:`build processes </builds>` have the following environment variables au
 
     The type of the version being built.
 
-    :Values: ``branch``, ``tag``, ``external`` (for :doc:`pull request builds </pull-requests>`), or ``unknown``
+    :Example: ``branch``
+    :Example: ``tag``
+    :Example: ``external`` (for :doc:`pull request builds </pull-requests>`)
+    :Example: ``unknown``
 
 .. envvar:: READTHEDOCS_VIRTUALENV_PATH
 


### PR DESCRIPTION
Consistency among all the examples in the variables.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10225.org.readthedocs.build/en/10225/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10225.org.readthedocs.build/en/10225/

<!-- readthedocs-preview dev end -->