### PR TITLE
Tests: Mock revoking build API key?

### DIFF
--- a/readthedocs/projects/tests/mockers.py
+++ b/readthedocs/projects/tests/mockers.py
@@ -262,3 +262,8 @@ class BuildEnvironmentMocker:
             f'{settings.SLUMBER_API_HOST}/api/v2/project/{self.project.pk}/',
             status_code=201,
         )
+
+        self.requestsmock.post(
+            f"{settings.SLUMBER_API_HOST}/api/v2/revoke/",
+            status_code=204,
+        )


### PR DESCRIPTION
@stsewd getting a lot of these in tests:

```
[error    ] Failed to revoke build api key. [readthedocs.projects.tasks.builds] artifacts=[] build_id=1 builder=aef5bfe565c3 commit=a1b2c3 project_slug=project status=failed version_slug=latest
Traceback (most recent call last):
  File "/usr/src/app/checkouts/readthedocs.org/readthedocs/projects/tasks/builds.py", line 765, in after_return
    self.data.api_client.revoke.post()
  File "/usr/src/app/checkouts/readthedocs.org/.tox/py310/lib/python3.10/site-packages/slumber/__init__.py", line 167, in post
    resp = self._request("POST", data=data, files=files, params=kwargs)
  File "/usr/src/app/checkouts/readthedocs.org/.tox/py310/lib/python3.10/site-packages/slumber/__init__.py", line 97, in _request
    resp = self._store["session"].request(method, url, data=data, params=params, files=files, headers=headers)
  File "/usr/src/app/checkouts/readthedocs.org/.tox/py310/lib/python3.10/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/src/app/checkouts/readthedocs.org/.tox/py310/lib/python3.10/site-packages/requests_mock/mocker.py", line 185, in _fake_send
    return _original_send(session, request, **kwargs)
  File "/usr/src/app/checkouts/readthedocs.org/.tox/py310/lib/python3.10/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
  File "/usr/src/app/checkouts/readthedocs.org/.tox/py310/lib/python3.10/site-packages/requests_mock/adapter.py", line 261, in send
    raise exceptions.NoMockAddress(request)
requests_mock.exceptions.NoMockAddress: No mock address: POST http://localhost:8000/api/v2/revoke/
```

Not sure if this is what we want to do, maybe we want to call the view in order to test it?
