### PR TITLE
Test: Verify "cat .readthedocs.yaml" was called

### DIFF
--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -705,6 +705,11 @@ class TestBuildTask(BuildEnvironmentBase):
         self.mocker.mocks["environment.run"].assert_has_calls(
             [
                 mock.call(
+                    "cat",
+                    "readthedocs.yaml",
+                    cwd="/tmp/readthedocs-tests/git-repository",
+                ),
+                mock.call(
                     "python3.7",
                     "-mvirtualenv",
                     mock.ANY,


### PR DESCRIPTION
While debugging some test assertions, I noticed that this was left out. It's possible because `assert_has_calls` doesn't care if there are additional calls before or after.