### PR TITLE
Proxito: test new implementation more broadly

### DIFF
--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -43,12 +43,7 @@ class ProjectAdminSerializer(ProjectSerializer):
     general API, mostly for fields used in the build process
     """
 
-    features = serializers.SlugRelatedField(
-        many=True,
-        read_only=True,
-        slug_field='feature_id',
-    )
-
+    features = serializers.ReadOnlyField()
     environment_variables = serializers.SerializerMethodField()
     skip = serializers.SerializerMethodField()
 

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -2017,7 +2017,9 @@ class Feature(models.Model):
         ),
         (
             USE_OLD_PROXITO_IMPLEMENTATION,
-            _("Proxito: Use old implementation for serving documentation files."),
+            _(
+                "Proxito: Use old Proxito implementation (no unresolver) for serving documentation files."
+            ),
         ),
         (
             ALLOW_VERSION_WARNING_BANNER,

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1302,7 +1302,9 @@ class Project(models.Model):
 
     @cached_property
     def features(self):
-        return list(Feature.objects.for_project(self).values_list('feature_id', flat=True))
+        return list(
+            Feature.objects.for_project(self).values_list("feature_id", flat=True)
+        )
 
     def has_feature(self, feature_id):
         """
@@ -2015,9 +2017,7 @@ class Feature(models.Model):
         ),
         (
             USE_OLD_PROXITO_IMPLEMENTATION,
-            _(
-                "Proxito: Use old implementation for serving documentation files."
-            ),
+            _("Proxito: Use old implementation for serving documentation files."),
         ),
         (
             ALLOW_VERSION_WARNING_BANNER,

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1300,9 +1300,9 @@ class Project(models.Model):
 
         return self.domains.filter(canonical=True).first()
 
-    @property
+    @cached_property
     def features(self):
-        return Feature.objects.for_project(self)
+        return list(Feature.objects.for_project(self).values_list('feature_id', flat=True))
 
     def has_feature(self, feature_id):
         """
@@ -1312,7 +1312,7 @@ class Project(models.Model):
         we consider the project to have the flag. This is used for deprecating a
         feature or changing behavior for new projects
         """
-        return self.features.filter(feature_id=feature_id).exists()
+        return feature_id in self.features
 
     def get_feature_value(self, feature, positive, negative):
         """
@@ -1449,9 +1449,6 @@ class APIProject(Project):
 
     def save(self, *args, **kwargs):
         return 0
-
-    def has_feature(self, feature_id):
-        return feature_id in self.features
 
     @property
     def show_advertising(self):
@@ -1924,6 +1921,7 @@ class Feature(models.Model):
     DISABLE_PAGEVIEWS = "disable_pageviews"
     RESOLVE_PROJECT_FROM_HEADER = "resolve_project_from_header"
     USE_UNRESOLVER_WITH_PROXITO = "use_unresolver_with_proxito"
+    USE_OLD_PROXITO_IMPLEMENTATION = "use_old_proxito_implementation"
     ALLOW_VERSION_WARNING_BANNER = "allow_version_warning_banner"
 
     # Versions sync related features
@@ -2013,6 +2011,12 @@ class Feature(models.Model):
             USE_UNRESOLVER_WITH_PROXITO,
             _(
                 "Proxito: Use new unresolver implementation for serving documentation files."
+            ),
+        ),
+        (
+            USE_OLD_PROXITO_IMPLEMENTATION,
+            _(
+                "Proxito: Use old implementation for serving documentation files."
             ),
         ),
         (

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -269,9 +269,9 @@ class ProxitoMiddleware(MiddlewareMixin):
 
         # This is hacky because Django wants a module for the URLConf,
         # instead of also accepting string
-        if project.urlconf and not project.has_feature(
+        if project.urlconf and (project.has_feature(Feature.USE_OLD_PROXITO_IMPLEMENTATION) or not project.has_feature(
             Feature.USE_UNRESOLVER_WITH_PROXITO
-        ):
+        )):
             # Stop Django from caching URLs
             # https://github.com/django/django/blob/7cf7d74/django/urls/resolvers.py#L65-L69  # noqa
             project_timestamp = project.modified_date.strftime("%Y%m%d.%H%M%S%f")

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -269,9 +269,10 @@ class ProxitoMiddleware(MiddlewareMixin):
 
         # This is hacky because Django wants a module for the URLConf,
         # instead of also accepting string
-        if project.urlconf and (project.has_feature(Feature.USE_OLD_PROXITO_IMPLEMENTATION) or not project.has_feature(
-            Feature.USE_UNRESOLVER_WITH_PROXITO
-        )):
+        if project.urlconf and (
+            project.has_feature(Feature.USE_OLD_PROXITO_IMPLEMENTATION)
+            or not project.has_feature(Feature.USE_UNRESOLVER_WITH_PROXITO)
+        ):
             # Stop Django from caching URLs
             # https://github.com/django/django/blob/7cf7d74/django/urls/resolvers.py#L65-L69  # noqa
             project_timestamp = project.modified_date.strftime("%Y%m%d.%H%M%S%f")

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -44,10 +44,13 @@ from .base import BaseDocServing
 class TestFullDocServing(BaseDocServing):
     # Test the full range of possible doc URL's
 
+    using_new_implementation = False
+
     def test_health_check(self):
         url = reverse('health_check')
         host = 'project.dev.readthedocs.io'
-        resp = self.client.get(url, HTTP_HOST=host)
+        with self.assertNumQueries(0):
+            resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json(), {'status': 200})
 
@@ -62,7 +65,9 @@ class TestFullDocServing(BaseDocServing):
     def test_subproject_serving(self):
         url = '/projects/subproject/en/latest/awesome.html'
         host = 'project.dev.readthedocs.io'
-        resp = self.client.get(url, HTTP_HOST=host)
+        expected_query_count = 8 if self.using_new_implementation else 9
+        with self.assertNumQueries(expected_query_count):
+            resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
             resp['x-accel-redirect'], '/proxito/media/html/subproject/latest/awesome.html',
         )
@@ -72,7 +77,9 @@ class TestFullDocServing(BaseDocServing):
         self.subproject.save()
         url = '/projects/subproject/awesome.html'
         host = 'project.dev.readthedocs.io'
-        resp = self.client.get(url, HTTP_HOST=host)
+        expected_query_count = 8 if self.using_new_implementation else 9
+        with self.assertNumQueries(expected_query_count):
+            resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
             resp['x-accel-redirect'], '/proxito/media/html/subproject/latest/awesome.html',
         )
@@ -80,7 +87,9 @@ class TestFullDocServing(BaseDocServing):
     def test_subproject_translation_serving(self):
         url = '/projects/subproject/es/latest/awesome.html'
         host = 'project.dev.readthedocs.io'
-        resp = self.client.get(url, HTTP_HOST=host)
+        expected_query_count = 9 if self.using_new_implementation else 10
+        with self.assertNumQueries(expected_query_count):
+            resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
             resp['x-accel-redirect'], '/proxito/media/html/subproject-translation/latest/awesome.html',
         )
@@ -88,7 +97,9 @@ class TestFullDocServing(BaseDocServing):
     def test_subproject_alias_serving(self):
         url = '/projects/this-is-an-alias/en/latest/awesome.html'
         host = 'project.dev.readthedocs.io'
-        resp = self.client.get(url, HTTP_HOST=host)
+        expected_query_count = 8 if self.using_new_implementation else 9
+        with self.assertNumQueries(expected_query_count):
+            resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
             resp['x-accel-redirect'], '/proxito/media/html/subproject-alias/latest/awesome.html',
         )
@@ -96,7 +107,8 @@ class TestFullDocServing(BaseDocServing):
     def test_translation_serving(self):
         url = '/es/latest/awesome.html'
         host = 'project.dev.readthedocs.io'
-        resp = self.client.get(url, HTTP_HOST=host)
+        with self.assertNumQueries(8):
+            resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
             resp['x-accel-redirect'], '/proxito/media/html/translation/latest/awesome.html',
         )
@@ -104,7 +116,8 @@ class TestFullDocServing(BaseDocServing):
     def test_normal_serving(self):
         url = '/en/latest/awesome.html'
         host = 'project.dev.readthedocs.io'
-        resp = self.client.get(url, HTTP_HOST=host)
+        with self.assertNumQueries(7):
+            resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
             resp['x-accel-redirect'], '/proxito/media/html/project/latest/awesome.html',
         )
@@ -114,7 +127,8 @@ class TestFullDocServing(BaseDocServing):
         self.project.save()
         url = '/awesome.html'
         host = 'project.dev.readthedocs.io'
-        resp = self.client.get(url, HTTP_HOST=host)
+        with self.assertNumQueries(7):
+            resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
             resp['x-accel-redirect'], '/proxito/media/html/project/latest/awesome.html',
         )
@@ -124,7 +138,8 @@ class TestFullDocServing(BaseDocServing):
         self.project.save()
         url = '/en/stable/awesome.html'
         host = 'project.dev.readthedocs.io'
-        resp = self.client.get(url, HTTP_HOST=host)
+        with self.assertNumQueries(7):
+            resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
             resp['x-accel-redirect'], '/proxito/media/html/project/latest/en/stable/awesome.html',
         )
@@ -133,7 +148,8 @@ class TestFullDocServing(BaseDocServing):
         host = 'project.dev.readthedocs.io'
         urls = ('/en/latest/awesome/', '/en/latest/awesome/index.html')
         for url in urls:
-            resp = self.client.get(url, HTTP_HOST=host)
+            with self.assertNumQueries(7):
+                resp = self.client.get(url, HTTP_HOST=host)
             self.assertEqual(
                 resp['x-accel-redirect'], '/proxito/media/html/project/latest/awesome/index.html',
             )
@@ -151,7 +167,8 @@ class TestFullDocServing(BaseDocServing):
         )
         url = '/awesome.html'
         host = 'project--10.dev.readthedocs.build'
-        resp = self.client.get(url, HTTP_HOST=host)
+        with self.assertNumQueries(6):
+            resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
             resp['x-accel-redirect'], '/proxito/media/external/html/project/10/awesome.html',
         )
@@ -167,7 +184,8 @@ class TestFullDocServing(BaseDocServing):
         )
         url = "/en/10/awesome.html"
         host = "project--10.dev.readthedocs.build"
-        resp = self.client.get(url, HTTP_HOST=host)
+        with self.assertNumQueries(6):
+            resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
             resp['x-accel-redirect'], '/proxito/media/external/html/project/10/awesome.html',
         )
@@ -191,7 +209,8 @@ class TestFullDocServing(BaseDocServing):
         self.project.save()
 
         host = "test--project--10.dev.readthedocs.build"
-        resp = self.client.get("/en/10/awesome.html", HTTP_HOST=host)
+        with self.assertNumQueries(6):
+            resp = self.client.get("/en/10/awesome.html", HTTP_HOST=host)
         self.assertEqual(
             resp['x-accel-redirect'], '/proxito/media/external/html/test--project/10/awesome.html',
         )
@@ -364,6 +383,9 @@ class TestFullDocServing(BaseDocServing):
 
 class ProxitoV2TestFullDocServing(TestFullDocServing):
     # TODO: remove this class once the new implementation is the default.
+
+    using_new_implementation = True
+
     def setUp(self):
         super().setUp()
         get(
@@ -378,7 +400,8 @@ class ProxitoV2TestFullDocServing(TestFullDocServing):
         self.project.save()
         url = "/projects/awesome.html"
         host = "project.dev.readthedocs.io"
-        resp = self.client.get(url, HTTP_HOST=host)
+        with self.assertNumQueries(7):
+            resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
             resp["x-accel-redirect"],
             "/proxito/media/html/project/latest/projects/awesome.html",

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -44,13 +44,10 @@ from .base import BaseDocServing
 class TestFullDocServing(BaseDocServing):
     # Test the full range of possible doc URL's
 
-    using_new_implementation = False
-
     def test_health_check(self):
         url = reverse('health_check')
         host = 'project.dev.readthedocs.io'
-        with self.assertNumQueries(0):
-            resp = self.client.get(url, HTTP_HOST=host)
+        resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json(), {'status': 200})
 
@@ -65,9 +62,7 @@ class TestFullDocServing(BaseDocServing):
     def test_subproject_serving(self):
         url = '/projects/subproject/en/latest/awesome.html'
         host = 'project.dev.readthedocs.io'
-        expected_query_count = 8 if self.using_new_implementation else 9
-        with self.assertNumQueries(expected_query_count):
-            resp = self.client.get(url, HTTP_HOST=host)
+        resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
             resp['x-accel-redirect'], '/proxito/media/html/subproject/latest/awesome.html',
         )
@@ -77,9 +72,7 @@ class TestFullDocServing(BaseDocServing):
         self.subproject.save()
         url = '/projects/subproject/awesome.html'
         host = 'project.dev.readthedocs.io'
-        expected_query_count = 8 if self.using_new_implementation else 9
-        with self.assertNumQueries(expected_query_count):
-            resp = self.client.get(url, HTTP_HOST=host)
+        resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
             resp['x-accel-redirect'], '/proxito/media/html/subproject/latest/awesome.html',
         )
@@ -87,9 +80,7 @@ class TestFullDocServing(BaseDocServing):
     def test_subproject_translation_serving(self):
         url = '/projects/subproject/es/latest/awesome.html'
         host = 'project.dev.readthedocs.io'
-        expected_query_count = 9 if self.using_new_implementation else 10
-        with self.assertNumQueries(expected_query_count):
-            resp = self.client.get(url, HTTP_HOST=host)
+        resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
             resp['x-accel-redirect'], '/proxito/media/html/subproject-translation/latest/awesome.html',
         )
@@ -97,9 +88,7 @@ class TestFullDocServing(BaseDocServing):
     def test_subproject_alias_serving(self):
         url = '/projects/this-is-an-alias/en/latest/awesome.html'
         host = 'project.dev.readthedocs.io'
-        expected_query_count = 8 if self.using_new_implementation else 9
-        with self.assertNumQueries(expected_query_count):
-            resp = self.client.get(url, HTTP_HOST=host)
+        resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
             resp['x-accel-redirect'], '/proxito/media/html/subproject-alias/latest/awesome.html',
         )
@@ -107,8 +96,7 @@ class TestFullDocServing(BaseDocServing):
     def test_translation_serving(self):
         url = '/es/latest/awesome.html'
         host = 'project.dev.readthedocs.io'
-        with self.assertNumQueries(8):
-            resp = self.client.get(url, HTTP_HOST=host)
+        resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
             resp['x-accel-redirect'], '/proxito/media/html/translation/latest/awesome.html',
         )
@@ -116,8 +104,7 @@ class TestFullDocServing(BaseDocServing):
     def test_normal_serving(self):
         url = '/en/latest/awesome.html'
         host = 'project.dev.readthedocs.io'
-        with self.assertNumQueries(7):
-            resp = self.client.get(url, HTTP_HOST=host)
+        resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
             resp['x-accel-redirect'], '/proxito/media/html/project/latest/awesome.html',
         )
@@ -127,8 +114,7 @@ class TestFullDocServing(BaseDocServing):
         self.project.save()
         url = '/awesome.html'
         host = 'project.dev.readthedocs.io'
-        with self.assertNumQueries(7):
-            resp = self.client.get(url, HTTP_HOST=host)
+        resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
             resp['x-accel-redirect'], '/proxito/media/html/project/latest/awesome.html',
         )
@@ -138,8 +124,7 @@ class TestFullDocServing(BaseDocServing):
         self.project.save()
         url = '/en/stable/awesome.html'
         host = 'project.dev.readthedocs.io'
-        with self.assertNumQueries(7):
-            resp = self.client.get(url, HTTP_HOST=host)
+        resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
             resp['x-accel-redirect'], '/proxito/media/html/project/latest/en/stable/awesome.html',
         )
@@ -148,8 +133,7 @@ class TestFullDocServing(BaseDocServing):
         host = 'project.dev.readthedocs.io'
         urls = ('/en/latest/awesome/', '/en/latest/awesome/index.html')
         for url in urls:
-            with self.assertNumQueries(7):
-                resp = self.client.get(url, HTTP_HOST=host)
+            resp = self.client.get(url, HTTP_HOST=host)
             self.assertEqual(
                 resp['x-accel-redirect'], '/proxito/media/html/project/latest/awesome/index.html',
             )
@@ -167,8 +151,7 @@ class TestFullDocServing(BaseDocServing):
         )
         url = '/awesome.html'
         host = 'project--10.dev.readthedocs.build'
-        with self.assertNumQueries(6):
-            resp = self.client.get(url, HTTP_HOST=host)
+        resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
             resp['x-accel-redirect'], '/proxito/media/external/html/project/10/awesome.html',
         )
@@ -184,8 +167,7 @@ class TestFullDocServing(BaseDocServing):
         )
         url = "/en/10/awesome.html"
         host = "project--10.dev.readthedocs.build"
-        with self.assertNumQueries(6):
-            resp = self.client.get(url, HTTP_HOST=host)
+        resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
             resp['x-accel-redirect'], '/proxito/media/external/html/project/10/awesome.html',
         )
@@ -209,8 +191,7 @@ class TestFullDocServing(BaseDocServing):
         self.project.save()
 
         host = "test--project--10.dev.readthedocs.build"
-        with self.assertNumQueries(6):
-            resp = self.client.get("/en/10/awesome.html", HTTP_HOST=host)
+        resp = self.client.get("/en/10/awesome.html", HTTP_HOST=host)
         self.assertEqual(
             resp['x-accel-redirect'], '/proxito/media/external/html/test--project/10/awesome.html',
         )
@@ -383,9 +364,6 @@ class TestFullDocServing(BaseDocServing):
 
 class ProxitoV2TestFullDocServing(TestFullDocServing):
     # TODO: remove this class once the new implementation is the default.
-
-    using_new_implementation = True
-
     def setUp(self):
         super().setUp()
         get(
@@ -400,8 +378,7 @@ class ProxitoV2TestFullDocServing(TestFullDocServing):
         self.project.save()
         url = "/projects/awesome.html"
         host = "project.dev.readthedocs.io"
-        with self.assertNumQueries(7):
-            resp = self.client.get(url, HTTP_HOST=host)
+        resp = self.client.get(url, HTTP_HOST=host)
         self.assertEqual(
             resp["x-accel-redirect"],
             "/proxito/media/html/project/latest/projects/awesome.html",

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -140,7 +140,7 @@ class ServeDocsBase(CDNCacheControlMixin, ServeRedirectMixin, ServeDocsMixin, Vi
                 # and we don't want to issue infinite redirects.
                 pass
 
-        if unresolved_domain.project.has_feature(Feature.USE_UNRESOLVER_WITH_PROXITO):
+        if not unresolved_domain.project.has_feature(Feature.USE_OLD_PROXITO_IMPLEMENTATION) and unresolved_domain.project.has_feature(Feature.USE_UNRESOLVER_WITH_PROXITO):
             return self.get_using_unresolver(request)
 
         original_version_slug = version_slug
@@ -528,7 +528,7 @@ class ServeError404Base(CDNCacheControlMixin, ServeRedirectMixin, ServeDocsMixin
         log.debug('Executing 404 handler.')
 
         unresolved_domain = request.unresolved_domain
-        if unresolved_domain.project.has_feature(Feature.USE_UNRESOLVER_WITH_PROXITO):
+        if not unresolved_domain.project.has_feature(Feature.USE_OLD_PROXITO_IMPLEMENTATION) and unresolved_domain.project.has_feature(Feature.USE_UNRESOLVER_WITH_PROXITO):
             return self.get_using_unresolver(request, proxito_path)
 
         # Parse the URL using the normal urlconf, so we get proper subdomain/translation data

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -140,7 +140,10 @@ class ServeDocsBase(CDNCacheControlMixin, ServeRedirectMixin, ServeDocsMixin, Vi
                 # and we don't want to issue infinite redirects.
                 pass
 
-        if not unresolved_domain.project.has_feature(Feature.USE_OLD_PROXITO_IMPLEMENTATION) and unresolved_domain.project.has_feature(Feature.USE_UNRESOLVER_WITH_PROXITO):
+        use_new_implementation = not unresolved_domain.project.has_feature(
+            Feature.USE_OLD_PROXITO_IMPLEMENTATION
+        ) and unresolved_domain.project.has_feature(Feature.USE_UNRESOLVER_WITH_PROXITO)
+        if use_new_implementation:
             return self.get_using_unresolver(request)
 
         original_version_slug = version_slug
@@ -528,7 +531,10 @@ class ServeError404Base(CDNCacheControlMixin, ServeRedirectMixin, ServeDocsMixin
         log.debug('Executing 404 handler.')
 
         unresolved_domain = request.unresolved_domain
-        if not unresolved_domain.project.has_feature(Feature.USE_OLD_PROXITO_IMPLEMENTATION) and unresolved_domain.project.has_feature(Feature.USE_UNRESOLVER_WITH_PROXITO):
+        use_new_implementation = not unresolved_domain.project.has_feature(
+            Feature.USE_OLD_PROXITO_IMPLEMENTATION
+        ) and unresolved_domain.project.has_feature(Feature.USE_UNRESOLVER_WITH_PROXITO)
+        if use_new_implementation:
             return self.get_using_unresolver(request, proxito_path)
 
         # Parse the URL using the normal urlconf, so we get proper subdomain/translation data

--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -294,6 +294,8 @@ class TestGitBackend(TestCase):
         repo.update()
         repo.checkout('submodule')
         self.assertTrue(repo.use_shallow_clone())
+        # Clear cache
+        del self.project.features
         fixture.get(
             Feature,
             projects=[self.project],


### PR DESCRIPTION
With this we can now exclude some projects from using the new implementation while testing it more broadly
by changing the date of the feature.

When we are ready to enable it for all projects, we can remove the USE_UNRESOLVER_WITH_PROXITO, and leave the other setting while we migrate the missing projects.

To avoid introducing another DB call, I'm caching the features from a project.