### PR TITLE
Docs: Add $READTHEDOCS_OUTPUT to environment variable reference

### DIFF
--- a/docs/user/reference/environment-variables.rst
+++ b/docs/user/reference/environment-variables.rst
@@ -53,7 +53,8 @@ All :doc:`build processes </builds>` have the following environment variables au
 
 .. envvar:: READTHEDOCS_OUTPUT
 
-    Base path for output formats when using custom :doc:`build.commands </build-customization>` to generate output.
+    Base path for well-known output directories. Files in these directories will automatically be found, uploaded and published.
+
     You need to concatenate an output format,
     for instance ``$READTHEDOCS_OUTPUT/html/`` or ``$READTHEDOCS_OUTPUT/pdf/``.
     You also need to create the directory,

--- a/docs/user/reference/environment-variables.rst
+++ b/docs/user/reference/environment-variables.rst
@@ -51,6 +51,19 @@ All :doc:`build processes </builds>` have the following environment variables au
 
     :Example: ``/home/docs/checkouts/readthedocs.org/user_builds/project/envs/version``
 
+.. envvar:: READTHEDOCS_OUTPUT
+
+    Base path for output formats when using custom :doc:`build.commands </build-customization>` to generate output.
+    You need to concatenate an output format,
+    for instance ``$READTHEDOCS_OUTPUT/html/`` or ``$READTHEDOCS_OUTPUT/pdf/``.
+    You also need to create the directory,
+    for instance by adding a command ``mkdir -p $READTHEDOCS_OUTPUT/html/`` before moving outputs into the destination.
+
+    .. seealso::
+
+       :ref:`build-customization:where to put files`
+          Information about using custom commands to generate output that will automatically be published once your build succeeds.
+
 .. envvar:: READTHEDOCS_CANONICAL_URL
 
     Canonical base URL for the version that is built.

--- a/docs/user/reference/environment-variables.rst
+++ b/docs/user/reference/environment-variables.rst
@@ -55,10 +55,13 @@ All :doc:`build processes </builds>` have the following environment variables au
 
     Base path for well-known output directories. Files in these directories will automatically be found, uploaded and published.
 
-    You need to concatenate an output format,
-    for instance ``$READTHEDOCS_OUTPUT/html/`` or ``$READTHEDOCS_OUTPUT/pdf/``.
-    You also need to create the directory,
-    for instance by adding a command ``mkdir -p $READTHEDOCS_OUTPUT/html/`` before moving outputs into the destination.
+    You need to concatenate an output format to this variable.
+    Currently valid formats are ``html``, ``pdf``, ``htmlzip`` and ``epub``.
+    (e.g. ``$READTHEDOCS_OUTPUT/html/`` or ``$READTHEDOCS_OUTPUT/pdf/``)
+    You also need to create the directory before moving outputs into the destination.
+    You can create it with the following command ``mkdir -p $READTHEDOCS_OUTPUT/html/``.
+    Note that only ``html`` supports multiple files,
+    the other formats should have one and only one file to be uploaded.
 
     .. seealso::
 


### PR DESCRIPTION
Seems like we forgot this one :)

Refs: https://github.com/readthedocs/readthedocs.org/pull/9913

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10407.org.readthedocs.build/en/10407/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10407.org.readthedocs.build/en/10407/

<!-- readthedocs-preview dev end -->