### PR TITLE
GitHub Action: remove `team-reviewers` because it requires a GH-PAT

### DIFF
--- a/.github/workflows/pip-tools.yaml
+++ b/.github/workflows/pip-tools.yaml
@@ -61,4 +61,3 @@ jobs:
           delete-branch: true
           branch: dependencies/pip-tools
           branch-suffix: short-commit-hash
-          team-reviewers: readthedocs/backend


### PR DESCRIPTION
It has been failing with

```
  Error: Unable to request reviewers. If requesting team reviewers a 'repo' scoped PAT is required.
  Error: Validation Failed: "Could not resolve to a node with the global id of 'T_kwDOAAWW-c4ATMYo'."
```

I'm removing it as `team-reviewers` it's not super important here. I'm getting this notification anyways and reviewing it.


It fails at this line https://github.com/readthedocs/readthedocs.org/actions/runs/5232561948/jobs/9447343798#step:11:121