### PR TITLE
Celery: use django-celery-beat scheduler

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -233,6 +233,7 @@ class CommunityBaseSettings(Settings):
             'polymorphic',
             'simple_history',
             'djstripe',
+            'django_celery_beat',
 
             # our apps
             'readthedocs.projects',
@@ -477,6 +478,7 @@ class CommunityBaseSettings(Settings):
     CELERY_CREATE_MISSING_QUEUES = True
 
     CELERY_DEFAULT_QUEUE = 'celery'
+    CELERYBEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
     CELERYBEAT_SCHEDULE = {
         'quarter-finish-inactive-builds': {
             'task': 'readthedocs.projects.tasks.utils.finish_inactive_builds',

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -507,7 +507,7 @@ class CommunityBaseSettings(Settings):
         },
         'weekly-delete-old-personal-audit-logs': {
             'task': 'readthedocs.audit.tasks.delete_old_personal_audit_logs',
-            'schedule': crontab(day_of_week='wednesday', minute=0, hour=7),
+            'schedule': crontab(day_of_week="wed", minute=0, hour=7),
             'options': {'queue': 'web'},
         },
         'every-day-resync-sso-organization-users': {
@@ -549,12 +549,12 @@ class CommunityBaseSettings(Settings):
         },
         'weekly-config-file-notification': {
             'task': 'readthedocs.projects.tasks.utils.deprecated_config_file_used_notification',
-            'schedule': crontab(day_of_week='wednesday', hour=11, minute=15),
+            'schedule': crontab(day_of_week="wed", hour=11, minute=15),
             'options': {'queue': 'web'},
         },
         'weekly-build-image-notification': {
             'task': 'readthedocs.projects.tasks.utils.deprecated_build_image_notification',
-            'schedule': crontab(day_of_week='wednesday', hour=9, minute=15),
+            'schedule': crontab(day_of_week="wed", hour=9, minute=15),
             'options': {'queue': 'web'},
         },
     }

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -34,7 +34,9 @@ botocore==1.31.17
     #   boto3
     #   s3transfer
 celery==5.2.7
-    # via -r requirements/pip.txt
+    # via
+    #   -r requirements/pip.txt
+    #   django-celery-beat
 certifi==2023.7.22
     # via
     #   -r requirements/pip.txt
@@ -68,6 +70,10 @@ click-repl==0.3.0
     # via
     #   -r requirements/pip.txt
     #   celery
+cron-descriptor==1.4.0
+    # via
+    #   -r requirements/pip.txt
+    #   django-celery-beat
 cryptography==41.0.3
     # via
     #   -r requirements/pip.txt
@@ -97,6 +103,7 @@ django==4.2.4
     #   django-allauth
     #   django-annoying
     #   django-cacheops
+    #   django-celery-beat
     #   django-cors-headers
     #   django-csp
     #   django-debug-toolbar
@@ -107,6 +114,7 @@ django==4.2.4
     #   django-storages
     #   django-structlog
     #   django-taggit
+    #   django-timezone-field
     #   djangorestframework
     #   jsonfield
 django-allauth==0.51.0
@@ -117,13 +125,15 @@ django-autoslug==1.9.9
     # via -r requirements/pip.txt
 django-cacheops==7.0.1
     # via -r requirements/pip.txt
+django-celery-beat==2.5.0
+    # via -r requirements/pip.txt
 django-cors-headers==4.2.0
     # via -r requirements/pip.txt
 django-crispy-forms==1.14.0
     # via -r requirements/pip.txt
 django-csp==3.7
     # via -r requirements/pip.txt
-django-debug-toolbar==4.1.0
+django-debug-toolbar==4.2.0
     # via -r requirements/pip.txt
 django-elasticsearch-dsl==7.3
     # via -r requirements/pip.txt
@@ -151,6 +161,10 @@ django-structlog==2.2.0
     # via -r requirements/pip.txt
 django-taggit==4.0.0
     # via -r requirements/pip.txt
+django-timezone-field==5.1
+    # via
+    #   -r requirements/pip.txt
+    #   django-celery-beat
 django-vanilla-views==3.0.0
     # via -r requirements/pip.txt
 djangorestframework==3.14.0
@@ -275,11 +289,16 @@ pyjwt[crypto]==2.8.0
     #   django-allauth
 pyquery==2.0.0
     # via -r requirements/pip.txt
+python-crontab==3.0.0
+    # via
+    #   -r requirements/pip.txt
+    #   django-celery-beat
 python-dateutil==2.8.2
     # via
     #   -r requirements/pip.txt
     #   botocore
     #   elasticsearch-dsl
+    #   python-crontab
 python3-openid==3.2.0
     # via
     #   -r requirements/pip.txt
@@ -288,6 +307,7 @@ pytz==2023.3
     # via
     #   -r requirements/pip.txt
     #   celery
+    #   django-timezone-field
     #   djangorestframework
 pyyaml==6.0.1
     # via -r requirements/pip.txt
