### PR TITLE
Fix docker setting

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -676,7 +676,7 @@ class CommunityBaseSettings(Settings):
     RTD_DOCKER_BUILD_SETTINGS['tools']['python']['3'] = RTD_DOCKER_BUILD_SETTINGS['tools']['python']['3.11']
     # This is used for the image used to clone the users repo,
     # since we can't read their config file image choice before cloning
-    RTD_DOCKER_CLONE_IMAGE = RTD_DOCKER_BUILD_SETTINGS["os"]["ubuntu-22.04"],
+    RTD_DOCKER_CLONE_IMAGE = RTD_DOCKER_BUILD_SETTINGS["os"]["ubuntu-22.04"]
 
     def _get_docker_memory_limit(self):
         try:


### PR DESCRIPTION
The value has a trailing `,`, this makes it a tuple, docker doesn't like this.