### PR TITLE
Bower: disable `strict-ssl`

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "strict-ssl": false
+}


### PR DESCRIPTION
I had to disable strict SSL on Bower due to an error with jQuery: https://github.com/bower/bower/issues/2608

I'm not sure if this is strictly required, but I'm creating a PR in case we need to this in production as well.

Related #10356