### PR TITLE
Update gold docs to reflect cross-site cookie reality

### DIFF
--- a/docs/user/advertising/ad-blocking.rst
+++ b/docs/user/advertising/ad-blocking.rst
@@ -56,11 +56,13 @@ Going ad-free
 may completely remove advertising for all visitors to their projects.
 Thank you for supporting Read the Docs.
 
-Previously, being either a Gold member or
-`Supporter <https://readthedocs.org/sustainability/#donations>`_
-meant that a user got an ad-free experience while logged-in.
-While we didn't remove this capability, the cross-site cookies needed
-to make that work are no longer well supported by major browsers outside of Chrome.
+.. note::
+
+   Previously, Gold members or
+   `Supporters <https://readthedocs.org/sustainability/#donations>`_
+   were provided an ad-free reading experience across all projects on Read the Docs while logged-in.
+   However, the cross-site cookies needed to make that work are no longer supported by major browsers outside of Chrome,
+   and this feature will soon disappear entirely.
 
 
 Statistics and data

--- a/docs/user/advertising/ad-blocking.rst
+++ b/docs/user/advertising/ad-blocking.rst
@@ -52,11 +52,15 @@ or simply the **Read the Docs Ads list**.
 Going ad-free
 -------------
 
-Users can go completely ad-free when logged in
-by becoming a `Gold member <https://readthedocs.org/accounts/gold/>`_
-or a `Supporter <https://readthedocs.org/sustainability/#donations>`_.
-Gold members may also completely remove advertising for all visitors to their projects.
+`Gold members <https://readthedocs.org/accounts/gold/>`_
+may completely remove advertising for all visitors to their projects.
 Thank you for supporting Read the Docs.
+
+Previously, being either a Gold member or
+`Supporter <https://readthedocs.org/sustainability/#donations>`_
+meant that a user got an ad-free experience while logged-in.
+While we didn't remove this capability, the cross-site cookies needed
+to make that work are no longer well supported by major browsers outside of Chrome.
 
 
 Statistics and data

--- a/docs/user/advertising/ethical-advertising.rst
+++ b/docs/user/advertising/ethical-advertising.rst
@@ -158,10 +158,8 @@ Opting out
 
 We have added multiple ways to opt out of the advertising on Read the Docs.
 
-1. You can go completely ad-free
-   by becoming a `Gold member <https://readthedocs.org/accounts/gold/>`_
-   or a `Supporter <https://readthedocs.org/sustainability/#donations>`_.
-   Additionally, Gold members may remove advertising from their projects for all visitors.
+1. `Gold members <https://readthedocs.org/accounts/gold/>`_
+   may remove advertising from their projects for all visitors.
 
 2. You can opt out of seeing paid advertisements on documentation pages:
 

--- a/docs/user/advertising/index.rst
+++ b/docs/user/advertising/index.rst
@@ -23,14 +23,12 @@ that respects user privacy.
 We recognize that advertising is not for everyone.
 You may :ref:`opt out of paid advertising <advertising/ethical-advertising:Opting Out>`
 although you will still see :ref:`community ads <advertising/ethical-advertising:Community Ads>`.
-You can go ad-free by `becoming a Gold member`_ or a `Supporter`_ of Read the Docs.
-Gold members can also remove advertising from their projects for all visitors.
+`Gold members`_ may also remove advertising from their projects for all visitors.
 
 For businesses looking to remove advertising,
 please consider :doc:`Read the Docs for Business </commercial/index>`.
 
-.. _becoming a Gold member: https://readthedocs.org/accounts/gold/
-.. _Supporter: https://readthedocs.org/sustainability/#donations
+.. _Gold members: https://readthedocs.org/accounts/gold/
 
 .. toctree::
     :maxdepth: 2

