### PR TITLE
Docs: update Conda to its latest available version

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -339,6 +339,32 @@ Take a look at the following example:
      configuration: docs/conf.py
 
 
+Update Conda version
+^^^^^^^^^^^^^^^^^^^^
+
+Projects using Conda may need to install the latest available version of Conda.
+This can be done by using the ``pre_create_environment`` user-defined job to update Conda
+before creating the environment.
+Take a look at the following example:
+
+
+.. code-block:: yaml
+   :caption: .readthedocs.yaml
+
+    version: 2
+
+    build:
+      os: "ubuntu-22.04"
+      tools:
+        python: "miniconda3-4.7"
+      jobs:
+        pre_create_environment:
+          - conda update --yes --quiet --name=base --channel=defaults conda
+
+    conda:
+      environment: environment.yml
+
+
 .. _build_commands_introduction:
 
 Override the build process


### PR DESCRIPTION
Example using `build.jobs.pre_create_environment` to update Conda. We will link this example in the email we will be sending to users when deprecating/removing `UPDATE_CONDA_STARTUP` feature flag.

See #9779

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10493.org.readthedocs.build/en/10493/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10493.org.readthedocs.build/en/10493/

<!-- readthedocs-preview dev end -->