### PR TITLE
 API V2: remove write access to superusers

### DIFF
--- a/docs/dev/settings.rst
+++ b/docs/dev/settings.rst
@@ -19,22 +19,6 @@ memory
     Examples: '200m' for 200MB of total memory, or '2g' for 2GB of
     total memory.
 
-SLUMBER_USERNAME
-----------------
-
-.. Don't set this automatically, lest we leak something. We are using the dev
-   settings in the conf.py, but it's probably a good idea to be safe.
-
-The username to use when connecting to the Read the Docs API. Used for hitting the API while building the docs.
-
-SLUMBER_PASSWORD
-----------------
-
-.. Don't set this automatically, lest we leak something. We are using the dev
-   settings in the conf.py, but it's probably a good idea to be safe.
-
-The password to use when connecting to the Read the Docs API. Used for hitting the API while building the docs.
-
 USE_SUBDOMAIN
 ---------------
 

--- a/readthedocs/api/v2/permissions.py
+++ b/readthedocs/api/v2/permissions.py
@@ -16,7 +16,7 @@ class IsOwner(permissions.BasePermission):
         return request.user in obj.users.all()
 
 
-class APIRestrictedPermission(permissions.BasePermission):
+class ReadOnlyPermission(permissions.BasePermission):
 
     """Allow read-only access to authenticated and anonymous users."""
 

--- a/readthedocs/api/v2/permissions.py
+++ b/readthedocs/api/v2/permissions.py
@@ -18,26 +18,10 @@ class IsOwner(permissions.BasePermission):
 
 class APIRestrictedPermission(permissions.BasePermission):
 
-    """
-    Allow admin write, authenticated and anonymous read only.
-
-    This differs from :py:class:`APIPermission` by not allowing for
-    authenticated POSTs. This permission is endpoints like ``/api/v2/build/``,
-    which are used by admin users to coordinate build instance creation, but
-    only should be readable by end users.
-    """
+    """Allow read-only access to authenticated and anonymous users."""
 
     def has_permission(self, request, view):
-        return (
-            request.method in permissions.SAFE_METHODS or
-            (request.user and request.user.is_staff)
-        )
-
-    def has_object_permission(self, request, view, obj):
-        return (
-            request.method in permissions.SAFE_METHODS or
-            (request.user and request.user.is_staff)
-        )
+        return request.method in permissions.SAFE_METHODS
 
 
 class IsAuthorizedToViewVersion(permissions.BasePermission):
@@ -89,6 +73,8 @@ class HasBuildAPIKey(BaseHasAPIKey):
     to avoid having to parse and validate the key again on each view.
     The key is injected in the ``request.build_api_key`` attribute
     only if it's valid, otherwise it's set to ``None``.
