### PR TITLE
CI: trigger circleci job on readthedocs-ext on merge

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Trigger tests in corporate
+    - name: Trigger tests in readthedocs-corporate
       run: |
         curl --request POST \
         --silent --output /dev/null \
-        --url https://circleci.com/api/v2/project/gh/${{ secrets.CORPORATE_REPO }}/pipeline \
+        --url https://circleci.com/api/v2/project/gh/readthedocs/readthedocs-corporate/pipeline \
         --user '${{ secrets.CIRCLECI_USER_TOKEN }}:' \
         --header 'content-type: application/json' \
-        --data '{"branch": "main", "parameters":{"CIRCLE_JOB": "${{ secrets.CIRCLECI_JOB }}"}}'
+        --data '{"branch": "main", "parameters":{"CIRCLE_JOB": "tests"}}'
+
+    - name: Trigger tests in readthedocs-ext
+      run: |
+        curl --request POST \
+        --silent --output /dev/null \
+        --url https:/circleci.com/api/v2/project/gh/readthedocs/readthedocs-ext/pipeline \
+        --user '${{ secrets.CIRCLECI_USER_TOKEN }}:' \
+        --header 'content-type: application/json' \
+        --data '{"branch": "main", "parameters":{"CIRCLE_JOB": "tests"}}'


### PR DESCRIPTION
Same as we do with readthedocs-corporate,
there was a bug that could have been caught with this.

Also, don't think we need to hide the repo and job name, we have linked to those repos from public places already.