### PR TITLE
Add notes on private repo support in our install docs

### DIFF
--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -32,6 +32,27 @@ Set up your environment
 
       git clone --recurse-submodules https://github.com/readthedocs/readthedocs.org/
 
+#. Install or clone additional repositories:
+
+   .. note::
+
+      This step is only required for Read the Docs core team members.
+
+   Core team should at very least have all required packages installed in their development image.
+   To install these packages you must define a GitHub token before building your image:
+
+   .. prompt:: bash
+
+      export GITHUB_TOKEN="..."
+      export GITHUB_USER="..."
+
+   In order to make development changes on any of our private repositories,
+   such as ``ext`` or ``ext-theme``, you will also need to check these repositories out:
+
+   .. prompt:: bash
+
+      git clone --recurse-submodules https://github.com/readthedocs/ext/
+
 #. Install the requirements from ``common`` submodule:
 
    .. prompt:: bash
@@ -48,10 +69,6 @@ Set up your environment
 
       inv docker.build
 
-   .. tip::
-
-      If you pass the ``GITHUB_TOKEN`` and ``GITHUB_USER`` environment variables to this command,
-      it will add support for readthedocs-ext.
 
 #. Pull down Docker images for the builders:
 


### PR DESCRIPTION
I'm not settled on whether this is the best place for this or not, but
it's probably _the best place we have currently_.

Not fully tested, but if these commands don't work exactly, at least
it's a clue as to what needs to happen.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10230.org.readthedocs.build/en/10230/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10230.org.readthedocs.build/en/10230/

<!-- readthedocs-preview dev end -->