### PR TITLE
Docs: Replace navigation instructions with direct URLs w/ organization chooser

### DIFF
--- a/docs/user/commercial/subscriptions.rst
+++ b/docs/user/commercial/subscriptions.rst
@@ -15,11 +15,8 @@ You can always find our most up to date pricing information on our `pricing page
 Managing your subscription
 --------------------------
 
-* Go to https://readthedocs.com/organizations/.
-* Select your organization from this list.
-* Select :guilabel:`Settings` at the top of the page.
-* Select the :guilabel:`Subscription` tab on the left.
-* Click :guilabel:`Manage Subscription`.
+1. Navigate to the `subscription management page <https://readthedocs.com/organizations/choose/subscription_detail/>`__.
+2. Click :guilabel:`Manage Subscription`.
 
 This action will take you to the Stripe billing portal where you can manage your subscription.
 

--- a/docs/user/guides/manage-read-the-docs-teams.rst
+++ b/docs/user/guides/manage-read-the-docs-teams.rst
@@ -13,22 +13,25 @@ Adding a user to a team
 
 Adding a user to a team gives them all the permissions available to that team,
 whether it's *read-only* or *admin*.
-This can be done by:
+
+Follow these steps:
 
 1. Navigate to the `teams management page <https://readthedocs.com/organizations/choose/organization_team_list/>`__.
-2. Click on :guilabel:`<team name>`.
-3. Clicking :guilabel:`Invite Member`.
+2. Click on a :guilabel:`<team name>`.
+3. Click :guilabel:`Invite Member`.
 4. Input the user's Read the Docs username or email address.
-5. Clicking :guilabel:`Add member`.
+5. Click :guilabel:`Add member`.
 
 Removing a user from a team
 ----------------------------
 
-Removing a user from a team removes all permissions that team gave them
+Removing a user from a team removes all permissions that team gave them.
+
+Follow these steps:
 
 1. Navigate to the `teams management page <https://readthedocs.com/organizations/choose/organization_team_list/>`__.
 2. Click on :guilabel:`<team name>`.
-3. Clicking :guilabel:`Remove` next to the user.
+3. Click :guilabel:`Remove` next to the user.
 
 
 Grant access to users to import a project

--- a/docs/user/guides/manage-read-the-docs-teams.rst
+++ b/docs/user/guides/manage-read-the-docs-teams.rst
@@ -15,18 +15,20 @@ Adding a user to a team gives them all the permissions available to that team,
 whether it's *read-only* or *admin*.
 This can be done by:
 
-* Navigating to :guilabel:`<Username dropdown>` > :guilabel:`Organizations` > :guilabel:`<Organization name>` > :guilabel:`Teams` > :guilabel:`<Team name>`
-* Clicking :guilabel:`Invite Member`.
-* Input the user's Read the Docs username or email address.
-* Clicking :guilabel:`Add member`.
+1. Navigate to the `teams management page <https://readthedocs.com/organizations/choose/organization_team_list/>`__.
+2. Click on :guilabel:`<team name>`.
+3. Clicking :guilabel:`Invite Member`.
+4. Input the user's Read the Docs username or email address.
+5. Clicking :guilabel:`Add member`.
 
 Removing a user from a team
 ----------------------------
 
 Removing a user from a team removes all permissions that team gave them
 
-* Navigating to :guilabel:`<Username dropdown>` > :guilabel:`Organizations` > :guilabel:`<Organization name>` > :guilabel:`Teams` > :guilabel:`<Team name>`
-* Clicking :guilabel:`Remove` next to the user.
+1. Navigate to the `teams management page <https://readthedocs.com/organizations/choose/organization_team_list/>`__.
+2. Click on :guilabel:`<team name>`.
+3. Clicking :guilabel:`Remove` next to the user.
 
 
 Grant access to users to import a project

