### PR TITLE
Docs: remove `setuptools` from our docs

### DIFF
--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -221,15 +221,12 @@ Example:
          path: .
          extra_requirements:
            - docs
-       - method: setuptools
-         path: package
 
 With the previous settings, Read the Docs will execute the next commands:
 
 .. prompt:: bash $
 
    pip install .[docs]
-   python package/setup.py install
 
 python.system_packages
 ``````````````````````


### PR DESCRIPTION
Follow up from #10489