@@ -366,7 +386,9 @@ typing-extensions==4.7.1
     #   -r requirements/pip.txt
     #   asgiref
 tzdata==2023.3
-    # via -r requirements/pip.txt
+    # via
+    #   -r requirements/pip.txt
+    #   django-celery-beat
 ua-parser==0.18.0
     # via
     #   -r requirements/pip.txt

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -36,7 +36,9 @@ botocore==1.31.17
 cachetools==5.3.1
     # via tox
 celery==5.2.7
-    # via -r requirements/pip.txt
+    # via
+    #   -r requirements/pip.txt
+    #   django-celery-beat
 certifi==2023.7.22
     # via
     #   -r requirements/pip.txt
@@ -73,6 +75,10 @@ click-repl==0.3.0
     #   celery
 colorama==0.4.6
     # via tox
+cron-descriptor==1.4.0
+    # via
+    #   -r requirements/pip.txt
+    #   django-celery-beat
 cryptography==41.0.3
     # via
     #   -r requirements/pip.txt
@@ -106,6 +112,7 @@ django==4.2.4
     #   django-allauth
     #   django-annoying
     #   django-cacheops
+    #   django-celery-beat
     #   django-cors-headers
     #   django-csp
     #   django-debug-toolbar
@@ -116,6 +123,7 @@ django==4.2.4
     #   django-storages
     #   django-structlog
     #   django-taggit
+    #   django-timezone-field
     #   djangorestframework
     #   jsonfield
 django-allauth==0.51.0
@@ -125,6 +133,8 @@ django-annoying==0.10.6
 django-autoslug==1.9.9
     # via -r requirements/pip.txt
 django-cacheops==7.0.1
+    # via -r requirements/pip.txt
+django-celery-beat==2.5.0
     # via -r requirements/pip.txt
 django-cors-headers==4.2.0
     # via -r requirements/pip.txt
@@ -160,6 +170,10 @@ django-structlog==2.2.0
     # via -r requirements/pip.txt
 django-taggit==4.0.0
     # via -r requirements/pip.txt
+django-timezone-field==5.1
+    # via
+    #   -r requirements/pip.txt
+    #   django-celery-beat
 django-vanilla-views==3.0.0
     # via -r requirements/pip.txt
 djangorestframework==3.14.0
@@ -304,11 +318,16 @@ pyquery==2.0.0
     # via -r requirements/pip.txt
 pyrepl==0.9.0
     # via fancycompleter
+python-crontab==3.0.0
+    # via
+    #   -r requirements/pip.txt
+    #   django-celery-beat
 python-dateutil==2.8.2
     # via
     #   -r requirements/pip.txt
     #   botocore
     #   elasticsearch-dsl
+    #   python-crontab
 python3-openid==3.2.0
     # via
     #   -r requirements/pip.txt
@@ -317,6 +336,7 @@ pytz==2023.3
     # via
     #   -r requirements/pip.txt
     #   celery
+    #   django-timezone-field
     #   djangorestframework
 pyyaml==6.0.1
     # via -r requirements/pip.txt
@@ -397,7 +417,9 @@ typing-extensions==4.7.1
     #   -r requirements/pip.txt
     #   asgiref
 tzdata==2023.3
-    # via -r requirements/pip.txt
+    # via
+    #   -r requirements/pip.txt
+    #   django-celery-beat
 ua-parser==0.18.0
     # via
     #   -r requirements/pip.txt

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -67,6 +67,7 @@ redis
 # TypeError: MyException.__init__() missing 1 required positional argument: 'b'
 # >>>
 celery==5.2.7
+django-celery-beat
 
 # Docker images need a dependency explicity marked for tzdata in order to have
 # necessary timezone data.

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -19,7 +19,9 @@ botocore==1.31.17
     #   boto3
     #   s3transfer
 celery==5.2.7
-    # via -r requirements/pip.in
+    # via
+    #   -r requirements/pip.in
+    #   django-celery-beat
 certifi==2023.7.22
     # via
     #   elasticsearch
@@ -40,6 +42,8 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.3.0
     # via celery
+cron-descriptor==1.4.0
+    # via django-celery-beat
 cryptography==41.0.3
     # via pyjwt
 cssselect==1.2.0
@@ -59,6 +63,7 @@ django==4.2.4
     #   django-allauth
     #   django-annoying
     #   django-cacheops
+    #   django-celery-beat
     #   django-cors-headers
     #   django-csp
     #   django-debug-toolbar
@@ -69,6 +74,7 @@ django==4.2.4
     #   django-storages
     #   django-structlog
     #   django-taggit
+    #   django-timezone-field
     #   djangorestframework
     #   jsonfield
 django-allauth==0.51.0
@@ -78,6 +84,8 @@ django-annoying==0.10.6
 django-autoslug==1.9.9
     # via -r requirements/pip.in
 django-cacheops==7.0.1
