### PR TITLE
CI: Add requirements/testing.txt to pre-commit cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,10 +46,11 @@ jobs:
       - run: git submodule update --init
       # Recipe: https://pre-commit.com/#managing-ci-caches
       - run:
-          name: Combine pre-commit config and python versions for caching
+          name: Combine pre-commit config, python version and testing requirements for caching
           command: |
             cp common/pre-commit-config.yaml pre-commit-cache-key.txt
             python --version --version >> pre-commit-cache-key.txt
+            cat requirements/testing.txt >> pre-commit-cache-key.txt
       - restore_cache:
           keys:
           - pre-commit-cache-{{ checksum "pre-commit-cache-key.txt" }}


### PR DESCRIPTION
Pre-commit depends on this requirement file,
if it's changed, the cache key should be invalidated.

extracted from https://github.com/readthedocs/readthedocs.org/pull/10642/files#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47, since it's making all PRs fail.