### PR TITLE
Do not show paths in 404s

### DIFF
--- a/readthedocs/templates/errors/404/include_error_message.html
+++ b/readthedocs/templates/errors/404/include_error_message.html
@@ -3,7 +3,7 @@
   <p>
     {% blocktrans trimmed with project_slug=project.slug %}
       You are browsing the documentation of <code>{{ project_slug }}</code>.
-      The {{ not_found_subject }} you are looking for at <code>{{ path_not_found }}</code> was not found.
+      The {{ not_found_subject }} you are looking for was not found.
     {% endblocktrans %}
   </p>
 


### PR DESCRIPTION
This responds to a concern of showing paths that are from URLs.

We are still keeping the context variable in case it's useful in later contextualized scenarios.

Note: Previously, the path was not considered a safe string and enclosed in `<code>`.