### PR TITLE
Try to bump up config file search in ranking

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -36,6 +36,8 @@ search:
     # Deprecated content
     api/v1.html: -1
     config-file/v1.html: -5
+    config-file/v2.html: 5
+    config-file/index.html: 5
 
     # Useful content, but not something we want most users finding
     changelog.html: -6


### PR DESCRIPTION
I've noticed this page is hard to get search results for. I wasn't
getting search hits until mostly typing out "configuration". This seems
more a problem with word root or missing search terms on the config file
page, but I do agree that the page title should be "Configuration file"