### PR TITLE
Update support page

### DIFF
--- a/docs/user/support.rst
+++ b/docs/user/support.rst
@@ -7,7 +7,7 @@ We're happy to assist with any questions or problems you have using either of ou
 .. note::
    Read the Docs does not offer support for questions or problems with documentation tools or content.
    If you have a question or problem using a particular documentation tool,
-   you can refer to `community provided resources <Community provided resources>`_ instead.
+   you should refer to `external resources <External resources>`_ for help instead.
 
 Some examples of requests that we support are:
 
@@ -33,8 +33,8 @@ These provide step-by-step solutions to common user requests.
         Please fill out the form at https://readthedocs.org/support/,
         and we will reply as soon as possible.
 
-Community provided resources
-----------------------------
+External resources
+------------------
 
 If you have questions about how to use a documentation tool or authoring content for your project,
 or have an issue that isn't related to a bug with Read the Docs,

--- a/docs/user/support.rst
+++ b/docs/user/support.rst
@@ -24,9 +24,8 @@ These provide step-by-step solutions to common user requests.
 
         Please fill out the form at https://readthedocs.com/support/.
 
-        Our team responds to support requests during our normal business hours,
-        Monday through Friday, 8:00am to 5:00pm Pacific time.
-        We will reply within 2 business days or earlier for most plans.
+        Our team responds to support requests within 2 business days or earlier for most plans.
+        Faster support response times and support SLAs are available with plan upgrades.
 
    .. tab:: |org_brand|
 

--- a/docs/user/support.rst
+++ b/docs/user/support.rst
@@ -1,53 +1,61 @@
 Site support
 ============
 
-Usage questions
----------------
+Read the Docs offers support for projects on our :doc:`Read the Docs for Business </commercial/index>` and |org_brand| platforms.
+We're happy to assist with any questions or problems you have using either of our platforms.
 
-If you have questions about how to use Read the Docs, or have an issue that
-isn't related to a bug, `Stack Overflow`_ is the best place to ask.  Tag
-questions with ``read-the-docs`` so other folks can find them easily.
+.. note::
+   Read the Docs does not offer support for questions or problems with documentation tools or content.
+   If you have a question or problem using a particular documentation tool,
+   you can refer to `community provided resources <Community provided resources>`_ instead.
 
-Good questions for Stack Overflow would be:
+Some examples of requests that we support are:
 
-* "What is the best way to structure the table of contents across a project?"
-* "How do I structure translations inside of my project for easiest contribution from users?"
-* "How do I use Sphinx to use SVG images in HTML output but PNG in PDF output?"
+- "How do I transfer ownership of a Read the Docs project to another maintainer?"
+- "Why are my project builds being cancelled automatically?"
+- "How do I manage my subscription?"
 
 You might also find the answers you are looking for in our :doc:`documentation guides </guides/index>`.
-These provide step-by-step solutions to common user requirements.
-
-User support
-------------
-
-If you need a specific request for your project or account,
-like more resources, change of the project's slug or username.
+These provide step-by-step solutions to common user requests.
 
 .. tabs::
+
+   .. tab:: |com_brand|
+
+        Please fill out the form at https://readthedocs.com/support/.
+
+        Our team responds to support requests during our normal business hours,
+        Monday through Friday, 8:00am to 5:00pm Pacific time.
+        We will reply within 2 business days or earlier for most plans.
 
    .. tab:: |org_brand|
 
         Please fill out the form at https://readthedocs.org/support/,
         and we will reply as soon as possible.
 
-   .. tab:: |com_brand|
+Community provided resources
+----------------------------
 
-        Please fill out the form at https://readthedocs.com/support/,
-        and we will reply within 1 business day for most plans.
+If you have questions about how to use a documentation tool or authoring content for your project,
+or have an issue that isn't related to a bug with Read the Docs,
+`Stack Overflow`_ is the best place for your question.
+
+Examples of good questions for Stack Overflow are:
+
+* "What is the best way to structure the table of contents across a project?"
+* "How do I structure translations inside of my project for easiest contribution from users?"
+* "How do I use Sphinx to use SVG images in HTML output but PNG in PDF output?"
+
+.. tip::
+   Tag questions with ``read-the-docs`` so other folks can find them easily.
 
 Bug reports
 -----------
 
-If you have an issue with the actual functioning of the site,
+If you have an issue with the actual functioning of Read the Docs,
 you can file bug reports on our `GitHub issue tracker`_.
-You can also :doc:`contribute <rtd-dev:contribute>` to Read the Docs,
+You can also :doc:`contribute changes and fixes <rtd-dev:contribute>` to Read the Docs,
 as the code is open source.
-
-Priority support
-----------------
-
-We offer priority support with :doc:`Read the Docs for Business </commercial/index>`
-and we have a dedicated team that responds to support requests during business hours.
 
 .. _Stack Overflow: https://stackoverflow.com/questions/tagged/read-the-docs
 .. _Github issue tracker: https://github.com/readthedocs/readthedocs.org/issues


### PR DESCRIPTION
This addresses a few issues with the support page:

- The first section mentions Stack Overflow, but we should probably
  highlight our search first
- Adds some boundaries on our user support
  - Adds example questions back for user support
  - Directly calls out what we don't support
- Description of our support is broken up and needed a few updates
  - Mentions reponse time of 1 day, which is accurate but doesn't match
    our pricing
  - Mention our support hours
- Cleans up some of the language

Rendered: https://docs--10580.org.readthedocs.build/en/10580/support.html


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10580.org.readthedocs.build/en/10580/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10580.org.readthedocs.build/en/10580/

<!-- readthedocs-preview dev end -->