### PR TITLE
API V3: add IsAuthenticated to permissions

### DIFF
--- a/readthedocs/api/v3/tests/test_builds.py
+++ b/readthedocs/api/v3/tests/test_builds.py
@@ -19,26 +19,36 @@ from .mixins import APIEndpointMixin
 class BuildsEndpointTests(APIEndpointMixin):
 
     def test_projects_builds_list(self):
-        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
-        response = self.client.get(
-            reverse(
-                'projects-builds-list',
-                kwargs={
-                    'parent_lookup_project__slug': self.project.slug,
-                }),
+        url = reverse(
+            "projects-builds-list",
+            kwargs={
+                "parent_lookup_project__slug": self.project.slug,
+            },
         )
+
+        self.client.logout()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 401)
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
     def test_projects_builds_detail(self):
-        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
-        response = self.client.get(
-            reverse(
-                'projects-builds-detail',
-                kwargs={
-                    'parent_lookup_project__slug': self.project.slug,
-                    'build_pk': self.build.pk,
-                }),
+        url = reverse(
+            "projects-builds-detail",
+            kwargs={
+                "parent_lookup_project__slug": self.project.slug,
+                "build_pk": self.build.pk,
+            },
         )
+
+        self.client.logout()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 401)
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
         self.assertDictEqual(
@@ -47,16 +57,21 @@ class BuildsEndpointTests(APIEndpointMixin):
         )
 
     def test_projects_versions_builds_list_post(self):
-        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
-        self.assertEqual(self.project.builds.count(), 1)
-        response = self.client.post(
-            reverse(
-                'projects-versions-builds-list',
-                kwargs={
-                    'parent_lookup_project__slug': self.project.slug,
-                    'parent_lookup_version__slug': self.version.slug,
-                }),
+        url = reverse(
+            "projects-versions-builds-list",
+            kwargs={
+                "parent_lookup_project__slug": self.project.slug,
+                "parent_lookup_version__slug": self.version.slug,
+            },
         )
+
+        self.client.logout()
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 401)
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        self.assertEqual(self.project.builds.count(), 1)
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 202)
         self.assertEqual(self.project.builds.count(), 2)
 

--- a/readthedocs/api/v3/tests/test_environmentvariables.py
+++ b/readthedocs/api/v3/tests/test_environmentvariables.py
@@ -132,15 +132,19 @@ class EnvironmentVariablessEndpointTests(APIEndpointMixin):
         )
 
     def test_projects_environmentvariables_detail_delete(self):
-        self.assertEqual(self.project.environmentvariable_set.count(), 1)
-        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
-        response = self.client.delete(
-            reverse(
-                'projects-environmentvariables-detail',
-                kwargs={
-                    'parent_lookup_project__slug': self.project.slug,
-                    'environmentvariable_pk': self.environmentvariable.pk,
-                }),
+        url = reverse(
+            "projects-environmentvariables-detail",
+            kwargs={
+                "parent_lookup_project__slug": self.project.slug,
+                "environmentvariable_pk": self.environmentvariable.pk,
+            },
         )
+        self.client.logout()
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 401)
+
+        self.assertEqual(self.project.environmentvariable_set.count(), 1)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.delete(url)
         self.assertEqual(response.status_code, 204)
         self.assertEqual(self.project.environmentvariable_set.count(), 0)

--- a/readthedocs/api/v3/tests/test_redirects.py
+++ b/readthedocs/api/v3/tests/test_redirects.py
@@ -170,23 +170,25 @@ class RedirectsEndpointTests(APIEndpointMixin):
 
 
     def test_projects_redirects_detail_put(self):
+        url = reverse(
+            "projects-redirects-detail",
+            kwargs={
+                "parent_lookup_project__slug": self.project.slug,
+                "redirect_pk": self.redirect.pk,
+            },
+        )
         data = {
             'from_url': '/changed/',
             'to_url': '/toanother/',
             'type': 'page',
         }
 
+        self.client.logout()
+        response = self.client.put(url, data)
+        self.assertEqual(response.status_code, 401)
+
         self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
-        response = self.client.put(
-            reverse(
-                'projects-redirects-detail',
-                kwargs={
-                    'parent_lookup_project__slug': self.project.slug,
-                    'redirect_pk': self.redirect.pk,
-                },
-            ),
-            data,
-        )
+        response = self.client.put(url, data)
         self.assertEqual(response.status_code, 200)
 
         response_json = response.json()
@@ -197,16 +199,20 @@ class RedirectsEndpointTests(APIEndpointMixin):
         )
 
     def test_projects_redirects_detail_delete(self):
-        self.assertEqual(self.project.redirects.count(), 1)
-        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
-        response = self.client.delete(
-            reverse(
-                'projects-redirects-detail',
-                kwargs={
-                    'parent_lookup_project__slug': self.project.slug,
-                    'redirect_pk': self.redirect.pk,
-                },
-            ),
+        url = reverse(
+            "projects-redirects-detail",
+            kwargs={
+                "parent_lookup_project__slug": self.project.slug,
+                "redirect_pk": self.redirect.pk,
+            },
         )
+
+        self.client.logout()
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 401)
+
+        self.assertEqual(self.project.redirects.count(), 1)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.delete(url)
         self.assertEqual(response.status_code, 204)
         self.assertEqual(self.project.redirects.count(), 0)

--- a/readthedocs/api/v3/tests/test_remoteorganizations.py
+++ b/readthedocs/api/v3/tests/test_remoteorganizations.py
@@ -36,10 +36,14 @@ class RemoteOrganizationEndpointTests(APIEndpointMixin):
         )
 
     def test_remote_organization_list(self):
