### PR TITLE
Build: always use `gvisor` Docker runtime

### DIFF
--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -59,6 +59,8 @@ Set up your environment
 
       pip install -r common/dockerfiles/requirements.txt
 
+#. Set up gVisor following :doc:`rtd-dev:guides/gvisor`.
+
 #. Build the Docker image for the servers:
 
    .. warning::

--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -140,14 +140,12 @@ class BuildDirector:
         )
 
     def create_build_environment(self):
-        use_gvisor = self.data.config.using_build_tools and self.data.config.build.jobs
         self.build_environment = self.data.environment_class(
             project=self.data.project,
             version=self.data.version,
             config=self.data.config,
             build=self.data.build,
             environment=self.get_build_env_vars(),
-            use_gvisor=use_gvisor,
             api_client=self.data.api_client,
         )
 

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1909,7 +1909,6 @@ class Feature(models.Model):
     CONDA_APPEND_CORE_REQUIREMENTS = "conda_append_core_requirements"
     ALL_VERSIONS_IN_HTML_CONTEXT = "all_versions_in_html_context"
     CDN_ENABLED = "cdn_enabled"
-    DOCKER_GVISOR_RUNTIME = "gvisor_runtime"
     RECORD_404_PAGE_VIEWS = "record_404_page_views"
     ALLOW_FORCED_REDIRECTS = "allow_forced_redirects"
     DISABLE_PAGEVIEWS = "disable_pageviews"
@@ -1981,10 +1980,6 @@ class Feature(models.Model):
                 "Proxito: CDN support for a project's public versions when privacy levels "
                 "are enabled."
             ),
-        ),
-        (
-            DOCKER_GVISOR_RUNTIME,
-            _("Build: Use Docker gVisor runtime to create build container."),
         ),
         (
             RECORD_404_PAGE_VIEWS,


### PR DESCRIPTION
Remove the feature flag to decide whether or not Docker should use `gVisor`. This is currently enabled by default to all the projects since last week, so I think we are safe to remove it since it has been working fine.

Related #9779 