### PR TITLE
Development: install Docker and Docker Compose with official guides

### DIFF
--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -28,7 +28,7 @@ Install external dependencies (Docker, Docker Compose, gVisor)
 
 #. Install Docker by following `the official guide <https://docs.docker.com/get-docker/>`_.
 #. Install Docker Compose with `the official instructions <https://docs.docker.com/compose/install/>`_.
-#. Iinstall and set up gVisor following :doc:`rtd-dev:guides/gvisor`.
+#. Install and set up gVisor following :doc:`rtd-dev:guides/gvisor`.
 
 
 Set up your environment

--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -23,6 +23,13 @@ A development setup can be hosted by your laptop, in a VM, on a separate server 
    We do not recommend to follow this guide to deploy an instance of Read the Docs for production.
 
 
+Install Docker and Docker Compose
+---------------------------------
+
+#. Install Docker by following `the official guide <https://docs.docker.com/get-docker/>`_
+#. Install Docker Compose with `the official instructions <https://docs.docker.com/compose/install/>`_
+
+
 Set up your environment
 -----------------------
 

--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -23,11 +23,12 @@ A development setup can be hosted by your laptop, in a VM, on a separate server 
    We do not recommend to follow this guide to deploy an instance of Read the Docs for production.
 
 
-Install Docker and Docker Compose
----------------------------------
+Install external dependencies (Docker, Docker Compose, gVisor)
+--------------------------------------------------------------
 
-#. Install Docker by following `the official guide <https://docs.docker.com/get-docker/>`_
-#. Install Docker Compose with `the official instructions <https://docs.docker.com/compose/install/>`_
+#. Install Docker by following `the official guide <https://docs.docker.com/get-docker/>`_.
+#. Install Docker Compose with `the official instructions <https://docs.docker.com/compose/install/>`_.
+#. Iinstall and set up gVisor following :doc:`rtd-dev:guides/gvisor`.
 
 
 Set up your environment
@@ -66,7 +67,6 @@ Set up your environment
 
       pip install -r common/dockerfiles/requirements.txt
 
-#. Set up gVisor following :doc:`rtd-dev:guides/gvisor`.
 
 #. Build the Docker image for the servers:
 


### PR DESCRIPTION
Closes #9351
Requires: https://github.com/readthedocs/common/pull/183

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10561.org.readthedocs.build/en/10561/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10561.org.readthedocs.build/en/10561/

<!-- readthedocs-preview dev end -->