### PR TITLE
Build: add `mambaforge-22.09` as newer Python tool

### DIFF
--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -330,6 +330,7 @@ You can use several interpreters and versions, from CPython, Miniconda, and Mamb
   - ``3.11``
   - ``miniconda3-4.7``
   - ``mambaforge-4.10``
+  - ``mambaforge-22.9``
 
 build.tools.nodejs
 ``````````````````

--- a/docs/user/guides/conda.rst
+++ b/docs/user/guides/conda.rst
@@ -126,7 +126,7 @@ with these contents:
    build:
      os: "ubuntu-20.04"
      tools:
-       python: "mambaforge-4.10"
+       python: "mambaforge-22.9"
 
    conda:
      environment: environment.yml

--- a/readthedocs/builds/constants_docker.py
+++ b/readthedocs/builds/constants_docker.py
@@ -40,6 +40,7 @@ RTD_DOCKER_BUILD_SETTINGS = {
             "3": "3.11.4",
             "miniconda3-4.7": "miniconda3-4.7.12",
             "mambaforge-4.10": "mambaforge-4.10.3-10",
+            "mambaforge-22.9": "mambaforge-22.9.0-3",
         },
         "nodejs": {
             "14": "14.20.1",

--- a/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
+++ b/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
@@ -177,7 +177,8 @@
                     "3.10",
                     "3.11",
                     "miniconda3-4.7",
-                    "mambaforge-4.10"
+                    "mambaforge-4.10",
+                    "mambaforge-22.9"
                   ]
                 },
                 "nodejs": {


### PR DESCRIPTION
Our latest Mamba version is pretty old and it seems that it's not updating Conda to its latest version, even if we try to force it.

Closes #10564

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10572.org.readthedocs.build/en/10572/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10572.org.readthedocs.build/en/10572/

<!-- readthedocs-preview dev end -->