### PR TITLE
Docs: Split email notifications and webhook notifications into separate howtos

### DIFF
--- a/docs/user/build-notifications.rst
+++ b/docs/user/build-notifications.rst
@@ -1,7 +1,7 @@
 Build notifications via webhooks and email
 ==========================================
 
-Build notifications can alert you when your builds fail so you can take immediate action.
+Build notifications can alert you when your documentation builds fail so you can take immediate action.
 We offer the following methods for being notified:
 
 Email notifications:

--- a/docs/user/build-notifications.rst
+++ b/docs/user/build-notifications.rst
@@ -2,6 +2,7 @@ Build notifications via webhooks and email
 ==========================================
 
 Build notifications can alert you when your builds fail so you can take immediate action.
+We offer the following methods for being notified:
 
 Email notifications:
   Read the Docs allows you to configure build notifications via email.
@@ -22,7 +23,7 @@ Build Status Webhooks:
         so you always know that your docs are deploying successfully.
 
     :doc:`/guides/build/webhooks`
-        Steps for setting up build notifications with webhooks,
+        Steps for setting up build notifications via webhooks,
         including examples for popular platforms like Slack and Discord.
 
     :doc:`pull-requests`

--- a/docs/user/build-notifications.rst
+++ b/docs/user/build-notifications.rst
@@ -17,8 +17,12 @@ Build Status Webhooks:
   Webhooks can be customized through your own template and a variety of variable substitutions.
 
 .. seealso::
-    :doc:`/guides/build-notifications`
-        All the practical steps for setting up build notifications
+    :doc:`/guides/build/email-notifications`
+        Enable email notifications in a second.
+
+    :doc:`/guides/build/webhooks`
+        Steps for setting up build notifications with webhooks,
+        including examples for popular platforms like Slack and Discord.
 
     :doc:`pull-requests`
         Similarly to build notifications, you can also configure automated feedback for your pull requests.

--- a/docs/user/build-notifications.rst
+++ b/docs/user/build-notifications.rst
@@ -17,6 +17,10 @@ Build Status Webhooks:
 
   Webhooks can be customized through your own template and a variety of variable substitutions.
 
+.. note::
+
+   We don't trigger email notifications or build status webhooks on :doc:`builds from pull requests </pull-requests>`.
+
 .. seealso::
     :doc:`/guides/build/email-notifications`
         Enable email notifications on failed builds,
@@ -27,4 +31,5 @@ Build Status Webhooks:
         including examples for popular platforms like Slack and Discord.
 
     :doc:`pull-requests`
-        Similarly to build notifications, you can also configure automated feedback for your pull requests.
+        Similarly to build notifications,
+        you can also configure automated feedback for your pull requests.

--- a/docs/user/build-notifications.rst
+++ b/docs/user/build-notifications.rst
@@ -1,12 +1,12 @@
-Build Notifications and Webhooks
-================================
+Build notifications via webhooks and email
+==========================================
 
-Read the Docs features a number of build notification mechanisms.
 Build notifications can alert you when your builds fail so you can take immediate action.
 
 Email notifications:
-  Read the Docs allows you to configure emails that can be sent on failing builds.
-  This makes sure you know when your builds have failed.
+  Read the Docs allows you to configure build notifications via email.
+  When builds fail,
+  configured email addresses are notified.
 
 Build Status Webhooks:
   Build notifications can happen via :term:`webhooks <webhook>`.

--- a/docs/user/build-notifications.rst
+++ b/docs/user/build-notifications.rst
@@ -18,7 +18,8 @@ Build Status Webhooks:
 
 .. seealso::
     :doc:`/guides/build/email-notifications`
-        Enable email notifications in a second.
+        Enable email notifications on failed builds,
+        so you always know that your docs are deploying successfully.
 
     :doc:`/guides/build/webhooks`
         Steps for setting up build notifications with webhooks,

--- a/docs/user/build-notifications.rst
+++ b/docs/user/build-notifications.rst
@@ -29,7 +29,3 @@ Build Status Webhooks:
     :doc:`/guides/build/webhooks`
         Steps for setting up build notifications via webhooks,
         including examples for popular platforms like Slack and Discord.
-
-    :doc:`pull-requests`
-        Similarly to build notifications,
-        you can also configure automated feedback for your pull requests.

--- a/docs/user/guides/build/email-notifications.rst
+++ b/docs/user/guides/build/email-notifications.rst
@@ -9,12 +9,12 @@ This makes sure that you are aware of failures happening in an otherwise automat
 
 .. seealso::
 
