### PR TITLE
Dev: Disable cacheops in proxito docker environment

### DIFF
--- a/dockerfiles/settings/proxito.py
+++ b/dockerfiles/settings/proxito.py
@@ -6,7 +6,11 @@ from .docker_compose import DockerBaseSettings
 class ProxitoDevSettings(CommunityProxitoSettingsMixin, DockerBaseSettings):
     DONT_HIT_DB = False
 
-    CACHEOPS_ENABLED = True
+    # Disabled because of issues like
+    # ResponseError: Error running script (call to f_1880dea5c524f6a37a650f715fa630416a2fe1fd):
+    # @user_script:50: @user_script: 50: Wrong number of args calling Redis command From Lua script
+    # (this issue goes away after a few reloads)
+    CACHEOPS_ENABLED = False
 
     # El Proxito does not have django-debug-toolbar installed
     @property


### PR DESCRIPTION
This is causing issues in Docker development. Not sure if it's enabled for proxito in production?

Example:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.10/dist-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python3.10/dist-packages/django/views/generic/base.py", line 70, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/src/app/checkouts/readthedocs.org/readthedocs/core/mixins.py", line 55, in dispatch
    response = super().dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/django/views/generic/base.py", line 98, in dispatch
    return handler(request, *args, **kwargs)
  File "/usr/src/app/checkouts/readthedocs.org/readthedocs/proxito/views/serve.py", line 157, in get
    return self.get_using_unresolver(request)
  File "/usr/src/app/checkouts/readthedocs.org/readthedocs/proxito/views/serve.py", line 385, in get_using_unresolver
    unresolved = unresolver.unresolve_path(
  File "/usr/src/app/checkouts/readthedocs.org/readthedocs/core/unresolver.py", line 203, in unresolve_path
    return self._unresolve(
  File "/usr/src/app/checkouts/readthedocs.org/readthedocs/core/unresolver.py", line 216, in _unresolve
    current_project, version, filename = self._unresolve_path_with_parent_project(
  File "/usr/src/app/checkouts/readthedocs.org/readthedocs/core/unresolver.py", line 391, in _unresolve_path_with_parent_project
    response = self._match_multiversion_project(
  File "/usr/src/app/checkouts/readthedocs.org/readthedocs/core/unresolver.py", line 283, in _match_multiversion_project
    version = project.versions(manager=manager).filter(slug=version_slug).first()
  File "/usr/local/lib/python3.10/dist-packages/cacheops/query.py", line 331, in first
    return self._no_monkey.first(self._clone().cache())
  File "/usr/local/lib/python3.10/dist-packages/django/db/models/query.py", line 674, in first
    for obj in (self if self.ordered else self.order_by('pk'))[:1]:
  File "/usr/local/lib/python3.10/dist-packages/django/db/models/query.py", line 280, in __iter__
    self._fetch_all()
  File "/usr/local/lib/python3.10/dist-packages/cacheops/query.py", line 261, in _fetch_all
    self._cache_results(cache_key, self._result_cache)
  File "/usr/local/lib/python3.10/dist-packages/cacheops/query.py", line 179, in _cache_results
    cache_thing(self._prefix, cache_key, results,
  File "/usr/local/lib/python3.10/dist-packages/funcy/decorators.py", line 45, in wrapper
    return deco(call, *dargs, **dkwargs)
  File "/usr/local/lib/python3.10/dist-packages/cacheops/redis.py", line 16, in handle_connection_failure
    return call()
  File "/usr/local/lib/python3.10/dist-packages/funcy/decorators.py", line 66, in __call__
    return self._func(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.10/dist-packages/cacheops/getset.py", line 44, in cache_thing
    load_script('cache_thing')(
  File "/usr/local/lib/python3.10/dist-packages/redis/commands/core.py", line 5807, in __call__
    return client.evalsha(self.sha, len(keys), *args)
  File "/usr/local/lib/python3.10/dist-packages/redis/commands/core.py", line 5194, in evalsha
    return self._evalsha("EVALSHA", sha, numkeys, *keys_and_args)
  File "/usr/local/lib/python3.10/dist-packages/redis/commands/core.py", line 5178, in _evalsha
    return self.execute_command(command, sha, numkeys, *keys_and_args)
  File "/usr/local/lib/python3.10/dist-packages/redis/client.py", line 1258, in execute_command
    return conn.retry.call_with_retry(
  File "/usr/local/lib/python3.10/dist-packages/redis/retry.py", line 46, in call_with_retry
    return do()
  File "/usr/local/lib/python3.10/dist-packages/redis/client.py", line 1259, in <lambda>
    lambda: self._send_command_parse_response(
  File "/usr/local/lib/python3.10/dist-packages/redis/client.py", line 1235, in _send_command_parse_response
    return self.parse_response(conn, command_name, **options)
  File "/usr/local/lib/python3.10/dist-packages/redis/client.py", line 1275, in parse_response
    response = connection.read_response()
  File "/usr/local/lib/python3.10/dist-packages/redis/connection.py", line 882, in read_response
    raise response

Exception Type: ResponseError at /en/latest/
Exception Value: Error running script (call to f_1880dea5c524f6a37a650f715fa630416a2fe1fd): @user_script:50: @user_script: 50: Wrong number of args calling Redis command From Lua script
```