### PR TITLE
Addons: return `ethicalads` data on `/_/addons/` endpoint

### DIFF
--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -312,6 +312,8 @@ class AddonsResponse:
                     "ethicalads": {
                         "enabled": True,
                         # NOTE: this endpoint is not authenticated, the user checks are done over an annonymous user for now
+                        #
+                        # NOTE: it requires ``settings.USE_PROMOS=True`` to return ``ad_free=false`` here
                         "ad_free": is_ad_free_user(AnonymousUser())
                         or is_ad_free_project(project),
                         "campaign_types": get_campaign_types(AnonymousUser(), project),

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -310,6 +310,7 @@ class AddonsResponse:
             data["addons"].update(
                 {
                     "ethicalads": {
+                        "enabled": True,
                         # NOTE: this endpoint is not authenticated, the user checks are done over an annonymous user for now
                         "ad_free": is_ad_free_user(AnonymousUser())
                         or is_ad_free_project(project),

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -299,7 +299,7 @@ class AddonsResponse:
 
         # Update this data with ethicalads
         if "readthedocsext.donate" in settings.INSTALLED_APPS:
-            from readthedocsext.donate.utils import (
+            from readthedocsext.donate.utils import (  # noqa
                 get_campaign_types,
                 get_project_keywords,
                 get_publisher,


### PR DESCRIPTION
This data is consumed by the sponsorship addons to display an ad using EthicalAds.

Related https://github.com/readthedocs/addons/issues/67
Requires: https://github.com/readthedocs/readthedocs-ext/pull/546