+    :doc:`/guides/build/webhooks`
+        How to use webhooks to be notified about builds on popular platforms like Slack and Discord.
+
     :doc:`/pull-requests`
         Similarly to email notifications,
         you can also configure automated feedback for your pull requests.
-
-    :doc:`/guides/build/webhooks`
-        How to use webhooks to be notified about builds on popular platforms like Slack and Discord.
 
 
 Email notifications

--- a/docs/user/guides/build/email-notifications.rst
+++ b/docs/user/guides/build/email-notifications.rst
@@ -1,0 +1,40 @@
+How to enable email notifications
+=================================
+
+In this guide, you can learn how to setup build notification via email.
+
+.. note::
+
+   Currently we don't send email notifications on :doc:`builds from pull requests </pull-requests>`.
+
+.. tip::
+    :doc:`/pull-requests`
+        Similarly to email notifications,
+        you can also configure automated feedback for your pull requests.
+
+
+Email notifications
+-------------------
+
+Read the Docs allows you to configure emails that can be sent on failing builds.
+This makes sure you know when your builds have failed.
+
+Take these steps to enable build notifications using email:
+
+* Go to :menuselection:`Admin --> Notifications` in your project.
+* Fill in the **Email** field under the **New Email Notifications** heading
+* Submit the form
+
+Who is notified?
+----------------
+
+If you are a single owner of a project,
+*you* will get notified.
+
+If your project has several members,
+then the following are notified:
+
+* All :term:`maintainers <maintainer>` (|org_brand|)
+* All owners of an :doc:`organization </commercial/organizations>` (|com_brand|)
+  that owns the project,
+  or members of teams with admin access to the project.

--- a/docs/user/guides/build/email-notifications.rst
+++ b/docs/user/guides/build/email-notifications.rst
@@ -1,7 +1,7 @@
 How to setup email notifications
 ================================
 
-In this guide,
+In this brief guide,
 you can learn how to setup a simple build notification via email.
 
 Read the Docs allows you to configure emails that will be notified on failing builds.
@@ -13,20 +13,19 @@ This makes sure that you are aware of failures happening in an otherwise automat
         How to use webhooks to be notified about builds on popular platforms like Slack and Discord.
 
     :doc:`/pull-requests`
-        Similarly to email notifications,
-        you can also configure automated feedback for your pull requests.
+        Configure automated feedback and documentation site previews for your pull requests.
 
 
 Email notifications
 -------------------
 
-Take these steps to enable build notifications using email:
+Follow these steps to add an email address to be notified about build failures:
 
 * Go to :menuselection:`Admin --> Notifications` in your project.
 * Fill in the **Email** field under the **New Email Notifications** heading
 * Press :guilabel:`Add` and the email is saved and will be displayed in the list of **Existing notifications**.
 
-A newly added email will be notified once a build fails.
+The newly added email address will be notified once a build fails.
 
 
 .. note::

--- a/docs/user/guides/build/email-notifications.rst
+++ b/docs/user/guides/build/email-notifications.rst
@@ -1,40 +1,34 @@
-How to enable email notifications
-=================================
+How to setup email notifications
+================================
 
-In this guide, you can learn how to setup build notification via email.
+In this guide,
+you can learn how to setup a simple build notification via email.
 
-.. note::
+Read the Docs allows you to configure emails that will be notified on failing builds.
+This makes sure that you are aware of failures happening in an otherwise automated process.
 
-   Currently we don't send email notifications on :doc:`builds from pull requests </pull-requests>`.
+.. seealso::
 
-.. tip::
     :doc:`/pull-requests`
         Similarly to email notifications,
         you can also configure automated feedback for your pull requests.
+
+    :doc:`/guides/build/webhooks`
+        How to use webhooks to be notified about builds on popular platforms like Slack and Discord.
 
 
 Email notifications
 -------------------
 
-Read the Docs allows you to configure emails that can be sent on failing builds.
-This makes sure you know when your builds have failed.
-
 Take these steps to enable build notifications using email:
 
 * Go to :menuselection:`Admin --> Notifications` in your project.
 * Fill in the **Email** field under the **New Email Notifications** heading
-* Submit the form
+* Press :guilabel:`Add` and the email is saved and will be displayed in the list of **Existing notifications**.
 
-Who is notified?
-----------------
+A newly added email will be notified once a build fails.
 
-If you are a single owner of a project,
-*you* will get notified.
 
-If your project has several members,
-then the following are notified:
+.. note::
 
-* All :term:`maintainers <maintainer>` (|org_brand|)
-* All owners of an :doc:`organization </commercial/organizations>` (|com_brand|)
-  that owns the project,
-  or members of teams with admin access to the project.
+   We don't send email notifications on :doc:`builds from pull requests </pull-requests>`.

