### PR TITLE
Test with explicit number of concurrent builds

### DIFF
--- a/readthedocs/api/v3/tests/test_builds.py
+++ b/readthedocs/api/v3/tests/test_builds.py
@@ -3,12 +3,17 @@ from unittest import mock
 from django.test import override_settings
 from django.urls import reverse
 
+from readthedocs.subscriptions.constants import TYPE_CONCURRENT_BUILDS
+
 from .mixins import APIEndpointMixin
 
 
 @override_settings(
     RTD_ALLOW_ORGANIZATIONS=False,
     ALLOW_PRIVATE_REPOS=False,
+    RTD_DEFAULT_FEATURES={
+        TYPE_CONCURRENT_BUILDS: 4,
+    },
 )
 @mock.patch('readthedocs.projects.tasks.builds.update_docs_task', mock.MagicMock())
 class BuildsEndpointTests(APIEndpointMixin):

--- a/readthedocs/rtd_tests/tests/test_core_utils.py
+++ b/readthedocs/rtd_tests/tests/test_core_utils.py
@@ -3,7 +3,7 @@
 from unittest import mock
 
 import pytest
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django_dynamic_fixture import get
 
 from readthedocs.builds.constants import BUILD_STATE_BUILDING, LATEST
@@ -11,8 +11,14 @@ from readthedocs.builds.models import Build, Version
 from readthedocs.core.utils import slugify, trigger_build
 from readthedocs.doc_builder.exceptions import BuildMaxConcurrencyError
 from readthedocs.projects.models import Project
+from readthedocs.subscriptions.constants import TYPE_CONCURRENT_BUILDS
 
 
+@override_settings(
+    RTD_DEFAULT_FEATURES={
+        TYPE_CONCURRENT_BUILDS: 4,
+    }
+)
 class CoreUtilTests(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
This makes test pass on .com,
since there all features are given by the org subscription.