### PR TITLE
APIv3: add `analytics` field to `Project` object

### DIFF
--- a/docs/user/api/v3.rst
+++ b/docs/user/api/v3.rst
@@ -174,6 +174,14 @@ Projects list
                     "latest": "{VERSION}",
                     "19.0.2": "{VERSION}"
                 },
+                "analytics": {
+                    "google": {
+                         "code": "UA-XXXXX"
+                    },
+                    "readthedocs": {
+                         "enabled": true
+                    }
+                }
                 "_links": {
                     "_self": "/api/v3/projects/pip/",
                     "versions": "/api/v3/projects/pip/versions/",
@@ -279,6 +287,14 @@ Project details
             },
             "privacy_level": "public",
             "external_builds_privacy_level": "public",
+            "analytics": {
+                "google": {
+                     "code": "UA-XXXXX"
+                },
+                "readthedocs": {
+                     "enabled": true
+                }
+            }
             "_links": {
                 "_self": "/api/v3/projects/pip/",
                 "versions": "/api/v3/projects/pip/versions/",

--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -605,6 +605,18 @@ class ProjectUpdateSerializer(SettingsOverrideObject):
     _default_class = ProjectUpdateSerializerBase
 
 
+class AnalyticsSerializer(serializers.Serializer):
+
+    readthedocs = serializers.SerializerMethodField()
+    google = serializers.SerializerMethodField()
+
+    def get_readthedocs(self, obj):
+        return {"enabled": not obj.analytics_disabled}
+
+    def get_google(self, obj):
+        return {"code": obj.analytics_code}
+
+
 class ProjectSerializer(FlexFieldsModelSerializer):
 
     """
@@ -616,6 +628,7 @@ class ProjectSerializer(FlexFieldsModelSerializer):
        But we have organization.owners.
     """
 
+    analytics = AnalyticsSerializer(source="*")
     homepage = serializers.SerializerMethodField()
     language = LanguageSerializer()
     programming_language = ProgrammingLanguageSerializer()
@@ -637,21 +650,22 @@ class ProjectSerializer(FlexFieldsModelSerializer):
     class Meta:
         model = Project
         fields = [
-            'id',
-            'name',
-            'slug',
-            'created',
-            'modified',
-            'language',
-            'programming_language',
-            'homepage',
-            'repository',
-            'default_version',
-            'default_branch',
-            'subproject_of',
-            'translation_of',
-            'urls',
-            'tags',
+            "id",
+            "name",
+            "slug",
+            "created",
+            "modified",
+            "language",
+            "programming_language",
+            "analytics",
+            "homepage",
+            "repository",
+            "default_version",
+            "default_branch",
+            "subproject_of",
+            "translation_of",
+            "urls",
+            "tags",
             "privacy_level",
             "external_builds_privacy_level",
 

--- a/readthedocs/api/v3/tests/responses/projects-detail.json
+++ b/readthedocs/api/v3/tests/responses/projects-detail.json
@@ -76,6 +76,14 @@
         "translations": "https://readthedocs.org/api/v3/projects/project/translations/",
         "versions": "https://readthedocs.org/api/v3/projects/project/versions/"
     },
+    "analytics": {
+        "google": {
+            "code": null
+        },
+        "readthedocs": {
+            "enabled": true
+        }
+    },
     "modified": "2019-04-29T12:00:00Z",
     "name": "project",
     "programming_language": {


### PR DESCRIPTION
New `analytics` field that exposes:

- the Google code if the project has it configured
- whether or not the global Google/Plausible Read the Docs analytics is enabled

This field is going to be useful for the new "Analytics Addon".

Related #10216