### PR TITLE
Docs: Define 'maintainer' so we can reference it

### DIFF
--- a/docs/user/glossary.rst
+++ b/docs/user/glossary.rst
@@ -48,14 +48,9 @@ so that you have a reference for how we're using them.
       A *maintainer* is a special role that only exists on |org_brand|.
       The creator of a project on |org_brand| can invite other collaborators as *maintainers* with full ownership rights.
 
-      At least one maintainer of a Read the Docs project should have admin rights to the Git repository.
-      This ensures that all settings of the Git repository can remain updated over time.
+      The *maintainer* role does not exist on |com_brand|, which instead provides :doc:`/commercial/organizations`.
 
-      Git provider integration is active through the authentication of the maintainter that creates the integration.
-      If a maintainer is removed,
-      make sure to verify and potentially recreate all Git integration *if* removing the maintainer that originally configured this.
-
-      On |com_brand|, you can use :doc:`/commercial/organizations`.
+      Please see :ref:`guides/git-repo-automatic:Projects with several admins` for more information.
 
    pinning
       To *pin* a requirement means to explicitly specify which version should be used.

--- a/docs/user/glossary.rst
+++ b/docs/user/glossary.rst
@@ -50,7 +50,7 @@ so that you have a reference for how we're using them.
 
       The *maintainer* role does not exist on |com_brand|, which instead provides :doc:`/commercial/organizations`.
 
-      Please see :ref:`guides/git-repo-automatic:Projects with several admins` for more information.
+      Please see :ref:`guides/setup/git-repo-automatic:Projects with several admins` for more information.
 
    pinning
       To *pin* a requirement means to explicitly specify which version should be used.

--- a/docs/user/glossary.rst
+++ b/docs/user/glossary.rst
@@ -44,6 +44,19 @@ so that you have a reference for how we're using them.
       and rules for publication of documentation can be :doc:`automated </automation-rules>`.
       Similar to :term:`Docs as Code`.
 
+   maintainer
+      A *maintainer* is a special role that only exists on |org_brand|.
+      The creator of a project on |org_brand| can invite other collaborators as *maintainers* with full ownership rights.
+
+      At least one maintainer of a Read the Docs project should have admin rights to the Git repository.
+      This ensures that all settings of the Git repository can remain updated over time.
+
+      Git provider integration is active through the authentication of the maintainter that creates the integration.
+      If a maintainer is removed,
+      make sure to verify and potentially recreate all Git integration *if* removing the maintainer that originally configured this.
+
+      On |com_brand|, you can use :doc:`/commercial/organizations`.
+
    pinning
       To *pin* a requirement means to explicitly specify which version should be used.
       *Pinning* software requirements is the most important technique to make a project :term:`reproducible`.

--- a/docs/user/guides/setup/git-repo-automatic.rst
+++ b/docs/user/guides/setup/git-repo-automatic.rst
@@ -94,11 +94,10 @@ We also use the token to send back build statuses and preview URLs for :doc:`pul
 Projects with several admins
 ----------------------------
 
-If your project is using :doc:`Organizations </commercial/organizations>` (|com_brand|) or :term:`maintainers` (|org_brand|),
+If your project is using :doc:`Organizations </commercial/organizations>` (|com_brand|) or :term:`maintainers <maintainer>` (|org_brand|),
 then you need to be aware of *who* is setting up the integration for the project.
 
-At least one admin of a Read the Docs project should have admin rights to the Git repository.
-This ensures that all settings of the Git repository can remain updated over time.
+The admin of the Read the Docs project who sets up the project through the automatic import should also have admin rights to the Git repository.
 
 Git provider integration is active through the authentication of the admin that creates the integration.
 If an admin is removed,

--- a/docs/user/guides/setup/git-repo-automatic.rst
+++ b/docs/user/guides/setup/git-repo-automatic.rst
@@ -91,6 +91,18 @@ We also use the token to send back build statuses and preview URLs for :doc:`pul
   This is a function offered by all Git providers.
 
 
+Projects with several admins
+----------------------------
+
+If your project is using :doc:`Organizations </commercial/organizations>` (|com_brand|) or :term:`maintainers` (|org_brand|),
+then you need to be aware of *who* is setting up the integration for the project.
+
+At least one admin of a Read the Docs project should have admin rights to the Git repository.
+This ensures that all settings of the Git repository can remain updated over time.
+
+Git provider integration is active through the authentication of the admin that creates the integration.
+If an admin is removed,
+make sure to verify and potentially recreate all Git integration *if* removing the maintainer that originally configured this.
 
 Permissions for connected accounts
 ----------------------------------


### PR DESCRIPTION
@agjohnson Some context: I'm adding doc links to all future Dashboard pages. The "Maintainers" page falls a bit outside of category since it's a feature that only exists on .org

Instead of posting an issue that's never gonna get fixed, I think we can just add this quick glossary item.

Review:

* Do you spot something technically incorrect?
* Welcome to pass the review to someone else :+1: 

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10381.org.readthedocs.build/en/10381/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10381.org.readthedocs.build/en/10381/

<!-- readthedocs-preview dev end -->