### PR TITLE
Docs: Correct title case for SEO occurrences

### DIFF
--- a/docs/user/guides/best-practice/index.rst
+++ b/docs/user/guides/best-practice/index.rst
@@ -19,7 +19,7 @@ we have become familiar with a number of methods that work well and which we con
     learn how to protect your project against breaking randomly.
     **This is one of our most popular guides!**
 
-⏩️ :doc:`Search Engine Optimization (SEO) for documentation projects </guides/technical-docs-seo-guide>`
+⏩️ :doc:`Search engine optimization (SEO) for documentation projects </guides/technical-docs-seo-guide>`
     This article explains how documentation can be optimized to appear in search results,
     increasing traffic to your docs.
 
@@ -33,5 +33,5 @@ we have become familiar with a number of methods that work well and which we con
    Deprecating content </guides/deprecating-content>
    Best practices for linking to your documentation </guides/best-practice/links>
    Creating reproducible builds </guides/reproducible-builds>
-   Search Engine Optimization (SEO) for documentation projects </guides/technical-docs-seo-guide>
+   Search engine optimization (SEO) for documentation projects </guides/technical-docs-seo-guide>
    Hiding a version </guides/hiding-a-version>

--- a/docs/user/guides/content/index.rst
+++ b/docs/user/guides/content/index.rst
@@ -1,7 +1,7 @@
 How-to guides: content, themes and SEO
 ======================================
 
-⏩️ :doc:`Search Engine Optimization (SEO) for documentation projects </guides/technical-docs-seo-guide>`
+⏩️ :doc:`Search engine optimization (SEO) for documentation projects </guides/technical-docs-seo-guide>`
     This article explains how documentation can be optimized to appear in search results,
     ultimately increasing traffic to your docs.
 
@@ -65,7 +65,7 @@ How-to guides: content, themes and SEO
    :maxdepth: 1
    :hidden:
 
-   Search Engine Optimization (SEO) for documentation projects </guides/technical-docs-seo-guide>
+   Search engine optimization (SEO) for documentation projects </guides/technical-docs-seo-guide>
    Using traffic analytics </analytics>
    Using search analytics </guides/search-analytics>
    Enabling canonical URLs </guides/canonical-urls>

--- a/docs/user/guides/technical-docs-seo-guide.rst
+++ b/docs/user/guides/technical-docs-seo-guide.rst
@@ -1,4 +1,4 @@
-How to do Search Engine Optimization (SEO) for documentation projects
+How to do search engine optimization (SEO) for documentation projects
 =====================================================================
 
 .. meta::

--- a/docs/user/science.rst
+++ b/docs/user/science.rst
@@ -102,7 +102,7 @@ Here's a brief overview of some :doc:`features </reference/features>` that peopl
     Search analytics
         What are people searching for and do they get hits? From each search query in your documentation, we collect a neat little statistic that can help to improve the discoverability and relevance of your documentation.
 
-    SEO - Don't reinvent Search Engine Optimization
+    SEO - Don't reinvent search engine optimization
         Use built-in SEO best-practices from Sphinx, its themes and Read the Docs hosting. This can give you a good ranking on search engines as a direct outcome of simply writing and publishing your documentation project.
 
 .. dropdown:: 🌱 Grow your own solutions


### PR DESCRIPTION
A little gramma :gift: for @agjohnson :heart: 

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10409.org.readthedocs.build/en/10409/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10409.org.readthedocs.build/en/10409/

<!-- readthedocs-preview dev end -->