### PR TITLE
Update docs about setuptools dependency

### DIFF
--- a/docs/user/build-default-versions.rst
+++ b/docs/user/build-default-versions.rst
@@ -52,7 +52,8 @@ pip:
   Latest version by default.
 
 setuptools:
-  ``58.2.0`` or older.
+  Projects using ``setup.py install`` as installation method use ``58.2.0`` or older.
+  All other projects use the latest version.
 
 mock:
   ``1.0.1`` (could be removed in the future).


### PR DESCRIPTION
Ref https://github.com/readthedocs/readthedocs.org/pull/10268

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10270.org.readthedocs.build/en/10270/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10270.org.readthedocs.build/en/10270/

<!-- readthedocs-preview dev end -->