### PR TITLE
Notifications: email about `DONT_SHALLOW_CLONE` deprecated feature flag

### DIFF
--- a/readthedocs/core/management/commands/contact_owners.py
+++ b/readthedocs/core/management/commands/contact_owners.py
@@ -49,7 +49,11 @@ class Command(BaseCommand):
        to be included in the notification.
     * ``email.md`` is a Markdown file with the first line as the subject,
       and the rest is the content.
-      Note that ``user`` and ``domain`` are available in the context.
+
+      The context available is:
+        * ``user``
+        * ``projects``
+        * ``production_uri``
 
     .. code:: markdown
 
@@ -57,7 +61,7 @@ class Command(BaseCommand):
 
        Dear {{ user.firstname }},
 
-       Greetings from [Read the Docs]({{ domain }}).
+       Greetings from [Read the Docs]({{ production_uri }}).
 
     .. note::
 
@@ -143,7 +147,7 @@ class Command(BaseCommand):
             users = AdminPermission.owners(organization)
         elif usernames:
             file = Path(usernames)
-            with file.open() as f:
+            with file.open(encoding="utf8") as f:
                 usernames = f.readlines()
 
             # remove "\n" from lines
@@ -178,14 +182,14 @@ class Command(BaseCommand):
         notification_content = ''
         if options['notification']:
             file = Path(options['notification'])
-            with file.open() as f:
+            with file.open(encoding="utf8") as f:
                 notification_content = f.read()
 
         email_subject = ''
         email_content = ''
         if options['email']:
             file = Path(options['email'])
-            with file.open() as f:
+            with file.open(encoding="utf8") as f:
                 content = f.read().split('\n')
             email_subject = content[0].strip()
             email_content = '\n'.join(content[1:]).strip()

--- a/readthedocs/core/management/commands/emails/unshallow-clone-email.md
+++ b/readthedocs/core/management/commands/emails/unshallow-clone-email.md
@@ -1,0 +1,23 @@
+[Action required] Unshallow your clone via the configuration file
+
+{% load projects_tags %}
+Some time ago we added an on-request "feature flag" to allow users to unshallow their Git repository
+when clonning them as part of the build process.
+With the introduction of the ability to [customize the build process](https://docs.readthedocs.io/en/latest/build-customization.html) via `build.jobs` and `build.commands`,
+this feature flag is not required anymore and we are deprecating it.
+Now, users have the ability to unshallow the Git repository clone without contacting support.
+
+We are sending you this email because you are a maintainer of the following projects that have
+this "feature flag" enabled and you should unshallow your clone now by using the configuration file:
+
+{% spaceless %}
+{% for project in projects %}
+{% if project|has_feature:"dont_shallow_clone" %}
+* [{{ production_uri }}{{ project.get_absolute_url }}]({{ project.slug }})
+{% endif %}
+{% endfor %}
+{% endspaceless %}
+
+Note this feature flag will be completely removed on **August 28th**.
+Please, refer to [the example we have in the documentation](https://docs.readthedocs.io/en/latest/build-customization.html#unshallow-git-clone)
+to unshallow your clone via the configuration file if your projects still require it.

--- a/readthedocs/core/utils/contact.py
+++ b/readthedocs/core/utils/contact.py
@@ -1,5 +1,4 @@
 import structlog
-from pprint import pprint
 
 import markdown
 from django.conf import settings
@@ -34,7 +33,7 @@ def contact_users(
     :param string notification_content: Content for the sticky notification (markdown)
     :param context_function: A callable that will receive an user
      and return a dict of additional context to be used in the email/notification content
-    :param bool dryrun: If `True` don't sent the email or notification, just print the content
+    :param bool dryrun: If `True` don't sent the email or notification, just logs the content
 
     The `email_content` and `notification_content` contents will be rendered using
     a template with the following context::
@@ -91,16 +90,12 @@ def contact_users(
             try:
                 if not dryrun:
                     backend.send(notification)
-                else:
-                    pprint(markdown.markdown(
-                        notification_template.render(Context(context))
-                    ))
             except Exception:
                 log.exception('Notification failed to send')
                 failed_notifications.add(user.username)
             else:
                 log.info(
-                    'Successfully set notification.',
+                    "Successfully sent notification.",
                     user_username=user.username,
                     count=count,
                     total=total,
@@ -140,8 +135,6 @@ def contact_users(
                 }
                 if not dryrun:
                     send_mail(**kwargs)
-                else:
-                    pprint(kwargs)
             except Exception:
                 log.exception('Email failed to send')
                 failed_emails.update(emails)

--- a/readthedocs/projects/templatetags/projects_tags.py
+++ b/readthedocs/projects/templatetags/projects_tags.py
@@ -25,3 +25,9 @@ def sort_version_aware(versions):
 def is_project_user(user, project):
     """Checks if the user has access to the project."""
     return user in AdminPermission.members(project)
+
+
+@register.filter
+def has_feature(project, feature):
+    """Check if the project has a particular feature flag."""
+    return project.has_feature(feature)


### PR DESCRIPTION
This PR prepare an email notification to be sent to users with projects using this feature flag. We use a similar pattern than the one used for the deprecation of the configuration file: 1 email per user listing all their projects affected [^1].

There are set of different changes in this PR (each set has it's own commit to make it easier to review):

* Expand the `contact_owners.py` management command
  - Follow the convention we have in other notifications regarding the context: us `production_uri` instead of `domain`
  - Add all the `projects` for a particular user to the context, so we can show actions specific to those projects
  - Use the internal `get_context_data()` and `extra_context=` to follow the pattern stablished for the `Notification` class.
* Add a template filter to check if a `Project` has a feature flag or not
* Write an initial email to be reviewed by the team

### Preview

![Screenshot_2023-06-22_18-19-48](https://github.com/readthedocs/readthedocs.org/assets/244656/d7740810-9131-4272-ab16-13e5774233e5)


[^1]: I'd like to standardize this pattern in a generic way somehow, but I don't want to deviate too much right, so I made some small changes to allow me to do this in a simple way for now.

Related: #9779 