### PR TITLE
OAuth: catch `TokenExpiredError` exception

### DIFF
--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -7,7 +7,7 @@ import structlog
 from allauth.socialaccount.providers.github.views import GitHubOAuth2Adapter
 from django.conf import settings
 from django.urls import reverse
-from oauthlib.oauth2.rfc6749.errors import InvalidGrantError
+from oauthlib.oauth2.rfc6749.errors import InvalidGrantError, TokenExpiredError
 from requests.exceptions import RequestException
 
 from readthedocs.builds import utils as build_utils
@@ -517,5 +517,7 @@ class GitHubService(Service):
             log.exception('GitHub commit status creation failed for project.')
         except InvalidGrantError:
             log.info("Invalid GitHub grant for user.", exc_info=True)
+        except TokenExpiredError:
+            log.info("GitHub token expired for user.", exc_info=True)
 
         return False

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -8,7 +8,7 @@ import structlog
 from allauth.socialaccount.providers.gitlab.views import GitLabOAuth2Adapter
 from django.conf import settings
 from django.urls import reverse
-from oauthlib.oauth2.rfc6749.errors import InvalidGrantError
+from oauthlib.oauth2.rfc6749.errors import InvalidGrantError, TokenExpiredError
 from requests.exceptions import RequestException
 
 from readthedocs.builds import utils as build_utils
@@ -604,5 +604,7 @@ class GitLabService(Service):
             )
         except InvalidGrantError:
             log.info("Invalid GitLab grant for user.", exc_info=True)
+        except TokenExpiredError:
+            log.info("GitLab token expired for user.", exc_info=True)
 
         return False


### PR DESCRIPTION
There is nothing we can do in this case. So, we are logging the exception instead of sending it to Sentry as an error.

In the future we could handle this exception differently and communicate these errors to the users so they can re-install Read the Docs app in their GH accounts.

Sentry: https://read-the-docs.sentry.io/issues/3526635712/

Based on: https://github.com/readthedocs/readthedocs.org/pull/10082