### PR TITLE
Small index page tweak

### DIFF
--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -160,7 +160,7 @@ These guides provide step-by-step instructions in key areas to get you up to spe
 Reference
 ---------
 
-Need to know how something works? 
+Need to know how something works?
 Here are a few of the most important reference docs:
 
 .. Descriptions here sound like reference

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -160,7 +160,8 @@ These guides provide step-by-step instructions in key areas to get you up to spe
 Reference
 ---------
 
-Need to know how something works? Here are a few of the most important reference docs:
+Need to know how something works? 
+Here are a few of the most important reference docs:
 
 .. Descriptions here sound like reference
 

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -138,7 +138,8 @@ Get a high-level overview of our platform:
 How-to guides
 -------------
 
-Need to get something specific done? These guides provide step-by-step instructions on various areas:
+Need to get something specific done?
+These guides provide step-by-step instructions in key areas to get you up to speed faster:
 
 .. Descriptions here are active, learn, setup, etc.
 .. The chosen sample of how-tos is intended reflect to width of the how-to section
@@ -159,7 +160,7 @@ Need to get something specific done? These guides provide step-by-step instructi
 Reference
 ---------
 
-Need to know how something works? Our references provide the details:
+Need to know how something works? Here are a few of the most important reference docs:
 
 .. Descriptions here sound like reference
 


### PR DESCRIPTION
Fixes what I immediate could spot in #10300

A bigger related change is coming in #10071 where the explanation section is made more understandable by splitting up introduction and advanced content.

Thanks @hughesnyc :pray: 

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10358.org.readthedocs.build/en/10358/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10358.org.readthedocs.build/en/10358/

<!-- readthedocs-preview dev end -->