### PR TITLE
Deprecation: send emails to "active projects" only

### DIFF
--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -237,8 +237,9 @@ def deprecated_config_file_used_notification():
             project.versions.filter(slug=project.default_version).only("id").first()
         )
         if version:
+            years_ago = timezone.now() - timezone.timedelta(days=365)  # 1 years ago
             build = (
-                version.builds.filter(success=True)
+                version.builds.filter(success=True, date__gt=years_ago)
                 .only("_config")
                 .order_by("-date")
                 .first()

--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -237,7 +237,8 @@ def deprecated_config_file_used_notification():
             project.versions.filter(slug=project.default_version).only("id").first()
         )
         if version:
-            years_ago = timezone.now() - timezone.timedelta(days=365)  # 1 years ago
+            # Use a fixed date here to avoid changing the date on each run
+            years_ago = timezone.datetime(2022, 6, 1)
             build = (
                 version.builds.filter(success=True, date__gt=years_ago)
                 .only("_config")

--- a/readthedocs/templates/projects/notifications/deprecated_config_file_used_email.html
+++ b/readthedocs/templates/projects/notifications/deprecated_config_file_used_email.html
@@ -13,7 +13,8 @@ The timeline for this deprecation is as follows:
     <li><strong>Monday, September 25, 2023</strong>: Fully remove support for building documentation without configuration file v2.</li>
 </ul>
 
-We have identified that the following projects which you maintain are impacted by this deprecation:
+We have identified that the following projects which you maintain, are impacted by this deprecation.
+Note that we changed our policy for sending this deprecation email to only projects with a successful build in the last year.
 
 <ul>
 {% for project in projects|slice:":15" %}

--- a/readthedocs/templates/projects/notifications/deprecated_config_file_used_email.html
+++ b/readthedocs/templates/projects/notifications/deprecated_config_file_used_email.html
@@ -13,8 +13,7 @@ The timeline for this deprecation is as follows:
     <li><strong>Monday, September 25, 2023</strong>: Fully remove support for building documentation without configuration file v2.</li>
 </ul>
 
-We have identified that the following projects which you maintain, are impacted by this deprecation.
-Note that we changed our policy for sending this deprecation email to only projects with a successful build in the last year.
+We have identified that the following projects which you maintain, and were built in the last year, are impacted by this deprecation:
 
 <ul>
 {% for project in projects|slice:":15" %}

--- a/readthedocs/templates/projects/notifications/deprecated_config_file_used_email.txt
+++ b/readthedocs/templates/projects/notifications/deprecated_config_file_used_email.txt
@@ -11,7 +11,8 @@ The timeline for this deprecation is as follows:
 * Monday, September 4, 2023: Do a third and final brownout (temporarily enforce this deprecation) for 48 hours: 00:01 PST to September 5, 2023 23:59 PST (midnight)
 * Monday, September 25, 2023: Fully remove support for building documentation without configuration file v2.
 
-We have identified the following projects where you are a maintainer are impacted by this deprecation:
+We have identified that the following projects which you maintain, are impacted by this deprecation.
+Note that we changed our policy for sending this deprecation email to only projects with a successful build in the last year.
 
 {% for project in projects|slice:":15" %}
 * {{ project.slug }} ({{ production_uri }}{{ project.get_absolute_url }})

--- a/readthedocs/templates/projects/notifications/deprecated_config_file_used_email.txt
+++ b/readthedocs/templates/projects/notifications/deprecated_config_file_used_email.txt
@@ -11,8 +11,7 @@ The timeline for this deprecation is as follows:
 * Monday, September 4, 2023: Do a third and final brownout (temporarily enforce this deprecation) for 48 hours: 00:01 PST to September 5, 2023 23:59 PST (midnight)
 * Monday, September 25, 2023: Fully remove support for building documentation without configuration file v2.
 
-We have identified that the following projects which you maintain, are impacted by this deprecation.
-Note that we changed our policy for sending this deprecation email to only projects with a successful build in the last year.
+We have identified that the following projects which you maintain, and were built in the last year, are impacted by this deprecation:
 
 {% for project in projects|slice:":15" %}
 * {{ project.slug }} ({{ production_uri }}{{ project.get_absolute_url }})


### PR DESCRIPTION
We are filtering the query to only send emails to users with projects that have a successful build in the last year.