### PR TITLE
Dashboard: Update docs link

### DIFF
--- a/readthedocs/templates/projects/integration_webhook_detail.html
+++ b/readthedocs/templates/projects/integration_webhook_detail.html
@@ -65,7 +65,7 @@
     <p>
       {% blocktrans trimmed %}
         For more information on manually configuring a webhook, refer to
-        <a href="https://docs.readthedocs.io/page/webhooks.html">
+        <a href="https://docs.readthedocs.io/page/guides/setup/git-repo-automatic.html">
           our webhook documentation
         </a>
       {% endblocktrans %}


### PR DESCRIPTION
We probably want people to go here firstly: https://docs.readthedocs.io/en/latest/guides/setup/git-repo-automatic.html