### PR TITLE
Email: trust GH and GL emails and mark them as verified

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -742,6 +742,7 @@ class CommunityBaseSettings(Settings):
 
     SOCIALACCOUNT_PROVIDERS = {
         'github': {
+            "VERIFIED_EMAIL": True,
             'SCOPE': [
                 'user:email',
                 'read:org',
@@ -750,6 +751,7 @@ class CommunityBaseSettings(Settings):
             ],
         },
         'gitlab': {
+            "VERIFIED_EMAIL": True,
             'SCOPE': [
                 'api',
                 'read_user',


### PR DESCRIPTION
This will reduce the amount of emails we send and also provide a better UX to users registering in our platform.

Related https://github.com/readthedocs/readthedocs-ops/issues/1269