### PR TITLE
Analytics API: check if absolute_uri isn't present

### DIFF
--- a/readthedocs/analytics/proxied_api.py
+++ b/readthedocs/analytics/proxied_api.py
@@ -53,11 +53,12 @@ class BaseAnalyticsView(CDNCacheControlMixin, APIView):
         project = self._get_project()
         version = self._get_version()
         absolute_uri = self.request.GET.get('absolute_uri')
-        self.increase_page_view_count(
-            project=project,
-            version=version,
-            absolute_uri=absolute_uri,
-        )
+        if absolute_uri:
+            self.increase_page_view_count(
+                project=project,
+                version=version,
+                absolute_uri=absolute_uri,
+            )
         return Response(status=200)
 
     # pylint: disable=no-self-use


### PR DESCRIPTION
ref https://read-the-docs.sentry.io/issues/4066157775/?alert_rule_id=242443&alert_timestamp=1680770304794&alert_type=email&environment=production&project=161479&ref_fallback=expt&referrer=alert_email

Example https://docs.readthedocs.io/_/api/v2/analytics/?project=docs&version=stable