### PR TITLE
Proxito: easy migration to custom path prefixes

### DIFF
--- a/readthedocs/core/resolver.py
+++ b/readthedocs/core/resolver.py
@@ -100,7 +100,7 @@ class ResolverBase:
         # TODO: remove this when all projects have migrated to path prefixes.
         # Allow users to override their own URLConf
         # This logic could be cleaned up with a standard set of variable replacements
-        if urlconf:
+        if urlconf and not custom_prefix:
             path = urlconf
             path = path.replace(
                 "$version",

--- a/readthedocs/core/resolver.py
+++ b/readthedocs/core/resolver.py
@@ -99,7 +99,12 @@ class ResolverBase:
 
         # TODO: remove this when all projects have migrated to path prefixes.
         # Allow users to override their own URLConf
-        # This logic could be cleaned up with a standard set of variable replacements
+        # If a custom prefix is given, we don't use the custom URLConf,
+        # since they are not compatible with each other.
+        # We also don't check if the project has the new proxito implementation
+        # enabled, this is so we can start generating links with the new
+        # custom prefixes without starting to serve docs with it (this helps to ease
+        # the migration from urlconf to custom prefixes).
         if urlconf and not custom_prefix:
             path = urlconf
             path = path.replace(

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -269,8 +269,9 @@ class ProxitoMiddleware(MiddlewareMixin):
 
         # This is hacky because Django wants a module for the URLConf,
         # instead of also accepting string
-        if project.urlconf:
-
+        if project.urlconf and not project.has_feature(
+            Feature.USE_UNRESOLVER_WITH_PROXITO
+        ):
             # Stop Django from caching URLs
             # https://github.com/django/django/blob/7cf7d74/django/urls/resolvers.py#L65-L69  # noqa
             project_timestamp = project.modified_date.strftime("%Y%m%d.%H%M%S%f")

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -48,7 +48,6 @@ class ProxitoMiddleware(MiddlewareMixin):
         'embed_api',
     )
 
-    # pylint: disable=no-self-use
     def add_proxito_headers(self, request, response):
         """Add debugging and cache headers to proxito responses."""
 
@@ -217,22 +216,22 @@ class ProxitoMiddleware(MiddlewareMixin):
             raise DomainDNSHttp404(
                 http_status=400,
                 domain=exc.domain,
-            )
+            ) from exc
         except (InvalidSubdomainError, InvalidExternalDomainError) as exc:
             log.debug("Invalid project set on the subdomain.")
             # Raise a contextualized 404 that will be handled by proxito's 404 handler
             raise ProjectHttp404(
                 domain=exc.domain,
-            )
+            ) from exc
         except InvalidCustomDomainError as exc:
             # Some person is CNAMEing to us without configuring a domain - 404.
             log.debug("CNAME 404.", domain=exc.domain)
             # Raise a contextualized 404 that will be handled by proxito's 404 handler
             raise DomainDNSHttp404(
                 domain=exc.domain,
-            )
-        except InvalidXRTDSlugHeaderError:
-            raise SuspiciousOperation("Invalid X-RTD-Slug header.")
+            ) from exc
+        except InvalidXRTDSlugHeaderError as exc:
+            raise SuspiciousOperation("Invalid X-RTD-Slug header.") from exc
 
         self._set_request_attributes(request, unresolved_domain)
 


### PR DESCRIPTION
With this we would be able to start generating
links using the path-prefix while serving docs with the old proxito implementation.

And this also allows us to start using the new implementation with just enabling the feature flag for a project. This is, without having to unset the `urlconf` attribute. This help us to have zero downtime while migrating projects.