### PR TITLE
Build: allow multi-line commands on `build.commands`

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -376,10 +376,13 @@ class DockerBuildCommand(BuildCommand):
                 for part in self.command
             )
         )
-        return "/bin/sh -c '{prefix}\n{cmd}'".format(
-            prefix=prefix,
-            cmd=command,
-        )
+        if prefix:
+            # Using `;` or `\n` to separate the `prefix` where we define the
+            # variables with the `command` itself, have the same effect.
+            # However, using `;` is more explicit.
+            # See https://github.com/readthedocs/readthedocs.org/pull/10334
+            return f"/bin/sh -c '{prefix}; {command}'"
+        return f"/bin/sh -c '{command}'"
 
     def _escape_command(self, cmd):
         r"""Escape the command by prefixing suspicious chars with `\`."""

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -376,7 +376,7 @@ class DockerBuildCommand(BuildCommand):
                 for part in self.command
             )
         )
-        return "/bin/sh -c '{prefix}{cmd}'".format(
+        return "/bin/sh -c '{prefix}\n{cmd}'".format(
             prefix=prefix,
             cmd=command,
         )


### PR DESCRIPTION
This is another attempt to fix this issue. It follows the suggestion posted by @bensze01 in https://github.com/readthedocs/readthedocs.org/issues/10103. It looks simple and I think it makes sense to give it a try since it doesn't seem to be harmful.

I tested it locally with the branch
https://github.com/readthedocs/test-builds/tree/build-commands-multiline and it worked fine. Note that without this PR the branch linked fails.

Related #10133
Related #10119
Related #10206

External PRs that should be solved by this one:
* https://github.com/pypi/warehouse/pull/12953
* https://github.com/pypi/warehouse/pull/12953

Closes #10103
Closes #10208