### PR TITLE
MkDocs: fix `USE_MKDOCS_LATEST` feature flag logic

### DIFF
--- a/docs/user/build-default-versions.rst
+++ b/docs/user/build-default-versions.rst
@@ -41,7 +41,6 @@ Sphinx:
 
 Mkdocs:
   Projects created before April 3, 2019 (April 23, 2019 for :doc:`/commercial/index`) use ``0.17.3``.
-  Projects created before March 9, 2021 use ``1.0.4``.
   New projects use the latest version.
 
 sphinx-rtd-theme:

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -211,8 +211,8 @@ class Virtualenv(PythonEnvironment):
                     positive='mkdocs==0.17.3',
                     negative=self.project.get_feature_value(
                         Feature.USE_MKDOCS_LATEST,
-                        positive='mkdocs<1.1',
-                        negative='mkdocs',
+                        positive="mkdocs",
+                        negative="mkdocs<1.1",
                     ),
                 ),
             )

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -209,12 +209,8 @@ class Virtualenv(PythonEnvironment):
                 self.project.get_feature_value(
                     Feature.DEFAULT_TO_MKDOCS_0_17_3,
                     positive='mkdocs==0.17.3',
-                    negative=self.project.get_feature_value(
-                        Feature.USE_MKDOCS_LATEST,
-                        positive="mkdocs",
-                        negative="mkdocs<1.1",
-                    ),
-                ),
+                    negative="mkdocs",
+                )
             )
         else:
             requirements.extend(

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1927,7 +1927,6 @@ class Feature(models.Model):
     DONT_INSTALL_LATEST_PIP = 'dont_install_latest_pip'
     USE_SPHINX_LATEST = 'use_sphinx_latest'
     DEFAULT_TO_MKDOCS_0_17_3 = 'default_to_mkdocs_0_17_3'
-    USE_MKDOCS_LATEST = 'use_mkdocs_latest'
     USE_SPHINX_RTD_EXT_LATEST = 'rtd_sphinx_ext_latest'
 
     # Search related features
@@ -2034,7 +2033,6 @@ class Feature(models.Model):
             DEFAULT_TO_MKDOCS_0_17_3,
             _("MkDOcs: Install mkdocs 0.17.3 by default"),
         ),
-        (USE_MKDOCS_LATEST, _("MkDocs: Use latest version of MkDocs")),
         (
             USE_SPHINX_RTD_EXT_LATEST,
             _("Sphinx: Use latest version of the Read the Docs Sphinx extension"),


### PR DESCRIPTION
The logic was inverted and we were installing old MkDocs version to projects with `USE_MKDOCS_LATEST` feature flag.

Closes #10402