### PR TITLE
Build: avoid breaking builds when a new argument is added to a task

### DIFF
--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -238,7 +238,11 @@ class SyncRepositoryTask(SyncRepositoryMixin, Task):
     base=SyncRepositoryTask,
     bind=True,
 )
-def sync_repository_task(self, version_id):
+def sync_repository_task(self, version_id, **kwargs):
+    # In case we pass more arguments than expected, log them and ignore them,
+    # so we don't break builds while we deploy a change that requires an extra argument.
+    if kwargs:
+        log.warning("Extra arguments passed to sync_repository_task", arguments=kwargs)
     lock_id = f"{self.name}-lock-{self.data.project.slug}"
     with memcache_lock(
         lock_id=lock_id, lock_expire=60, app_identifier=self.app.oid
@@ -939,5 +943,9 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
     bind=True,
     ignore_result=True,
 )
-def update_docs_task(self, version_id, build_id, build_commit=None):
+def update_docs_task(self, version_id, build_id, build_commit=None, **kwargs):
+    # In case we pass more arguments than expected, log them and ignore them,
+    # so we don't break builds while we deploy a change that requires an extra argument.
+    if kwargs:
+        log.warning("Extra arguments passed to update_docs_task", arguments=kwargs)
     self.execute()


### PR DESCRIPTION
For https://github.com/readthedocs/readthedocs.org/pull/10289/ we are going to need to pass a new argument (build_api_key). And since we deploy webs first,
builders will have the old task that doesn't match the new signature, and the task will fail.

To avoid this, we can just accept any kwargs,
this obviously only works if the change is backwards compatible with the old code from the builders (in this case it will be).