### PR TITLE
Fixes on Git providers

### DIFF
--- a/docs/user/glossary.rst
+++ b/docs/user/glossary.rst
@@ -50,7 +50,7 @@ so that you have a reference for how we're using them.
 
       The *maintainer* role does not exist on |com_brand|, which instead provides :doc:`/commercial/organizations`.
 
-      Please see :ref:`guides/setup/git-repo-automatic:Projects with several admins` for more information.
+      Please see :ref:`guides/setup/git-repo-automatic:git provider integrations` for more information.
 
    pinning
       To *pin* a requirement means to explicitly specify which version should be used.

--- a/docs/user/guides/setup/git-repo-automatic.rst
+++ b/docs/user/guides/setup/git-repo-automatic.rst
@@ -91,17 +91,17 @@ We also use the token to send back build statuses and preview URLs for :doc:`pul
   This is a function offered by all Git providers.
 
 
-Projects with several admins
-----------------------------
+Git provider integrations
+-------------------------
 
 If your project is using :doc:`Organizations </commercial/organizations>` (|com_brand|) or :term:`maintainers <maintainer>` (|org_brand|),
 then you need to be aware of *who* is setting up the integration for the project.
 
-The admin of the Read the Docs project who sets up the project through the automatic import should also have admin rights to the Git repository.
+The Read the Docs user who sets up the project through the automatic import should also have admin rights to the Git repository.
 
-Git provider integration is active through the authentication of the admin that creates the integration.
-If an admin is removed,
-make sure to verify and potentially recreate all Git integration *if* removing the maintainer that originally configured this.
+A Git provider integration is active through the authentication of the user that creates the integration.
+If this user is removed,
+make sure to verify and potentially recreate all Git integrations for the project.
 
 Permissions for connected accounts
 ----------------------------------


### PR DESCRIPTION
From #10381 a few fixes missed before merging. Just a couple typos edits, but I'd also avoid introducing the term "admin" on top of user/maintainer/teams/etc.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10395.org.readthedocs.build/en/10395/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10395.org.readthedocs.build/en/10395/

<!-- readthedocs-preview dev end -->