### PR TITLE
Docs: do not fail when unshallow clone

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -102,7 +102,7 @@ To avoid this, it's possible to unshallow the :program:`git clone`:
        python: "3.10"
      jobs:
        post_checkout:
-         - git fetch --unshallow
+         - git fetch --unshallow  || true
 
 
 Cancel build based on a condition


### PR DESCRIPTION
Allow a Git repository to unshallow it even if it was already unshallowed. This avoids builds to fail.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10485.org.readthedocs.build/en/10485/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10485.org.readthedocs.build/en/10485/

<!-- readthedocs-preview dev end -->