### PR TITLE
Proxito: allow to serve external version on development

### DIFF
--- a/readthedocs/core/unresolver.py
+++ b/readthedocs/core/unresolver.py
@@ -445,7 +445,7 @@ class Unresolver:
         subdomain, *root_domain = domain.split(".", maxsplit=1)
         root_domain = root_domain[0] if root_domain else ""
 
-        if public_domain in domain:
+        if public_domain in domain and public_domain not in external_domain:
             # Serve from the PUBLIC_DOMAIN, ensuring it looks like `foo.PUBLIC_DOMAIN`.
             if public_domain == root_domain:
                 project_slug = subdomain


### PR DESCRIPTION
Since we are using `.devthedocs.org` and `.build.devthedocs.org`, the public domain is included in the external domain --this does not happen in production.

So, in local development this makes the PR to not be served and detected as a "Weird variation of our domain".

I'm not 100% sure this is the correct fix or it needs to handle other cases, but at least this solves my problem locally. @stsewd I know you have been working on all this code; feel free to adapt it in case there is something missing.