### PR TITLE
Docs: Typo fix for integrations.rst

### DIFF
--- a/docs/user/integrations.rst
+++ b/docs/user/integrations.rst
@@ -17,7 +17,7 @@ The Continuous Integration and Continuous Deployment (CI/CD) features are config
 such as GitHub, Bitbucket or GitLab.
 With each change committed to your repository, we are notified by the configured *webhook*.
 
-When a receive a *webhook* notification, we match it to a project's *Integration*.
+When we receive a *webhook* notification, we match it to a project's *Integration*.
 When a webhook is received, the matching project will then:
 
 * :doc:`Build </builds>` the latest commit.


### PR DESCRIPTION


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10474.org.readthedocs.build/en/10474/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10474.org.readthedocs.build/en/10474/

<!-- readthedocs-preview dev end -->