### PR TITLE
Build: Bug in `target_url`, failure to add "success" status if no external version exists

### DIFF
--- a/readthedocs/builds/constants.py
+++ b/readthedocs/builds/constants.py
@@ -3,6 +3,9 @@
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
+# BUILD_STATE is our *INTERNAL* representation of build states.
+# This is not to be confused with external representations of 'status'
+# that are sent back to Git providers.
 BUILD_STATE_TRIGGERED = "triggered"
 BUILD_STATE_CLONING = "cloning"
 BUILD_STATE_INSTALLING = "installing"
@@ -78,7 +81,9 @@ NON_REPOSITORY_VERSIONS = (
     STABLE,
 )
 
-# General Build Statuses
+# General build statuses, i.e. the status that is reported back to the
+# user on a Git Provider. This not the same as BUILD_STATE which the internal
+# representation.
 BUILD_STATUS_FAILURE = 'failed'
 BUILD_STATUS_PENDING = 'pending'
 BUILD_STATUS_SUCCESS = 'success'

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -377,14 +377,29 @@ class Version(TimeStampedModel):
         return self.identifier
 
     def get_absolute_url(self):
-        """Get absolute url to the docs of the version."""
+        """
+        Get the absolute URL to the docs of the version.
+
+        If the version doesn't have a successfully uploaded build, then we return the project's
+        dashboard page.
+
+        Because documentation projects can be hosted on separate domains, this function ALWAYS
+        returns with a full "http(s)://<domain>/" prefix.
+        """
         if not self.built and not self.uploaded:
-            return reverse(
-                'project_version_detail',
-                kwargs={
-                    'project_slug': self.project.slug,
-                    'version_slug': self.slug,
-                },
+            # TODO: Stop assuming protocol based on settings.DEBUG
+            # (this pattern is also used in builds.tasks for sending emails)
+            protocol = "http" if settings.DEBUG else "https"
+            return "{}://{}{}".format(
+                protocol,
+                settings.PRODUCTION_DOMAIN,
+                reverse(
+                    "project_version_detail",
+                    kwargs={
+                        "project_slug": self.project.slug,
+                        "version_slug": self.slug,
+                    },
+                ),
             )
         external = self.type == EXTERNAL
         return self.project.get_docs_url(

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -446,8 +446,8 @@ class GitHubService(Service):
         project = build.project
         owner, repo = build_utils.get_github_username_repo(url=project.repo)
 
-        # select the correct state and description.
-        github_build_state = SELECT_BUILD_STATUS[status]["github"]
+        # select the correct status and description.
+        github_build_status = SELECT_BUILD_STATUS[status]["github"]
         description = SELECT_BUILD_STATUS[status]["description"]
         statuses_url = f"https://api.github.com/repos/{owner}/{repo}/statuses/{commit}"
 
@@ -461,15 +461,15 @@ class GitHubService(Service):
         context = f'{settings.RTD_BUILD_STATUS_API_NAME}:{project.slug}'
 
         data = {
-            'state': github_build_state,
-            'target_url': target_url,
-            'description': description,
-            'context': context,
+            "state": github_build_status,
+            "target_url": target_url,
+            "description": description,
+            "context": context,
         }
 
         log.bind(
             project_slug=project.slug,
-            commit_status=github_build_state,
+            commit_status=github_build_status,
             user_username=self.user.username,
             statuses_url=statuses_url,
         )

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -472,6 +472,8 @@ class GitHubService(Service):
             commit_status=github_build_status,
             user_username=self.user.username,
             statuses_url=statuses_url,
+            target_url=target_url,
+            status=status,
         )
         resp = None
         try:

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -429,6 +429,8 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         """
         Celery handler to be executed when a task fails.
 
+        Updates build data, adds tasks to send build notifications.
+
         .. note::
 
            Since the task has failed, some attributes from the `self.data`
@@ -520,7 +522,10 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
             )
 
         # Update build object
-        self.data.build['success'] = False
+        if isinstance(exc, BuildUserSkip):
+            self.data.build["success"] = True
+        else:
+            self.data.build["success"] = False
 
     def get_valid_artifact_types(self):
         """

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -422,7 +422,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
     def _reset_build(self):
         # Reset build only if it has some commands already.
         if self.data.build.get("commands"):
-            log.info("Reseting build.")
+            log.info("Resetting build.")
             api_v2.build(self.data.build["id"]).reset.post()
 
     def on_failure(self, exc, task_id, args, kwargs, einfo):


### PR DESCRIPTION
Fixes https://github.com/readthedocs/readthedocs.org/issues/10364

Reviewing
---------

Nothing complicated here, the bug is very obvious: GitHub (and probably also GitLab) failed our API calls because we set a `target_url` like `target_url=/dashboard/test-builds2/version/2102/edit/` and GitHub said: `target_url must use http(s) scheme`

I added information to our logs that helped resolve this issue.

```
celery_1       | [warning  ] GitHub commit status creation failed. Unknown GitHub response. [readthedocs.oauth.services.github] build_id=87 builder=09e496859ed3 commit=1cd07f31dcecdcbedbbae5b0997a13879ae7f2f8 commit_status=success debug_data={'message': 'Validation Failed', 'errors': [{'resource': 'Status', 'code': 'custom', 'field': 'target_url', 'message': 'target_url must use http(s) scheme'}], 'documentation_url': 'https://docs.github.com/rest/commits/statuses#create-a-commit-status'} http_status_code=422 integration_type=github_webhook ip=140.82.115.29 parent_task_id=7bbed1ea-d40f-42c3-9f1b-1e9e43ed0631 path_resolved=/usr/src/app/checkouts/readthedocs.org/user_builds/09e496859ed3/test-builds2/checkouts/2102/.readthedocs.yaml project_slug=test-builds2 request_id=500601fc-3801-447e-b65c-d2f0cceff0e9 social_account_id=1 social_provider=github status=success statuses_url=https://api.github.com/repos/readthedocs/test-builds/statuses/1cd07f31dcecdcbedbbae5b0997a13879ae7f2f8 target_url=/dashboard/test-builds2/version/2102/edit/ task_id=f0c811bb-3276-464a-a2f7-6acbee788ce3 user_id=None user_username=x version_slug=2102 webhook_event=pull_request
```

Curious case
------------

Notice this line in the changeset: `if not self.built and not self.uploaded` 

This was the reason why SOME PRs had "success :heavy_check_mark:" while PRs where the FIRST commit was supposed to be skipped got "pending :yellow_circle:" forever.

Q&A
---

I had a look around the codebase for uses of `Version.get_absolute_url` and it's only used in ways that seem to have the correct output, i.e. does not prepend any additional https:// -- so we won't suddenly have `https://domain/https://domain` or similar :heavy_check_mark: 