### PR TITLE
Build: Handle commit hash on incoming webhooks and send commit status on all builds

### DIFF
--- a/readthedocs/api/v2/views/integrations.py
+++ b/readthedocs/api/v2/views/integrations.py
@@ -644,14 +644,10 @@ class GitLabWebhookView(WebhookMixin, APIView):
             except KeyError:
                 raise ParseError('Parameter "ref" is required')
 
-            try:
+            commit = None
+            # Commits are not present in GITLAB_TAG_PUSH
+            if "commits" in self.data and self.data["commits"]:
                 commit = self.data["commits"][0]["id"]
-            except IndexError:
-                raise ParseError("No commits found in push event.")
-            except KeyError:
-                raise ParseError(
-                    'Push event received with either no "commits" or no "id" key for commit.'
-                )
 
             return self.get_response_push(self.project, [(branch, commit)])
 

--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -249,6 +249,7 @@ def delete_closed_external_versions(limit=200, days=30 * 3):
     The commit status is updated to link to the build page, as the docs are removed.
     """
     days_ago = timezone.now() - timezone.timedelta(days=days)
+    # TODO: Might need to expand what we are cleaning up
     queryset = Version.external.filter(
         state=EXTERNAL_VERSION_STATE_CLOSED,
         modified__lte=days_ago,
@@ -381,7 +382,7 @@ def sync_versions_task(project_pk, tags_data, branches_data, **kwargs):
 )
 def send_build_status(build_pk, commit, status):
     """
-    Send Build Status to Git Status API for project external versions.
+    Send Build Status to Git Status API for all commits.
 
     It tries using these services' account in order:
 
@@ -480,7 +481,7 @@ def send_build_status(build_pk, commit, status):
 @app.task(queue='web')
 def send_build_notifications(version_pk, build_pk, event):
     version = Version.objects.get_object_or_log(pk=version_pk)
-    if not version or version.type == EXTERNAL:
+    if not version:
         return
 
     build = Build.objects.filter(pk=build_pk).first()

--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -481,7 +481,9 @@ def send_build_status(build_pk, commit, status):
 @app.task(queue='web')
 def send_build_notifications(version_pk, build_pk, event):
     version = Version.objects.get_object_or_log(pk=version_pk)
-    if not version:
+
+    # We do not send user notifications for external builds (pull requests)
+    if not version or version.type == EXTERNAL:
         return
 
     build = Build.objects.filter(pk=build_pk).first()

