### PR TITLE
DB: do not fetch `data` and others when deleting rows

### DIFF
--- a/readthedocs/analytics/tasks.py
+++ b/readthedocs/analytics/tasks.py
@@ -80,7 +80,11 @@ def delete_old_page_counts():
     """
     retention_days = settings.RTD_ANALYTICS_DEFAULT_RETENTION_DAYS
     days_ago = timezone.now().date() - timezone.timedelta(days=retention_days)
-    return PageView.objects.filter(
-        date__lt=days_ago,
-        date__gt=days_ago - timezone.timedelta(days=90),
-    ).delete()
+    return (
+        PageView.objects.filter(
+            date__lt=days_ago,
+            date__gt=days_ago - timezone.timedelta(days=90),
+        )
+        .only("id")
+        .delete()
+    )

--- a/readthedocs/analytics/tasks.py
+++ b/readthedocs/analytics/tasks.py
@@ -93,4 +93,3 @@ def delete_old_page_counts():
                 days_ago,
             ],
         )
-        return cursor.fetchall()

--- a/readthedocs/telemetry/tasks.py
+++ b/readthedocs/telemetry/tasks.py
@@ -1,6 +1,7 @@
 """Tasks related to telemetry."""
 
 from django.conf import settings
+from django.db import connections
 from django.utils import timezone
 
 from readthedocs.builds.models import Build
@@ -33,11 +34,16 @@ def delete_old_build_data():
     """
     retention_days = settings.RTD_TELEMETRY_DATA_RETENTION_DAYS
     days_ago = timezone.now().date() - timezone.timedelta(days=retention_days)
-    return (
-        BuildData.objects.filter(
-            created__lt=days_ago,
-            created__gt=days_ago - timezone.timedelta(days=90),
+    # NOTE: we are using raw SQL here to avoid Django doing a SELECT first to
+    # send `pre_` and `post_` delete signals
+    # See https://docs.djangoproject.com/en/4.2/ref/models/querysets/#delete
+    with connections["telemetry"].cursor() as cursor:
+        cursor.execute(
+            # "SELECT COUNT(*) FROM telemetry_builddata WHERE created BETWEEN %s AND %s",
+            "DELETE FROM telemetry_builddata WHERE created BETWEEN %s AND %s",
+            [
+                days_ago - timezone.timedelta(days=90),
+                days_ago,
+            ],
         )
-        .only("id")
-        .delete()
-    )
+        return cursor.fetchall()

--- a/readthedocs/telemetry/tasks.py
+++ b/readthedocs/telemetry/tasks.py
@@ -33,7 +33,11 @@ def delete_old_build_data():
     """
     retention_days = settings.RTD_TELEMETRY_DATA_RETENTION_DAYS
     days_ago = timezone.now().date() - timezone.timedelta(days=retention_days)
-    return BuildData.objects.filter(
-        created__lt=days_ago,
-        created__gt=days_ago - timezone.timedelta(days=90),
-    ).delete()
+    return (
+        BuildData.objects.filter(
+            created__lt=days_ago,
+            created__gt=days_ago - timezone.timedelta(days=90),
+        )
+        .only("id")
+        .delete()
+    )

--- a/readthedocs/telemetry/tasks.py
+++ b/readthedocs/telemetry/tasks.py
@@ -46,4 +46,3 @@ def delete_old_build_data():
                 days_ago,
             ],
         )
-        return cursor.fetchall()


### PR DESCRIPTION
This task was cancelled again. The query shows a SELECT first that fetchs the whole rows. I think we can reduce this time/memory by only fetching the ids.

Sentry https://read-the-docs.sentry.io/issues/4006261064/?project=148442&query=is%3Aunresolved+%21message%3A%22%21message%3A%22%21message%3A%22SystemExit%22+%21message%3A%22frame-ancestors%22&referrer=issue-stream&stream_index=9

Related https://github.com/readthedocs/readthedocs-ops/issues/1291