### PR TITLE
Requirements: upgrade DDT to avoid an issue

### DIFF
--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -136,7 +136,7 @@ django-crispy-forms==1.14.0
     # via -r requirements/pip.txt
 django-csp==3.7
     # via -r requirements/pip.txt
-django-debug-toolbar==4.0.0
+django-debug-toolbar==4.1.0
     # via -r requirements/pip.txt
 django-elasticsearch-dsl==7.3
     # via -r requirements/pip.txt

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -145,7 +145,7 @@ django-crispy-forms==1.14.0
     # via -r requirements/pip.txt
 django-csp==3.7
     # via -r requirements/pip.txt
-django-debug-toolbar==4.0.0
+django-debug-toolbar==4.1.0
     # via -r requirements/pip.txt
 django-elasticsearch-dsl==7.3
     # via -r requirements/pip.txt

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -92,7 +92,7 @@ django-crispy-forms==1.14.0
     # via -r requirements/pip.in
 django-csp==3.7
     # via -r requirements/pip.in
-django-debug-toolbar==4.0.0
+django-debug-toolbar==4.1.0
     # via -r requirements/pip.in
 django-elasticsearch-dsl==7.3
     # via -r requirements/pip.in

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -131,7 +131,7 @@ django-crispy-forms==1.14.0
     # via -r requirements/pip.txt
 django-csp==3.7
     # via -r requirements/pip.txt
-django-debug-toolbar==4.0.0
+django-debug-toolbar==4.1.0
     # via -r requirements/pip.txt
 django-dynamic-fixture==3.1.2
     # via -r requirements/testing.in


### PR DESCRIPTION
See https://github.com/jazzband/django-debug-toolbar/pull/1770

We hit this while doing a deploy.