### PR TITLE
CI: Use a cache for pre-commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,15 @@ jobs:
       - image: 'cimg/python:3.10'
     steps:
       - checkout
+      # Recipe: https://pre-commit.com/#managing-ci-caches
+      - run:
+          name: Combine precommit config and python versions for caching
+          command: |
+            cp .pre-commit-config.yaml pre-commit-cache-key.txt
+            python --version --version >> pre-commit-cache-key.txt
+      - restore_cache:
+          keys:
+          - v1-pc-cache-{{ checksum "pre-commit-cache-key.txt" }}
       - run: git submodule sync
       - run: git submodule update --init
       - run: pip install --user 'tox<5'
@@ -49,6 +58,10 @@ jobs:
           node-version: '10.17.0'
       - run: npm ci
       - run: tox -e eslint
+      - save_cache:
+          key: v1-pc-cache-{{ checksum "pre-commit-cache-key.txt" }}
+          paths:
+          - ~/.cache/pre-commit
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
             python --version --version >> pre-commit-cache-key.txt
       - restore_cache:
           keys:
-          - v1-pc-cache-{{ checksum "pre-commit-cache-key.txt" }}
+          - pre-commit-cache-{{ checksum "pre-commit-cache-key.txt" }}
       - run: pip install --user 'tox<5'
       - run: tox -e pre-commit
       - run: tox -e migrations
@@ -59,7 +59,7 @@ jobs:
       - run: npm ci
       - run: tox -e eslint
       - save_cache:
-          key: v1-pc-cache-{{ checksum "pre-commit-cache-key.txt" }}
+          key: pre-commit-cache-{{ checksum "pre-commit-cache-key.txt" }}
           paths:
           - ~/.cache/pre-commit
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,17 +40,17 @@ jobs:
       - image: 'cimg/python:3.10'
     steps:
       - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
       # Recipe: https://pre-commit.com/#managing-ci-caches
       - run:
-          name: Combine precommit config and python versions for caching
+          name: Combine pre-commit config and python versions for caching
           command: |
             cp common/pre-commit-config.yaml pre-commit-cache-key.txt
             python --version --version >> pre-commit-cache-key.txt
       - restore_cache:
           keys:
           - v1-pc-cache-{{ checksum "pre-commit-cache-key.txt" }}
-      - run: git submodule sync
-      - run: git submodule update --init
       - run: pip install --user 'tox<5'
       - run: tox -e pre-commit
       - run: tox -e migrations

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
       - run:
           name: Combine precommit config and python versions for caching
           command: |
-            cp .pre-commit-config.yaml pre-commit-cache-key.txt
+            cp common/pre-commit-config.yaml pre-commit-cache-key.txt
             python --version --version >> pre-commit-cache-key.txt
       - restore_cache:
           keys:


### PR DESCRIPTION
Circle CI spends 1 minute initializing pre-commit on every build.

Using this example from the pre-commit docs should be enough to cache the pre-commit environments across our builds.