### PR TITLE
API: add `?full_name=` icontains filter on RemoteRepository

### DIFF
--- a/docs/user/api/v3.rst
+++ b/docs/user/api/v3.rst
@@ -1852,6 +1852,7 @@ Remote repository listing
     The ``results`` in response is an array of remote repositories data.
 
     :query string name: return remote repositories containing the name
+    :query string full_name: return remote repositories containing the full name (it inclues the username/organization the project belongs to)
     :query string vcs_provider: return remote repositories for specific vcs provider (``github``, ``gitlab`` or ``bitbucket``)
     :query string organization: return remote repositories for specific remote organization (using remote organization ``slug``)
     :query string expand: allows to add/expand some extra fields in the response.

--- a/readthedocs/api/v3/filters.py
+++ b/readthedocs/api/v3/filters.py
@@ -60,15 +60,17 @@ class BuildFilter(filters.FilterSet):
 
 
 class RemoteRepositoryFilter(filters.FilterSet):
-    name = filters.CharFilter(field_name='name', lookup_expr='icontains')
-    organization = filters.CharFilter(field_name='organization__slug')
+    name = filters.CharFilter(field_name="name", lookup_expr="icontains")
+    full_name = filters.CharFilter(field_name="full_name", lookup_expr="icontains")
+    organization = filters.CharFilter(field_name="organization__slug")
 
     class Meta:
         model = RemoteRepository
         fields = [
-            'name',
-            'vcs_provider',
-            'organization',
+            "name",
+            "full_name",
+            "vcs_provider",
+            "organization",
         ]
 
 

--- a/readthedocs/api/v3/tests/test_remoterepositories.py
+++ b/readthedocs/api/v3/tests/test_remoterepositories.py
@@ -103,3 +103,19 @@ class RemoteRepositoryEndpointTests(APIEndpointMixin):
             response_data,
             self._get_response_dict('remoterepositories-list'),
         )
+
+    def test_remote_repository_list_full_name_filter(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.get(
+            reverse("remoterepositories-list"),
+            {"expand": ("projects," "remote_organization"), "full_name": "proj"},
+        )
+        self.assertEqual(response.status_code, 200)
+
+        response_data = response.json()
+        self.assertEqual(len(response_data["results"]), 1)
+
+        self.assertDictEqual(
+            response_data,
+            self._get_response_dict("remoterepositories-list"),
+        )


### PR DESCRIPTION
This allows to perform queries like:

 * http://devthedocs.org/api/v3/remote/repositories/?full_name=getnikola
 * http://devthedocs.org/api/v3/remote/repositories/?full_name=readthedocs&expand=projects

Closes #10513