--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -47,7 +47,7 @@ def prepare_build(
     from readthedocs.builds.tasks import send_build_notifications
     from readthedocs.projects.models import Feature, Project, WebHookEvent
     from readthedocs.projects.tasks.builds import update_docs_task
-    from readthedocs.projects.tasks.utils import send_external_build_status
+    from readthedocs.projects.tasks.utils import trigger_send_build_status
 
     log.bind(project_slug=project.slug)
 
@@ -102,7 +102,7 @@ def prepare_build(
         log.bind(commit=commit)
 
         # Send pending Build Status using Git Status API for External Builds.
-        send_external_build_status(
+        trigger_send_build_status(
             version_type=version.type,
             build_pk=build.id,
             commit=commit,

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -66,7 +66,7 @@ from ..models import APIProject, Feature, WebHookEvent
 from ..signals import before_vcs
 from .mixins import SyncRepositoryMixin
 from .search import fileify
-from .utils import BuildRequest, clean_build, send_external_build_status
+from .utils import BuildRequest, clean_build, trigger_send_build_status
 
 log = structlog.get_logger(__name__)
 
@@ -512,7 +512,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
                 # was skipped on purpose.
                 status = BUILD_STATUS_SUCCESS
 
-            send_external_build_status(
+            trigger_send_build_status(
                 version_type=version_type,
                 build_pk=self.data.build['id'],
                 commit=self.data.build_commit,
@@ -629,7 +629,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         )
 
         if self.data.build_commit:
-            send_external_build_status(
+            trigger_send_build_status(
                 version_type=self.data.version.type,
                 build_pk=self.data.build['id'],
                 commit=self.data.build_commit,

--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -7,11 +7,7 @@ from django.db.models import Q
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from readthedocs.builds.constants import (
-    BUILD_FINAL_STATES,
-    BUILD_STATE_CANCELLED,
-    EXTERNAL,
-)
+from readthedocs.builds.constants import BUILD_FINAL_STATES, BUILD_STATE_CANCELLED
 from readthedocs.builds.models import Build
 from readthedocs.builds.tasks import send_build_status
 from readthedocs.core.utils.filesystem import safe_rmtree
@@ -138,20 +134,18 @@ def finish_inactive_builds():
     )
 
 
-def send_external_build_status(version_type, build_pk, commit, status):
+def trigger_send_build_status(version_type, build_pk, commit, status):
     """
-    Check if build is external and Send Build Status for project external versions.
+    Triggers the build send_build_status task.
 
-     :param version_type: Version type e.g EXTERNAL, BRANCH, TAG
-     :param build_pk: Build pk
-     :param commit: commit sha of the pull/merge request
-     :param status: build status failed, pending, or success to be sent.
+    :param version_type: Version type e.g EXTERNAL, BRANCH, TAG
+    :param build_pk: Build pk
+    :param commit: commit sha of the pull/merge request
+    :param status: build status failed, pending, or success to be sent.
     """
 
-    # Send status reports for only External (pull/merge request) Versions.
-    if version_type == EXTERNAL:
-        # call the task that actually send the build status.
-        send_build_status.delay(build_pk, commit, status)
+    # call the task that actually send the build status.
+    send_build_status.delay(build_pk, commit, status)
 
 
 class BuildRequest(Request):

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -399,7 +399,7 @@ class TestBuildTask(BuildEnvironmentBase):
 
     @mock.patch("readthedocs.projects.tasks.builds.fileify")
     @mock.patch("readthedocs.projects.tasks.builds.build_complete")
-    @mock.patch("readthedocs.projects.tasks.builds.send_external_build_status")
+    @mock.patch("readthedocs.projects.tasks.builds.trigger_send_build_status")
     @mock.patch("readthedocs.projects.tasks.builds.UpdateDocsTask.send_notifications")
     @mock.patch("readthedocs.projects.tasks.builds.clean_build")
     @mock.patch("readthedocs.doc_builder.director.load_yaml_config")
@@ -408,7 +408,7 @@ class TestBuildTask(BuildEnvironmentBase):
         load_yaml_config,
         clean_build,
         send_notifications,
-        send_external_build_status,
+        trigger_send_build_status,
         build_complete,
         fileify,
     ):
@@ -451,7 +451,7 @@ class TestBuildTask(BuildEnvironmentBase):
             event=WebHookEvent.BUILD_PASSED,
         )
 
-        send_external_build_status.assert_called_once_with(
+        trigger_send_build_status.assert_called_once_with(
             version_type=self.version.type,
             build_pk=self.build.pk,
             commit=self.build.commit,
@@ -591,7 +591,7 @@ class TestBuildTask(BuildEnvironmentBase):
         # build_media_storage.delete_directory
 
     @mock.patch("readthedocs.projects.tasks.builds.build_complete")
-    @mock.patch("readthedocs.projects.tasks.builds.send_external_build_status")
+    @mock.patch("readthedocs.projects.tasks.builds.trigger_send_build_status")
     @mock.patch("readthedocs.projects.tasks.builds.UpdateDocsTask.execute")
     @mock.patch("readthedocs.projects.tasks.builds.UpdateDocsTask.send_notifications")
     @mock.patch("readthedocs.projects.tasks.builds.clean_build")
@@ -600,7 +600,7 @@ class TestBuildTask(BuildEnvironmentBase):
         clean_build,
         send_notifications,
         execute,
-        send_external_build_status,
+        trigger_send_build_status,
         build_complete,
     ):
         assert not BuildData.objects.all().exists()
@@ -624,7 +624,7 @@ class TestBuildTask(BuildEnvironmentBase):
             event=WebHookEvent.BUILD_FAILED,
         )
 
-        send_external_build_status.assert_called_once_with(
+        trigger_send_build_status.assert_called_once_with(
             version_type=self.version.type,
             build_pk=self.build.pk,
             commit=self.build.commit,

--- a/readthedocs/rtd_tests/tests/test_projects_tasks.py
+++ b/readthedocs/rtd_tests/tests/test_projects_tasks.py
@@ -35,6 +35,12 @@ class SendBuildStatusTests(TestCase):
 
     @patch('readthedocs.projects.tasks.utils.send_build_status')
     def test_send_external_build_status_with_internal_version(self, send_build_status):
+        """
+        Verify that an active version/branch emits a build status.
+
+        Example: A new commit is pushed to 'main' branch. This is usually triggered by a webhook and
+        an update should be send back to the Git provider with build status and URL.
+        """
         trigger_send_build_status(
             self.internal_version.type,
             self.internal_build.id,
@@ -42,4 +48,8 @@ class SendBuildStatusTests(TestCase):
             BUILD_STATUS_SUCCESS,
         )
 
-        send_build_status.delay.assert_not_called()
+        send_build_status.delay.assert_called_once_with(
+            self.internal_build.id,
+            self.external_build.commit,
+            BUILD_STATUS_SUCCESS,
+        )

--- a/readthedocs/rtd_tests/tests/test_projects_tasks.py
+++ b/readthedocs/rtd_tests/tests/test_projects_tasks.py
@@ -6,7 +6,7 @@ from django_dynamic_fixture import get
 from readthedocs.builds.constants import BUILD_STATUS_SUCCESS, EXTERNAL
 from readthedocs.builds.models import Build, Version
 from readthedocs.projects.models import Project
-from readthedocs.projects.tasks.utils import send_external_build_status
+from readthedocs.projects.tasks.utils import trigger_send_build_status
 
 
 class SendBuildStatusTests(TestCase):
@@ -20,7 +20,7 @@ class SendBuildStatusTests(TestCase):
 
     @patch('readthedocs.projects.tasks.utils.send_build_status')
     def test_send_external_build_status_with_external_version(self, send_build_status):
-        send_external_build_status(
+        trigger_send_build_status(
             self.external_version.type,
             self.external_build.id,
             self.external_build.commit,
@@ -35,7 +35,7 @@ class SendBuildStatusTests(TestCase):
 
     @patch('readthedocs.projects.tasks.utils.send_build_status')
     def test_send_external_build_status_with_internal_version(self, send_build_status):
-        send_external_build_status(
+        trigger_send_build_status(
             self.internal_version.type,
             self.internal_build.id,
             self.external_build.commit,


### PR DESCRIPTION
Fixes https://github.com/readthedocs/readthedocs.org/issues/7084

## Notes for reviewers

**_I hope you're okay about starting the review a bit high-level:_**

* I wrote my notes for the implementation, starting here: https://github.com/readthedocs/readthedocs.org/issues/7084#issuecomment-1547809333

* Please make sure to read this comment about issues that I suggest to handle separately https://github.com/readthedocs/readthedocs.org/pull/10320#issuecomment-1550324581

* The implementation should maintain fallback support for previous behavior, i.e. "no commit ID supplied": If there for some reason exists a scenario where the commit ID isn't provided in the webhook event (tag pushes or we don't detect it correctly?), then we will just log the event on warning level but continue as before. I prefer that we go this way, since it's hard to guarantee that we have understood all potential events that are pushed to the webhook.

* Noting that the risks of out-of-order webhook events and builds are very low and already exist to some extend, I prefer an approach where we will discuss and solve this separately.

## Work log

* [x] Pre-analysis to figure out the correct solution
* [x] Implementation and local Q&A with GitHub OAuth App
* [x] Updates to tests w/ some new scenarios
* [x] Understand a bit more potential cases we need to investigate.
  * Out of order webhook events
  * Force pushes and deleted commits
* [x] Understand if auto-cancel feature works on existing PR push events where commit IDs were already used and how/if that worked.

![image](https://github.com/readthedocs/readthedocs.org/assets/374612/95893048-58f0-4f4a-a5aa-1a288dd61d94)

![image](https://github.com/readthedocs/readthedocs.org/assets/374612/10e7e46d-a220-4c98-9885-d02667639aff)

Test with a build failure:

![image](https://github.com/readthedocs/readthedocs.org/assets/374612/ee0d868b-f049-4d69-9f34-08d06e63b2be)

Test with build success:

![image](https://github.com/readthedocs/readthedocs.org/assets/374612/4c142af7-cceb-4718-a0ea-eae6c1eb03fa)
