### PR TITLE
Requirements: use `psycopg3`

### DIFF
--- a/requirements/deploy.in
+++ b/requirements/deploy.in
@@ -2,8 +2,6 @@
 
 -r pip.txt
 
-psycopg2
-
 structlog-sentry
 
 newrelic

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -263,8 +263,16 @@ prompt-toolkit==3.0.39
     #   -r requirements/pip.txt
     #   click-repl
     #   ipython
-psycopg2==2.9.7
-    # via -r requirements/deploy.in
+psycopg[binary,pool]==3.1.10
+    # via -r requirements/pip.txt
+psycopg-binary==3.1.10
+    # via
+    #   -r requirements/pip.txt
+    #   psycopg
+psycopg-pool==3.1.7
+    # via
+    #   -r requirements/pip.txt
+    #   psycopg
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
@@ -374,6 +382,8 @@ typing-extensions==4.7.1
     # via
     #   -r requirements/pip.txt
     #   asgiref
+    #   psycopg
+    #   psycopg-pool
 tzdata==2023.3
     # via
     #   -r requirements/pip.txt

--- a/requirements/docker.in
+++ b/requirements/docker.in
@@ -2,9 +2,6 @@
 
 -r pip.txt
 
-# https://www.psycopg.org/docs/install.html#psycopg-vs-psycopg-binary
-psycopg2-binary
-
 # run tests
 tox
 

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -286,8 +286,16 @@ prompt-toolkit==3.0.39
     #   -r requirements/pip.txt
     #   click-repl
     #   ipython
-psycopg2-binary==2.9.7
-    # via -r requirements/docker.in
+psycopg[binary,pool]==3.1.10
+    # via -r requirements/pip.txt
+psycopg-binary==3.1.10
+    # via
+    #   -r requirements/pip.txt
+    #   psycopg
+psycopg-pool==3.1.7
+    # via
+    #   -r requirements/pip.txt
+    #   psycopg
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
@@ -405,6 +413,8 @@ typing-extensions==4.7.1
     # via
     #   -r requirements/pip.txt
     #   asgiref
+    #   psycopg
+    #   psycopg-pool
 tzdata==2023.3
     # via
     #   -r requirements/pip.txt

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -7,6 +7,9 @@ django-extensions
 django-polymorphic
 django-autoslug
 
+# https://www.psycopg.org/psycopg3/docs/basic/install.html
+psycopg[binary,pool]
+
 # 3.1.0 includes changes that require running `makemigrations`
 # https://django-simple-history.readthedocs.io/en/latest/#changes
 django-simple-history==3.0.0

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -185,6 +185,12 @@ platformdirs==3.10.0
     # via virtualenv
 prompt-toolkit==3.0.39
     # via click-repl
+psycopg[binary,pool]==3.1.10
+    # via -r requirements/pip.in
+psycopg-binary==3.1.10
+    # via psycopg
+psycopg-pool==3.1.7
+    # via psycopg
 pycparser==2.21
     # via cffi
 pygments==2.16.1
@@ -259,7 +265,10 @@ structlog==23.1.0
 tomli==2.0.1
     # via dparse
 typing-extensions==4.7.1
-    # via asgiref
+    # via
+    #   asgiref
+    #   psycopg
+    #   psycopg-pool
 tzdata==2023.3
     # via
     #   -r requirements/pip.in

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -265,6 +265,16 @@ prompt-toolkit==3.0.39
     # via
     #   -r requirements/pip.txt
     #   click-repl
+psycopg[binary,pool]==3.1.10
+    # via -r requirements/pip.txt
+psycopg-binary==3.1.10
+    # via
+    #   -r requirements/pip.txt
+    #   psycopg
+psycopg-pool==3.1.7
+    # via
+    #   -r requirements/pip.txt
+    #   psycopg
 pycparser==2.21
     # via
     #   -r requirements/pip.txt
@@ -405,6 +415,8 @@ typing-extensions==4.7.1
     # via
     #   -r requirements/pip.txt
     #   asgiref
+    #   psycopg
+    #   psycopg-pool
 tzdata==2023.3
     # via
     #   -r requirements/pip.txt


### PR DESCRIPTION
Now we are on Django 4.2 we can use the latest version of psycopg.

Closes #10596