### PR TITLE
Remove dead code

### DIFF
--- a/readthedocs/api/v2/views/model_views.py
+++ b/readthedocs/api/v2/views/model_views.py
@@ -17,7 +17,7 @@ from readthedocs.api.v2.utils import normalize_build_command
 from readthedocs.builds.constants import INTERNAL
 from readthedocs.builds.models import Build, BuildCommandResult, Version
 from readthedocs.oauth.models import RemoteOrganization, RemoteRepository
-from readthedocs.oauth.services import GitHubService, registry
+from readthedocs.oauth.services import registry
 from readthedocs.projects.models import Domain, Project
 from readthedocs.storage import build_commands_storage
 
@@ -183,20 +183,6 @@ class ProjectViewSet(DisableListEndpoint, UserSelectViewSet):
         versions = project.versions(manager=INTERNAL).filter(active=True)
         return Response({
             'versions': VersionSerializer(versions, many=True).data,
-        })
-
-    @decorators.action(
-        detail=True,
-        permission_classes=[permissions.IsAdminUser],
-    )
-    def token(self, request, **kwargs):
-        project = get_object_or_404(
-            Project.objects.api(request.user),
-            pk=kwargs['pk'],
-        )
-        token = GitHubService.get_token_for_project(project, force_local=True)
-        return Response({
-            'token': token,
         })
 
     @decorators.action(detail=True)

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -4,17 +4,14 @@ import json
 import re
 
 import structlog
-from allauth.socialaccount.models import SocialToken
 from allauth.socialaccount.providers.github.views import GitHubOAuth2Adapter
 from django.conf import settings
 from django.urls import reverse
 from oauthlib.oauth2.rfc6749.errors import InvalidGrantError
 from requests.exceptions import RequestException
 
-from readthedocs.api.v2.client import api
 from readthedocs.builds import utils as build_utils
 from readthedocs.builds.constants import BUILD_FINAL_STATES, SELECT_BUILD_STATUS
-from readthedocs.core.permissions import AdminPermission
 from readthedocs.integrations.models import Integration
 
 from ..constants import GITHUB
@@ -520,25 +517,3 @@ class GitHubService(Service):
             log.info("Invalid GitHub grant for user.", exc_info=True)
 
         return False
-
-    @classmethod
-    def get_token_for_project(cls, project, force_local=False):
-        """Get access token for project by iterating over project users."""
-        # TODO why does this only target GitHub?
-        if not settings.ALLOW_PRIVATE_REPOS:
-            return None
-        token = None
-        try:
-            if settings.DONT_HIT_DB and not force_local:
-                token = api.project(project.pk).token().get()['token']
-            else:
-                for user in AdminPermission.admins(project):
-                    tokens = SocialToken.objects.filter(
-                        account__user=user,
-                        app__provider=cls.adapter.provider_id,
-                    )
-                    if tokens.exists():
-                        token = tokens[0].token
-        except Exception:
-            log.exception('Failed to get token for project')
-        return token

--- a/readthedocs/projects/utils.py
+++ b/readthedocs/projects/utils.py
@@ -4,27 +4,11 @@ import csv
 import os
 
 import structlog
-from django.conf import settings
 from django.http import StreamingHttpResponse
 
 from readthedocs.core.utils.filesystem import safe_open
 
 log = structlog.get_logger(__name__)
-
-
-# TODO make this a classmethod of Version
-def version_from_slug(slug, version):
-    from readthedocs.api.v2.client import api
-    from readthedocs.builds.models import APIVersion, Version
-    if settings.DONT_HIT_DB:
-        version_data = api.version().get(
-            project=slug,
-            slug=version,
-        )['results'][0]
-        v = APIVersion(**version_data)
-    else:
-        v = Version.objects.get(project__slug=slug, slug=version)
-    return v
 
 
 def safe_write(filename, contents):

--- a/readthedocs/rtd_tests/tests/test_project.py
+++ b/readthedocs/rtd_tests/tests/test_project.py
@@ -63,12 +63,6 @@ class TestProject(ProjectMixin, TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(resp['subprojects'][0]['id'], 23)
 
-    def test_token(self):
-        r = self.client.get('/api/v2/project/6/token/', {})
-        resp = json.loads(r.content)
-        self.assertEqual(r.status_code, 200)
-        self.assertEqual(resp['token'], None)
-
     def test_has_pdf(self):
         # The project has a pdf if the PDF file exists on disk.
         with fake_paths_by_regex(r'\.pdf$'):


### PR DESCRIPTION
- We are not using the `project/token` endpoint, and it was always returning/looking for the GitHub token.
- version_from_slug isn't used either