### PR TITLE
Import: remove extra/advanced step from project import wizard

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -86,7 +86,7 @@ class ProjectBasicsForm(ProjectForm):
 
     class Meta:
         model = Project
-        fields = ("name", "repo", "default_branch")
+        fields = ("name", "repo", "default_branch", "language")
 
     remote_repository = forms.IntegerField(
         widget=forms.HiddenInput(),
@@ -94,13 +94,7 @@ class ProjectBasicsForm(ProjectForm):
     )
 
     def __init__(self, *args, **kwargs):
-        show_advanced = kwargs.pop('show_advanced', False)
         super().__init__(*args, **kwargs)
-        if show_advanced:
-            self.fields['advanced'] = forms.BooleanField(
-                required=False,
-                label=_('Edit advanced project options'),
-            )
         self.fields['repo'].widget.attrs['placeholder'] = self.placehold_repo()
         self.fields['repo'].widget.attrs['required'] = True
 

--- a/readthedocs/projects/views/mixins.py
+++ b/readthedocs/projects/views/mixins.py
@@ -100,12 +100,11 @@ class ProjectImportMixin:
 
     """Helpers to import a Project."""
 
-    def finish_import_project(self, request, project, tags=None):
+    def finish_import_project(self, request, project):
         """
         Perform last steps to import a project into Read the Docs.
 
         - Add the user from request as maintainer
-        - Set all the tags to the project
         - Send Django Signal
         - Trigger initial build
 
@@ -115,18 +114,11 @@ class ProjectImportMixin:
         :param project: Project instance just imported (already saved)
         :param tags: tags to add to the project
         """
-        if not tags:
-            tags = []
-
         project.users.add(request.user)
-        for tag in tags:
-            project.tags.add(tag)
-
         log.info(
             'Project imported.',
             project_slug=project.slug,
             user_username=request.user.username,
-            tags=tags,
         )
 
         # TODO: this signal could be removed, or used for sync task

--- a/readthedocs/rtd_tests/tests/test_project_forms.py
+++ b/readthedocs/rtd_tests/tests/test_project_forms.py
@@ -74,9 +74,10 @@ class TestProjectForms(TestCase):
         with override_settings(ALLOW_PRIVATE_REPOS=False):
             for url, valid in public_urls:
                 initial = {
-                    'name': 'foo',
-                    'repo_type': 'git',
-                    'repo': url,
+                    "name": "foo",
+                    "repo_type": "git",
+                    "repo": url,
+                    "language": "en",
                 }
                 form = ProjectBasicsForm(initial)
                 self.assertEqual(form.is_valid(), valid, msg=url)
@@ -84,18 +85,20 @@ class TestProjectForms(TestCase):
         with override_settings(ALLOW_PRIVATE_REPOS=True):
             for url, valid in private_urls:
                 initial = {
-                    'name': 'foo',
-                    'repo_type': 'git',
-                    'repo': url,
+                    "name": "foo",
+                    "repo_type": "git",
+                    "repo": url,
+                    "language": "en",
                 }
                 form = ProjectBasicsForm(initial)
                 self.assertEqual(form.is_valid(), valid, msg=url)
 
     def test_empty_slug(self):
         initial = {
-            'name': "''",
-            'repo_type': 'git',
-            'repo': 'https://github.com/user/repository',
+            "name": "''",
+            "repo_type": "git",
+            "repo": "https://github.com/user/repository",
+            "language": "en",
         }
         form = ProjectBasicsForm(initial)
         self.assertFalse(form.is_valid())
@@ -112,9 +115,10 @@ class TestProjectForms(TestCase):
 
         form = ProjectBasicsForm(
             {
-                'repo': 'http://github.com/test/test',
-                'name': 'name',
-                'repo_type': REPO_TYPE_GIT,
+                "repo": "http://github.com/test/test",
+                "name": "name",
+                "repo_type": REPO_TYPE_GIT,
+                "language": "en",
             },
             instance=project,
         )
@@ -144,11 +148,14 @@ class TestProjectForms(TestCase):
         self.assertDictEqual(form.errors, {'tags': [error_msg]})
 
     def test_strip_repo_url(self):
-        form = ProjectBasicsForm({
-            'name': 'foo',
-            'repo_type': 'git',
-            'repo': 'https://github.com/rtfd/readthedocs.org/'
-        })
+        form = ProjectBasicsForm(
+            {
+                "name": "foo",
+                "repo_type": "git",
+                "repo": "https://github.com/rtfd/readthedocs.org/",
+                "language": "en",
+            }
+        )
         self.assertTrue(form.is_valid())
         self.assertEqual(
             form.cleaned_data['repo'],


### PR DESCRIPTION
This commit removes the "Extra/Advanced" step and moves the "language" attribute to the "Basics" step -- the first one, since that field is important.

Closes #10392