### PR TITLE
Add USE_ORGANIZATIONS context variablea

### DIFF
--- a/readthedocs/core/context_processors.py
+++ b/readthedocs/core/context_processors.py
@@ -4,7 +4,6 @@ from django.conf import settings
 
 
 def readthedocs_processor(request):
-    # pylint: disable=unused-argument
     exports = {
         "PUBLIC_DOMAIN": settings.PUBLIC_DOMAIN,
         "PRODUCTION_DOMAIN": settings.PRODUCTION_DOMAIN,

--- a/readthedocs/core/context_processors.py
+++ b/readthedocs/core/context_processors.py
@@ -1,4 +1,3 @@
-
 """Template context processors for core app."""
 
 from django.conf import settings
@@ -7,16 +6,16 @@ from django.conf import settings
 def readthedocs_processor(request):
     # pylint: disable=unused-argument
     exports = {
-        'PUBLIC_DOMAIN': settings.PUBLIC_DOMAIN,
-        'PRODUCTION_DOMAIN': settings.PRODUCTION_DOMAIN,
-        'USE_SUBDOMAIN': settings.USE_SUBDOMAIN,
-        'GLOBAL_ANALYTICS_CODE': settings.GLOBAL_ANALYTICS_CODE,
-        'DASHBOARD_ANALYTICS_CODE': settings.DASHBOARD_ANALYTICS_CODE,
-        'SITE_ROOT': settings.SITE_ROOT + '/',
-        'TEMPLATE_ROOT': settings.TEMPLATE_ROOT + '/',
-        'DO_NOT_TRACK_ENABLED': settings.DO_NOT_TRACK_ENABLED,
-        'USE_PROMOS': settings.USE_PROMOS,
-        'USE_ORGANIZATIONS': settings.RTD_ALLOW_ORGANIZATIONS,
-        'SUPPORT_EMAIL': settings.SUPPORT_EMAIL,
+        "PUBLIC_DOMAIN": settings.PUBLIC_DOMAIN,
+        "PRODUCTION_DOMAIN": settings.PRODUCTION_DOMAIN,
+        "USE_SUBDOMAIN": settings.USE_SUBDOMAIN,
+        "GLOBAL_ANALYTICS_CODE": settings.GLOBAL_ANALYTICS_CODE,
+        "DASHBOARD_ANALYTICS_CODE": settings.DASHBOARD_ANALYTICS_CODE,
+        "SITE_ROOT": settings.SITE_ROOT + "/",
+        "TEMPLATE_ROOT": settings.TEMPLATE_ROOT + "/",
+        "DO_NOT_TRACK_ENABLED": settings.DO_NOT_TRACK_ENABLED,
+        "USE_PROMOS": settings.USE_PROMOS,
+        "USE_ORGANIZATIONS": settings.RTD_ALLOW_ORGANIZATIONS,
+        "SUPPORT_EMAIL": settings.SUPPORT_EMAIL,
     }
     return exports

--- a/readthedocs/core/context_processors.py
+++ b/readthedocs/core/context_processors.py
@@ -16,6 +16,7 @@ def readthedocs_processor(request):
         'TEMPLATE_ROOT': settings.TEMPLATE_ROOT + '/',
         'DO_NOT_TRACK_ENABLED': settings.DO_NOT_TRACK_ENABLED,
         'USE_PROMOS': settings.USE_PROMOS,
+        'USE_ORGANIZATIONS': settings.RTD_ALLOW_ORGANIZATIONS,
         'SUPPORT_EMAIL': settings.SUPPORT_EMAIL,
     }
     return exports

--- a/readthedocs/rtd_tests/tests/test_notifications.py
+++ b/readthedocs/rtd_tests/tests/test_notifications.py
@@ -74,6 +74,7 @@ class NotificationTests(TestCase):
                 'TEMPLATE_ROOT': mock.ANY,
                 'USE_PROMOS': mock.ANY,
                 'USE_SUBDOMAIN': mock.ANY,
+                'USE_ORGANIZATIONS': mock.ANY,
             },
         )
 
