### PR TITLE
Clarify forced redirects

### DIFF
--- a/docs/user/user-defined-redirects.rst
+++ b/docs/user/user-defined-redirects.rst
@@ -29,7 +29,7 @@ Limitations
 -----------
 
 - By default, redirects only apply on pages that don't exist.
-  **Forced redirects** allow you to apply redirects on existing pages, 
+  **Forced redirects** allow you to apply redirects on existing pages,
   but incur a small performance penalty, so aren't enabled by default.
   You can ask for them to be enabled via support.
 - Only :ref:`user-defined-redirects:page redirects` and :ref:`user-defined-redirects:exact redirects`

--- a/docs/user/user-defined-redirects.rst
+++ b/docs/user/user-defined-redirects.rst
@@ -25,18 +25,16 @@ the bad user experience of a 404 page is usually best to avoid.
      A guide to deprecating features and other topics in a documentation.
 
 
-Special features
-----------------
+Limitations
+-----------
 
-- By default, redirects are followed only if the requested page doesn't exist
-  (*404 File Not Found* error).
-  If you need to apply a redirect for files that exist,
-  **This option is only available on some plan levels**.
-  Please ask support if you need it for some reason.
-- :ref:`user-defined-redirects:page redirects` and :ref:`user-defined-redirects:exact redirects`
+- By default, redirects only apply on pages that don't exist.
+  **Forced Redirects** allow you to apply redirects on existing pages, 
+  but incur a small performance penalty, so aren't enabled by default.
+  You can ask for them to be enabled via support.
+- Only :ref:`user-defined-redirects:page redirects` and :ref:`user-defined-redirects:exact redirects`
   can redirect to URLs outside Read the Docs,
   just include the protocol in ``To URL``, e.g ``https://example.com``.
-
 
 Built-in redirects
 ------------------

--- a/docs/user/user-defined-redirects.rst
+++ b/docs/user/user-defined-redirects.rst
@@ -29,7 +29,7 @@ Limitations
 -----------
 
 - By default, redirects only apply on pages that don't exist.
-  **Forced Redirects** allow you to apply redirects on existing pages, 
+  **Forced redirects** allow you to apply redirects on existing pages, 
   but incur a small performance penalty, so aren't enabled by default.
   You can ask for them to be enabled via support.
 - Only :ref:`user-defined-redirects:page redirects` and :ref:`user-defined-redirects:exact redirects`


### PR DESCRIPTION
This language somehow got removed. 

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10577.org.readthedocs.build/en/10577/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10577.org.readthedocs.build/en/10577/

<!-- readthedocs-preview dev end -->