--- a/docs/user/guides/build/index.rst
+++ b/docs/user/guides/build/index.rst
@@ -1,11 +1,14 @@
 How-to guides: build process
 ============================
 
-⏩️ :doc:`Setup build notifications and webhooks </guides/build-notifications>`
-    Build notifications can alert you when your builds fail so you can take immediate action.
-    In this guide,
-    you will learn how to get notified through various available channel integrations,
-    including email and chat.
+⏩️ :doc:`Enable email notifications </guides/build/email-notifications>`
+    Email notifications can alert you when your builds fail.
+    This is the most simple way to monitor your documentation builds,
+    it only requires you to switch it on.
+
+⏩️ :doc:`Setup webhook notifications </guides/build/webhooks>`
+    Webhook notifications can alert you when your builds fail so you can take immediate action.
+    We show examples of how to use the webhooks on popular platforms like Slack and Discord.
 
 ⏩️ :doc:`Configuring pull request builds </guides/pull-requests>`
     Have your documentation built and access a preview for every :doc:`pull request builds </pull-requests>`.
@@ -28,7 +31,8 @@ How-to guides: build process
    :maxdepth: 1
    :hidden:
 
-   Setup build notifications and webhooks </guides/build-notifications>
+   Enable email notifications </guides/build/email-notifications>
+   Setup webhook notifications </guides/build/webhooks>
    Configuring pull request builds </guides/pull-requests>
    Using custom environment variables </guides/environment-variables>
    Managing versions automatically </guides/automation-rules>

--- a/docs/user/guides/build/index.rst
+++ b/docs/user/guides/build/index.rst
@@ -1,7 +1,7 @@
 How-to guides: build process
 ============================
 
-⏩️ :doc:`Enable email notifications </guides/build/email-notifications>`
+⏩️ :doc:`Setup email notifications </guides/build/email-notifications>`
     Email notifications can alert you when your builds fail.
     This is the most simple way to monitor your documentation builds,
     it only requires you to switch it on.
@@ -31,7 +31,7 @@ How-to guides: build process
    :maxdepth: 1
    :hidden:
 
-   Enable email notifications </guides/build/email-notifications>
+   Setup email notifications </guides/build/email-notifications>
    Setup webhook notifications </guides/build/webhooks>
    Configuring pull request builds </guides/pull-requests>
    Using custom environment variables </guides/environment-variables>

--- a/docs/user/guides/build/webhooks.rst
+++ b/docs/user/guides/build/webhooks.rst
@@ -1,22 +1,24 @@
-How to setup webhook notifications
+How to setup build status webhooks
 ==================================
 
-In this guide, you can learn how to setup build notification with webhooks.
-Build notifications can alert you when your builds fail so you can take immediate action.
+In this guide,
+you can learn how to setup build notifications via webhooks.
+
+Read the Docs can notify external :term:`webhooks <webhook>` when builds are triggered, successful or failed.
+In that way,
+you can receive build notifications in your own monitoring channels and be alerted you when your builds fail so you can take immediate action.
 
 .. seealso::
 
     :doc:`/guides/build/email-notifications`
-        How to setup a basic email notification for build failures.
+        Setup basic email notifications for build failures.
 
     :doc:`/pull-requests`
-        Similarly to email notifications,
-        you can also configure automated feedback for your pull requests.
+        Configure automated feedback and documentation site previews for your pull requests.
+
 
 Build status webhooks
 ---------------------
-
-Read the Docs can also send webhooks when builds are triggered, successful or failed.
 
 Take these steps to enable build notifications using a webhook:
 

--- a/docs/user/guides/build/webhooks.rst
+++ b/docs/user/guides/build/webhooks.rst
@@ -9,6 +9,10 @@ Build notifications can alert you when your builds fail so you can take immediat
     :doc:`/guides/build/email-notifications`
         How to setup a basic email notification for build failures.
 
+    :doc:`/pull-requests`
+        Similarly to email notifications,
+        you can also configure automated feedback for your pull requests.
+
 Build status webhooks
 ---------------------
 

--- a/docs/user/guides/build/webhooks.rst
+++ b/docs/user/guides/build/webhooks.rst
@@ -1,37 +1,18 @@
-How to setup build notifications and webhooks
-=============================================
+How to setup webhook notifications
+==================================
 
-In this guide, you can learn how to setup a number of build notification mechanisms.
+In this guide, you can learn how to setup build notification with webhooks.
 Build notifications can alert you when your builds fail so you can take immediate action.
 
 .. note::
 
