### PR TITLE
docs: Correct typo

### DIFF
--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -221,7 +221,7 @@ Example:
          path: .
          extra_requirements:
            - docs
-       - method: pip
+       - method: setuptools
          path: package
 
 With the previous settings, Read the Docs will execute the next commands:


### PR DESCRIPTION
The example uses the 'pip' install method but the explanation suggests it should have used 'pip'.


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10489.org.readthedocs.build/en/10489/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10489.org.readthedocs.build/en/10489/

<!-- readthedocs-preview dev end -->