--- a/readthedocs/gold/templates/gold/subscription_detail.html
+++ b/readthedocs/gold/templates/gold/subscription_detail.html
@@ -44,8 +44,7 @@ Read the Docs Gold
 
     <p>
     {% blocktrans trimmed %}
-      Becoming a Gold member makes Read the Docs ad-free when you are logged-in.
-      Gold members may also completely remove advertising for all visitors to their projects.
+      Gold members may completely remove advertising for all visitors to their projects.
     {% endblocktrans %}
     </p>
 

--- a/readthedocs/templates/profiles/private/advertising_profile.html
+++ b/readthedocs/templates/profiles/private/advertising_profile.html
@@ -13,40 +13,39 @@
   {% if request.user.gold.exists or request.user.goldonce.exists %}
     <p>
       {% blocktrans trimmed %}
-        Since you are a Gold member or Supporter, you are <strong>ad-free</strong> for as long as you are logged-in.
-        Thank you for supporting Read the Docs.
+        Thank you for supporting Read the Docs!
       {% endblocktrans%}
     </p>
-  {% else %}
-    <p>
-      {% blocktrans trimmed %}
-        Read the Docs is an open source project.
-        In order to maintain service, we rely on both the
-        support of our users, and from sponsor support.
-      {% endblocktrans %}
-    </p>
-
-    <p>
-      {% blocktrans trimmed %}
-        For more details on advertising on Read the Docs
-        including the privacy protections we have in place for users
-        and community advertising we run on behalf of the open source community,
-        see <a href="https://docs.readthedocs.io/page/advertising/ethical-advertising.html">our documentation</a>.
-      {% endblocktrans %}
-    </p>
-
-    <p>
-      {% url "gold_detail" as gold_detail %}
-      {% url "donate" as donate_url %}
-      {% blocktrans trimmed %}
-        You can <strong>go ad-free</strong> by becoming a <a href="{{ gold_detail }}">Gold member</a> or <a href="{{ donate_url }}">Supporter</a> of Read the Docs.
-      {% endblocktrans %}
-    </p>
-
-    <form method="POST" action=".">
-      {% csrf_token %}
-      {{ form.as_p }}
-      <input type="submit" name="submit" value="{% trans "Update advertisement preference" %}" id="submit"/>
-    </form>
   {% endif %}
+
+  <p>
+    {% blocktrans trimmed %}
+      Read the Docs is an open source project.
+      In order to maintain service, we rely on both the
+      support of our users, and from sponsor support.
+    {% endblocktrans %}
+  </p>
+
+  <p>
+    {% blocktrans trimmed %}
+      For more details on advertising on Read the Docs
+      including the privacy protections we have in place for users
+      and community advertising we run on behalf of the open source community,
+      see <a href="https://docs.readthedocs.io/page/advertising/ethical-advertising.html">our documentation</a>.
+    {% endblocktrans %}
+  </p>
+
+  <p>
+    {% url "gold_detail" as gold_detail %}
+    {% url "donate" as donate_url %}
+    {% blocktrans trimmed %}
+      You can <strong>go ad-free</strong> by becoming a <a href="{{ gold_detail }}">Gold member</a> or <a href="{{ donate_url }}">Supporter</a> of Read the Docs.
+    {% endblocktrans %}
+  </p>
+
+  <form method="POST" action=".">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <input type="submit" name="submit" value="{% trans "Update advertisement preference" %}" id="submit"/>
+  </form>
 {% endblock %}


### PR DESCRIPTION
Remove from our landing pages that being a gold member or supporter makes RTD ad free. We aren't removing that capability, but the cross site cookies needed to make that work do not work on Safari or Firefox. We'll leave the functionality in for Chrome users, but we aren't going to sell it since it doesn't work widely.

Basically, the API requests from `*.readthedocs.io` or user custom domains cannot make an authenticated request to readthedocs.org.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10459.org.readthedocs.build/en/10459/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10459.org.readthedocs.build/en/10459/

<!-- readthedocs-preview dev end -->