-   Currently we don't send notifications or trigger :term:`webhooks <webhook>`
-   on :doc:`builds from pull requests </pull-requests>`.
+   Currently we don't trigger :term:`webhooks <webhook>` on :doc:`builds from pull requests </pull-requests>`.
 
 
 .. tip::
     :doc:`/pull-requests`
-        Similarly to build notifications, you can also configure automated feedback for your pull requests.
-
-
-.. contents:: Contents
-    :local:
-
-
-Email notifications
--------------------
-
-Read the Docs allows you to configure emails that can be sent on failing builds.
-This makes sure you know when your builds have failed.
-
-Take these steps to enable build notifications using email:
-
-* Go to :guilabel:`Admin` > :guilabel:`Notifications` in your project.
-* Fill in the **Email** field under the **New Email Notifications** heading
-* Submit the form
-
-You should now get notified by email when your builds fail!
+        Similarly to webhook notifications,
+        you can also configure automated feedback for your pull requests.
 
 Build status webhooks
 ---------------------
@@ -40,7 +21,7 @@ Read the Docs can also send webhooks when builds are triggered, successful or fa
 
 Take these steps to enable build notifications using a webhook:
 
-* Go to :guilabel:`Admin` > :guilabel:`Webhooks` in your project.
+* Go to :menuselection:`Admin --> Webhooks` in your project.
 * Fill in the **URL** field and select what events will trigger the webhook
 * Modify the payload or leave the default (see below)
 * Click on :guilabel:`Save`
@@ -80,7 +61,7 @@ you will see the server response, the webhook request, and the payload.
    Activity of a webhook
 
 Custom payload examples
-~~~~~~~~~~~~~~~~~~~~~~~
+-----------------------
 
 You can customize the payload of the webhook to suit your needs,
 as long as it is valid JSON. Below you have a couple of examples,
@@ -93,84 +74,84 @@ and in the following section you will find all the available variables.
 
    Custom payload
 
-Slack
-+++++
+.. tabs::
 
-.. code-block:: json
+   .. tab:: Slack
 
-   {
-     "attachments": [
-       {
-         "color": "#db3238",
-         "blocks": [
-           {
-             "type": "section",
-             "text": {
-               "type": "mrkdwn",
-               "text": "*Read the Docs build failed*"
+      .. code-block:: json
+
+         {
+           "attachments": [
+             {
+               "color": "#db3238",
+               "blocks": [
+                 {
+                   "type": "section",
+                   "text": {
+                     "type": "mrkdwn",
+                     "text": "*Read the Docs build failed*"
+                   }
+                 },
+                 {
+                   "type": "section",
+                   "fields": [
+                     {
+                       "type": "mrkdwn",
+                       "text": "*Project*: <{{ project.url }}|{{ project.name }}>"
+                     },
+                     {
+                       "type": "mrkdwn",
+                       "text": "*Version*: {{ version.name }} ({{ build.commit }})"
+                     },
+                     {
+                       "type": "mrkdwn",
+                       "text": "*Build*: <{{ build.url }}|{{ build.id }}>"
+                     }
+                   ]
+                 }
+               ]
              }
-           },
-           {
-             "type": "section",
-             "fields": [
-               {
-                 "type": "mrkdwn",
-                 "text": "*Project*: <{{ project.url }}|{{ project.name }}>"
-               },
-               {
-                 "type": "mrkdwn",
-                 "text": "*Version*: {{ version.name }} ({{ build.commit }})"
-               },
-               {
-                 "type": "mrkdwn",
-                 "text": "*Build*: <{{ build.url }}|{{ build.id }}>"
-               }
-             ]
-           }
-         ]
-       }
-     ]
-   }
+           ]
+         }
 
-More information on `the Slack Incoming Webhooks documentation <https://api.slack.com/messaging/webhooks>`_.
+      More information on `the Slack Incoming Webhooks documentation <https://api.slack.com/messaging/webhooks>`_.
 
-Discord
-+++++++
+   .. tab:: Discord
 
-.. code-block:: json
+      .. code-block:: json
 
-   {
-     "username": "Read the Docs",
-     "content": "Read the Docs build failed",
-     "embeds": [
-       {
-         "title": "Build logs",
-         "url": "{{ build.url }}",
-         "color": 15258703,
-         "fields": [
-           {
-             "name": "*Project*",
-             "value": "{{ project.url }}",
-             "inline": true
-           },
-           {
-             "name": "*Version*",
-             "value": "{{ version.name }} ({{ build.commit }})",
-             "inline": true
-           },
-           {
-             "name": "*Build*",
-             "value": "{{ build.url }}"
-           }
-         ]
-       }
-     ]
-   }
+         {
+           "username": "Read the Docs",
+           "content": "Read the Docs build failed",
+           "embeds": [
+             {
+               "title": "Build logs",
+               "url": "{{ build.url }}",
+               "color": 15258703,
+               "fields": [
+                 {
+                   "name": "*Project*",
+                   "value": "{{ project.url }}",
+                   "inline": true
+                 },
+                 {
+                   "name": "*Version*",
+                   "value": "{{ version.name }} ({{ build.commit }})",
+                   "inline": true
+                 },
+                 {
+                   "name": "*Build*",
+                   "value": "{{ build.url }}"
+                 }
+               ]
+             }
+           ]
+         }
 
-More information on `the Discord webhooks documentation <https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks>`_.
+      More information on `the Discord webhooks documentation <https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks>`_.
 
 Variable substitutions reference
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------
 
 ``{{ event }}``
   Event that triggered the webhook, one of ``build:triggered``, ``build:failed``, or ``build:passed``.
@@ -213,7 +194,7 @@ Variable substitutions reference
   Version name.
 
 Validating the payload
-~~~~~~~~~~~~~~~~~~~~~~
+----------------------
 
 After you add a new webhook, Read the Docs will generate a secret key for it
 and uses it to generate a hash signature (HMAC-SHA256) for each payload
@@ -255,7 +236,7 @@ like this:
        )
 
 Legacy webhooks
