### PR TITLE
Addons: rename endpoint to make it nicer

### DIFF
--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -79,7 +79,7 @@ class TestReadTheDocsConfigJson(TestCase):
 
     def test_get_config_v0(self):
         r = self.client.get(
-            reverse("proxito_readthedocs_config_json"),
+            reverse("proxito_readthedocs_docs_addons"),
             {"url": "https://project.dev.readthedocs.io/en/latest/"},
             secure=True,
             HTTP_HOST="project.dev.readthedocs.io",
@@ -92,7 +92,7 @@ class TestReadTheDocsConfigJson(TestCase):
 
     def test_get_config_v1(self):
         r = self.client.get(
-            reverse("proxito_readthedocs_config_json"),
+            reverse("proxito_readthedocs_docs_addons"),
             {"url": "https://project.dev.readthedocs.io/en/latest/"},
             secure=True,
             HTTP_HOST="project.dev.readthedocs.io",
@@ -103,7 +103,7 @@ class TestReadTheDocsConfigJson(TestCase):
 
     def test_get_config_unsupported_version(self):
         r = self.client.get(
-            reverse("proxito_readthedocs_config_json"),
+            reverse("proxito_readthedocs_docs_addons"),
             {"url": "https://project.dev.readthedocs.io/en/latest/"},
             secure=True,
             HTTP_HOST="project.dev.readthedocs.io",

--- a/readthedocs/proxito/urls.py
+++ b/readthedocs/proxito/urls.py
@@ -115,7 +115,14 @@ proxied_urls = [
         ServeStaticFiles.as_view(),
         name="proxito_static_files",
     ),
-    # readthedocs-config.js
+    # readthedocs-docs-addons.js
+    path(
+        f"{DOC_PATH_PREFIX}addons/",
+        ReadTheDocsConfigJson.as_view(),
+        name="proxito_readthedocs_docs_addons",
+    ),
+    # TODO: remove `readthedocs-config/` endpoint once we have changed the URL
+    # in the js and we have deployed it.
     path(
         f"{DOC_PATH_PREFIX}readthedocs-config/",
         ReadTheDocsConfigJson.as_view(),


### PR DESCRIPTION
We are settled on "addons" as a name for all of this, so I'm renaming the endpoint to use `/_/addons/`. Note that I'm keeping the old one so we don't break anything when releasing this.