### PR TITLE
Docs: set title explicitly

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,12 +42,14 @@ multiproject_projects = {
         "use_config_file": False,
         "config": {
             "project": "Read the Docs user documentation",
+            "html_title": "Read the Docs user documentation",
         },
     },
     "dev": {
         "use_config_file": False,
         "config": {
             "project": "Read the Docs developer documentation",
+            "html_title": "Read the Docs developer documentation",
         },
     },
 }


### PR DESCRIPTION
The current title is "{page title} - Read the Docs user documentation 9.15.0 documentation"

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10519.org.readthedocs.build/en/10519/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10519.org.readthedocs.build/en/10519/

<!-- readthedocs-preview dev end -->