### PR TITLE
Build: use same version of setuptools when using `system_packages`

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -251,7 +251,7 @@ class Virtualenv(PythonEnvironment):
             # If this flag is present,
             # we need to cap setuptools again.
             # See https://github.com/readthedocs/readthedocs.org/issues/8775
-            requirements.append('setuptools<58.3.0')
+            requirements.append(setuptools_version)
         cmd.extend(requirements)
         self.build_env.run(
             *cmd,

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -248,9 +248,7 @@ class Virtualenv(PythonEnvironment):
             # even if it is already installed system-wide (and
             # --system-site-packages is used)
             cmd.append('-I')
-            # If this flag is present,
-            # we need to cap setuptools again.
-            # See https://github.com/readthedocs/readthedocs.org/issues/8775
+            # The same version of setuptools used above needs to be used here.
             requirements.append(setuptools_version)
         cmd.extend(requirements)
         self.build_env.run(

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -451,7 +451,7 @@ class TestPythonEnvironment(TestCase):
             "sphinx-rtd-theme",
             "readthedocs-sphinx-ext",
             "jinja2<3.1.0",
-            "setuptools<58.3.0",
+            "setuptools",
         ]
 
         self.assertEqual(self.build_env_mock.run.call_count, 2)


### PR DESCRIPTION
The same version installed before needs to match here, otherwise for some reason pip gives you an error when installing some packages.

Fixes https://github.com/readthedocs/readthedocs.org/issues/10285