+    # via -r requirements/pip.in
+django-celery-beat==2.5.0
     # via -r requirements/pip.in
 django-cors-headers==4.2.0
     # via -r requirements/pip.in
@@ -111,6 +119,8 @@ django-structlog==2.2.0
     # via -r requirements/pip.in
 django-taggit==4.0.0
     # via -r requirements/pip.in
+django-timezone-field==5.1
+    # via django-celery-beat
 django-vanilla-views==3.0.0
     # via -r requirements/pip.in
 djangorestframework==3.14.0
@@ -187,17 +197,21 @@ pyjwt[crypto]==2.8.0
     # via django-allauth
 pyquery==2.0.0
     # via -r requirements/pip.in
+python-crontab==3.0.0
+    # via django-celery-beat
 python-dateutil==2.8.2
     # via
     #   -r requirements/pip.in
     #   botocore
     #   elasticsearch-dsl
+    #   python-crontab
 python3-openid==3.2.0
     # via django-allauth
 pytz==2023.3
     # via
     #   -r requirements/pip.in
     #   celery
+    #   django-timezone-field
     #   djangorestframework
 pyyaml==6.0.1
     # via -r requirements/pip.in
@@ -254,7 +268,9 @@ tomli==2.0.1
 typing-extensions==4.7.1
     # via asgiref
 tzdata==2023.3
-    # via -r requirements/pip.in
+    # via
+    #   -r requirements/pip.in
+    #   django-celery-beat
 ua-parser==0.18.0
     # via user-agents
 unicode-slugify @ git+https://github.com/mozilla/unicode-slugify@b696c37

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -34,7 +34,9 @@ botocore==1.31.17
     #   boto3
     #   s3transfer
 celery==5.2.7
-    # via -r requirements/pip.txt
+    # via
+    #   -r requirements/pip.txt
+    #   django-celery-beat
 certifi==2023.7.22
     # via
     #   -r requirements/pip.txt
@@ -69,6 +71,10 @@ click-repl==0.3.0
     #   celery
 coverage[toml]==7.2.7
     # via pytest-cov
+cron-descriptor==1.4.0
+    # via
+    #   -r requirements/pip.txt
+    #   django-celery-beat
 cryptography==41.0.3
     # via
     #   -r requirements/pip.txt
@@ -96,6 +102,7 @@ django==4.2.4
     #   django-allauth
     #   django-annoying
     #   django-cacheops
+    #   django-celery-beat
     #   django-cors-headers
     #   django-csp
     #   django-debug-toolbar
@@ -106,6 +113,7 @@ django==4.2.4
     #   django-storages
     #   django-structlog
     #   django-taggit
+    #   django-timezone-field
     #   djangorestframework
     #   jsonfield
 django-allauth==0.51.0
@@ -115,6 +123,8 @@ django-annoying==0.10.6
 django-autoslug==1.9.9
     # via -r requirements/pip.txt
 django-cacheops==7.0.1
+    # via -r requirements/pip.txt
+django-celery-beat==2.5.0
     # via -r requirements/pip.txt
 django-cors-headers==4.2.0
     # via -r requirements/pip.txt
@@ -152,6 +162,10 @@ django-structlog==2.2.0
     # via -r requirements/pip.txt
 django-taggit==4.0.0
     # via -r requirements/pip.txt
+django-timezone-field==5.1
+    # via
+    #   -r requirements/pip.txt
+    #   django-celery-beat
 django-vanilla-views==3.0.0
     # via -r requirements/pip.txt
 djangorestframework==3.14.0
@@ -286,11 +300,16 @@ pytest-django==4.5.2
     # via -r requirements/testing.in
 pytest-mock==3.11.1
     # via -r requirements/testing.in
+python-crontab==3.0.0
+    # via
+    #   -r requirements/pip.txt
+    #   django-celery-beat
 python-dateutil==2.8.2
     # via
     #   -r requirements/pip.txt
     #   botocore
     #   elasticsearch-dsl
+    #   python-crontab
 python3-openid==3.2.0
     # via
     #   -r requirements/pip.txt
@@ -299,6 +318,7 @@ pytz==2023.3
     # via
     #   -r requirements/pip.txt
     #   celery
+    #   django-timezone-field
     #   djangorestframework
 pyyaml==6.0.1
     # via
@@ -391,7 +411,9 @@ typing-extensions==4.7.1
     #   -r requirements/pip.txt
     #   asgiref
 tzdata==2023.3
-    # via -r requirements/pip.txt
+    # via
+    #   -r requirements/pip.txt
+    #   django-celery-beat
 ua-parser==0.18.0
     # via
     #   -r requirements/pip.txt


### PR DESCRIPTION
This package allows us to store the periodic Celery tasks in the database.
Hopefully, it will help us to solve the issue we are having that periodic tasks
are triggered when building the AMI and also on deploys.

Closes readthedocs/readthedocs-ops#1384