### PR TITLE
Remove a superfluous space character

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -102,7 +102,7 @@ To avoid this, it's possible to unshallow the :program:`git clone`:
        python: "3.10"
      jobs:
        post_checkout:
-         - git fetch --unshallow  || true
+         - git fetch --unshallow || true
 
 
 Cancel build based on a condition


### PR DESCRIPTION


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10509.org.readthedocs.build/en/10509/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10509.org.readthedocs.build/en/10509/

<!-- readthedocs-preview dev end -->