### PR TITLE
Change a few configuration file options from required to not required

### DIFF
--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -194,7 +194,7 @@ The path to the requirements file, relative to the root of the project.
 
 :Key: ``requirements``
 :Type: ``path``
-:Required: ``true``
+:Required: ``false``
 
 Example:
 
@@ -222,7 +222,7 @@ The path to the package, relative to the root of the project.
 
 :Key: ``path``
 :Type: ``path``
-:Required: ``true``
+:Required: ``false``
 
 The installation method.
 
@@ -297,7 +297,7 @@ conda.environment
 The path to the Conda `environment file <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html>`_, relative to the root of the project.
 
 :Type: ``path``
-:Required: ``true``
+:Required: ``false``
 
 build
 ~~~~~


### PR DESCRIPTION
These are not required in our configuration specification

Resolves #10302

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10303.org.readthedocs.build/en/10303/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10303.org.readthedocs.build/en/10303/

<!-- readthedocs-preview dev end -->