### PR TITLE
Add a `cat` command and note in the build output when a config file is properly used.

### DIFF
--- a/readthedocs/doc_builder/config.py
+++ b/readthedocs/doc_builder/config.py
@@ -68,7 +68,8 @@ def load_yaml_config(version, readthedocs_yaml_path=None):
         config = BuildConfigV1(
             env_config=env_config,
             raw_config={},
-            source_file=checkout_path,
+            base_path=checkout_path,
+            source_file=None,
         )
         config.validate()
     return config

--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -111,7 +111,7 @@ class BuildDirector:
         # This works as confirmation for us & the user about which file is used,
         # as well as the fact that *any* config file is used.
         if self.data.config.source_file:
-            checkout_path = self.data.project.checkout_path(self.data.version.slug)
+            cwd = self.data.project.checkout_path(self.data.version.slug)
             command = self.vcs_environment.run(
                 "cat",
                 # Show user the relative path to the config file

--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -111,13 +111,14 @@ class BuildDirector:
         # This works as confirmation for us & the user about which file is used,
         # as well as the fact that *any* config file is used.
         if self.data.config.source_file:
+            checkout_path = self.data.project.checkout_path(self.data.version.slug)
             command = self.vcs_environment.run(
                 "cat",
                 # Show user the relative path to the config file
                 self.data.config.source_file.replace(
-                    self.data.config.base_path + "/", ""
+                    checkout_path + "/", ""
                 ),
-                cwd=self.data.config.base_path,
+                cwd=checkout_path,
             )
 
         self.run_build_job("post_checkout")

--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -106,6 +106,20 @@ class BuildDirector:
         #
         # self.run_build_job("pre_checkout")
         self.checkout()
+
+        # Output the path for the config file used.
+        # This works as confirmation for us & the user about which file is used,
+        # as well as the fact that *any* config file is used.
+        if self.data.config.source_file:
+            command = self.vcs_environment.run(
+                "cat",
+                # Show user the relative path to the config file
+                self.data.config.source_file.replace(
+                    self.data.config.base_path + "/", ""
+                ),
+                cwd=self.data.config.base_path,
+            )
+
         self.run_build_job("post_checkout")
 
         commit = self.data.build_commit or self.vcs_repository.commit

--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -115,10 +115,10 @@ class BuildDirector:
             command = self.vcs_environment.run(
                 "cat",
                 # Show user the relative path to the config file
-                self.data.config.source_file.replace(
-                    checkout_path + "/", ""
-                ),
-                cwd=checkout_path,
+                # TODO: Have our standard path replacement code catch this.
+                # https://github.com/readthedocs/readthedocs.org/pull/10413#discussion_r1230765843
+                self.data.config.source_file.replace(cwd + "/", ""),
+                cwd=cwd,
             )
 
         self.run_build_job("post_checkout")

--- a/readthedocs/templates/builds/build_detail.html
+++ b/readthedocs/templates/builds/build_detail.html
@@ -180,7 +180,7 @@ $(document).ready(function () {
             {% blocktrans trimmed %}
               <strong>Your build is properly using a configuration file ✅</strong><br/>
               {% if build.readthedocs_yaml_path %}}
-                The configuration file used was: <code>{{ build.config_file }}</code>.
+                The configuration file used was: <code>{{ build.readthedocs_yaml_path }}</code>.
               {% else %}
                 The configuration file used was: <code>.readthedocs.yaml</code>.
               {% endif %}

--- a/readthedocs/templates/builds/build_detail.html
+++ b/readthedocs/templates/builds/build_detail.html
@@ -174,6 +174,19 @@ $(document).ready(function () {
             {% endblocktrans %}
           </p>
         </div>
+      {% else %}
+        <div class="build-ideas">
+          <p>
+            {% blocktrans trimmed %}
+              <strong>Your build is properly using a configuration file ✅</strong><br/>
+              {% if build.readthedocs_yaml_path %}}
+                The configuration file used was: <code>{{ build.config_file }}</code>.
+              {% else %}
+                The configuration file used was: <code>.readthedocs.yaml</code>.
+              {% endif %}
+            {% endblocktrans %}
+          </p>
+        </div>
       {% endif %}
 
     {% endif %}

--- a/readthedocs/templates/builds/build_detail.html
+++ b/readthedocs/templates/builds/build_detail.html
@@ -174,14 +174,6 @@ $(document).ready(function () {
             {% endblocktrans %}
           </p>
         </div>
-      {% elif build.finished and not build.deprecated_config_used  %}
-        <div class="build-ideas">
-          <p>
-            {% blocktrans trimmed %}
-              <strong>Your build is properly using a configuration file ✅</strong><br/>
-            {% endblocktrans %}
-          </p>
-        </div>
       {% endif %}
 
     {% endif %}

--- a/readthedocs/templates/builds/build_detail.html
+++ b/readthedocs/templates/builds/build_detail.html
@@ -174,16 +174,11 @@ $(document).ready(function () {
             {% endblocktrans %}
           </p>
         </div>
-      {% else %}
+      {% elif build.finished and not build.deprecated_config_used  %}
         <div class="build-ideas">
           <p>
             {% blocktrans trimmed %}
               <strong>Your build is properly using a configuration file ✅</strong><br/>
-              {% if build.readthedocs_yaml_path %}}
-                The configuration file used was: <code>{{ build.readthedocs_yaml_path }}</code>.
-              {% else %}
-                The configuration file used was: <code>.readthedocs.yaml</code>.
-              {% endif %}
             {% endblocktrans %}
           </p>
         </div>


### PR DESCRIPTION
This is important for our config file migration,
so users are given feedback when they have properly configured the file.

This does two things:

* Adds a `cat <config_file>` to the build output, so users know a config is used, and which one
* Adds a small message above the build to share that the config file was used successfully. I will plan to remove this once our config file migration is over. 