### PR TITLE
Development: update docs to pull required images only

### DIFF
--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -76,7 +76,7 @@ Set up your environment
 
    .. prompt:: bash
 
-      inv docker.pull --only-required
+      inv docker.pull
 
 #. Start all the containers:
 


### PR DESCRIPTION
This also updates `common/` to pull down the correct Docker images.

Related: https://github.com/readthedocs/common/pull/181