### PR TITLE
Revert "Contact projects with a build in the last 3 years"

### DIFF
--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -394,7 +394,7 @@ def deprecated_build_image_notification():
         )
         if version:
             # Use a fixed date here to avoid changing the date on each run
-            years_ago = timezone.datetime(2020, 8, 1)
+            years_ago = timezone.datetime(2022, 8, 1)
             build = (
                 version.builds.filter(success=True, date__gt=years_ago)
                 .only("_config")

--- a/readthedocs/templates/projects/notifications/deprecated_config_file_used_email.html
+++ b/readthedocs/templates/projects/notifications/deprecated_config_file_used_email.html
@@ -13,7 +13,7 @@ The timeline for this deprecation is as follows:
     <li><strong>Monday, September 25, 2023</strong>: Fully remove support for building documentation without configuration file v2.</li>
 </ul>
 
-We have identified that the following projects which you maintain, and were built in the last 3 years, are impacted by this deprecation:
+We have identified that the following projects which you maintain, and were built in the last year, are impacted by this deprecation:
 
 <ul>
 {% for project in projects|slice:":15" %}

--- a/readthedocs/templates/projects/notifications/deprecated_config_file_used_email.txt
+++ b/readthedocs/templates/projects/notifications/deprecated_config_file_used_email.txt
@@ -11,7 +11,7 @@ The timeline for this deprecation is as follows:
 * Monday, September 4, 2023: Do a third and final brownout (temporarily enforce this deprecation) for 48 hours: 00:01 PST to September 5, 2023 23:59 PST (midnight)
 * Monday, September 25, 2023: Fully remove support for building documentation without configuration file v2.
 
-We have identified that the following projects which you maintain, and were built in the last 3 years, are impacted by this deprecation:
+We have identified that the following projects which you maintain, and were built in the last year, are impacted by this deprecation:
 
 {% for project in projects|slice:":15" %}
 * {{ project.slug }} ({{ production_uri }}{{ project.get_absolute_url }})


### PR DESCRIPTION
We wanted to contact more users with the first email and then only contact those projects with a build in the last year only.

### :date: **Merge this PR after August 15th deploy.**

This reverts commit 3d99b0bc5944777c32760f84f067fac7d0eb58d5.