+
+    This grants read and write access to the API.
     """
 
     model = BuildAPIKey

--- a/readthedocs/api/v2/views/model_views.py
+++ b/readthedocs/api/v2/views/model_views.py
@@ -14,11 +14,7 @@ from rest_framework.parsers import JSONParser, MultiPartParser
 from rest_framework.renderers import BaseRenderer, JSONRenderer
 from rest_framework.response import Response
 
-from readthedocs.api.v2.permissions import (
-    ReadOnlyPermission,
-    HasBuildAPIKey,
-    IsOwner,
-)
+from readthedocs.api.v2.permissions import HasBuildAPIKey, IsOwner, ReadOnlyPermission
 from readthedocs.api.v2.utils import normalize_build_command
 from readthedocs.builds.constants import INTERNAL
 from readthedocs.builds.models import Build, BuildCommandResult, Version

--- a/readthedocs/api/v2/views/model_views.py
+++ b/readthedocs/api/v2/views/model_views.py
@@ -15,7 +15,7 @@ from rest_framework.renderers import BaseRenderer, JSONRenderer
 from rest_framework.response import Response
 
 from readthedocs.api.v2.permissions import (
-    APIRestrictedPermission,
+    ReadOnlyPermission,
     HasBuildAPIKey,
     IsOwner,
 )
@@ -166,7 +166,7 @@ class ProjectViewSet(DisableListEndpoint, UpdateModelMixin, UserSelectViewSet):
 
     """List, filter, etc, Projects."""
 
-    permission_classes = [HasBuildAPIKey | APIRestrictedPermission]
+    permission_classes = [HasBuildAPIKey | ReadOnlyPermission]
     renderer_classes = (JSONRenderer,)
     serializer_class = ProjectSerializer
     admin_serializer_class = ProjectAdminSerializer
@@ -211,7 +211,7 @@ class ProjectViewSet(DisableListEndpoint, UpdateModelMixin, UserSelectViewSet):
 
 class VersionViewSet(DisableListEndpoint, UpdateModelMixin, UserSelectViewSet):
 
-    permission_classes = [HasBuildAPIKey | APIRestrictedPermission]
+    permission_classes = [HasBuildAPIKey | ReadOnlyPermission]
     renderer_classes = (JSONRenderer,)
     serializer_class = VersionSerializer
     admin_serializer_class = VersionAdminSerializer
@@ -229,7 +229,7 @@ class VersionViewSet(DisableListEndpoint, UpdateModelMixin, UserSelectViewSet):
 
 
 class BuildViewSet(DisableListEndpoint, UpdateModelMixin, UserSelectViewSet):
-    permission_classes = [HasBuildAPIKey | APIRestrictedPermission]
+    permission_classes = [HasBuildAPIKey | ReadOnlyPermission]
     renderer_classes = (JSONRenderer, PlainTextBuildRenderer)
     model = Build
     filterset_fields = ('project__slug', 'commit')
@@ -328,7 +328,7 @@ class BuildViewSet(DisableListEndpoint, UpdateModelMixin, UserSelectViewSet):
 
 class BuildCommandViewSet(DisableListEndpoint, CreateModelMixin, UserSelectViewSet):
     parser_classes = [JSONParser, MultiPartParser]
-    permission_classes = [HasBuildAPIKey | APIRestrictedPermission]
+    permission_classes = [HasBuildAPIKey | ReadOnlyPermission]
     renderer_classes = (JSONRenderer,)
     serializer_class = BuildCommandSerializer
     model = BuildCommandResult
@@ -346,7 +346,7 @@ class BuildCommandViewSet(DisableListEndpoint, CreateModelMixin, UserSelectViewS
 
 
 class DomainViewSet(DisableListEndpoint, UserSelectViewSet):
-    permission_classes = [APIRestrictedPermission]
+    permission_classes = [ReadOnlyPermission]
     renderer_classes = (JSONRenderer,)
     serializer_class = DomainSerializer
     model = Domain

--- a/readthedocs/api/v2/views/model_views.py
+++ b/readthedocs/api/v2/views/model_views.py
@@ -255,8 +255,9 @@ class BuildViewSet(DisableListEndpoint, UpdateModelMixin, UserSelectViewSet):
         project_slug = request.GET.get('project__slug')
         build_api_key = request.build_api_key
         if project_slug != build_api_key.project.slug:
-            log.info(
+            log.warning(
                 "Project slug doesn't match the one attached to the API key.",
+                api_key_id=build_api_key.id,
                 project_slug=project_slug,
             )
             raise Http404()

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -646,7 +646,7 @@ class APITests(TestCase):
 
         for user in [user_normal, user_admin]:
             client.force_authenticate(user=user)
-            resp = client.get('/api/v2/project/%s/' % (project.pk))
+            resp = client.get("/api/v2/project/%s/" % (project.pk))
             self.assertEqual(resp.status_code, 200)
             self.assertNotIn("conf_py_file", resp.data)
             self.assertNotIn("readthedocs_yaml_path", resp.data)
@@ -3077,9 +3077,9 @@ class APIVersionTests(TestCase):
             'pk': version.pk,
         }
         resp = self.client.get(
-            reverse('version-detail', kwargs=data),
-            content_type='application/json',
-            HTTP_AUTHORIZATION=f"Token {build_api_key}"
+            reverse("version-detail", kwargs=data),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Token {build_api_key}",
         )
         self.assertEqual(resp.status_code, 200)
 
@@ -3186,10 +3186,10 @@ class APIVersionTests(TestCase):
             'pk': version.pk,
         }
         resp = self.client.patch(
-            reverse('version-detail', kwargs=data),
-            data=json.dumps({'built': False, 'has_pdf': True}),
-            content_type='application/json',
-            HTTP_AUTHORIZATION=f"Token {build_api_key}"
+            reverse("version-detail", kwargs=data),
+            data=json.dumps({"built": False, "has_pdf": True}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Token {build_api_key}",
         )
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.data['built'], False)

--- a/readthedocs/rtd_tests/tests/test_api_permissions.py
+++ b/readthedocs/rtd_tests/tests/test_api_permissions.py
@@ -56,31 +56,7 @@ class APIRestrictedPermissionTests(TestCase):
         assertAllow('GET', is_admin=True)
         assertAllow('HEAD', is_admin=True)
         assertAllow('OPTIONS', is_admin=True)
-        assertAllow('DELETE', is_admin=True)
-        assertAllow('PATCH', is_admin=True)
-        assertAllow('POST', is_admin=True)
-        assertAllow('PUT', is_admin=True)
-
-    def test_object_permissions(self):
-        handler = APIRestrictedPermission()
-
-        obj = Mock()
-
-        assertAllow = partial(self.assertAllow, handler, obj=obj)
-        assertDisallow = partial(self.assertDisallow, handler, obj=obj)
-
-        assertAllow('GET', is_admin=False)
-        assertAllow('HEAD', is_admin=False)
-        assertAllow('OPTIONS', is_admin=False)
-        assertDisallow('DELETE', is_admin=False)
-        assertDisallow('PATCH', is_admin=False)
-        assertDisallow('POST', is_admin=False)
-        assertDisallow('PUT', is_admin=False)
-
-        assertAllow('GET', is_admin=True)
-        assertAllow('HEAD', is_admin=True)
-        assertAllow('OPTIONS', is_admin=True)
-        assertAllow('DELETE', is_admin=True)
-        assertAllow('PATCH', is_admin=True)
-        assertAllow('POST', is_admin=True)
-        assertAllow('PUT', is_admin=True)
+        assertDisallow('DELETE', is_admin=True)
+        assertDisallow('PATCH', is_admin=True)
+        assertDisallow('POST', is_admin=True)
+        assertDisallow('PUT', is_admin=True)

--- a/readthedocs/rtd_tests/tests/test_api_permissions.py
+++ b/readthedocs/rtd_tests/tests/test_api_permissions.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 from unittest.mock import Mock
 
-from readthedocs.api.v2.permissions import APIRestrictedPermission
+from readthedocs.api.v2.permissions import ReadOnlyPermission
 
 
 class APIRestrictedPermissionTests(TestCase):
@@ -39,8 +39,8 @@ class APIRestrictedPermissionTests(TestCase):
                 obj=obj,
             ))
 
-    def test_non_object_permissions(self):
-        handler = APIRestrictedPermission()
+    def test_read_only_permission(self):
+        handler = ReadOnlyPermission()
 
         assertAllow = partial(self.assertAllow, handler, obj=None)
         assertDisallow = partial(self.assertDisallow, handler, obj=None)
@@ -53,10 +53,10 @@ class APIRestrictedPermissionTests(TestCase):
         assertDisallow('POST', is_admin=False)
         assertDisallow('PUT', is_admin=False)
 
-        assertAllow('GET', is_admin=True)
-        assertAllow('HEAD', is_admin=True)
-        assertAllow('OPTIONS', is_admin=True)
-        assertDisallow('DELETE', is_admin=True)
-        assertDisallow('PATCH', is_admin=True)
-        assertDisallow('POST', is_admin=True)
-        assertDisallow('PUT', is_admin=True)
+        assertAllow("GET", is_admin=True)
+        assertAllow("HEAD", is_admin=True)
+        assertAllow("OPTIONS", is_admin=True)
+        assertDisallow("DELETE", is_admin=True)
+        assertDisallow("PATCH", is_admin=True)
+        assertDisallow("POST", is_admin=True)
+        assertDisallow("PUT", is_admin=True)

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -86,8 +86,6 @@ class CommunityBaseSettings(Settings):
 
     # slumber settings
     SLUMBER_API_HOST = 'https://readthedocs.org'
-    SLUMBER_USERNAME = None
-    SLUMBER_PASSWORD = None
 
     # Email
     DEFAULT_FROM_EMAIL = 'no-reply@readthedocs.org'

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -22,8 +22,6 @@ class DockerBaseSettings(CommunityBaseSettings):
     PUBLIC_API_URL = f'http://{PRODUCTION_DOMAIN}'
 
     SLUMBER_API_HOST = 'http://web:8000'
-    SLUMBER_USERNAME = 'admin'
-    SLUMBER_PASSWORD = 'admin'
 
     RTD_EXTERNAL_VERSION_DOMAIN = 'build.devthedocs.org'
 

--- a/readthedocs/settings/test.py
+++ b/readthedocs/settings/test.py
@@ -7,8 +7,6 @@ class CommunityTestSettings(CommunityBaseSettings):
 
     """Settings for testing environment (e.g. tox)"""
 
-    SLUMBER_USERNAME = 'test'
-    SLUMBER_PASSWORD = 'test'
     SLUMBER_API_HOST = 'http://localhost:8000'
 
     # A bunch of our tests check this value in a returned URL/Domain


### PR DESCRIPTION
We have access to some write operations using a build API token, we no longer need to grant access to superusers.

- All usage of super/staff users have been removed from the API, they have read-only access as any other user now.
- APIRestrictedPermission has been renamed to ReadOnlyPermission, since that's what it checks now.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10498.org.readthedocs.build/en/10498/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10498.org.readthedocs.build/en/10498/

<!-- readthedocs-preview dev end -->