### PR TITLE
Build: remove `using_rtd_theme` variable

### DIFF
--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -50,7 +50,6 @@ if os.path.exists('_static'):
 
 #Add project information to the template context.
 context = {
-    'using_theme': using_rtd_theme,
     'html_theme': html_theme,
     'current_version': "{{ version.verbose_name }}",
     'version_slug': "{{ version.slug }}",


### PR DESCRIPTION
This is missing from #10638

Closes #10654 