### PR TITLE
Doc: Remove broken reference

### DIFF
--- a/docs/user/guides/jupyter.rst
+++ b/docs/user/guides/jupyter.rst
@@ -410,8 +410,8 @@ As a result, there are three modes of operation:
 
 These approaches are not mutually exclusive,
 nor you have to use a single format for all your notebooks.
-For the examples in this document, we have used the :ref:`MyST Markdown
-format <jupytext:formats.md#myst-markdown>`.
+For the examples in this document, we have used the :doc:`MyST Markdown
+format <jupytext:formats>`.
 
 If you are using alternative formats for Jupyter notebooks,
 you can include them in your Sphinx documentation


### PR DESCRIPTION
MyST does not pass autosectionlabel to intersphinx - see https://github.com/executablebooks/MyST-Parser/issues/731

(doesn't look like that's gonna be fixed, neither)

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10382.org.readthedocs.build/en/10382/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10382.org.readthedocs.build/en/10382/

<!-- readthedocs-preview dev end -->