-~~~~~~~~~~~~~~~
+---------------
 
 Webhooks created before the custom payloads functionality was added to Read the Docs
 send a payload with the following structure:

--- a/docs/user/guides/build/webhooks.rst
+++ b/docs/user/guides/build/webhooks.rst
@@ -4,15 +4,10 @@ How to setup webhook notifications
 In this guide, you can learn how to setup build notification with webhooks.
 Build notifications can alert you when your builds fail so you can take immediate action.
 
-.. note::
+.. seealso::
 
-   Currently we don't trigger :term:`webhooks <webhook>` on :doc:`builds from pull requests </pull-requests>`.
-
-
-.. tip::
-    :doc:`/pull-requests`
-        Similarly to webhook notifications,
-        you can also configure automated feedback for your pull requests.
+    :doc:`/guides/build/email-notifications`
+        How to setup a basic email notification for build failures.
 
 Build status webhooks
 ---------------------
@@ -60,8 +55,13 @@ you will see the server response, the webhook request, and the payload.
 
    Activity of a webhook
 
+.. note::
+
+   We don't trigger :term:`webhooks <webhook>` on :doc:`builds from pull requests </pull-requests>`.
+
+
 Custom payload examples
------------------------
+~~~~~~~~~~~~~~~~~~~~~~~
 
 You can customize the payload of the webhook to suit your needs,
 as long as it is valid JSON. Below you have a couple of examples,
@@ -151,7 +151,7 @@ and in the following section you will find all the available variables.
       More information on `the Discord webhooks documentation <https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks>`_.
 
 Variable substitutions reference
---------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``{{ event }}``
   Event that triggered the webhook, one of ``build:triggered``, ``build:failed``, or ``build:passed``.

--- a/docs/user/guides/build/webhooks.rst
+++ b/docs/user/guides/build/webhooks.rst
@@ -4,7 +4,8 @@ How to setup build status webhooks
 In this guide,
 you can learn how to setup build notifications via webhooks.
 
-Read the Docs can notify external :term:`webhooks <webhook>` when builds are triggered, successful or failed.
+When a documentation build is *triggered*, *successful* or *failed*,
+Read the Docs can notify external APIs using :term:`webhooks <webhook>`.
 In that way,
 you can receive build notifications in your own monitoring channels and be alerted you when your builds fail so you can take immediate action.
 

--- a/docs/user/guides/setup/git-repo-manual.rst
+++ b/docs/user/guides/setup/git-repo-manual.rst
@@ -139,8 +139,11 @@ Use this URL when setting up a new integration with your provider ^^ these steps
 
 .. seealso::
 
-   :doc:`/guides/build-notifications`
-      Learn how to add custom build notifications.
+   :doc:`/guides/build/email-notifications`
+      Quickly enable email notifications.
+
+   :doc:`/guides/build/webhooks`
+      Learn how to add custom webhook notifications.
 
 
 .. _webhook-integration-generic:


### PR DESCRIPTION
This splits existing howtos into two separate articles:

* ~Very little text editing~ Editing a lot of the texts for clarity and smoothness
* Added cross-references
* Updated references
* Tabbed interface for Discord/Slack payload examples

Refs: #9747 

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10396.org.readthedocs.build/en/10396/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10396.org.readthedocs.build/en/10396/

<!-- readthedocs-preview dev end -->