@@ -238,6 +239,7 @@ class SiteNotificationTests(TestCase):
             'TEMPLATE_ROOT': mock.ANY,
             'USE_PROMOS': mock.ANY,
             'USE_SUBDOMAIN': mock.ANY,
+            'USE_ORGANIZATIONS': mock.ANY,
         }
         self.assertEqual(self.n.get_context_data(), context)
 

--- a/readthedocs/rtd_tests/tests/test_notifications.py
+++ b/readthedocs/rtd_tests/tests/test_notifications.py
@@ -22,79 +22,78 @@ from readthedocs.notifications.constants import (
 
 @override_settings(
     NOTIFICATION_BACKENDS=[
-        'readthedocs.notifications.backends.EmailBackend',
-        'readthedocs.notifications.backends.SiteBackend',
+        "readthedocs.notifications.backends.EmailBackend",
+        "readthedocs.notifications.backends.SiteBackend",
     ],
-    PRODUCTION_DOMAIN='readthedocs.org',
-    SUPPORT_EMAIL='support@readthedocs.org',
+    PRODUCTION_DOMAIN="readthedocs.org",
+    SUPPORT_EMAIL="support@readthedocs.org",
 )
-@mock.patch('readthedocs.notifications.notification.render_to_string')
-@mock.patch.object(Notification, 'send')
+@mock.patch("readthedocs.notifications.notification.render_to_string")
+@mock.patch.object(Notification, "send")
 class NotificationTests(TestCase):
-
     def test_notification_custom(self, send, render_to_string):
-        render_to_string.return_value = 'Test'
+        render_to_string.return_value = "Test"
 
         class TestNotification(Notification):
-            name = 'foo'
-            subject = 'This is {{ foo.id }}'
-            context_object_name = 'foo'
+            name = "foo"
+            subject = "This is {{ foo.id }}"
+            context_object_name = "foo"
 
         build = fixture.get(Build)
         req = mock.MagicMock()
         notify = TestNotification(context_object=build, request=req)
 
         self.assertEqual(
-            notify.get_template_names('email'),
-            ['builds/notifications/foo_email.html'],
+            notify.get_template_names("email"),
+            ["builds/notifications/foo_email.html"],
         )
         self.assertEqual(
-            notify.get_template_names('site'),
-            ['builds/notifications/foo_site.html'],
+            notify.get_template_names("site"),
+            ["builds/notifications/foo_site.html"],
         )
         self.assertEqual(
             notify.get_subject(),
-            'This is {}'.format(build.id),
+            "This is {}".format(build.id),
         )
         self.assertEqual(
             notify.get_context_data(),
             {
-                'foo': build,
-                'production_uri': 'https://readthedocs.org',
-                'request': req,
-
+                "foo": build,
+                "production_uri": "https://readthedocs.org",
+                "request": req,
                 # readthedocs_processor context
-                'DASHBOARD_ANALYTICS_CODE': mock.ANY,
-                'DO_NOT_TRACK_ENABLED': mock.ANY,
-                'GLOBAL_ANALYTICS_CODE': mock.ANY,
-                'PRODUCTION_DOMAIN': 'readthedocs.org',
-                'PUBLIC_DOMAIN': mock.ANY,
-                'SITE_ROOT': mock.ANY,
-                'SUPPORT_EMAIL': 'support@readthedocs.org',
-                'TEMPLATE_ROOT': mock.ANY,
-                'USE_PROMOS': mock.ANY,
-                'USE_SUBDOMAIN': mock.ANY,
-                'USE_ORGANIZATIONS': mock.ANY,
+                "DASHBOARD_ANALYTICS_CODE": mock.ANY,
+                "DO_NOT_TRACK_ENABLED": mock.ANY,
+                "GLOBAL_ANALYTICS_CODE": mock.ANY,
+                "PRODUCTION_DOMAIN": "readthedocs.org",
+                "PUBLIC_DOMAIN": mock.ANY,
+                "SITE_ROOT": mock.ANY,
+                "SUPPORT_EMAIL": "support@readthedocs.org",
+                "TEMPLATE_ROOT": mock.ANY,
+                "USE_PROMOS": mock.ANY,
+                "USE_SUBDOMAIN": mock.ANY,
+                "USE_ORGANIZATIONS": mock.ANY,
             },
         )
 
-        notify.render('site')
-        render_to_string.assert_has_calls([
-            mock.call(
-                context=mock.ANY,
-                template_name=['builds/notifications/foo_site.html'],
-            ),
-        ])
+        notify.render("site")
+        render_to_string.assert_has_calls(
+            [
+                mock.call(
+                    context=mock.ANY,
+                    template_name=["builds/notifications/foo_site.html"],
+                ),
+            ]
+        )
 
 
 class NotificationBackendTests(TestCase):
-
-    @mock.patch('readthedocs.notifications.backends.send_email')
+    @mock.patch("readthedocs.notifications.backends.send_email")
     def test_email_backend(self, send_email):
         class TestNotification(Notification):
-            name = 'foo'
-            subject = 'This is {{ foo.id }}'
-            context_object_name = 'foo'
+            name = "foo"
+            subject = "This is {{ foo.id }}"
+            context_object_name = "foo"
             level = ERROR
 
         build = fixture.get(Build)
@@ -118,12 +117,12 @@ class NotificationBackendTests(TestCase):
 
     @mock.patch("readthedocs.notifications.notification.render_to_string")
     def test_message_backend(self, render_to_string):
-        render_to_string.return_value = 'Test'
+        render_to_string.return_value = "Test"
 
         class TestNotification(Notification):
-            name = 'foo'
-            subject = 'This is {{ foo.id }}'
-            context_object_name = 'foo'
+            name = "foo"
+            subject = "This is {{ foo.id }}"
+            context_object_name = "foo"
 
         build = fixture.get(Build)
         user = fixture.get(User)
@@ -141,12 +140,12 @@ class NotificationBackendTests(TestCase):
     @mock.patch("readthedocs.notifications.notification.render_to_string")
     def test_message_anonymous_user(self, render_to_string):
         """Anonymous user still throwns exception on persistent messages."""
-        render_to_string.return_value = 'Test'
+        render_to_string.return_value = "Test"
 
         class TestNotification(Notification):
-            name = 'foo'
-            subject = 'This is {{ foo.id }}'
-            context_object_name = 'foo'
+            name = "foo"
+            subject = "This is {{ foo.id }}"
+            context_object_name = "foo"
 
         build = fixture.get(Build)
         user = AnonymousUser()
@@ -164,11 +163,11 @@ class NotificationBackendTests(TestCase):
         self.assertEqual(render_to_string.call_count, 1)
         self.assertEqual(PersistentMessage.objects.count(), 0)
 
-    @mock.patch('readthedocs.notifications.backends.send_email')
+    @mock.patch("readthedocs.notifications.backends.send_email")
     def test_non_persistent_message(self, send_email):
         class TestNotification(SiteNotification):
-            name = 'foo'
-            success_message = 'Test success message'
+            name = "foo"
+            success_message = "Test success message"
             success_level = INFO_NON_PERSISTENT
 
         user = fixture.get(User)
@@ -186,39 +185,38 @@ class NotificationBackendTests(TestCase):
         self.assertEqual(PersistentMessage.objects.filter(read=False).count(), 1)
 
         self.client.force_login(user)
-        response = self.client.get('/dashboard/')
-        self.assertContains(response, 'Test success message')
+        response = self.client.get("/dashboard/")
+        self.assertContains(response, "Test success message")
         self.assertEqual(PersistentMessage.objects.count(), 1)
         self.assertEqual(PersistentMessage.objects.filter(read=True).count(), 1)
 
-        response = self.client.get('/dashboard/')
-        self.assertNotContains(response, 'Test success message')
+        response = self.client.get("/dashboard/")
+        self.assertNotContains(response, "Test success message")
 
 
 @override_settings(
-    PRODUCTION_DOMAIN='readthedocs.org',
-    SUPPORT_EMAIL='support@readthedocs.org',
+    PRODUCTION_DOMAIN="readthedocs.org",
+    SUPPORT_EMAIL="support@readthedocs.org",
 )
 class SiteNotificationTests(TestCase):
-
     class TestSiteNotification(SiteNotification):
-        name = 'foo'
-        success_message = 'simple success message'
+        name = "foo"
+        success_message = "simple success message"
         failure_message = {
-            1: 'simple failure message',
-            2: '{{ object.name }} object name',
-            'three': '{{ object.name }} and {{ other.name }} render',
+            1: "simple failure message",
+            2: "{{ object.name }} object name",
+            "three": "{{ object.name }} and {{ other.name }} render",
         }
         success_level = INFO_NON_PERSISTENT
         failure_level = WARNING_NON_PERSISTENT
 
     def setUp(self):
         self.user = fixture.get(User)
-        self.context = {'other': {'name': 'other name'}}
+        self.context = {"other": {"name": "other name"}}
         self.n = self.TestSiteNotification(
             self.user,
             True,
-            context_object={'name': 'object name'},
+            context_object={"name": "object name"},
             extra_context=self.context,
         )
 
@@ -229,17 +227,17 @@ class SiteNotificationTests(TestCase):
             "production_uri": "https://readthedocs.org",
             "other": {"name": "other name"},
             # readthedocs_processor context
-            'DASHBOARD_ANALYTICS_CODE': mock.ANY,
-            'DO_NOT_TRACK_ENABLED': mock.ANY,
-            'GLOBAL_ANALYTICS_CODE': mock.ANY,
-            'PRODUCTION_DOMAIN': 'readthedocs.org',
-            'PUBLIC_DOMAIN': mock.ANY,
-            'SITE_ROOT': mock.ANY,
-            'SUPPORT_EMAIL': 'support@readthedocs.org',
-            'TEMPLATE_ROOT': mock.ANY,
-            'USE_PROMOS': mock.ANY,
-            'USE_SUBDOMAIN': mock.ANY,
-            'USE_ORGANIZATIONS': mock.ANY,
+            "DASHBOARD_ANALYTICS_CODE": mock.ANY,
+            "DO_NOT_TRACK_ENABLED": mock.ANY,
+            "GLOBAL_ANALYTICS_CODE": mock.ANY,
+            "PRODUCTION_DOMAIN": "readthedocs.org",
+            "PUBLIC_DOMAIN": mock.ANY,
+            "SITE_ROOT": mock.ANY,
+            "SUPPORT_EMAIL": "support@readthedocs.org",
+            "TEMPLATE_ROOT": mock.ANY,
+            "USE_PROMOS": mock.ANY,
+            "USE_SUBDOMAIN": mock.ANY,
+            "USE_ORGANIZATIONS": mock.ANY,
         }
         self.assertEqual(self.n.get_context_data(), context)
 
