### PR TITLE
Build: skip duplicated commands

### DIFF
--- a/readthedocs/api/v2/views/model_views.py
+++ b/readthedocs/api/v2/views/model_views.py
@@ -336,6 +336,11 @@ class BuildCommandViewSet(DisableListEndpoint, CreateModelMixin, UserSelectViewS
         build_api_key = self.request.build_api_key
         if not build_api_key.project.builds.filter(pk=build_pk).exists():
             raise PermissionDenied()
+
+        if BuildCommandResult.objects.filter(**serializer.validated_data).exists():
+            log.warning("Build command is duplicated. Skipping...")
+            return Response(status=status.HTTP_204_NO_CONTENT)
+
         return super().perform_create(serializer)
 
     def get_queryset_for_api_key(self, api_key):


### PR DESCRIPTION
Sometimes it happens the web servers are congested and the builder retries the API call to save the command in the database. However, one of the first attempts finally ended up working resulting in the command being saved twice.

This small chunk of code checks for the existence of the command before saving it into the database and logs a warning and return 204 if it already exists, instead of re-saving it again.

It's not a perfect solution, but it could help under similar circumstances.

Related https://github.com/readthedocs/readthedocs.org/issues/10567