### PR TITLE
Logs: remove caching without tags log warning

### DIFF
--- a/readthedocs/proxito/cache.py
+++ b/readthedocs/proxito/cache.py
@@ -45,11 +45,6 @@ def cache_response(response, cache_tags=None, force=True):
     if cache_tags:
         add_cache_tags(response, cache_tags)
     if force or CDN_CACHE_CONTROL_HEADER not in response.headers:
-        if not response.headers.get(CACHE_TAG_HEADER):
-            # Caching a response at the CDN level without cache tags is
-            # incorrect, since we won't be able to purge it otherwise.
-            log.warning("Caching response without cache tags.")
-
         response.headers[CDN_CACHE_CONTROL_HEADER] = "public"
 
 


### PR DESCRIPTION
This line is being logged because for some responses we add the cache tags later in the middleware.

We have plenty of tests to make sure the cache tags are present, so this isn't a problem.

This is filling our logs, so we are removing it.