### PR TITLE
Build: phase out git clone option `--no-single-branch` (one of several approaches)

### DIFF
--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -94,6 +94,7 @@ class BuildDirector:
             environment=self.vcs_environment,
             verbose_name=self.data.version.verbose_name,
             version_type=self.data.version.type,
+            version_identifier=self.data.version.identifier,
         )
 
         # We can't do too much on ``pre_checkout`` because we haven't

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -993,7 +993,12 @@ class Project(models.Model):
         )
 
     def vcs_repo(
-        self, environment, version=LATEST, verbose_name=None, version_type=None
+        self,
+        environment,
+        version=LATEST,
+        verbose_name=None,
+        version_type=None,
+        version_identifier=None,
     ):
         """
         Return a Backend object for this project able to handle VCS commands.
@@ -1012,8 +1017,12 @@ class Project(models.Model):
             repo = None
         else:
             repo = backend(
-                self, version, environment=environment,
-                verbose_name=verbose_name, version_type=version_type
+                self,
+                version,
+                environment=environment,
+                verbose_name=verbose_name,
+                version_type=version_type,
+                version_identifier=version_identifier,
             )
         return repo
 
@@ -1941,6 +1950,7 @@ class Feature(models.Model):
     INDEX_FROM_HTML_FILES = 'index_from_html_files'
 
     # Build related features
+    GIT_CLONE_SINGLE_BRANCH = "git_clone_single_branch"
     LIST_PACKAGES_INSTALLED_ENV = "list_packages_installed_env"
     VCS_REMOTE_LISTING = "vcs_remote_listing"
     SPHINX_PARALLEL = "sphinx_parallel"
@@ -2099,6 +2109,13 @@ class Feature(models.Model):
             _(
                 'Build: List packages installed in the environment ("pip list" or "conda list") '
                 'on build\'s output',
+            ),
+        ),
+        (
+            GIT_CLONE_SINGLE_BRANCH,
+            _(
+                "Build: Single branch clone - when cloning a repository, only fetch the single "
+                "relevant branch of the build."
             ),
         ),
         (

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -35,8 +35,6 @@ class Backend(BaseVCS):
     repo_depth = 50
 
     def __init__(self, *args, **kwargs):
-        # This branch name is used for speeding up git clones.
-        # If it's not specified, the remote HEAD will be used.
         super().__init__(*args, **kwargs)
         self.token = kwargs.get('token')
         self.repo_url = self._get_clone_url()
@@ -58,11 +56,7 @@ class Backend(BaseVCS):
         return self.run('git', 'remote', 'set-url', 'origin', url)
 
     def update(self):
-        """
-        Clone or update the repository.
-
-        :param branch_name: Specifies the branch name in case we need to clone a Git repo.
-        """
+        """Clone or update the repository."""
         super().update()
         if self.repo_exists():
             self.set_remote_url(self.repo_url)
@@ -74,9 +68,6 @@ class Backend(BaseVCS):
         if self.version_type == EXTERNAL:
             self.clone()
             return self.fetch()
-
-        if self.version_type == BRANCH:
-            return self.clone()
 
         return self.clone()
 
@@ -216,15 +207,14 @@ class Backend(BaseVCS):
             # elif self.version_type == TAG and self.version_identifier:
             #    cmd.extend(["--branch", self.version_identifier])
 
-            # Legacy behavior (tags)
+            # Legacy behavior (this is intended for tags)
             # If we cannot specify the branch to clone, we should get history for all remote types
-            # We always have to fetch after external versions are cloned.
             # External builds aren't relevant, there is always an individual fetch operation.
             # See self.update()
             elif not self.version_type == EXTERNAL:
                 cmd.extend(["--no-single-branch"])
 
-            # External builds / GitHub and GitLab pull requests:
+            # Notes about external builds / GitHub and GitLab pull requests:
             # We could clone the special branch 'refs/pull/<1234>' on GitHub
             # However, this trick is already 'pulled' (punintended) in .fetch() so all we need to do
             # here is to avoid --no-single-branch and other expensive things.

--- a/readthedocs/vcs_support/base.py
+++ b/readthedocs/vcs_support/base.py
@@ -61,6 +61,7 @@ class BaseVCS:
         environment,
         verbose_name=None,
         version_type=None,
+        version_identifier=None,
         **kwargs
     ):
         self.default_branch = project.default_branch
@@ -71,6 +72,11 @@ class BaseVCS:
         # required for External versions
         self.verbose_name = verbose_name
         self.version_type = version_type
+
+        # It's possible to specify which Git identifier that this VCS instance expects to
+        # fetch data for.
+        # This only works for branch and tag names. Not commit IDs.
+        self.version_identifier = version_identifier
 
         self.environment = environment
 


### PR DESCRIPTION
Fixes: https://github.com/readthedocs/readthedocs.org/issues/9736

* [x] Tested on branch builds
* [x] Tested with tag builds
* [x] Tested for PRs ( via this PR: https://github.com/readthedocs/test-builds/pull/2106 )
* [ ] Update tests