### PR TITLE
Celery: increase frequency of `delete_closed_external_versions` task

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -511,9 +511,11 @@ class CommunityBaseSettings(Settings):
                 'delete': True,
             },
         },
-        'every-day-delete-inactive-external-versions': {
+        'every-three-hour-delete-inactive-external-versions': {
             'task': 'readthedocs.builds.tasks.delete_closed_external_versions',
-            'schedule': crontab(minute=0, hour=1),
+            # Increase the frequency because we have 255k closed versions and they keep growing.
+            # It's better to increase this frequency than the `limit=` of the task.
+            'schedule': crontab(minute=0, hour='*/3'),
             'options': {'queue': 'web'},
         },
         'every-day-resync-remote-repositories': {


### PR DESCRIPTION
We have 255k versions that should have been deleted already, but we are executing the task with a limit of 200 version. This makes the task to not catch up with all the versions that has to delete, and we keep accumulating them.

This commit increases the frequency from "once a day" to "every 3 hours". It will help to catch up and to keep our database clean of closed PRs.

Related https://github.com/readthedocs/readthedocs-ops/issues/1291