### PR TITLE
Scripts: Add export statements and instruction to fetch awscli (compile_version_upload_s3.sh)

### DIFF
--- a/scripts/compile_version_upload_s3.sh
+++ b/scripts/compile_version_upload_s3.sh
@@ -19,6 +19,13 @@
 #
 #   inv docker.up
 #
+# You also need the "awscli" PyPi package in your local Python environment.
+#
+#   pip install awscli
+#
+# Note: The version that used is currently simply the latest. If there are issues in
+# the future, we can consider fetching the 'mc' client from MinIO instead.
+#
 #
 # PRODUCTION ENVIRONMENT
 #
@@ -121,10 +128,10 @@ then
     # Upload the .tar.gz to S3 development environment
     echo "Uploading to dev environment"
 
-    AWS_ENDPOINT_URL="${AWS_ENDPOINT_URL:-http://localhost:9000}"
-    AWS_BUILD_TOOLS_BUCKET="${AWS_BUILD_TOOLS_BUCKET:-build-tools}"
-    AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-admin}"
-    AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-password}"
+    export AWS_ENDPOINT_URL="${AWS_ENDPOINT_URL:-http://localhost:9000}"
+    export AWS_BUILD_TOOLS_BUCKET="${AWS_BUILD_TOOLS_BUCKET:-build-tools}"
+    export AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-admin}"
+    export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-password}"
 
     aws --endpoint-url $AWS_ENDPOINT_URL s3 cp $OS-$TOOL-$VERSION.tar.gz s3://$AWS_BUILD_TOOLS_BUCKET
 


### PR DESCRIPTION
Just quickly updating the script...

1) I received some error "credentials not found" until the environment variables got exported. But otherwise it worked fine :+1: 

https://github.com/readthedocs/readthedocs.org/blob/main/requirements/pip.in#L37

2) awscli has been removed from our requirements so needs to be added manually to the environment. Since it's not terribly important, I added a note that we MIGHT use mc (as the docker containers also do) in case there are issues with it.

https://github.com/readthedocs/readthedocs.org/blob/main/requirements/pip.in#L37