### PR TITLE
Proxito: allow to generate proxied API URLs with a prefix

### DIFF
--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -31,6 +31,7 @@ class ProjectSerializer(serializers.ModelSerializer):
             'users',
             'canonical_url',
             'urlconf',
+            'custom_prefix',
         )
 
 

--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -17,21 +17,21 @@ class ProjectSerializer(serializers.ModelSerializer):
     class Meta:
         model = Project
         fields = (
-            'id',
-            'name',
-            'slug',
-            'description',
-            'language',
-            'programming_language',
-            'repo',
-            'repo_type',
-            'default_version',
-            'default_branch',
-            'documentation_type',
-            'users',
-            'canonical_url',
-            'urlconf',
-            'custom_prefix',
+            "id",
+            "name",
+            "slug",
+            "description",
+            "language",
+            "programming_language",
+            "repo",
+            "repo_type",
+            "default_version",
+            "default_branch",
+            "documentation_type",
+            "users",
+            "canonical_url",
+            "urlconf",
+            "custom_prefix",
         )
 
 

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -723,8 +723,8 @@ class Project(models.Model):
         # docs pages under the prefix, not special paths like `/_/`.
         # Projects using the old implementation, need to proxy `/_/`
         # paths as is, this is, without the prefix, while those projects
-        # migrate to the new implementation, we will prefix special paths,
-        # they are manually un-prefixed in nginx.
+        # migrate to the new implementation, we will prefix special paths
+        # when generating links, these paths will be manually un-prefixed in nginx.
         if self.custom_prefix and self.has_feature(
             Feature.USE_PROXIED_APIS_WITH_PREFIX
         ):

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -725,7 +725,9 @@ class Project(models.Model):
         # paths as is, this is, without the suffix, while those projects
         # migrate to the new implementation, we will prefix special paths,
         # they are manually un-prefixed in nginx.
-        if self.custom_prefix and self.has_feature(Feature.USE_PROXIED_APIS_WITH_PREFIX):
+        if self.custom_prefix and self.has_feature(
+            Feature.USE_PROXIED_APIS_WITH_PREFIX
+        ):
             return self.custom_prefix
         if self.urlconf:
             # Return the value before the first defined variable,

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -693,11 +693,9 @@ class Project(models.Model):
         This needs to start with a slash at the root of the domain,
         and end without a slash
         """
-        if self.urlconf:
-            # Add our proxied api host at the first place we have a $variable
-            # This supports both subpaths & normal root hosting
-            path_prefix = self.custom_path_prefix
-            return unsafe_join_url_path(path_prefix, "/_")
+        custom_prefix = self.proxied_api_prefix
+        if custom_prefix:
+            return unsafe_join_url_path(custom_prefix, "/_")
         return '/_'
 
     @property
@@ -715,12 +713,20 @@ class Project(models.Model):
         return f"{self.proxied_api_host}/static/"
 
     @property
-    def custom_path_prefix(self):
+    def proxied_api_prefix(self):
         """
-        Get the path prefix from the custom urlconf.
+        Get the path prefix for proxied API paths (``/_/``).
 
         Returns `None` if the project doesn't have a custom urlconf.
         """
+        # When using a custom prefix, we can only handle serving
+        # docs pages under the prefix, not special paths like `/_/`.
+        # Projects using the old implementation, need to proxy `/_/`
+        # paths as is, this is, without the suffix, while those projects
+        # migrate to the new implementation, we will prefix special paths,
+        # they are manually un-prefixed in nginx.
+        if self.custom_prefix and self.has_feature(Feature.USE_PROXIED_APIS_WITH_PREFIX):
+            return self.custom_prefix
         if self.urlconf:
             # Return the value before the first defined variable,
             # as that is a prefix and not part of our normal doc patterns.
@@ -1930,6 +1936,7 @@ class Feature(models.Model):
     DISABLE_PAGEVIEWS = "disable_pageviews"
     RESOLVE_PROJECT_FROM_HEADER = "resolve_project_from_header"
     USE_UNRESOLVER_WITH_PROXITO = "use_unresolver_with_proxito"
+    USE_PROXIED_APIS_WITH_PREFIX = "use_proxied_apis_with_prefix"
     ALLOW_VERSION_WARNING_BANNER = "allow_version_warning_banner"
 
     # Versions sync related features
@@ -2018,6 +2025,12 @@ class Feature(models.Model):
             USE_UNRESOLVER_WITH_PROXITO,
             _(
                 "Proxito: Use new unresolver implementation for serving documentation files."
+            ),
+        ),
+        (
+            USE_PROXIED_APIS_WITH_PREFIX,
+            _(
+                "Proxito: Use proxied APIs (/_/*) with the custom prefix if the project has one (Project.custom_prefix)."
             ),
         ),
         (

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -722,7 +722,7 @@ class Project(models.Model):
         # When using a custom prefix, we can only handle serving
         # docs pages under the prefix, not special paths like `/_/`.
         # Projects using the old implementation, need to proxy `/_/`
-        # paths as is, this is, without the suffix, while those projects
+        # paths as is, this is, without the prefix, while those projects
         # migrate to the new implementation, we will prefix special paths,
         # they are manually un-prefixed in nginx.
         if self.custom_prefix and self.has_feature(

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -3176,6 +3176,7 @@ class APIVersionTests(TestCase):
                 "use_system_packages": False,
                 "users": [1],
                 "urlconf": None,
+                "custom_prefix": None,
             },
             "privacy_level": "public",
             "downloads": {},


### PR DESCRIPTION
This will allow us to migrate a client from .com to the new implementation, without downtime or changes in their setup. There is another PR in coporate-ops, and the steps to do the migration will be in the meta issue.

- Ref https://github.com/readthedocs/readthedocs.org/issues/10181
- Ref https://github.com/readthedocs/readthedocs.org/issues/10408
- Ref https://github.com/readthedocs/meta/issues/124