### PR TITLE
Deprecation: improve Celery task db query

### DIFF
--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -271,6 +271,14 @@ def deprecated_config_file_used_notification():
     queryset = User.objects.filter(username__in=users, profile__banned=False).order_by(
         "id"
     )
+
+    # Exclude users that already have an unread notification.
+    # Our notifications backend already performs de-duplication of notifications automatically.
+    # However, this is only to speed up things here since this loop takes the most time.
+    queryset = queryset.exclude(
+        message__message__startswith="Your project(s)", message__read=False
+    )
+
     n_users = queryset.count()
     for i, user in enumerate(queryset.iterator()):
         if i % 500 == 0:

--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -272,13 +272,6 @@ def deprecated_config_file_used_notification():
         "id"
     )
 
-    # Exclude users that already have an unread notification.
-    # Our notifications backend already performs de-duplication of notifications automatically.
-    # However, this is only to speed up things here since this loop takes the most time.
-    queryset = queryset.exclude(
-        message__message__startswith="Your project(s)", message__read=False
-    )
-
     n_users = queryset.count()
     for i, user in enumerate(queryset.iterator()):
         if i % 500 == 0:

--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -299,7 +299,7 @@ def deprecated_config_file_used_notification():
         user_projects = list(set(user_projects) & projects)
 
         user_project_slugs = ", ".join(user_projects[:5])
-        if user_projects.count() > 5:
+        if len(user_projects) > 5:
             user_project_slugs += " and others..."
 
         n_site = DeprecatedConfigFileSiteNotification(

--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -291,9 +291,8 @@ def deprecated_config_file_used_notification():
             )
 
         # All the projects for this user that don't have a configuration file
-        # Use set() intersection in Python that's pretty quick and only pass
-        # these few projects slugs to the db query.
-        # Otherwise we pass 82k, which makes the query pretty slow.
+        # Use set() intersection in Python that's pretty quick since we only need the slugs.
+        # Otherwise we have to pass 82k slugs to the DB query, which makes it pretty slow.
         user_projects = AdminPermission.projects(user, admin=True).values_list(
             "slug", flat=True
         )


### PR DESCRIPTION
This commit excludes the users that already have an unread notification with this message. This is only to avoid performing db queries for users where our notification backend won't add a new notification anyways. This will improve the performance of this task making it to run faster (hopefully).