### PR TITLE
Revert "Proxito: inject hosting integration header for `build.commands` (#10219)"

### DIFF
--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -281,20 +281,9 @@ class ProxitoMiddleware(MiddlewareMixin):
 
     def add_hosting_integrations_headers(self, request, response):
         project_slug = getattr(request, "path_project_slug", "")
-        version_slug = getattr(request, "path_version_slug", "")
-
         if project_slug:
             project = Project.objects.get(slug=project_slug)
             if project.has_feature(Feature.HOSTING_INTEGRATIONS):
-                response["X-RTD-Hosting-Integrations"] = "true"
-
-            # Inject the new integrations for versions using `build.commands`
-            version = project.versions.filter(slug=version_slug).first()
-            if (
-                version
-                and version.config
-                and version.config.get("build", {}).get("commands", {}) != []
-            ):
                 response["X-RTD-Hosting-Integrations"] = "true"
 
     def process_response(self, request, response):  # noqa


### PR DESCRIPTION
This reverts commit 27215d29b372369e1103d4b480dace77b69ad655.
