### PR TITLE
Build: install all the latest Python "core requirements"

### DIFF
--- a/docs/user/build-default-versions.rst
+++ b/docs/user/build-default-versions.rst
@@ -56,20 +56,25 @@ setuptools:
   All other projects use the latest version.
 
 mock:
-  ``1.0.1`` (could be removed in the future).
+  ``1.0.1``.
+  Projects created after August 7, 2023 won't install this dependency by default.
+
 
 pillow:
-  ``5.4.1`` when using Python 2.7, 3.4, 3.5, 3.6, 3.7. Otherwise, its latest version
-  (could be removed in the future).
+  ``5.4.1`` when using Python 2.7, 3.4, 3.5, 3.6, 3.7. Otherwise, its latest version.
+  Projects created after August 7, 2023 won't install this dependency by default.
 
 alabaster:
-  ``0.7.x`` (could be removed in the future).
+  ``0.7.x``.
+  Projects created after August 7, 2023 won't install this dependency by default.
 
 commonmark:
-  ``0.8.1`` (could be removed in the future).
+  ``0.8.1``.
+  Projects created after August 7, 2023 won't install this dependency by default.
 
 recommonmark:
-  ``0.5.0`` (could be removed in the future).
+  ``0.5.0``.
+  Projects created after August 7, 2023 won't install this dependency by default.
 
 Conda
 ~~~~~
@@ -90,13 +95,16 @@ sphinx-rtd-theme:
   Latest version by default installed via ``conda``.
 
 mock:
-  Latest version by default installed via ``pip`` (could be removed in the future).
+  Latest version by default installed via ``pip``.
+  Projects created after August 7, 2023 won't install this dependency by default.
 
 pillow:
-  Latest version by default installed via ``pip`` (could be removed in the future).
+  Latest version by default installed via ``pip``.
+  Projects created after August 7, 2023 won't install this dependency by default.
 
 recommonmark:
-  Latest version by default installed via ``conda`` (could be removed in the future).
+  Latest version by default installed via ``conda``.
+  Projects created after August 7, 2023 won't install this dependency by default.
 
 Internal dependencies
 ---------------------

--- a/docs/user/build-default-versions.rst
+++ b/docs/user/build-default-versions.rst
@@ -47,6 +47,7 @@ Mkdocs:
 sphinx-rtd-theme:
   Projects created before October 20, 2020 (January 21, 2021 for :doc:`/commercial/index`) use ``0.4.3``.
   New projects use the latest version.
+  Projects created after August 7, 2023 won't install this dependency by default.
 
 pip:
   Latest version by default.
@@ -54,6 +55,7 @@ pip:
 setuptools:
   Projects using ``setup.py install`` as installation method use ``58.2.0`` or older.
   All other projects use the latest version.
+  Projects created after August 7, 2023 will always use the latest version.
 
 mock:
   ``1.0.1``.
@@ -93,6 +95,7 @@ Sphinx:
 
 sphinx-rtd-theme:
   Latest version by default installed via ``conda``.
+  Projects created after August 7, 2023 won't install this dependency by default.
 
 mock:
   Latest version by default installed via ``pip``.

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -174,7 +174,7 @@ class Virtualenv(PythonEnvironment):
 
         By enabling the feature flag ``INSTALL_LATEST_CORE_REQUIREMENTS``
         projects will automatically get installed all the latest core
-        requirements: pip, sphinx, mock, alabaster, setuptools, etc.
+        requirements: pip, setuptools, sphinx, readthedocs-sphinx-ext and mkdocs.
 
         This is the new behavior and where we are moving towards.
         """
@@ -187,9 +187,7 @@ class Virtualenv(PythonEnvironment):
         )
 
         # Second, install all the latest core requirements
-        requirements = [
-            "setuptools",
-        ]
+        requirements = []
 
         if self.config.doctype == "mkdocs":
             requirements.append("mkdocs")
@@ -197,7 +195,6 @@ class Virtualenv(PythonEnvironment):
             requirements.extend(
                 [
                     "sphinx",
-                    "sphinx-rtd-theme",
                     "readthedocs-sphinx-ext",
                 ]
             )
@@ -529,7 +526,7 @@ class Conda(PythonEnvironment):
             pip_requirements.append("mkdocs")
         else:
             pip_requirements.append("readthedocs-sphinx-ext")
-            conda_requirements.extend(["sphinx", "sphinx_rtd_theme"])
+            conda_requirements.extend(["sphinx"])
 
         return pip_requirements, conda_requirements
 

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -188,10 +188,6 @@ class Virtualenv(PythonEnvironment):
 
         # Second, install all the latest core requirements
         requirements = [
-            "mock",
-            "alabaster",
-            "commonmark",
-            "recommonmark",
             "setuptools",
         ]
 

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1930,6 +1930,7 @@ class Feature(models.Model):
     DEFAULT_TO_MKDOCS_0_17_3 = 'default_to_mkdocs_0_17_3'
     USE_MKDOCS_LATEST = 'use_mkdocs_latest'
     USE_SPHINX_RTD_EXT_LATEST = 'rtd_sphinx_ext_latest'
+    INSTALL_LATEST_CORE_REQUIREMENTS = "install_latest_core_requirements"
 
     # Search related features
     DISABLE_SERVER_SIDE_SEARCH = 'disable_server_side_search'
@@ -2043,6 +2044,12 @@ class Feature(models.Model):
         (
             USE_SPHINX_RTD_EXT_LATEST,
             _("Sphinx: Use latest version of the Read the Docs Sphinx extension"),
+        ),
+        (
+            INSTALL_LATEST_CORE_REQUIREMENTS,
+            _(
+                "Build: Install all the latest versions of Read the Docs core requirements"
+            ),
         ),
 
         # Search related features.


### PR DESCRIPTION
I created a new feature flag called `INSTALL_LATEST_CORE_REQUIREMENTS` that does
not depend on any other feature flag. Its goal is to always install the latest
Python packages.

We are trying to move away from pinning the dependencies on our side and telling
users to do that on their side if they want to have reproducible builds over
time.

I think this is the best outcome for new projects since they will immediately
use the latest versions of everything instead of old (and maybe broken)
dependencies.

I propose to set a particular date for this feature flag and make new projects
to start building with all the latest dependencies. This will, at least, stop
making the problem bigger. Later, we can decide how to communicate to old
projects that we are going to install the latest requirements and if they don't
want that, they should pin their dependencies. We can follow our new and shiny
deprecation path we have built and tested in the last month.

Related readthedocs/meta#8
Related #9562
Related #10402
Related #9081

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10508.org.readthedocs.build/en/10508/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10508.org.readthedocs.build/en/10508/

<!-- readthedocs-preview dev end -->