### PR TITLE
Images: Add tzdata as explicit requirement

### DIFF
--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -383,6 +383,7 @@ selectolax==0.3.14
 six==1.16.0
     # via
     #   -r requirements/pip.txt
+    #   asttokens
     #   click-repl
     #   django-annoying
     #   django-elasticsearch-dsl
@@ -459,6 +460,8 @@ typing-extensions==4.6.3
     # via
     #   -r requirements/pip.txt
     #   asgiref
+tzdata==2023.3
+    # via -r requirements/pip.txt
 ua-parser==0.16.1
     # via
     #   -r requirements/pip.txt

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -43,6 +43,7 @@ celery
 # Docker images need a dependency explicity marked for tzdata in order to have
 # necessary timezone data.
 # https://github.com/readthedocs/readthedocs.org/issues/10453
+# TODO: remove this dependency once we upgrade Celery. It should auto-install it.
 tzdata
 
 # 0.52.0 requires creating a new email template:

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -40,6 +40,11 @@ Pygments
 django-redis
 celery
 
+# Docker images need a dependency explicity marked for tzdata in order to have
+# necessary timezone data.
+# https://github.com/readthedocs/readthedocs.org/issues/10453
+tzdata
+
 # 0.52.0 requires creating a new email template:
 #  templates/account/email/acccount_already_exists_message.html
 # See https://github.com/readthedocs/readthedocs.org/pull/9853#discussion_r1060496492

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -287,6 +287,8 @@ toml==0.10.2
     # via dparse
 typing-extensions==4.6.3
     # via asgiref
+tzdata==2023.3
+    # via -r requirements/pip.in
 ua-parser==0.16.1
     # via user-agents
 unicode-slugify @ git+https://github.com/mozilla/unicode-slugify@b696c37

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -414,11 +414,15 @@ toml==0.10.2
     #   -r requirements/pip.txt
     #   dparse
 tomli==2.0.1
-    # via pytest
+    # via
+    #   coverage
+    #   pytest
 typing-extensions==4.6.3
     # via
     #   -r requirements/pip.txt
     #   asgiref
+tzdata==2023.3
+    # via -r requirements/pip.txt
 ua-parser==0.16.1
     # via
     #   -r requirements/pip.txt


### PR DESCRIPTION
Requirements updated with the new `inv requirements.update -p tzdata`

Fixes https://github.com/readthedocs/readthedocs.org/issues/10453

Note to @stsewd - the invoke command generated what I assume are expected results. But it contained an error at the end. We might also wanna print the text "Warning, this command takes some minutes to finish" :)


```
# The following packages are considered to be unsafe in a requirements file:
# setuptools
    WARNING: Did not find branch or tag 'b696c37', assuming revision or ref.
    error: subprocess-exited-with-error
    
    × python setup.py egg_info did not run successfully.
    │ exit code: 1
    ╰─> [25 lines of output]
        /home/user/.virtualenvs/readthedocs.org/lib/python3.10/site-packages/setuptools/config/setupcfg.py:516: SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use license_files instead.
          warnings.warn(msg, warning_class)
        running egg_info
        creating /tmp/pip-pip-egg-info-umem36pm/psycopg2.egg-info
        writing /tmp/pip-pip-egg-info-umem36pm/psycopg2.egg-info/PKG-INFO
        writing dependency_links to /tmp/pip-pip-egg-info-umem36pm/psycopg2.egg-info/dependency_links.txt
        writing top-level names to /tmp/pip-pip-egg-info-umem36pm/psycopg2.egg-info/top_level.txt
        writing manifest file '/tmp/pip-pip-egg-info-umem36pm/psycopg2.egg-info/SOURCES.txt'
        
        Error: pg_config executable not found.
        
        pg_config is required to build psycopg2 from source.  Please add the directory
        containing pg_config to the $PATH or specify the full executable path with the
        option:
        
            python setup.py build_ext --pg-config /path/to/pg_config build ...
        
        or with the pg_config option in 'setup.cfg'.
        
        If you prefer to avoid building psycopg2 from source, please install the PyPI
        'psycopg2-binary' package instead.
        
        For further information please check the 'doc/src/install.rst' file (also at
        <https://www.psycopg.org/docs/install.html>).
        
        [end of output]
    
    note: This error originates from a subprocess, and is likely not a problem with pip.
```