--- a/docs/user/guides/setup-single-sign-on-github-gitlab-bitbucket.rst
+++ b/docs/user/guides/setup-single-sign-on-github-gitlab-bitbucket.rst
@@ -27,9 +27,9 @@ Enabling SSO
 
 You can enable this feature in your organization by:
 
-* Navigate to :guilabel:`<Username dropdown>` > :guilabel:`Organizations` > :guilabel:`<Organization name>` > :guilabel:`Settings` > :guilabel:`Authorization`
-* Select :guilabel:`GitHub, GitLab or Bitbucket` on the :guilabel:`Provider` dropdown.
-* Select :guilabel:`Save`
+1. Navigate to the `authorization setting page <https://readthedocs.com/organizations/choose/organization_sso/>`__.
+2. Select :guilabel:`GitHub, GitLab or Bitbucket` on the :guilabel:`Provider` dropdown.
+3. Select :guilabel:`Save`
 
 .. warning::
     Once you enable this option,

--- a/docs/user/guides/setup-single-sign-on-google-email.rst
+++ b/docs/user/guides/setup-single-sign-on-google-email.rst
@@ -30,11 +30,9 @@ Enabling SSO
 By default, users that sign up with a Google account do not have any permissions over any project.
 However, you can define which teams users matching your company's domain email address will auto-join when they sign up.
 
-You can enable this feature in your organization:
-
-* Navigate to :menuselection:`<Username dropdown> > Organizations --> <Organization Name> --> Settings --> Authorization`
-* Select **Google** in the :guilabel:`Provider` drop-down.
-* Specify your Google Workspace domain in the :guilabel:`Domain` input field and press :guilabel:`Save`.
+1. Navigate to the `authorization setting page <https://readthedocs.com/organizations/choose/organization_sso/>`__.
+2. Select **Google** in the :guilabel:`Provider` drop-down.
+3. Specify your Google Workspace domain in the :guilabel:`Domain` input field and press :guilabel:`Save`.
 
 Configure team for all users to join
 ------------------------------------
@@ -42,10 +40,11 @@ Configure team for all users to join
 You can mark one or many teams that users are automatically joined when they sign up with a matching email address.
 Configure this option by:
 
-* Navigating to :guilabel:`<Username dropdown>` > :guilabel:`Organizations` > :guilabel:`<Organization name>` > :guilabel:`Teams` > :guilabel:`<Team name>`
-* Click :guilabel:`Edit team`
-* Enable *Auto join users with an organization's email address to this team*.
-* Click :guilabel:`Save`
+1. Navigate to the `teams management page <https://readthedocs.com/organizations/choose/organization_team_list/>`__.
+2. Click the :guilabel:`<team name>`.
+3. Click :guilabel:`Edit team`
+4. Enable *Auto join users with an organization's email address to this team*.
+5. Click :guilabel:`Save`
 
 With this enabled,
 all users that sign up with their ``employee@company.com`` email will automatically join this team.

--- a/docs/user/shared/organization-permissions.rst
+++ b/docs/user/shared/organization-permissions.rst
@@ -6,8 +6,8 @@ you need to be an *owner* of that organization.
 
 You can validate your ownership of the Organization with these steps:
 
-* Navigate to :guilabel:`<Username dropdown>` > :guilabel:`Organizations` > :guilabel:`<Organization name>`
-* Look at the :guilabel:`Owners` section on the right menu.
+1. Navigate to the `organization management page <https://readthedocs.com/organizations/choose/organization_detail/>`__.
+2. Look at the :guilabel:`Owners` section on the right menu.
 
 If you'd like to modify this setting and are not an owner,
 you can ask an existing organization owner to take the actions listed.


### PR DESCRIPTION
Fixes #10403 

I noticed that we're pretty inconsistent around whether to write Click, Choose, Select, Press etc... would be nice to have something in the style guide on that.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10457.org.readthedocs.build/en/10457/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10457.org.readthedocs.build/en/10457/

<!-- readthedocs-preview dev end -->