### PR TITLE
Build: do not set `sphinx_rtd_theme` theme automatically

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -217,8 +217,6 @@ class BaseSphinx(BaseBuilder):
         )
 
         data = {
-            "html_theme": "sphinx_rtd_theme",
-            "html_theme_import": "sphinx_rtd_theme",
             "current_version": self.version.verbose_name,
             "project": self.project,
             "version": self.version,
@@ -256,9 +254,6 @@ class BaseSphinx(BaseBuilder):
             # Features
             "docsearch_disabled": self.project.has_feature(
                 Feature.DISABLE_SERVER_SIDE_SEARCH
-            ),
-            "skip_html_theme_path": self.project.has_feature(
-                Feature.SKIP_SPHINX_HTML_THEME_PATH
             ),
         }
 

--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -48,48 +48,6 @@ if not 'html_static_path' in globals():
 if os.path.exists('_static'):
     html_static_path.append('_static')
 
-# Add RTD Theme only if they aren't overriding it already
-using_rtd_theme = (
-    (
-        'html_theme' in globals() and
-        html_theme in ['default'] and
-        # Allow people to bail with a hack of having an html_style
-        'html_style' not in globals()
-    ) or 'html_theme' not in globals()
-)
-if using_rtd_theme:
-    html_theme = '{{ html_theme }}'
-    html_style = None
-    html_theme_options = {}
-
-{% comment %}
-# Legacy behavior for html_theme_path:
-# It is suspected that old builds with sphinx_rtd_theme required an extra
-# definition of html_theme_path in order to work.
-# This behavior is seen documented for old releases of sphinx_rtd_theme.
-# An example of old instructions:
-# https://github.com/readthedocs/sphinx_rtd_theme/blob/abd951a9cd98851269b8b5f5e59b1b4d29b1416c/README.rst
-# Discussion of issue:
-# https://github.com/readthedocs/readthedocs.org/pull/9654
-#
-# We need to isolate the old legacy behavior because it causes Sphinx
-# to skip calling the theme's setup(app) so its initialization never happens.
-{% endcomment %}
-# This following legacy behavior will gradually be sliced out until its deprecated and removed.
-# Skipped for Sphinx 6+
-# Skipped by internal Feature flag SKIP_SPHINX_HTML_THEME_PATH
-# Skipped by all new projects since SKIP_SPHINX_HTML_THEME_PATH's introduction (jan 2023)
-if (
-        using_rtd_theme
-        and version_info < (6,0)
-        and not {{ skip_html_theme_path|yesno:"True,False" }}
-    ):
-    theme = importlib.import_module('{{ html_theme_import }}')
-    if 'html_theme_path' in globals():
-        html_theme_path.append(theme.get_html_theme_path())
-    else:
-        html_theme_path = [theme.get_html_theme_path()]
-
 # Define websupport2_base_url and websupport2_static_url
 if globals().get('websupport2_base_url', False):
     websupport2_base_url = '{{ api_host }}/websupport'

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1925,7 +1925,6 @@ class Feature(models.Model):
 
     # Feature constants - this is not a exhaustive list of features, features
     # may be added by other packages
-    SKIP_SPHINX_HTML_THEME_PATH = "skip_sphinx_html_theme_path"
     MKDOCS_THEME_RTD = "mkdocs_theme_rtd"
     API_LARGE_DATA = "api_large_data"
     DONT_SHALLOW_CLONE = "dont_shallow_clone"
@@ -1967,12 +1966,6 @@ class Feature(models.Model):
     SCALE_IN_PROTECTION = "scale_in_prtection"
 
     FEATURES = (
-        (
-            SKIP_SPHINX_HTML_THEME_PATH,
-            _(
-                "Sphinx: Do not define html_theme_path on Sphinx < 6.0",
-            ),
-        ),
         (
             MKDOCS_THEME_RTD,
             _("MkDocs: Use Read the Docs theme for MkDocs as default theme"),


### PR DESCRIPTION
We are not installing `sphinx-rtd-theme` automatically on new projects. However, we are setting `sphinx_rtd_theme` automatically on their `docs/conf.py`.

This PR removes that magic to auto-set the theme and leave the theme to what the user has defined.

* Related: https://github.com/readthedocs/readthedocs.org/issues/2483
* Closes: https://github.com/readthedocs/readthedocs.org/issues/10626