@@ -252,19 +250,19 @@ class SiteNotificationTests(TestCase):
 
     def test_message(self):
         self.n.reason = 1
-        self.assertEqual(self.n.get_message(True), 'simple success message')
-        self.n.reason = 'three'
-        self.assertEqual(self.n.get_message(True), 'simple success message')
+        self.assertEqual(self.n.get_message(True), "simple success message")
+        self.n.reason = "three"
+        self.assertEqual(self.n.get_message(True), "simple success message")
 
         self.n.reason = 1
-        self.assertEqual(self.n.get_message(False), 'simple failure message')
+        self.assertEqual(self.n.get_message(False), "simple failure message")
         self.n.reason = 2
-        self.assertEqual(self.n.get_message(False), 'object name object name')
-        self.n.reason = 'three'
-        self.assertEqual(self.n.get_message(False), 'object name and other name render')
+        self.assertEqual(self.n.get_message(False), "object name object name")
+        self.n.reason = "three"
+        self.assertEqual(self.n.get_message(False), "object name and other name render")
 
         # Invalid reason
         self.n.reason = None
-        with mock.patch('readthedocs.notifications.notification.log') as mock_log:
-            self.assertEqual(self.n.get_message(False), '')
+        with mock.patch("readthedocs.notifications.notification.log") as mock_log:
+            self.assertEqual(self.n.get_message(False), "")
             mock_log.error.assert_called_once()


### PR DESCRIPTION
This copies USE_SUBDOMAIN and USE_PROMOS pattern for use in the templates when
adding features for organizations/commercial. This would supersede checks like
``PRODUCTION_DOMAIN == "readthedocs.com"`` and friends.