### PR TITLE
Set `SECURE_PROXY_SSL_HEADER` when using docker compose

### DIFF
--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -25,6 +25,8 @@ class DockerBaseSettings(CommunityBaseSettings):
 
     RTD_EXTERNAL_VERSION_DOMAIN = "build.devthedocs.org"
 
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
     STATIC_URL = "/static/"
 
     # In the local docker environment, nginx should be trusted to set the host correctly

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -25,6 +25,12 @@ class DockerBaseSettings(CommunityBaseSettings):
 
     RTD_EXTERNAL_VERSION_DOMAIN = "build.devthedocs.org"
 
+    # When using ngrok + HTTPS, forms are blocked because the schema from the final URL
+    # doesn't match the one from the origin header.
+    # Previously only the host was checked, this was changed in 4.0:
+    # https://docs.djangoproject.com/en/4.2/releases/4.0/#csrf
+    #
+    # Reference: https://docs.djangoproject.com/en/4.2/ref/settings/#secure-proxy-ssl-header
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
     STATIC_URL = "/static/"


### PR DESCRIPTION
When using ngrok + https, forms are blocked
because the schema from the final URL doesn't match the one from the origin header.

Previously only the host was checked, this
was changed in 4.0
https://docs.djangoproject.com/en/4.2/releases/4.0/#csrf

ref https://docs.djangoproject.com/en/4.2/ref/settings/#secure-proxy-ssl-header