### PR TITLE
Add an initial doclist extension.

### DIFF
--- a/docs/_ext/doclist.py
+++ b/docs/_ext/doclist.py
@@ -1,0 +1,50 @@
+from docutils import nodes
+from sphinx.util.docutils import SphinxDirective
+
+
+class MyListDirective(SphinxDirective):
+    has_content = True
+
+    def run(self):
+        docname = self.content[0]
+        doc = self.state.document.settings.env.get_doctree(docname)
+
+        definition_list = nodes.definition_list()
+
+        paragraphs = [p for p in doc.traverse() if isinstance(p, nodes.paragraph)]
+        if not paragraphs:
+            return []
+
+        paragraph = paragraphs[0]
+        content = paragraph.astext()
+        sentences = content.split(".")[:2]
+
+        text = ". ".join(sentences)
+
+        builder = self.state.document.settings.env.app.builder
+        refuri = builder.get_relative_uri(
+            self.state.document.settings.env.docname, docname
+        )
+
+        # import ipdb; ipdb.set_trace()
+
+        title = doc.next_node(nodes.title)
+        if title:
+            link = nodes.reference("", "")
+            link["refdocname"] = docname
+            link["refuri"] = refuri
+            link.append(nodes.Text(title.astext()))
+
+        para = nodes.paragraph()
+        para += nodes.Text(text)
+
+        definition_list += nodes.definition_list_item(
+            "Test2", nodes.term("", "", link), nodes.definition("", para)
+        )
+
+        return [definition_list]
+
+
+def setup(app):
+    app.add_directive("doclist", MyListDirective)
+    return {"parallel_read_safe": True}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,7 @@ extensions = [
     "sphinxcontrib.video",
     "sphinxemoji.sphinxemoji",
     "sphinxext.opengraph",
+    "doclist",
 ]
 
 multiproject_projects = {

--- a/docs/user/tutorials/index.rst
+++ b/docs/user/tutorials/index.rst
@@ -42,3 +42,9 @@ Tutorials
    /intro/import-guide
    /config-file/index
    /examples
+
+
+Testing
+-------
+
+.. doclist:: intro/getting-started-with-sphinx


### PR DESCRIPTION
This creates a definition list of the document,
and the first 2 paragraphs of the doc to make a nice index.

This is just a first attempt at this,
but something we've wanted to not keep repeating the same content over and over again.

## Screenshot

```
Testing
-------

.. doclist:: intro/getting-started-with-sphinx
```

<img width="688" alt="Screenshot 2023-07-20 at 3 27 28 PM" src="https://github.com/readthedocs/readthedocs.org/assets/25510/5a8ac8e2-6e74-400d-ba67-a5290e329d75">


## Ideas for improvement

We likely want to have some kind of metadata in the file or similar that's a description that's used first, and then fallback to the top sentence or two, since we don't always want the first 2 sentences to be a good fit for the listing description. 

Fixes https://github.com/readthedocs/readthedocs.org/issues/10157