-        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
-        response = self.client.get(
-            reverse('remoteorganizations-list')
-        )
+        url = reverse("remoteorganizations-list")
+
+        self.client.logout()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 401)
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
         self.assertDictEqual(

--- a/readthedocs/api/v3/tests/test_remoterepositories.py
+++ b/readthedocs/api/v3/tests/test_remoterepositories.py
@@ -66,16 +66,15 @@ class RemoteRepositoryEndpointTests(APIEndpointMixin):
         )
 
     def test_remote_repository_list(self):
-        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
-        response = self.client.get(
-            reverse('remoterepositories-list'),
-            {
-                'expand': (
-                    'projects,'
-                    'remote_organization'
-                )
-            }
-        )
+        url = reverse("remoterepositories-list")
+        data = {"expand": ("projects," "remote_organization")}
+
+        self.client.logout()
+        response = self.client.get(url, data)
+        self.assertEqual(response.status_code, 401)
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.get(url, data)
         self.assertEqual(response.status_code, 200)
 
         self.assertDictEqual(

--- a/readthedocs/api/v3/tests/test_subprojects.py
+++ b/readthedocs/api/v3/tests/test_subprojects.py
@@ -15,15 +15,19 @@ class SubprojectsEndpointTests(APIEndpointMixin):
         self._create_subproject()
 
     def test_projects_subprojects_list(self):
-        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
-        response = self.client.get(
-            reverse(
+        url = reverse(
                 'projects-subprojects-list',
                 kwargs={
                     'parent_lookup_parent__slug': self.project.slug,
                 },
-            ),
         )
+
+        self.client.logout()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 401)
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(
             response.json(),
@@ -31,15 +35,20 @@ class SubprojectsEndpointTests(APIEndpointMixin):
         )
 
     def test_projects_subprojects_detail(self):
-        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
-        response = self.client.get(
-            reverse(
-                'projects-subprojects-detail',
-                kwargs={
-                    'parent_lookup_parent__slug': self.project.slug,
-                    'alias_slug': self.project_relationship.alias,
-                }),
+        url = reverse(
+            "projects-subprojects-detail",
+            kwargs={
+                "parent_lookup_parent__slug": self.project.slug,
+                "alias_slug": self.project_relationship.alias,
+            },
         )
+
+        self.client.logout()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 401)
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(
             response.json(),
@@ -49,20 +58,23 @@ class SubprojectsEndpointTests(APIEndpointMixin):
     def test_projects_subprojects_list_post(self):
         newproject = self._create_new_project()
         self.assertEqual(self.project.subprojects.count(), 1)
-        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
+        url = reverse(
+            "projects-subprojects-list",
+            kwargs={
+                "parent_lookup_parent__slug": self.project.slug,
+            },
+        )
         data = {
             'child': newproject.slug,
             'alias': 'subproject-alias',
         }
-        response = self.client.post(
-            reverse(
-                'projects-subprojects-list',
-                kwargs={
-                    'parent_lookup_parent__slug': self.project.slug,
-                },
-            ),
-            data,
-        )
+
+        self.client.logout()
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, 401)
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.post(url, data)
 
         self.assertEqual(response.status_code, 201)
         self.assertEqual(self.project.subprojects.count(), 2)
@@ -233,17 +245,20 @@ class SubprojectsEndpointTests(APIEndpointMixin):
         self.assertEqual(self.others_project.subprojects.count(), 0)
 
     def test_projects_subprojects_detail_delete(self):
-        self.assertEqual(self.project.subprojects.count(), 1)
-        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
-        response = self.client.delete(
-            reverse(
-                'projects-subprojects-detail',
-                kwargs={
-                    'parent_lookup_parent__slug': self.project.slug,
-                    'alias_slug': self.project_relationship.alias,
-                },
-            ),
+        url = reverse(
+            "projects-subprojects-detail",
+            kwargs={
+                "parent_lookup_parent__slug": self.project.slug,
+                "alias_slug": self.project_relationship.alias,
+            },
         )
+        self.client.logout()
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, 401)
+
+        self.assertEqual(self.project.subprojects.count(), 1)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.delete(url)
         self.assertEqual(response.status_code, 204)
         self.assertEqual(self.project.subprojects.count(), 0)
 

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -414,7 +414,9 @@ class OrganizationsViewSet(
     lookup_url_kwarg = 'organization_slug'
     queryset = Organization.objects.all()
     serializer_class = OrganizationSerializer
-    permission_classes = [UserOrganizationsListing | IsOrganizationAdminMember]
+    permission_classes = [
+        IsAuthenticated & (UserOrganizationsListing | IsOrganizationAdminMember)
+    ]
     permit_list_expands = [
         'projects',
         'teams',
@@ -443,7 +445,7 @@ class OrganizationsProjectsViewSet(
     lookup_url_kwarg = 'project_slug'
     queryset = Project.objects.all()
     serializer_class = ProjectSerializer
-    permission_classes = [IsOrganizationAdminMember]
+    permission_classes = [IsAuthenticated & IsOrganizationAdminMember]
     permit_list_expands = [
         'organization',
         'organization.teams',


### PR DESCRIPTION
This isn't a security vulnerability,
we were filtering by the current user.

This was just causing errors, since we were expecting a real user in some queries.

These views are used in .com only, so I have added tests there.
Also, went ahead and added tests for all other endpoints that didn't have them.

Ref https://read-the-docs.sentry.io/issues/4261898141/?alert_rule_id=242443&alert_timestamp=1687234764178&alert_type=email&environment=production&project=161479&referrer=alert_email