### PR TITLE
Sphinx: don't override html_context by default

### DIFF
--- a/docs/user/feature-flags.rst
+++ b/docs/user/feature-flags.rst
@@ -17,8 +17,6 @@ Available flags
 Makes Read the Docs to install all the requirements at once on ``conda create`` step.
 This helps users to pin dependencies on conda and to improve build time.
 
-``DONT_OVERWRITE_SPHINX_CONTEXT``: Do not overwrite context vars in conf.py with Read the Docs context.
-
 ``DONT_CREATE_INDEX``: Do not create index.md or README.rst if the project does not have one.
 
 When Read the Docs detects that your project doesn't have an ``index.md`` or ``README.rst``,

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -258,9 +258,6 @@ class BaseSphinx(BaseBuilder):
             'display_gitlab': display_gitlab,
 
             # Features
-            'dont_overwrite_sphinx_context': self.project.has_feature(
-                Feature.DONT_OVERWRITE_SPHINX_CONTEXT,
-            ),
             "docsearch_disabled": self.project.has_feature(
                 Feature.DISABLE_SERVER_SIDE_SEARCH
             ),

--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -160,13 +160,9 @@ if version_info >= (1, 8):
 {% block extra_context %}{% endblock %}
 
 if 'html_context' in globals():
-    {% if dont_overwrite_sphinx_context %}
     for key in context:
         if key not in html_context:
             html_context[key] = context[key]
-    {% else %}
-    html_context.update(context)
-    {% endif %}
 else:
     html_context = context
 

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1862,7 +1862,6 @@ class Feature(models.Model):
     # Feature constants - this is not a exhaustive list of features, features
     # may be added by other packages
     ALLOW_DEPRECATED_WEBHOOKS = "allow_deprecated_webhooks"
-    DONT_OVERWRITE_SPHINX_CONTEXT = "dont_overwrite_sphinx_context"
     SKIP_SPHINX_HTML_THEME_PATH = "skip_sphinx_html_theme_path"
     MKDOCS_THEME_RTD = "mkdocs_theme_rtd"
     API_LARGE_DATA = "api_large_data"
@@ -1915,12 +1914,6 @@ class Feature(models.Model):
 
     FEATURES = (
         (ALLOW_DEPRECATED_WEBHOOKS, _("Webhook: Allow deprecated webhook views")),
-        (
-            DONT_OVERWRITE_SPHINX_CONTEXT,
-            _(
-                "Sphinx: Do not overwrite context vars in conf.py with Read the Docs context",
-            ),
-        ),
         (
             SKIP_SPHINX_HTML_THEME_PATH,
             _(


### PR DESCRIPTION
We have this feature enabled on .org and .com,
we haven't heard any complaints.

Closes https://github.com/readthedocs/readthedocs.org/issues/10293

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10394.org.readthedocs.build/en/10394/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10394.org.readthedocs.build/en/10394/

<!-- readthedocs-preview dev end -->