### PR TITLE
Builds: set scale-in protection before/after each build

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1940,6 +1940,7 @@ class Feature(models.Model):
     # Build related features
     HOSTING_INTEGRATIONS = "hosting_integrations"
     NO_CONFIG_FILE_DEPRECATED = "no_config_file"
+    SCALE_IN_PROTECTION = "scale_in_prtection"
 
     FEATURES = (
         (
@@ -2074,6 +2075,10 @@ class Feature(models.Model):
         (
             NO_CONFIG_FILE_DEPRECATED,
             _("Build: Building without a configuration file is deprecated."),
+        ),
+        (
+            SCALE_IN_PROTECTION,
+            _("Build: Set scale-in protection before/after building."),
         ),
     )
 

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -747,7 +747,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         # Disable scale-in protection on this instance
         if self.data.project.has_feature(Feature.SCALE_IN_PROTECTION):
             set_builder_scale_in_protection.delay(
-                instace=socket.gethostname(),
+                instance=socket.gethostname(),
                 protected_from_scale_in=False,
             )
 

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -385,7 +385,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
     def before_start(self, task_id, args, kwargs):
         # Enable scale-in protection on this instance
         set_builder_scale_in_protection.delay(
-            instace=socket.gethostname(),
+            instance=socket.gethostname(),
             protected_from_scale_in=True,
         )
 

--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -347,7 +347,7 @@ def set_builder_scale_in_protection(instance, protected_from_scale_in):
     )
 
     # web-extra-i-0c3e866c4e323928f
-    hostname_match = re.match(r"([a-z\-]+)-(i-[a-z0-9]+)", instance)
+    hostname_match = re.match(r"([a-z\-]+)-(i-[a-f0-9]+)", instance)
     if not hostname_match:
         log.warning(
             "Unable to set scale-in protection. Hostname name matching not found.",

--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -1,6 +1,8 @@
 import datetime
 import os
+import re
 
+import boto3
 import structlog
 from celery.worker.request import Request
 from django.conf import settings
@@ -319,6 +321,49 @@ def deprecated_config_file_used_notification():
         "Finish sending deprecated config file notifications.",
         time_elapsed=(datetime.datetime.now() - start_datetime).seconds,
     )
+
+
+@app.task(queue="web")
+def set_builder_scale_in_protection(instance, protected_from_scale_in):
+    """
+    Set scale-in protection on this builder ``instance``.
+
+    This way, AWS will not scale-in this instance while it's building the documentation.
+    This is pretty useful for long running tasks.
+    """
+    log.bind(instance=instance, protected_from_scale_in=protected_from_scale_in)
+
+    if settings.DEBUG or settings.RTD_DOCKER_COMPOSE:
+        log.info(
+            "Running development environment. Skipping scale-in protection.",
+        )
+        return
+
+    asg = boto3.client(
+        "autoscaling",
+        aws_access_key_id=settings.RTD_AWS_SCALE_IN_ACCESS_KEY,
+        aws_secret_access_key=settings.RTD_AWS_SCALE_IN_SECRET_ACCESS_KEY,
+        region_name=settings.RTD_AWS_SCALE_IN_REGION_NAME,
+    )
+
+    # web-extra-i-0c3e866c4e323928f
+    hostname_match = re.match(r"([a-z\-]+)-(i-[a-z0-9]+)", instance)
+    if not hostname_match:
+        log.warning(
+            "Unable to set scale-in protection. Hostname name matching not found.",
+        )
+        return
+    scaling_group, instance_id = hostname_match.groups()
+
+    # Set protection on instance
+    try:
+        asg.set_instance_protection(
+            InstanceIds=[instance_id],
+            AutoScalingGroupName=scaling_group,
+            ProtectedFromScaleIn=protected_from_scale_in,
+        )
+    except Exception:
+        log.exception("Failed when trying to set instance protection.")
 
 
 class BuildRequest(Request):

--- a/readthedocs/rtd_tests/tests/test_project_forms.py
+++ b/readthedocs/rtd_tests/tests/test_project_forms.py
@@ -1,3 +1,4 @@
+from unittest import mock
 
 from django.contrib.auth.models import User
 from django.test import TestCase
@@ -258,6 +259,7 @@ class TestProjectAdvancedForm(TestCase):
         self.assertTrue(form.is_valid())
         self.assertEqual(self.project.privacy_level, PRIVATE)
 
+    @mock.patch("readthedocs.projects.tasks.builds.update_docs_task")
     @override_settings(ALLOW_PRIVATE_REPOS=False)
     def test_custom_readthedocs_yaml(self):
         custom_readthedocs_yaml_path = "folder/.readthedocs.yaml"

--- a/readthedocs/rtd_tests/tests/test_project_forms.py
+++ b/readthedocs/rtd_tests/tests/test_project_forms.py
@@ -261,7 +261,7 @@ class TestProjectAdvancedForm(TestCase):
 
     @mock.patch("readthedocs.projects.tasks.builds.update_docs_task")
     @override_settings(ALLOW_PRIVATE_REPOS=False)
-    def test_custom_readthedocs_yaml(self):
+    def test_custom_readthedocs_yaml(self, update_docs_task):
         custom_readthedocs_yaml_path = "folder/.readthedocs.yaml"
         form = ProjectAdvancedForm(
             {


### PR DESCRIPTION
We use AWS scale-in protection to protect our instances from being scaled-in automatically while running a build. This avoids killing the build in the middle while it's running.

Besides, it could help us to be more aggressive to scale-in if we consider without degrading user experience.

Related https://github.com/readthedocs/readthedocs-ops/issues/1324
Requires: https://github.com/readthedocs/readthedocs-ops/pull/1356