### PR TITLE
Build: define `html_theme` variable

### DIFF
--- a/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
+++ b/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl
@@ -48,6 +48,11 @@ if not 'html_static_path' in globals():
 if os.path.exists('_static'):
     html_static_path.append('_static')
 
+# Define this variable in case it's not defined by the user.
+# It defaults to `alabaster` which is the default from Sphinx.
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_theme
+html_theme = globals().get('html_theme', 'alabaster')
+
 #Add project information to the template context.
 context = {
     'html_theme': html_theme,


### PR DESCRIPTION
Use the global value or `alabaster` if not defined by the user. It default to `alabaster` because it's the default value for Sphinx.

Closes #10662 
Related #10638