### PR TITLE
Build: merge `BaseEnvironment` with `BuildEnvironment`

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -429,6 +429,7 @@ class BaseBuildEnvironment:
         config=None,
         environment=None,
         record=True,
+        **kwargs,
     ):
         self.project = project
         self._environment = environment or {}
@@ -447,7 +448,8 @@ class BaseBuildEnvironment:
         return
 
     def record_command(self, command):
-        pass
+        if self.record:
+            command.save()
 
     def run(self, *cmd, **kwargs):
         """Shortcut to run command from environment."""

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -430,7 +430,7 @@ class BaseBuildEnvironment:
         environment=None,
         record=True,
     ):
-        self.project= project
+        self.project = project
         self._environment = environment or {}
         self.commands = []
         self.version = version

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -481,16 +481,14 @@ class BaseBuildEnvironment:
 
         # Remove PATH from env, and set it to bin_path if it isn't passed in
         environment = self._environment.copy()
-        env_path = environment.pop('BIN_PATH', None)
-        if 'bin_path' not in kwargs and env_path:
-            kwargs['bin_path'] = env_path
-        if 'environment' in kwargs:
-            raise BuildAppError('environment can\'t be passed in via commands.')
-        kwargs['environment'] = environment
-
-        # ``build_env`` is passed as ``kwargs`` when it's called from a
-        # ``*BuildEnvironment``
-        build_cmd = cls(cmd, build_env=self, **kwargs)
+        env_path = environment.pop("BIN_PATH", None)
+        if "bin_path" not in kwargs and env_path:
+            kwargs["bin_path"] = env_path
+        if "environment" in kwargs:
+            raise BuildAppError("environment can't be passed in via commands.")
+        kwargs["environment"] = environment
+        kwargs["build_env"] = self
+        build_cmd = cls(cmd, **kwargs)
         build_cmd.run()
 
         if record:

--- a/readthedocs/vcs_support/base.py
+++ b/readthedocs/vcs_support/base.py
@@ -38,7 +38,7 @@ class BaseVCS:
     """
     Base for VCS Classes.
 
-    VCS commands are ran inside a ``LocalEnvironment``.
+    VCS commands are ran inside a ``BaseBuildEnvironment`` subclass.
     """
 
     supports_tags = False  # Whether this VCS supports tags or not.

--- a/readthedocs/vcs_support/base.py
+++ b/readthedocs/vcs_support/base.py
@@ -38,7 +38,7 @@ class BaseVCS:
     """
     Base for VCS Classes.
 
-    VCS commands are ran inside a ``BaseBuildEnvironment`` subclass.
+    VCS commands are executed inside a ``BaseBuildEnvironment`` subclass.
     """
 
     supports_tags = False  # Whether this VCS supports tags or not.


### PR DESCRIPTION
We aren't using the LocalEnvironment class,
only the BuildEnvironment, so there is no need to keep BaseEnvironment seperated from BuildEnvironment.

Doing this small refactors while trying to implement https://github.com/readthedocs/readthedocs.org/pull/10289/.