### PR TITLE
Addons: manage single version projects

### DIFF
--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -180,6 +180,9 @@ class AddonsResponse:
             .only("slug")
             .order_by("slug")
         )
+        version_downloads = (
+            version.get_downloads(pretty=True).items() if version else []
+        )
         project_translations = (
             project.translations.all().only("language").order_by("language")
         )
@@ -283,7 +286,7 @@ class AddonsResponse:
                             "name": name,
                             "url": url,
                         }
-                        for name, url in version.get_downloads(pretty=True).items()
+                        for name, url in version_downloads
                     ],
                     # TODO: find a way to get this data in a reliably way.
                     # We don't have a simple way to map a URL to a file in the repository.

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -174,15 +174,21 @@ class AddonsResponse:
         It tries to follow some similarity with the APIv3 for already-known resources
         (Project, Version, Build, etc).
         """
-        versions_active_built_not_hidden = (
-            Version.internal.public(project=project, only_active=True, only_built=True)
-            .exclude(hidden=True)
-            .only("slug")
-            .order_by("slug")
-        )
-        version_downloads = (
-            version.get_downloads(pretty=True).items() if version else []
-        )
+        version_downloads = []
+        versions_active_built_not_hidden = Version.objects.none()
+
+        if not project.single_version:
+            versions_active_built_not_hidden = (
+                Version.internal.public(
+                    project=project, only_active=True, only_built=True
+                )
+                .exclude(hidden=True)
+                .only("slug")
+                .order_by("slug")
+            )
+            if version:
+                version_downloads = version.get_downloads(pretty=True).items()
+
         project_translations = (
             project.translations.all().only("language").order_by("language")
         )


### PR DESCRIPTION
* Do not show "Versions" section when project is single version
* Handle downloads when `version=None`

Solves: https://read-the-docs.sentry.io/issues/4437207301/?project=148442
Related https://github.com/readthedocs/readthedocs.org/issues/10685
Closes #10680 