### PR TITLE
Reduce logging of common redirects and expected items

### DIFF
--- a/readthedocs/proxito/redirects.py
+++ b/readthedocs/proxito/redirects.py
@@ -76,13 +76,13 @@ def canonical_redirect(request, project, redirect_type, external_version_slug=No
 
     if from_url == to:
         # check that we do have a response and avoid infinite redirect
-        log.warning(
+        log.debug(
             "Infinite Redirect: FROM URL is the same than TO URL.",
             url=to,
         )
         raise InfiniteRedirectException()
 
-    log.info(
+    log.debug(
         "Canonical Redirect.", host=request.get_host(), from_url=from_url, to_url=to
     )
     resp = HttpResponseRedirect(to)

--- a/readthedocs/proxito/views/mixins.py
+++ b/readthedocs/proxito/views/mixins.py
@@ -378,7 +378,7 @@ class ServeRedirectMixin:
         # Redirects shouldn't change the domain, version or language.
         # However, if the new_path is already an absolute URI, just use it
         new_path = request.build_absolute_uri(new_path)
-        log.info(
+        log.debug(
             'Redirecting...',
             from_url=request.build_absolute_uri(proxito_path),
             to_url=new_path,
@@ -394,7 +394,7 @@ class ServeRedirectMixin:
             and new_path_parsed.path == old_path_parsed.path
         ):
             # check that we do have a response and avoid infinite redirect
-            log.warning(
+            log.debug(
                 'Infinite Redirect: FROM URL is the same than TO URL.',
                 url=new_path,
             )

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -308,7 +308,6 @@ class ServeDocsBase(CDNCacheControlMixin, ServeRedirectMixin, ServeDocsMixin, Vi
                 .exists()
             )
             # For .com we need to check if the project supports custom domains.
-            # pylint: disable=protected-access
             if canonical_domain and resolver._use_cname(project):
                 log.debug(
                     "Proxito Public Domain -> Canonical Domain Redirect.",
@@ -525,7 +524,6 @@ class ServeError404Base(CDNCacheControlMixin, ServeRedirectMixin, ServeDocsMixin
         with the default version and finally, if none of them are found, the Read
         the Docs default page (Maze Found) is rendered by Django and served.
         """
-        # pylint: disable=too-many-locals
         log.bind(proxito_path=proxito_path)
         log.debug('Executing 404 handler.')
 
@@ -691,7 +689,7 @@ class ServeError404Base(CDNCacheControlMixin, ServeRedirectMixin, ServeDocsMixin
                     storage_root_path, tryfile
                 )
                 if build_media_storage.exists(storage_filename_path):
-                    log.info(
+                    log.debug(
                         "Serving custom 404.html page.",
                         version_slug_404=version_404.slug,
                         storage_filename_path=storage_filename_path,

--- a/readthedocs/search/documents.py
+++ b/readthedocs/search/documents.py
@@ -22,8 +22,8 @@ class RTDDocTypeMixin:
         # Hack a fix to our broken connection pooling
         # This creates a new connection on every request,
         # but actually works :)
-        log.info('Hacking Elastic indexing to fix connection pooling')
-        self.using = Elasticsearch(**settings.ELASTICSEARCH_DSL['default'])
+        log.debug("Hacking Elastic indexing to fix connection pooling")
+        self.using = Elasticsearch(**settings.ELASTICSEARCH_DSL["default"])
         super().update(*args, **kwargs)
 
 

--- a/readthedocs/search/faceted_search.py
+++ b/readthedocs/search/faceted_search.py
@@ -69,8 +69,8 @@ class RTDFacetedSearch(FacetedSearch):
         # Hack a fix to our broken connection pooling
         # This creates a new connection on every request,
         # but actually works :)
-        log.info('Hacking Elastic to fix search connection pooling')
-        self.using = Elasticsearch(**settings.ELASTICSEARCH_DSL['default'])
+        log.debug("Hacking Elastic to fix search connection pooling")
+        self.using = Elasticsearch(**settings.ELASTICSEARCH_DSL["default"])
 
         filters = filters or {}
 


### PR DESCRIPTION
This should massively reduce the amount of logs we're showing:


![Screenshot 2023-06-28 at 10 35 49 AM](https://github.com/readthedocs/readthedocs.org/assets/25510/c3eb5675-87ec-427f-ba47-32016d25d482)

Chart: https://chart-embed.service.newrelic.com/herald/026e34db-4e14-4867-8bce-85845402be24?height=400px&timepicker=true