### PR TITLE
Black pass number 2

### DIFF
--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -12,7 +12,7 @@ from readthedocs.projects.models import Domain, Project
 
 
 class ProjectSerializer(serializers.ModelSerializer):
-    canonical_url = serializers.ReadOnlyField(source='get_docs_url')
+    canonical_url = serializers.ReadOnlyField(source="get_docs_url")
 
     class Meta:
         model = Project
@@ -46,7 +46,7 @@ class ProjectAdminSerializer(ProjectSerializer):
     features = serializers.SlugRelatedField(
         many=True,
         read_only=True,
-        slug_field='feature_id',
+        slug_field="feature_id",
     )
 
     environment_variables = serializers.SerializerMethodField()
@@ -124,7 +124,7 @@ class VersionSerializer(serializers.ModelSerializer):
     project = serializers.SerializerMethodField()
     project_serializer_class = ProjectSerializer
 
-    downloads = serializers.DictField(source='get_downloads', read_only=True)
+    downloads = serializers.DictField(source="get_downloads", read_only=True)
 
     class Meta:
         model = Version
@@ -248,11 +248,11 @@ class BuildSerializer(serializers.ModelSerializer):
     """
 
     commands = BuildCommandReadOnlySerializer(many=True, read_only=True)
-    project_slug = serializers.ReadOnlyField(source='project.slug')
-    version_slug = serializers.ReadOnlyField(source='get_version_slug')
+    project_slug = serializers.ReadOnlyField(source="project.slug")
+    version_slug = serializers.ReadOnlyField(source="get_version_slug")
     docs_url = serializers.SerializerMethodField()
-    state_display = serializers.ReadOnlyField(source='get_state_display')
-    commit_url = serializers.ReadOnlyField(source='get_commit_url')
+    state_display = serializers.ReadOnlyField(source="get_state_display")
+    commit_url = serializers.ReadOnlyField(source="get_commit_url")
     # Jsonfield needs an explicit serializer
     # https://github.com/dmkoch/django-jsonfield/issues/188#issuecomment-300439829
     config = serializers.JSONField(required=False, allow_null=True)
@@ -260,7 +260,7 @@ class BuildSerializer(serializers.ModelSerializer):
     class Meta:
         model = Build
         # `_config` should be excluded to avoid conflicts with `config`
-        exclude = ('builder', '_config')
+        exclude = ("builder", "_config")
 
     def get_docs_url(self, obj):
         if obj.version:
@@ -281,7 +281,7 @@ class BuildAdminSerializer(BuildSerializer):
 
     class Meta(BuildSerializer.Meta):
         # `_config` should be excluded to avoid conflicts with `config`
-        exclude = ('_config',)
+        exclude = ("_config",)
 
 
 class BuildAdminReadOnlySerializer(BuildAdminSerializer):
@@ -309,20 +309,22 @@ class DomainSerializer(serializers.ModelSerializer):
     class Meta:
         model = Domain
         fields = (
-            'id',
-            'project',
-            'domain',
-            'canonical',
-            'machine',
-            'cname',
+            "id",
+            "project",
+            "domain",
+            "canonical",
+            "machine",
+            "cname",
         )
 
 
 class RemoteOrganizationSerializer(serializers.ModelSerializer):
-
     class Meta:
         model = RemoteOrganization
-        exclude = ('email', 'users',)
+        exclude = (
+            "email",
+            "users",
+        )
 
 
 class RemoteRepositorySerializer(serializers.ModelSerializer):
@@ -333,22 +335,22 @@ class RemoteRepositorySerializer(serializers.ModelSerializer):
 
     # This field does create an additional query per object returned
     matches = serializers.SerializerMethodField()
-    admin = serializers.SerializerMethodField('is_admin')
+    admin = serializers.SerializerMethodField("is_admin")
 
     class Meta:
         model = RemoteRepository
-        exclude = ('users',)
+        exclude = ("users",)
 
     def get_matches(self, obj):
-        request = self.context['request']
+        request = self.context["request"]
         if request.user is not None and request.user.is_authenticated:
             return obj.matches(request.user)
 
     def is_admin(self, obj):
-        request = self.context['request']
+        request = self.context["request"]
 
         # Use annotated value from RemoteRepositoryViewSet queryset
-        if hasattr(obj, 'admin'):
+        if hasattr(obj, "admin"):
             return obj.admin
 
         if request.user and request.user.is_authenticated:
@@ -367,15 +369,16 @@ class ProviderSerializer(serializers.Serializer):
 class SocialAccountSerializer(serializers.ModelSerializer):
 
     username = serializers.SerializerMethodField()
-    avatar_url = serializers.URLField(source='get_avatar_url')
-    provider = ProviderSerializer(source='get_provider')
+    avatar_url = serializers.URLField(source="get_avatar_url")
+    provider = ProviderSerializer(source="get_provider")
 
     class Meta:
         model = SocialAccount
-        exclude = ('extra_data',)
+        exclude = ("extra_data",)
 
     def get_username(self, obj):
         return (
-            obj.extra_data.get('username') or obj.extra_data.get('login')
+            obj.extra_data.get("username")
+            or obj.extra_data.get("login")
             # FIXME: which one is GitLab?
         )

--- a/readthedocs/api/v3/permissions.py
+++ b/readthedocs/api/v3/permissions.py
@@ -34,10 +34,10 @@ class UserProjectsListing(BasePermission):
     """Allow access to ``/projects`` (user's projects listing)."""
 
     def has_permission(self, request, view):
-        if view.basename == 'projects' and view.action in (
-                'list',
-                'create',  # used to create Form in BrowsableAPIRenderer
-                None,  # needed for BrowsableAPIRenderer
+        if view.basename == "projects" and view.action in (
+            "list",
+            "create",  # used to create Form in BrowsableAPIRenderer
+            None,  # needed for BrowsableAPIRenderer
         ):
             # hitting ``/projects/``, allowing
             return True
@@ -58,7 +58,7 @@ class PublicDetailPrivateListing(BasePermission):
         # permissions restrictions than for a detail action (since it only
         # returns one superproject if exists). ``list`` and ``retrieve`` are
         # DRF standard action names (same as ``update`` or ``partial_update``).
-        if view.detail and view.action in ('list', 'retrieve', 'superproject'):
+        if view.detail and view.action in ("list", "retrieve", "superproject"):
             # detail view is only allowed on list/retrieve actions (not
             # ``update`` or ``partial_update``).
             return True
@@ -81,7 +81,6 @@ class IsProjectAdmin(BasePermission):
 
 
 class IsOrganizationAdmin(BasePermission):
-
     def has_permission(self, request, view):
         organization = view._get_parent_organization()
         if view.has_admin_permission(request.user, organization):
@@ -96,11 +95,10 @@ class IsOrganizationAdminMember(BasePermission):
 
 
 class UserOrganizationsListing(BasePermission):
-
     def has_permission(self, request, view):
-        if view.basename == 'organizations' and view.action in (
-                'list',
-                None,  # needed for BrowsableAPIRenderer
+        if view.basename == "organizations" and view.action in (
+            "list",
+            None,  # needed for BrowsableAPIRenderer
         ):
             # hitting ``/organizations/``, allowing
             return True
@@ -120,10 +118,9 @@ class CommonPermissionsBase(BasePermission):
         if not IsAuthenticated().has_permission(request, view):
             return False
 
-        return (
-            UserProjectsListing().has_permission(request, view) or
-            PublicDetailPrivateListing().has_permission(request, view)
-        )
+        return UserProjectsListing().has_permission(
+            request, view
+        ) or PublicDetailPrivateListing().has_permission(request, view)
 
 
 class CommonPermissions(SettingsOverrideObject):

--- a/readthedocs/api/v3/tests/test_builds.py
+++ b/readthedocs/api/v3/tests/test_builds.py
@@ -16,9 +16,8 @@ from .mixins import APIEndpointMixin
         [RTDProductFeature(TYPE_CONCURRENT_BUILDS, value=4).to_item()]
     ),
 )
-@mock.patch('readthedocs.projects.tasks.builds.update_docs_task', mock.MagicMock())
+@mock.patch("readthedocs.projects.tasks.builds.update_docs_task", mock.MagicMock())
 class BuildsEndpointTests(APIEndpointMixin):
-
     def test_projects_builds_list(self):
         url = reverse(
             "projects-builds-list",
@@ -54,7 +53,7 @@ class BuildsEndpointTests(APIEndpointMixin):
 
         self.assertDictEqual(
             response.json(),
-            self._get_response_dict('projects-builds-detail'),
+            self._get_response_dict("projects-builds-detail"),
         )
 
     def test_projects_versions_builds_list_post(self):
@@ -77,8 +76,8 @@ class BuildsEndpointTests(APIEndpointMixin):
         self.assertEqual(self.project.builds.count(), 2)
 
         response_json = response.json()
-        response_json['build']['created'] = '2019-04-29T14:00:00Z'
+        response_json["build"]["created"] = "2019-04-29T14:00:00Z"
         self.assertDictEqual(
             response_json,
-            self._get_response_dict('projects-versions-builds-list_POST'),
+            self._get_response_dict("projects-versions-builds-list_POST"),
         )

--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -64,21 +64,21 @@ class TaskRouter:
     N_LAST_BUILDS = 15
     TIME_AVERAGE = 350
 
-    BUILD_DEFAULT_QUEUE = 'build:default'
-    BUILD_LARGE_QUEUE = 'build:large'
+    BUILD_DEFAULT_QUEUE = "build:default"
+    BUILD_LARGE_QUEUE = "build:large"
 
     def route_for_task(self, task, args, kwargs, **__):
-        log.debug('Executing TaskRouter.', task=task)
+        log.debug("Executing TaskRouter.", task=task)
         if task not in (
-            'readthedocs.projects.tasks.builds.update_docs_task',
-            'readthedocs.projects.tasks.builds.sync_repository_task',
+            "readthedocs.projects.tasks.builds.update_docs_task",
+            "readthedocs.projects.tasks.builds.sync_repository_task",
         ):
-            log.debug('Skipping routing non-build task.', task=task)
+            log.debug("Skipping routing non-build task.", task=task)
             return
 
         version = self._get_version(task, args, kwargs)
         if not version:
-            log.debug('No Build/Version found. No routing task.', task=task)
+            log.debug("No Build/Version found. No routing task.", task=task)
             return
 
         project = version.project
@@ -86,7 +86,7 @@ class TaskRouter:
         # Do not override the queue defined in the project itself
         if project.build_queue:
             log.info(
-                'Skipping routing task because project has a custom queue.',
+                "Skipping routing task because project has a custom queue.",
                 project_slug=project.slug,
                 queue=project.build_queue,
             )
@@ -97,75 +97,74 @@ class TaskRouter:
         # so that users will have the same outcome for PR's as normal builds.
         if version.type == EXTERNAL:
             last_build_for_default_version = (
-                project.builds
-                .filter(version__slug=project.get_default_version(), builder__isnull=False)
-                .order_by('-date')
+                project.builds.filter(
+                    version__slug=project.get_default_version(), builder__isnull=False
+                )
+                .order_by("-date")
                 .first()
             )
             if last_build_for_default_version:
-                if 'default' in last_build_for_default_version.builder:
+                if "default" in last_build_for_default_version.builder:
                     routing_queue = self.BUILD_DEFAULT_QUEUE
                 else:
                     routing_queue = self.BUILD_LARGE_QUEUE
                 log.info(
-                    'Routing task because is a external version.',
+                    "Routing task because is a external version.",
                     project_slug=project.slug,
                     queue=routing_queue,
                 )
                 return routing_queue
 
-        last_builds = version.builds.order_by('-date')[:self.N_LAST_BUILDS]
+        last_builds = version.builds.order_by("-date")[: self.N_LAST_BUILDS]
         # Version has used conda in previous builds
         for build in last_builds.iterator():
-            build_tools_python = ''
+            build_tools_python = ""
             conda = None
             if build.config:
                 build_tools_python = (
-                    build.config
-                    .get('build', {})
-                    .get('tools', {})
-                    .get('python', {})
-                    .get('version', '')
+                    build.config.get("build", {})
+                    .get("tools", {})
+                    .get("python", {})
+                    .get("version", "")
                 )
-                conda = build.config.get('conda', None)
+                conda = build.config.get("conda", None)
 
-            uses_conda = any([
-                conda,
-                build_tools_python.startswith('miniconda'),
-            ])
+            uses_conda = any(
+                [
+                    conda,
+                    build_tools_python.startswith("miniconda"),
+                ]
+            )
             if uses_conda:
                 log.info(
-                    'Routing task because project uses conda.',
+                    "Routing task because project uses conda.",
                     project_slug=project.slug,
                     queue=self.BUILD_LARGE_QUEUE,
                 )
                 return self.BUILD_LARGE_QUEUE
 
         successful_builds_count = (
-            version.builds
-            .filter(success=True)
-            .order_by('-date')
-            .count()
+            version.builds.filter(success=True).order_by("-date").count()
         )
         # We do not have enough builds for this version yet
         if successful_builds_count < self.MIN_SUCCESSFUL_BUILDS:
             log.info(
-                'Routing task because it does not have enough successful builds yet.',
+                "Routing task because it does not have enough successful builds yet.",
                 project_slug=project.slug,
                 queue=self.BUILD_LARGE_QUEUE,
             )
             return self.BUILD_LARGE_QUEUE
 
         log.debug(
-            'No routing task because no conditions were met.',
+            "No routing task because no conditions were met.",
             project_slug=project.slug,
         )
         return
 
     def _get_version(self, task, args, kwargs):
         tasks = [
-            'readthedocs.projects.tasks.builds.update_docs_task',
-            'readthedocs.projects.tasks.builds.sync_repository_task',
+            "readthedocs.projects.tasks.builds.update_docs_task",
+            "readthedocs.projects.tasks.builds.sync_repository_task",
         ]
         version = None
         if task in tasks:
@@ -174,13 +173,13 @@ class TaskRouter:
                 version = Version.objects.get(pk=version_pk)
             except Version.DoesNotExist:
                 log.debug(
-                    'Version does not exist. Routing task to default queue.',
+                    "Version does not exist. Routing task to default queue.",
                     version_id=version_pk,
                 )
         return version
 
 
-@app.task(queue='web', bind=True)
+@app.task(queue="web", bind=True)
 def archive_builds_task(self, days=14, limit=200, delete=False):
     """
     Task to archive old builds to cold storage.
@@ -191,23 +190,21 @@ def archive_builds_task(self, days=14, limit=200, delete=False):
     if not settings.RTD_SAVE_BUILD_COMMANDS_TO_STORAGE:
         return
 
-    lock_id = '{0}-lock'.format(self.name)
+    lock_id = "{0}-lock".format(self.name)
     with memcache_lock(lock_id, LOCK_EXPIRE, self.app.oid) as acquired:
         if not acquired:
-            log.warning('Archive Builds Task still locked')
+            log.warning("Archive Builds Task still locked")
             return False
 
         max_date = timezone.now() - timezone.timedelta(days=days)
         queryset = (
-            Build.objects
-            .exclude(cold_storage=True)
+            Build.objects.exclude(cold_storage=True)
             .filter(
                 date__lt=max_date,
                 date__gt=max_date - timezone.timedelta(days=90),
             )
-            .prefetch_related('commands')
-            .only('date', 'cold_storage')
-            [:limit]
+            .prefetch_related("commands")
+            .only("date", "cold_storage")[:limit]
         )
 
         for build in queryset:
@@ -235,14 +232,14 @@ def archive_builds_task(self, days=14, limit=200, delete=False):
                     if delete:
                         build.commands.all().delete()
                 except IOError:
-                    log.exception('Cold Storage save failure')
+                    log.exception("Cold Storage save failure")
                     continue
 
             build.cold_storage = True
             build.save()
 
 
-@app.task(queue='web')
+@app.task(queue="web")
 def delete_closed_external_versions(limit=200, days=30 * 3):
     """
     Delete external versions that have been marked as closed after ``days``.
@@ -260,7 +257,11 @@ def delete_closed_external_versions(limit=200, days=30 * 3):
             if last_build:
                 status = BUILD_STATUS_PENDING
                 if last_build.finished:
-                    status = BUILD_STATUS_SUCCESS if last_build.success else BUILD_STATUS_FAILURE
+                    status = (
+                        BUILD_STATUS_SUCCESS
+                        if last_build.success
+                        else BUILD_STATUS_FAILURE
+                    )
                 send_build_status(
                     build_pk=last_build.pk,
                     commit=last_build.commit,
@@ -283,11 +284,7 @@ def delete_closed_external_versions(limit=200, days=30 * 3):
             version.delete()
 
 
-@app.task(
-    max_retries=1,
-    default_retry_delay=60,
-    queue='web'
-)
+@app.task(max_retries=1, default_retry_delay=60, queue="web")
 def sync_versions_task(project_pk, tags_data, branches_data, **kwargs):
     """
     Sync the version data in the repo (from build server) into our database.
@@ -345,7 +342,7 @@ def sync_versions_task(project_pk, tags_data, branches_data, **kwargs):
             branches_data=branches_data,
         )
     except Exception:
-        log.exception('Sync Versions Error')
+        log.exception("Sync Versions Error")
         return False
 
     try:
@@ -357,7 +354,7 @@ def sync_versions_task(project_pk, tags_data, branches_data, **kwargs):
         # Don't interrupt the request if something goes wrong
         # in the automation rules.
         log.exception(
-            'Failed to execute automation rules.',
+            "Failed to execute automation rules.",
             project_slug=project.slug,
             versions=added_versions,
         )
@@ -367,7 +364,7 @@ def sync_versions_task(project_pk, tags_data, branches_data, **kwargs):
     new_stable = project.get_stable_version()
     if promoted_version and new_stable and new_stable.active:
         log.info(
-            'Triggering new stable build.',
+            "Triggering new stable build.",
             project_slug=project.slug,
             version_identifier=new_stable.identifier,
         )
@@ -375,21 +372,14 @@ def sync_versions_task(project_pk, tags_data, branches_data, **kwargs):
 
         # Marking the tag that is considered the new stable version as
         # active and building it if it was just added.
-        if (
-            activate_new_stable and
-            promoted_version.slug in added_versions
-        ):
+        if activate_new_stable and promoted_version.slug in added_versions:
             promoted_version.active = True
             promoted_version.save()
             trigger_build(project=project, version=promoted_version)
     return True
 
 
-@app.task(
-    max_retries=3,
-    default_retry_delay=60,
-    queue='web'
-)
+@app.task(max_retries=3, default_retry_delay=60, queue="web")
 def send_build_status(build_pk, commit, status):
     """
     Send Build Status to Git Status API for project external versions.
@@ -417,7 +407,7 @@ def send_build_status(build_pk, commit, status):
         status=status,
     )
 
-    log.debug('Sending build status.')
+    log.debug("Sending build status.")
 
     if provider_name in [GITHUB_BRAND, GITLAB_BRAND]:
         # get the service class for the project e.g: GitHubService.
@@ -433,7 +423,9 @@ def send_build_status(build_pk, commit, status):
                     # because User's are not related to Project's directly in
                     # Read the Docs for Business
                     user__in=AdminPermission.members(build.project),
-                ).select_related('account', 'user').only('user', 'account')
+                )
+                .select_related("account", "user")
+                .only("user", "account")
             )
 
             # Try using any of the users' maintainer accounts
@@ -449,12 +441,12 @@ def send_build_status(build_pk, commit, status):
 
                 if success:
                     log.debug(
-                        'Build status report sent correctly.',
+                        "Build status report sent correctly.",
                         user_username=relation.user.username,
                     )
                     return True
         else:
-            log.warning('Project does not have a RemoteRepository.')
+            log.warning("Project does not have a RemoteRepository.")
             # Try to send build status for projects with no RemoteRepository
             for user in users:
                 services = service_class.for_user(user)
@@ -468,7 +460,7 @@ def send_build_status(build_pk, commit, status):
                     )
                     if success:
                         log.debug(
-                            'Build status report sent correctly using an user account.',
+                            "Build status report sent correctly using an user account.",
                             user_username=user.username,
                         )
                         return True
@@ -478,17 +470,17 @@ def send_build_status(build_pk, commit, status):
             # to all the users of the project.
             notification = GitBuildStatusFailureNotification(
                 context_object=build.project,
-                extra_context={'provider_name': provider_name},
+                extra_context={"provider_name": provider_name},
                 user=user,
                 success=False,
             )
             notification.send()
 
-        log.info('No social account or repository permission available.')
+        log.info("No social account or repository permission available.")
         return False
 
 
-@app.task(queue='web')
+@app.task(queue="web")
 def send_build_notifications(version_pk, build_pk, event):
     version = Version.objects.get_object_or_log(pk=version_pk)
     if not version or version.type == EXTERNAL:
@@ -524,32 +516,28 @@ class BuildNotificationSender:
         Webhooks choose to what events they subscribe to.
         """
         if self.event == WebHookEvent.BUILD_FAILED:
-            email_addresses = (
-                self.project.emailhook_notifications.all()
-                .values_list('email', flat=True)
+            email_addresses = self.project.emailhook_notifications.all().values_list(
+                "email", flat=True
             )
             for email in email_addresses:
                 try:
                     self.send_email(email)
                 except Exception:
                     log.exception(
-                        'Failed to send email notification.',
+                        "Failed to send email notification.",
                         email=email,
                         project_slug=self.project.slug,
                         version_slug=self.version.slug,
                         build_id=self.build.id,
                     )
 
-        webhooks = (
-            self.project.webhook_notifications
-            .filter(events__name=self.event)
-        )
+        webhooks = self.project.webhook_notifications.filter(events__name=self.event)
         for webhook in webhooks:
             try:
                 self.send_webhook(webhook)
             except Exception:
                 log.exception(
-                    'Failed to send webhook.',
+                    "Failed to send webhook.",
                     webhook_id=webhook.id,
                     project_slug=self.project.slug,
                     version_slug=self.version.slug,
@@ -558,19 +546,19 @@ class BuildNotificationSender:
 
     def send_email(self, email):
         """Send email notifications for build failures."""
-        protocol = 'http' if settings.DEBUG else 'https'
+        protocol = "http" if settings.DEBUG else "https"
         context = {
-            'version': {
-                'verbose_name': self.version.verbose_name,
+            "version": {
+                "verbose_name": self.version.verbose_name,
             },
-            'project': {
-                'name': self.project.name,
+            "project": {
+                "name": self.project.name,
             },
-            'build': {
-                'pk': self.build.pk,
-                'error': self.build.error,
+            "build": {
+                "pk": self.build.pk,
+                "error": self.build.error,
             },
-            'build_url': '{}://{}{}'.format(
+            "build_url": "{}://{}{}".format(
                 protocol,
                 settings.PRODUCTION_DOMAIN,
                 self.build.get_absolute_url(),
@@ -580,25 +568,25 @@ class BuildNotificationSender:
                 settings.PRODUCTION_DOMAIN,
                 reverse("build-detail", args=[self.build.pk, "txt"]),
             ),
-            'unsubscribe_url': '{}://{}{}'.format(
+            "unsubscribe_url": "{}://{}{}".format(
                 protocol,
                 settings.PRODUCTION_DOMAIN,
-                reverse('projects_notifications', args=[self.project.slug]),
+                reverse("projects_notifications", args=[self.project.slug]),
             ),
         }
 
         if self.build.commit:
-            title = _('Failed: {project[name]} ({commit})').format(
+            title = _("Failed: {project[name]} ({commit})").format(
                 commit=self.build.commit[:8],
                 **context,
             )
         else:
-            title = _('Failed: {project[name]} ({version[verbose_name]})').format(
+            title = _("Failed: {project[name]} ({version[verbose_name]})").format(
                 **context
             )
 
         log.info(
-            'Sending email notification.',
+            "Sending email notification.",
             email=email,
             project_slug=self.project.slug,
             version_slug=self.version.slug,
@@ -607,8 +595,8 @@ class BuildNotificationSender:
         send_email(
             email,
             title,
-            template='projects/email/build_failed.txt',
-            template_html='projects/email/build_failed.html',
+            template="projects/email/build_failed.txt",
+            template_html="projects/email/build_failed.html",
             context=context,
         )
 
@@ -632,29 +620,31 @@ class BuildNotificationSender:
         )
         if not payload:
             # Default payload from old webhooks.
-            payload = json.dumps({
-                'name': self.project.name,
-                'slug': self.project.slug,
-                'build': {
-                    'id': self.build.id,
-                    'commit': self.build.commit,
-                    'state': self.build.state,
-                    'success': self.build.success,
-                    'date': self.build.date.strftime('%Y-%m-%d %H:%M:%S'),
-                },
-            })
+            payload = json.dumps(
+                {
+                    "name": self.project.name,
+                    "slug": self.project.slug,
+                    "build": {
+                        "id": self.build.id,
+                        "commit": self.build.commit,
+                        "state": self.build.state,
+                        "success": self.build.success,
+                        "date": self.build.date.strftime("%Y-%m-%d %H:%M:%S"),
+                    },
+                }
+            )
 
         headers = {
-            'content-type': 'application/json',
-            'User-Agent': f'Read-the-Docs/{__version__} ({settings.PRODUCTION_DOMAIN})',
-            'X-RTD-Event': self.event,
+            "content-type": "application/json",
+            "User-Agent": f"Read-the-Docs/{__version__} ({settings.PRODUCTION_DOMAIN})",
+            "X-RTD-Event": self.event,
         }
         if webhook.secret:
-            headers['X-Hub-Signature'] = webhook.sign_payload(payload)
+            headers["X-Hub-Signature"] = webhook.sign_payload(payload)
 
         try:
             log.info(
-                'Sending webhook notification.',
+                "Sending webhook notification.",
                 webhook_id=webhook.id,
                 project_slug=self.project.slug,
                 version_slug=self.version.slug,
@@ -672,7 +662,7 @@ class BuildNotificationSender:
             )
         except Exception:
             log.exception(
-                'Failed to POST to webhook url.',
+                "Failed to POST to webhook url.",
                 webhook_id=webhook.id,
                 webhook_url=webhook.url,
             )

--- a/readthedocs/builds/tests/test_build_queryset.py
+++ b/readthedocs/builds/tests/test_build_queryset.py
@@ -29,7 +29,7 @@ class TestBuildQuerySet:
                 state=state,
             )
         assert (False, 2, 4) == Build.objects.concurrent(project)
-        for state in ('building', 'cloning'):
+        for state in ("building", "cloning"):
             fixture.get(
                 Build,
                 project=project,
@@ -70,7 +70,7 @@ class TestBuildQuerySet:
             )
         assert (False, 2, 4) == Build.objects.concurrent(translation)
 
-        for state in ('building', 'cloning'):
+        for state in ("building", "cloning"):
             fixture.get(
                 Build,
                 project=translation,
@@ -103,7 +103,7 @@ class TestBuildQuerySet:
 
         project = organization.projects.first()
         assert (True, 4, 4) == Build.objects.concurrent(project)
-        for state in ('building', 'cloning'):
+        for state in ("building", "cloning"):
             fixture.get(
                 Build,
                 project=project,

--- a/readthedocs/core/resolver.py
+++ b/readthedocs/core/resolver.py
@@ -106,14 +106,14 @@ class ResolverBase:
         )
 
     def resolve_path(
-            self,
-            project,
-            filename='',
-            version_slug=None,
-            language=None,
-            single_version=None,
-            subdomain=None,
-            cname=None,
+        self,
+        project,
+        filename="",
+        version_slug=None,
+        language=None,
+        single_version=None,
+        subdomain=None,
+        cname=None,
     ):
         """Resolve a URL with a subset of fields defined."""
         version_slug = version_slug or project.get_default_version()
@@ -169,10 +169,15 @@ class ResolverBase:
         return settings.PRODUCTION_DOMAIN
 
     def resolve(
-            self, project, require_https=False, filename='', query_params='',
-            external=None, **kwargs
+        self,
+        project,
+        require_https=False,
+        filename="",
+        query_params="",
+        external=None,
+        **kwargs,
     ):
-        version_slug = kwargs.get('version_slug')
+        version_slug = kwargs.get("version_slug")
 
         if version_slug is None:
             version_slug = project.get_default_version()
@@ -192,25 +197,27 @@ class ResolverBase:
         else:
             domain = settings.PRODUCTION_DOMAIN
 
-        use_https_protocol = any([
-            # Rely on the ``Domain.https`` field
-            use_custom_domain and custom_domain.https,
-            # or force it if specified
-            require_https,
-            # or fallback to settings
-            settings.PUBLIC_DOMAIN_USES_HTTPS and
-            settings.PUBLIC_DOMAIN and
-            any([
-                settings.PUBLIC_DOMAIN in domain,
-                settings.RTD_EXTERNAL_VERSION_DOMAIN in domain,
-            ]),
-        ])
-        protocol = 'https' if use_https_protocol else 'http'
-
-        path = self.resolve_path(
-            project, filename=filename, **kwargs
+        use_https_protocol = any(
+            [
+                # Rely on the ``Domain.https`` field
+                use_custom_domain and custom_domain.https,
+                # or force it if specified
+                require_https,
+                # or fallback to settings
+                settings.PUBLIC_DOMAIN_USES_HTTPS
+                and settings.PUBLIC_DOMAIN
+                and any(
+                    [
+                        settings.PUBLIC_DOMAIN in domain,
+                        settings.RTD_EXTERNAL_VERSION_DOMAIN in domain,
+                    ]
+                ),
+            ]
         )
-        return urlunparse((protocol, domain, path, '', query_params, ''))
+        protocol = "https" if use_https_protocol else "http"
+
+        path = self.resolve_path(project, filename=filename, **kwargs)
+        return urlunparse((protocol, domain, path, "", query_params, ""))
 
     def get_subproject_url_prefix(self, project, external_version_slug=None):
         """
@@ -336,20 +343,21 @@ class ResolverBase:
 
     def _get_external_subdomain(self, project, version_slug):
         """Determine domain for an external version."""
-        subdomain_slug = project.slug.replace('_', '-')
+        subdomain_slug = project.slug.replace("_", "-")
         # Version slug is in the domain so we can properly serve single-version projects
         # and have them resolve the proper version from the PR.
-        return f'{subdomain_slug}--{version_slug}.{settings.RTD_EXTERNAL_VERSION_DOMAIN}'
+        return (
+            f"{subdomain_slug}--{version_slug}.{settings.RTD_EXTERNAL_VERSION_DOMAIN}"
+        )
 
     def _get_project_subdomain(self, project):
         """Determine canonical project domain as subdomain."""
-        subdomain_slug = project.slug.replace('_', '-')
-        return '{}.{}'.format(subdomain_slug, settings.PUBLIC_DOMAIN)
+        subdomain_slug = project.slug.replace("_", "-")
+        return "{}.{}".format(subdomain_slug, settings.PUBLIC_DOMAIN)
 
     def _is_external(self, project, version_slug):
         type_ = (
-            project.versions
-            .values_list('type', flat=True)
+            project.versions.values_list("type", flat=True)
             .filter(slug=version_slug)
             .first()
         )
@@ -361,7 +369,7 @@ class ResolverBase:
 
         This basically means stripping /.
         """
-        filename = filename.lstrip('/')
+        filename = filename.lstrip("/")
         return filename
 
     def _use_custom_domain(self, custom_domain):
@@ -387,7 +395,7 @@ class ResolverBase:
 class Resolver(SettingsOverrideObject):
 
     _default_class = ResolverBase
-    _override_setting = 'RESOLVER_CLASS'
+    _override_setting = "RESOLVER_CLASS"
 
 
 resolver = Resolver()

--- a/readthedocs/core/utils/filesystem.py
+++ b/readthedocs/core/utils/filesystem.py
@@ -23,6 +23,7 @@ log = structlog.get_logger(__name__)
 
 MAX_FILE_SIZE_BYTES = 1024 * 1024 * 1024 * 1  # 1 GB
 
+
 def _assert_path_is_inside_docroot(path):
     resolved_path = path.absolute().resolve()
     docroot = Path(settings.DOCROOT).absolute()

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -280,7 +280,7 @@ class DockerBuildCommand(BuildCommand):
     """
 
     bash_escape_re = re.compile(
-        r"([\t\ \!\"\#\$\&\'\(\)\*\:\;\<\>\?\@" r"\[\\\]\^\`\{\|\}\~])"
+        r"([\t\ \!\"\#\$\&\'\(\)\*\:\;\<\>\?\@" r"\[\\\]\^\`\{\|\}\~])"  # noqa
     )
 
     def __init__(self, *args, escape_command=True, **kwargs):

--- a/readthedocs/doc_builder/exceptions.py
+++ b/readthedocs/doc_builder/exceptions.py
@@ -11,10 +11,14 @@ class BuildBaseException(Exception):
     status_code = None
 
     def __init__(self, message=None, **kwargs):
-        self.status_code = kwargs.pop(
-            'status_code',
-            None,
-        ) or self.status_code or 1
+        self.status_code = (
+            kwargs.pop(
+                "status_code",
+                None,
+            )
+            or self.status_code
+            or 1
+        )
         self.message = message or self.message or self.get_default_message()
         super().__init__(message, **kwargs)
 
@@ -88,7 +92,7 @@ class ProjectBuildsSkippedError(BuildUserError):
 
 class YAMLParseError(BuildUserError):
     GENERIC_WITH_PARSE_EXCEPTION = gettext_noop(
-        'Problem in your project\'s configuration. {exception}',
+        "Problem in your project's configuration. {exception}",
     )
 
 
@@ -111,17 +115,17 @@ class PDFNotFound(BuildUserError):
 
 class MkDocsYAMLParseError(BuildUserError):
     GENERIC_WITH_PARSE_EXCEPTION = gettext_noop(
-        'Problem parsing MkDocs YAML configuration. {exception}',
+        "Problem parsing MkDocs YAML configuration. {exception}",
     )
 
     INVALID_DOCS_DIR_CONFIG = gettext_noop(
         'The "docs_dir" config from your MkDocs YAML config file has to be a '
-        'string with relative or absolute path.',
+        "string with relative or absolute path.",
     )
 
     INVALID_DOCS_DIR_PATH = gettext_noop(
         'The "docs_dir" config from your MkDocs YAML config file does not '
-        'contain a valid path.',
+        "contain a valid path.",
     )
 
     INVALID_EXTRA_CONFIG = gettext_noop(

--- a/readthedocs/integrations/migrations/0007_update-provider-data.py
+++ b/readthedocs/integrations/migrations/0007_update-provider-data.py
@@ -6,9 +6,7 @@ def forwards_func(apps, schema_editor):
     """Old models with provider_data='' are being fetched as str instead of json."""
     Integration = apps.get_model("integrations", "Integration")
 
-    Integration.objects.filter(
-        provider_data="",
-    ).update(
+    Integration.objects.filter(provider_data="",).update(
         provider_data={},
     )
 

--- a/readthedocs/integrations/migrations/0007_update-provider-data.py
+++ b/readthedocs/integrations/migrations/0007_update-provider-data.py
@@ -6,7 +6,9 @@ def forwards_func(apps, schema_editor):
     """Old models with provider_data='' are being fetched as str instead of json."""
     Integration = apps.get_model("integrations", "Integration")
 
-    Integration.objects.filter(provider_data="",).update(
+    Integration.objects.filter(
+        provider_data="",
+    ).update(
         provider_data={},
     )
 

--- a/readthedocs/organizations/tests/test_views.py
+++ b/readthedocs/organizations/tests/test_views.py
@@ -26,13 +26,13 @@ class OrganizationViewTests(RequestFactoryTestMixin, TestCase):
     """Organization views tests."""
 
     def setUp(self):
-        self.owner = get(User, username='owner', email='owner@example.com')
+        self.owner = get(User, username="owner", email="owner@example.com")
         self.owner.emailaddress_set.create(email=self.owner.email, verified=True)
         self.project = get(Project)
         self.organization = get(
             Organization,
-            name='test-org',
-            slug='test-org',
+            name="test-org",
+            slug="test-org",
             owners=[self.owner],
             projects=[self.project],
         )
@@ -42,20 +42,20 @@ class OrganizationViewTests(RequestFactoryTestMixin, TestCase):
     def test_update(self):
         org_slug = self.organization.slug
         resp = self.client.post(
-            reverse('organization_edit', args=[self.organization.slug]),
+            reverse("organization_edit", args=[self.organization.slug]),
             data={
-                'name': 'New name',
-                'email': 'dev@example.com',
-                'description': 'Description',
-                'url': 'https://readthedocs.org',
-            }
+                "name": "New name",
+                "email": "dev@example.com",
+                "description": "Description",
+                "url": "https://readthedocs.org",
+            },
         )
         self.assertEqual(resp.status_code, 302)
         self.organization.refresh_from_db()
-        self.assertEqual(self.organization.name, 'New name')
-        self.assertEqual(self.organization.email, 'dev@example.com')
-        self.assertEqual(self.organization.url, 'https://readthedocs.org')
-        self.assertEqual(self.organization.description, 'Description')
+        self.assertEqual(self.organization.name, "New name")
+        self.assertEqual(self.organization.email, "dev@example.com")
+        self.assertEqual(self.organization.url, "https://readthedocs.org")
+        self.assertEqual(self.organization.description, "Description")
         # The slug hasn't changed.
         self.assertEqual(self.organization.slug, org_slug)
 
@@ -66,14 +66,14 @@ class OrganizationViewTests(RequestFactoryTestMixin, TestCase):
         So changing it to something that will generate an existing slug
         shouldn't matter.
         """
-        new_name = 'Test Org'
+        new_name = "Test Org"
         org_slug = self.organization.slug
         self.assertNotEqual(new_name, self.organization.name)
         self.assertEqual(slugify(new_name), org_slug)
 
         resp = self.client.post(
-            reverse('organization_edit', args=[self.organization.slug]),
-            data={'name': new_name},
+            reverse("organization_edit", args=[self.organization.slug]),
+            data={"name": new_name},
         )
         self.assertEqual(resp.status_code, 302)
         self.organization.refresh_from_db()
@@ -83,26 +83,20 @@ class OrganizationViewTests(RequestFactoryTestMixin, TestCase):
     def test_delete(self):
         """Delete organization on post."""
         resp = self.client.post(
-            reverse('organization_delete', args=[self.organization.slug])
+            reverse("organization_delete", args=[self.organization.slug])
         )
         self.assertEqual(resp.status_code, 302)
 
-        self.assertFalse(Organization.objects
-                         .filter(pk=self.organization.pk)
-                         .exists())
-        self.assertFalse(Team.objects
-                         .filter(pk=self.team.pk)
-                         .exists())
-        self.assertFalse(Project.objects
-                        .filter(pk=self.project.pk)
-                        .exists())
+        self.assertFalse(Organization.objects.filter(pk=self.organization.pk).exists())
+        self.assertFalse(Team.objects.filter(pk=self.team.pk).exists())
+        self.assertFalse(Project.objects.filter(pk=self.project.pk).exists())
 
     def test_add_owner(self):
-        url = reverse('organization_owner_add', args=[self.organization.slug])
-        user = get(User, username='test-user', email='test-user@example.com')
+        url = reverse("organization_owner_add", args=[self.organization.slug])
+        user = get(User, username="test-user", email="test-user@example.com")
         user.emailaddress_set.create(email=user.email, verified=False)
 
-        user_b = get(User, username='test-user-b', email='test-user-b@example.com')
+        user_b = get(User, username="test-user-b", email="test-user-b@example.com")
         user_b.emailaddress_set.create(email=user_b.email, verified=True)
 
         # Adding an already owner.
@@ -156,12 +150,11 @@ class OrganizationViewTests(RequestFactoryTestMixin, TestCase):
     ),
 )
 class OrganizationSecurityLogTests(TestCase):
-
     def setUp(self):
-        self.owner = get(User, username='owner')
-        self.member = get(User, username='member')
-        self.project = get(Project, slug='project')
-        self.project_b = get(Project, slug='project-b')
+        self.owner = get(User, username="owner")
+        self.member = get(User, username="member")
+        self.project = get(Project, slug="project")
+        self.project_b = get(Project, slug="project-b")
         self.organization = get(
             Organization,
             owners=[self.owner],
@@ -173,9 +166,9 @@ class OrganizationSecurityLogTests(TestCase):
             members=[self.member],
         )
 
-        self.another_owner = get(User, username='another-owner')
-        self.another_member = get(User, username='another-member')
-        self.another_project = get(Project, slug='another-project')
+        self.another_owner = get(User, username="another-owner")
+        self.another_member = get(User, username="another-member")
+        self.another_project = get(Project, slug="another-project")
         self.another_organization = get(
             Organization,
             owners=[self.another_owner],
@@ -196,8 +189,8 @@ class OrganizationSecurityLogTests(TestCase):
             AuditLog.DOWNLOAD,
         ]
         ips = [
-            '10.10.10.1',
-            '10.10.10.2',
+            "10.10.10.1",
+            "10.10.10.2",
         ]
         users = [self.owner, self.member, self.another_owner, self.another_member]
         projects = [self.project, self.project_b, self.another_project]
@@ -227,45 +220,50 @@ class OrganizationSecurityLogTests(TestCase):
         # Show logs for self.organization only.
         resp = self.client.get(self.url)
         self.assertEqual(resp.status_code, 200)
-        auditlogs = resp.context_data['object_list']
+        auditlogs = resp.context_data["object_list"]
         self.assertQuerySetEqual(auditlogs, self.queryset)
 
         # Show logs filtered by project.
-        resp = self.client.get(self.url + '?project=project')
+        resp = self.client.get(self.url + "?project=project")
         self.assertEqual(resp.status_code, 200)
         auditlogs = resp.context_data["object_list"]
         self.assertQuerySetEqual(
             auditlogs, self.queryset.filter(log_project_slug="project")
         )
 
-        resp = self.client.get(self.url + '?project=another-project')
+        resp = self.client.get(self.url + "?project=another-project")
         self.assertEqual(resp.status_code, 200)
-        auditlogs = resp.context_data['object_list']
+        auditlogs = resp.context_data["object_list"]
         self.assertEqual(auditlogs.count(), 0)
 
         # Show logs filtered by IP.
         ip = "10.10.10.2"
         resp = self.client.get(self.url + f"?ip={ip}")
         self.assertEqual(resp.status_code, 200)
-        auditlogs = resp.context_data['object_list']
+        auditlogs = resp.context_data["object_list"]
         self.assertQuerySetEqual(auditlogs, self.queryset.filter(ip=ip))
 
         # Show logs filtered by action.
-        for action in [AuditLog.AUTHN, AuditLog.AUTHN_FAILURE, AuditLog.PAGEVIEW, AuditLog.DOWNLOAD]:
-            resp = self.client.get(self.url + f'?action={action}')
+        for action in [
+            AuditLog.AUTHN,
+            AuditLog.AUTHN_FAILURE,
+            AuditLog.PAGEVIEW,
+            AuditLog.DOWNLOAD,
+        ]:
+            resp = self.client.get(self.url + f"?action={action}")
             self.assertEqual(resp.status_code, 200)
-            auditlogs = resp.context_data['object_list']
+            auditlogs = resp.context_data["object_list"]
             self.assertQuerySetEqual(auditlogs, self.queryset.filter(action=action))
 
         # Show logs filtered by user.
-        resp = self.client.get(self.url + '?user=member')
+        resp = self.client.get(self.url + "?user=member")
         self.assertEqual(resp.status_code, 200)
         auditlogs = resp.context_data["object_list"]
         self.assertQuerySetEqual(
             auditlogs, self.queryset.filter(log_user_username="member")
         )
 
-    @mock.patch('django.utils.timezone.now')
+    @mock.patch("django.utils.timezone.now")
     def test_filter_by_date(self, now_mock):
         date = timezone.datetime(year=2021, month=1, day=15)
         now_mock.return_value = date
@@ -281,29 +279,31 @@ class OrganizationSecurityLogTests(TestCase):
         date = timezone.datetime(year=2021, month=4, day=24)
         AuditLog.objects.filter(action=AuditLog.AUTHN_FAILURE).update(created=date)
 
-        resp = self.client.get(self.url + '?date_before=2020-10-10')
+        resp = self.client.get(self.url + "?date_before=2020-10-10")
         self.assertEqual(resp.status_code, 200)
-        auditlogs = resp.context_data['object_list']
+        auditlogs = resp.context_data["object_list"]
         self.assertEqual(auditlogs.count(), 0)
 
-        resp = self.client.get(self.url + '?date_after=2023-10-10')
+        resp = self.client.get(self.url + "?date_after=2023-10-10")
         self.assertEqual(resp.status_code, 200)
-        auditlogs = resp.context_data['object_list']
+        auditlogs = resp.context_data["object_list"]
         self.assertEqual(auditlogs.count(), 0)
 
-        resp = self.client.get(self.url + '?date_before=2021-03-9')
+        resp = self.client.get(self.url + "?date_before=2021-03-9")
         self.assertEqual(resp.status_code, 200)
-        auditlogs = resp.context_data['object_list']
+        auditlogs = resp.context_data["object_list"]
         self.assertQuerySetEqual(auditlogs, self.queryset.filter(action=AuditLog.AUTHN))
 
-        resp = self.client.get(self.url + '?date_after=2021-03-11')
+        resp = self.client.get(self.url + "?date_after=2021-03-11")
         self.assertEqual(resp.status_code, 200)
         auditlogs = resp.context_data["object_list"]
         self.assertQuerySetEqual(
             auditlogs, self.queryset.filter(action=AuditLog.AUTHN_FAILURE)
         )
 
-        resp = self.client.get(self.url + '?date_after=2021-01-01&date_before=2021-03-10')
+        resp = self.client.get(
+            self.url + "?date_after=2021-01-01&date_before=2021-03-10"
+        )
         self.assertEqual(resp.status_code, 200)
         auditlogs = resp.context_data["object_list"]
         self.assertQuerySetEqual(
@@ -312,17 +312,13 @@ class OrganizationSecurityLogTests(TestCase):
 
     def test_download_csv(self):
         self.assertEqual(AuditLog.objects.count(), 160)
-        resp = self.client.get(
-            self.url,
-            {'download': 'true'}
-        )
+        resp = self.client.get(self.url, {"download": "true"})
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp['Content-Type'], 'text/csv')
+        self.assertEqual(resp["Content-Type"], "text/csv")
 
         # convert streaming data to csv format
         content = [
-            line.decode()
-            for line in b''.join(resp.streaming_content).splitlines()
+            line.decode() for line in b"".join(resp.streaming_content).splitlines()
         ]
         csv_data = list(csv.reader(content))
         # All records + the header.
@@ -355,7 +351,6 @@ class OrganizationInviteViewTests(RequestFactoryTestMixin, TestCase):
 
 @override_settings(RTD_ALLOW_ORGANIZATIONS=True)
 class OrganizationSignupTestCase(TestCase):
-
     def tearDown(self):
         cache.clear()
 
@@ -364,18 +359,18 @@ class OrganizationSignupTestCase(TestCase):
         user = get(User)
         self.client.force_login(user)
         data = {
-            'name': 'Testing Organization',
-            'email': 'billing@email.com',
+            "name": "Testing Organization",
+            "email": "billing@email.com",
         }
-        resp = self.client.post(reverse('organization_create'), data=data)
+        resp = self.client.post(reverse("organization_create"), data=data)
         self.assertEqual(Organization.objects.count(), 1)
 
         org = Organization.objects.first()
-        self.assertEqual(org.name, 'Testing Organization')
-        self.assertEqual(org.email, 'billing@email.com')
+        self.assertEqual(org.name, "Testing Organization")
+        self.assertEqual(org.email, "billing@email.com")
         self.assertRedirects(
             resp,
-            reverse('organization_detail', kwargs={'slug': org.slug}),
+            reverse("organization_detail", kwargs={"slug": org.slug}),
         )
 
 

--- a/readthedocs/projects/tasks/mixins.py
+++ b/readthedocs/projects/tasks/mixins.py
@@ -104,8 +104,7 @@ class SyncRepositoryMixin:
         :param data: Dict containing the versions from tags and branches
         """
         version_names = [
-            version['verbose_name']
-            for version in tags_data + branches_data
+            version["verbose_name"] for version in tags_data + branches_data
         ]
         counter = Counter(version_names)
         for reserved_name in [STABLE_VERBOSE_NAME, LATEST_VERBOSE_NAME]:

--- a/readthedocs/projects/views/mixins.py
+++ b/readthedocs/projects/views/mixins.py
@@ -28,9 +28,9 @@ class ProjectRelationMixin:
     :cvar project_context_object_name: Context object name for project
     """
 
-    project_lookup_url_kwarg = 'project_slug'
-    project_lookup_field = 'project'
-    project_context_object_name = 'project'
+    project_lookup_url_kwarg = "project_slug"
+    project_lookup_field = "project"
+    project_context_object_name = "project"
 
     def get_project_queryset(self):
         return Project.objects.for_admin_user(user=self.request.user)
@@ -60,7 +60,7 @@ class ProjectRelationListMixin:
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['subprojects_and_urls'] = self._get_subprojects_and_urls()
+        context["subprojects_and_urls"] = self._get_subprojects_and_urls()
         return context
 
     def _get_subprojects_and_urls(self):
@@ -74,7 +74,7 @@ class ProjectRelationListMixin:
         subprojects_and_urls = []
 
         project = self.get_project()
-        subprojects = project.subprojects.select_related('child')
+        subprojects = project.subprojects.select_related("child")
 
         if not subprojects.exists():
             return subprojects_and_urls
@@ -116,7 +116,7 @@ class ProjectImportMixin:
         """
         project.users.add(request.user)
         log.info(
-            'Project imported.',
+            "Project imported.",
             project_slug=project.slug,
             user_username=request.user.username,
         )
@@ -139,6 +139,7 @@ class ProjectImportMixin:
             return None
 
         from readthedocs.oauth.tasks import attach_webhook
+
         task_promise = chain(
             attach_webhook.si(project.pk, user.pk),
             update_docs,

--- a/readthedocs/proxito/tests/test_custom_path_prefixes.py
+++ b/readthedocs/proxito/tests/test_custom_path_prefixes.py
@@ -9,7 +9,6 @@ from readthedocs.proxito.tests.base import BaseDocServing
     RTD_EXTERNAL_VERSION_DOMAIN="readthedocs.build",
 )
 class TestCustomPathPrefixes(BaseDocServing):
-
     def test_custom_prefix_multi_version_project(self):
         self.project.custom_prefix = "/custom/prefix/"
         self.project.save()

--- a/readthedocs/proxito/tests/test_redirects.py
+++ b/readthedocs/proxito/tests/test_redirects.py
@@ -12,20 +12,20 @@ from .base import BaseDocServing
 
 
 @override_settings(
-    PUBLIC_DOMAIN='dev.readthedocs.io',
+    PUBLIC_DOMAIN="dev.readthedocs.io",
     RTD_EXTERNAL_VERSION_DOMAIN="dev.readthedocs.build",
     PUBLIC_DOMAIN_USES_HTTPS=True,
     RTD_DEFAULT_FEATURES=dict([RTDProductFeature(type=TYPE_CNAME).to_item()]),
 )
 class RedirectTests(BaseDocServing):
-
     def test_root_url_no_slash(self):
         r = self.client.get(
             "", secure=True, headers={"host": "project.dev.readthedocs.io"}
         )
         self.assertEqual(r.status_code, 302)
         self.assertEqual(
-            r['Location'], 'https://project.dev.readthedocs.io/en/latest/',
+            r["Location"],
+            "https://project.dev.readthedocs.io/en/latest/",
         )
         self.assertEqual(r.headers["CDN-Cache-Control"], "public")
         self.assertEqual(r.headers["Cache-Tag"], "project")
@@ -37,7 +37,8 @@ class RedirectTests(BaseDocServing):
         )
         self.assertEqual(r.status_code, 302)
         self.assertEqual(
-            r['Location'], 'https://project.dev.readthedocs.io/en/latest/',
+            r["Location"],
+            "https://project.dev.readthedocs.io/en/latest/",
         )
         self.assertEqual(r.headers["CDN-Cache-Control"], "public")
         self.assertEqual(r.headers["Cache-Tag"], "project")
@@ -50,7 +51,8 @@ class RedirectTests(BaseDocServing):
         r = self.client.get("/", headers={"host": self.domain.domain}, secure=True)
         self.assertEqual(r.status_code, 302)
         self.assertEqual(
-            r['Location'], f'https://{self.domain.domain}/en/latest/',
+            r["Location"],
+            f"https://{self.domain.domain}/en/latest/",
         )
         self.assertEqual(r.headers["CDN-Cache-Control"], "public")
         self.assertEqual(r.headers["Cache-Tag"], "project")
@@ -63,7 +65,8 @@ class RedirectTests(BaseDocServing):
         r = self.client.get("", headers={"host": self.domain.domain}, secure=True)
         self.assertEqual(r.status_code, 302)
         self.assertEqual(
-            r['Location'], f'https://{self.domain.domain}/en/latest/',
+            r["Location"],
+            f"https://{self.domain.domain}/en/latest/",
         )
         self.assertEqual(r.headers["CDN-Cache-Control"], "public")
         self.assertEqual(r.headers["Cache-Tag"], "project")
@@ -85,7 +88,8 @@ class RedirectTests(BaseDocServing):
         )
         self.assertEqual(r.status_code, 302)
         self.assertEqual(
-            r['Location'], 'https://project.dev.readthedocs.io/projects/subproject/en/latest/',
+            r["Location"],
+            "https://project.dev.readthedocs.io/projects/subproject/en/latest/",
         )
         self.assertEqual(r.headers["CDN-Cache-Control"], "public")
         self.assertEqual(r.headers["Cache-Tag"], "subproject")
@@ -99,7 +103,8 @@ class RedirectTests(BaseDocServing):
         )
         self.assertEqual(r.status_code, 302)
         self.assertEqual(
-            r['Location'], 'https://project.dev.readthedocs.io/projects/subproject/en/latest/',
+            r["Location"],
+            "https://project.dev.readthedocs.io/projects/subproject/en/latest/",
         )
         self.assertEqual(r.headers["CDN-Cache-Control"], "public")
         self.assertEqual(r.headers["Cache-Tag"], "subproject")
@@ -115,7 +120,8 @@ class RedirectTests(BaseDocServing):
         )
         self.assertEqual(r.status_code, 302)
         self.assertEqual(
-            r['Location'], 'https://project.dev.readthedocs.io/projects/subproject/',
+            r["Location"],
+            "https://project.dev.readthedocs.io/projects/subproject/",
         )
         self.assertEqual(r.headers["CDN-Cache-Control"], "public")
         self.assertEqual(r.headers["Cache-Tag"], "subproject,subproject:latest")
@@ -152,7 +158,8 @@ class RedirectTests(BaseDocServing):
         )
         self.assertEqual(r.status_code, 302)
         self.assertEqual(
-            r['Location'], 'https://project.dev.readthedocs.io/projects/subproject/en/latest/',
+            r["Location"],
+            "https://project.dev.readthedocs.io/projects/subproject/en/latest/",
         )
         self.assertEqual(r.headers["CDN-Cache-Control"], "public")
         self.assertEqual(r.headers["Cache-Tag"], "subproject")
@@ -167,7 +174,8 @@ class RedirectTests(BaseDocServing):
         )
         self.assertEqual(r.status_code, 302)
         self.assertEqual(
-            r['Location'], 'https://project.dev.readthedocs.io/projects/subproject/en/latest/foo/bar',
+            r["Location"],
+            "https://project.dev.readthedocs.io/projects/subproject/en/latest/foo/bar",
         )
         self.assertEqual(r.headers["CDN-Cache-Control"], "public")
         self.assertEqual(r.headers["Cache-Tag"], "subproject")
@@ -184,7 +192,8 @@ class RedirectTests(BaseDocServing):
         )
         self.assertEqual(r.status_code, 302)
         self.assertEqual(
-            r['Location'], 'https://docs1.example.com/projects/subproject/en/latest/foo/bar',
+            r["Location"],
+            "https://docs1.example.com/projects/subproject/en/latest/foo/bar",
         )
         self.assertEqual(r.headers["CDN-Cache-Control"], "public")
         self.assertEqual(r.headers["Cache-Tag"], "subproject")
@@ -201,7 +210,8 @@ class RedirectTests(BaseDocServing):
         )
         self.assertEqual(r.status_code, 302)
         self.assertEqual(
-            r['Location'], 'https://project.dev.readthedocs.io/projects/subproject/',
+            r["Location"],
+            "https://project.dev.readthedocs.io/projects/subproject/",
         )
         self.assertEqual(r.headers["CDN-Cache-Control"], "public")
         self.assertEqual(r.headers["Cache-Tag"], "subproject")
@@ -214,7 +224,8 @@ class RedirectTests(BaseDocServing):
         )
         self.assertEqual(r.status_code, 302)
         self.assertEqual(
-            r['Location'], 'https://project.dev.readthedocs.io/projects/subproject/foo/bar/',
+            r["Location"],
+            "https://project.dev.readthedocs.io/projects/subproject/foo/bar/",
         )
         self.assertEqual(r.headers["CDN-Cache-Control"], "public")
         self.assertEqual(r.headers["Cache-Tag"], "subproject")
@@ -229,7 +240,8 @@ class RedirectTests(BaseDocServing):
         )
         self.assertEqual(r.status_code, 302)
         self.assertEqual(
-            r['Location'], 'https://docs1.example.com/projects/subproject/foo/bar',
+            r["Location"],
+            "https://docs1.example.com/projects/subproject/foo/bar",
         )
         self.assertEqual(r.headers["CDN-Cache-Control"], "public")
         self.assertEqual(r.headers["Cache-Tag"], "subproject")
@@ -243,8 +255,7 @@ class RedirectTests(BaseDocServing):
         )
         self.assertEqual(r.status_code, 302)
         self.assertEqual(
-            r['Location'],
-            'https://project.dev.readthedocs.io/en/latest/?foo=bar'
+            r["Location"], "https://project.dev.readthedocs.io/en/latest/?foo=bar"
         )
         self.assertEqual(r.headers["CDN-Cache-Control"], "public")
         self.assertEqual(r.headers["Cache-Tag"], "project")
@@ -257,7 +268,8 @@ class RedirectTests(BaseDocServing):
         r = self.client.get("/", headers={"host": self.domain.domain})
         self.assertEqual(r.status_code, 302)
         self.assertEqual(
-            r['Location'], f'https://{self.domain.domain}/',
+            r["Location"],
+            f"https://{self.domain.domain}/",
         )
         self.assertEqual(r.headers["CDN-Cache-Control"], "public")
         self.assertEqual(r.headers["Cache-Tag"], "project")
@@ -269,7 +281,8 @@ class RedirectTests(BaseDocServing):
         )
         self.assertEqual(r.status_code, 302)
         self.assertEqual(
-            r['Location'], f'https://{self.domain.domain}/en/latest/404after302',
+            r["Location"],
+            f"https://{self.domain.domain}/en/latest/404after302",
         )
         self.assertEqual(r.headers["CDN-Cache-Control"], "public")
         self.assertEqual(r.headers["Cache-Tag"], "project")
@@ -285,7 +298,8 @@ class RedirectTests(BaseDocServing):
         )
         self.assertEqual(r.status_code, 302)
         self.assertEqual(
-            r['Location'], f'https://{self.domain.domain}/',
+            r["Location"],
+            f"https://{self.domain.domain}/",
         )
         self.assertEqual(r.headers["CDN-Cache-Control"], "public")
         self.assertEqual(r.headers["Cache-Tag"], "project")
@@ -299,7 +313,8 @@ class RedirectTests(BaseDocServing):
         )
         self.assertEqual(r.status_code, 302)
         self.assertEqual(
-            r['Location'], f'https://{self.domain.domain}/en/latest/404after302',
+            r["Location"],
+            f"https://{self.domain.domain}/en/latest/404after302",
         )
         self.assertEqual(r.headers["CDN-Cache-Control"], "public")
         self.assertEqual(r.headers["Cache-Tag"], "project")
@@ -311,7 +326,8 @@ class RedirectTests(BaseDocServing):
         )
         self.assertEqual(r.status_code, 302)
         self.assertEqual(
-            r['Location'], f'https://project.dev.readthedocs.io/es/latest/',
+            r["Location"],
+            f"https://project.dev.readthedocs.io/es/latest/",
         )
         self.assertEqual(r.headers["CDN-Cache-Control"], "public")
         self.assertEqual(r.headers["Cache-Tag"], "translation")
@@ -323,7 +339,8 @@ class RedirectTests(BaseDocServing):
         )
         self.assertEqual(r.status_code, 302)
         self.assertEqual(
-            r['Location'], f'https://project.dev.readthedocs.io/es/latest/',
+            r["Location"],
+            f"https://project.dev.readthedocs.io/es/latest/",
         )
         self.assertEqual(r.headers["CDN-Cache-Control"], "public")
         self.assertEqual(r.headers["Cache-Tag"], "translation")
@@ -338,67 +355,73 @@ class RedirectTests(BaseDocServing):
         )
         self.assertEqual(r.status_code, 302)
         self.assertEqual(
-            r['Location'],
-            'https://project.dev.readthedocs.io/en/latest/test.html',
+            r["Location"],
+            "https://project.dev.readthedocs.io/en/latest/test.html",
         )
         self.assertEqual(r.headers["CDN-Cache-Control"], "public")
         self.assertEqual(r.headers["Cache-Tag"], "project")
         self.assertEqual(r["X-RTD-Redirect"], RedirectType.system.name)
 
     def test_slash_redirect(self):
-        host = 'project.dev.readthedocs.io'
+        host = "project.dev.readthedocs.io"
 
-        url = '/en/latest////awesome.html'
+        url = "/en/latest////awesome.html"
         resp = self.client.get(url, secure=True, headers={"host": host})
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(
-            resp['Location'], '/en/latest/awesome.html',
+            resp["Location"],
+            "/en/latest/awesome.html",
         )
         self.assertEqual(resp.headers["CDN-Cache-Control"], "public")
         self.assertEqual(resp.headers["Cache-Tag"], "project")
 
-        url = '/en/latest////awesome.html'
+        url = "/en/latest////awesome.html"
         resp = self.client.get(url, secure=True, headers={"host": host})
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(
-            resp['Location'], '/en/latest/awesome.html',
+            resp["Location"],
+            "/en/latest/awesome.html",
         )
         self.assertEqual(resp.headers["CDN-Cache-Control"], "public")
         self.assertEqual(resp.headers["Cache-Tag"], "project")
 
-        url = '/en/latest////awesome///index.html'
+        url = "/en/latest////awesome///index.html"
         resp = self.client.get(url, secure=True, headers={"host": host})
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(
-            resp['Location'], '/en/latest/awesome/index.html',
+            resp["Location"],
+            "/en/latest/awesome/index.html",
         )
         self.assertEqual(resp.headers["CDN-Cache-Control"], "public")
         self.assertEqual(resp.headers["Cache-Tag"], "project")
 
-        url = '/en/latest////awesome///index.html?foo=bar'
+        url = "/en/latest////awesome///index.html?foo=bar"
         resp = self.client.get(url, secure=True, headers={"host": host})
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(
-            resp['Location'], '/en/latest/awesome/index.html?foo=bar',
+            resp["Location"],
+            "/en/latest/awesome/index.html?foo=bar",
         )
         self.assertEqual(resp.headers["CDN-Cache-Control"], "public")
         self.assertEqual(resp.headers["Cache-Tag"], "project")
 
-        url = '/en/latest////awesome///'
+        url = "/en/latest////awesome///"
         resp = self.client.get(url, secure=True, headers={"host": host})
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(
-            resp['Location'], '/en/latest/awesome/',
+            resp["Location"],
+            "/en/latest/awesome/",
         )
         self.assertEqual(resp.headers["CDN-Cache-Control"], "public")
         self.assertEqual(resp.headers["Cache-Tag"], "project")
 
         # Don't change the values of params
-        url = '/en/latest////awesome///index.html?foo=bar//bas'
+        url = "/en/latest////awesome///index.html?foo=bar//bas"
         resp = self.client.get(url, secure=True, headers={"host": host})
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(
-            resp['Location'], '/en/latest/awesome/index.html?foo=bar//bas',
+            resp["Location"],
+            "/en/latest/awesome/index.html?foo=bar//bas",
         )
         self.assertEqual(resp.headers["CDN-Cache-Control"], "public")
         self.assertEqual(resp.headers["Cache-Tag"], "project")

--- a/readthedocs/proxito/views/mixins.py
+++ b/readthedocs/proxito/views/mixins.py
@@ -197,7 +197,7 @@ class ServeDocsMixin:
         """Create an audit log of the page view if audit is enabled."""
         # Remove any query args (like the token access from AWS).
         path_only = urlparse(path).path
-        track_file = path_only.endswith(('.html', '.pdf', '.epub', '.zip'))
+        track_file = path_only.endswith((".html", ".pdf", ".epub", ".zip"))
         if track_file and self._is_audit_enabled(project):
             action = AuditLog.DOWNLOAD if download else AuditLog.PAGEVIEW
             AuditLog.objects.new(
@@ -235,23 +235,23 @@ class ServeDocsMixin:
         """
         original_path = copy.copy(path)
         if not path.startswith(f"/{root_path}/"):
-            if path[0] == '/':
+            if path[0] == "/":
                 path = path[1:]
             path = f"/{root_path}/{path}"
 
         log.debug(
-            'Nginx serve.',
+            "Nginx serve.",
             original_path=original_path,
             path=path,
         )
 
         content_type, encoding = mimetypes.guess_type(path)
-        content_type = content_type or 'application/octet-stream'
+        content_type = content_type or "application/octet-stream"
         response = HttpResponse(
-            f'Serving internal path: {path}', content_type=content_type
+            f"Serving internal path: {path}", content_type=content_type
         )
         if encoding:
-            response['Content-Encoding'] = encoding
+            response["Content-Encoding"] = encoding
 
         # NGINX does not support non-ASCII characters in the header, so we
         # convert the IRI path to URI so it's compatible with what NGINX expects
@@ -259,7 +259,7 @@ class ServeDocsMixin:
         # https://github.com/benoitc/gunicorn/issues/1448
         # https://docs.djangoproject.com/en/1.11/ref/unicode/#uri-and-iri-handling
         x_accel_redirect = iri_to_uri(path)
-        response['X-Accel-Redirect'] = x_accel_redirect
+        response["X-Accel-Redirect"] = x_accel_redirect
 
         # Needed to strip any GET args, etc.
         response.proxito_path = urlparse(path).path
@@ -276,19 +276,20 @@ class ServeDocsMixin:
         return serve(request, path, root_path)
 
     def _serve_401(self, request, project):
-        res = render(request, '401.html')
+        res = render(request, "401.html")
         res.status_code = 401
-        log.debug('Unauthorized access to documentation.', project_slug=project.slug)
+        log.debug("Unauthorized access to documentation.", project_slug=project.slug)
         return res
 
     def allowed_user(self, request, version):
         return True
 
     def _spam_response(self, request, project):
-        if 'readthedocsext.spamfighting' in settings.INSTALLED_APPS:
+        if "readthedocsext.spamfighting" in settings.INSTALLED_APPS:
             from readthedocsext.spamfighting.utils import is_serve_docs_denied  # noqa
+
             if is_serve_docs_denied(project):
-                return render(request, template_name='spam.html', status=410)
+                return render(request, template_name="spam.html", status=410)
 
 
 class ServeRedirectMixin:
@@ -365,7 +366,7 @@ class ServeRedirectMixin:
         # However, if the new_path is already an absolute URI, just use it
         new_path = request.build_absolute_uri(new_path)
         log.debug(
-            'Redirecting...',
+            "Redirecting...",
             from_url=request.build_absolute_uri(proxito_path),
             to_url=new_path,
             http_status_code=http_status,
@@ -381,7 +382,7 @@ class ServeRedirectMixin:
         ):
             # check that we do have a response and avoid infinite redirect
             log.debug(
-                'Infinite Redirect: FROM URL is the same than TO URL.',
+                "Infinite Redirect: FROM URL is the same than TO URL.",
                 url=new_path,
             )
             raise InfiniteRedirectException()

--- a/readthedocs/redirects/querysets.py
+++ b/readthedocs/redirects/querysets.py
@@ -78,7 +78,10 @@ class RedirectQuerySet(models.QuerySet):
             redirect_type="exact",
             full_path__exact=F("from_url"),
         )
-        sphinx_html = Q(redirect_type="sphinx_html", path__endswith="/",) | Q(
+        sphinx_html = Q(
+            redirect_type="sphinx_html",
+            path__endswith="/",
+        ) | Q(
             redirect_type="sphinx_html",
             path__endswith="/index.html",
         )

--- a/readthedocs/redirects/querysets.py
+++ b/readthedocs/redirects/querysets.py
@@ -78,10 +78,7 @@ class RedirectQuerySet(models.QuerySet):
             redirect_type="exact",
             full_path__exact=F("from_url"),
         )
-        sphinx_html = Q(
-            redirect_type="sphinx_html",
-            path__endswith="/",
-        ) | Q(
+        sphinx_html = Q(redirect_type="sphinx_html", path__endswith="/",) | Q(
             redirect_type="sphinx_html",
             path__endswith="/index.html",
         )

--- a/readthedocs/rtd_tests/files/conf.py
+++ b/readthedocs/rtd_tests/files/conf.py
@@ -7,22 +7,21 @@ from datetime import datetime
 from recommonmark.parser import CommonMarkParser
 
 extensions = []
-templates_path = ['templates', '_templates', '.templates']
-source_suffix = ['.rst', '.md']
+templates_path = ["templates", "_templates", ".templates"]
+source_suffix = [".rst", ".md"]
 source_parsers = {
-            '.md': CommonMarkParser,
-        }
-master_doc = 'index'
-project = u'Pip'
+    ".md": CommonMarkParser,
+}
+master_doc = "index"
+project = "Pip"
 copyright = str(datetime.now().year)
-version = '0.8.1'
-release = '0.8.1'
-exclude_patterns = ['_build']
-pygments_style = 'sphinx'
-htmlhelp_basename = 'pip'
-html_theme = 'sphinx_rtd_theme'
+version = "0.8.1"
+release = "0.8.1"
+exclude_patterns = ["_build"]
+pygments_style = "sphinx"
+htmlhelp_basename = "pip"
+html_theme = "sphinx_rtd_theme"
 file_insertion_enabled = False
 latex_documents = [
-  ('index', 'pip.tex', u'Pip Documentation',
-   u'', 'manual'),
+    ("index", "pip.tex", "Pip Documentation", "", "manual"),
 ]

--- a/readthedocs/rtd_tests/tests/test_backend.py
+++ b/readthedocs/rtd_tests/tests/test_backend.py
@@ -25,18 +25,18 @@ from readthedocs.rtd_tests.utils import (
 
 
 # Avoid trying to save the commands via the API
-@mock.patch('readthedocs.doc_builder.environments.BuildCommand.save', mock.MagicMock())
+@mock.patch("readthedocs.doc_builder.environments.BuildCommand.save", mock.MagicMock())
 class TestGitBackend(TestCase):
     def setUp(self):
         git_repo = make_test_git()
         super().setUp()
-        self.eric = User(username='eric')
-        self.eric.set_password('test')
+        self.eric = User(username="eric")
+        self.eric.set_password("test")
         self.eric.save()
         self.project = Project.objects.create(
-            name='Test Project',
-            repo_type='git',
-            #Our top-level checkout
+            name="Test Project",
+            repo_type="git",
+            # Our top-level checkout
             repo=git_repo,
         )
         self.project.users.add(self.eric)
@@ -55,23 +55,23 @@ class TestGitBackend(TestCase):
         repo_path = self.project.repo
         default_branches = [
             # comes from ``make_test_git`` function
-            'submodule',
-            'invalidsubmodule',
+            "submodule",
+            "invalidsubmodule",
         ]
         branches = [
-            'develop',
-            'master',
-            '2.0.X',
-            'release/2.0.0',
-            'release/foo/bar',
+            "develop",
+            "master",
+            "2.0.X",
+            "release/2.0.0",
+            "release/foo/bar",
             "with\xa0space",
         ]
         for branch in branches:
             create_git_branch(repo_path, branch)
 
-        create_git_tag(repo_path, 'v01')
-        create_git_tag(repo_path, 'v02', annotated=True)
-        create_git_tag(repo_path, 'release-ünîø∂é')
+        create_git_tag(repo_path, "v01")
+        create_git_tag(repo_path, "v02", annotated=True)
+        create_git_tag(repo_path, "release-ünîø∂é")
 
         repo = self.project.vcs_repo(environment=self.build_environment)
         # create the working dir if it not exists. It's required to ``cwd`` to
@@ -156,7 +156,7 @@ class TestGitBackend(TestCase):
     def test_git_checkout_invalid_revision(self):
         repo = self.project.vcs_repo(environment=self.build_environment)
         repo.update()
-        version = 'invalid-revision'
+        version = "invalid-revision"
         with self.assertRaises(RepositoryError) as e:
             repo.checkout(version)
         self.assertEqual(
@@ -360,18 +360,17 @@ class TestGitBackend(TestCase):
 
 
 # Avoid trying to save the commands via the API
-@mock.patch('readthedocs.doc_builder.environments.BuildCommand.save', mock.MagicMock())
+@mock.patch("readthedocs.doc_builder.environments.BuildCommand.save", mock.MagicMock())
 class TestHgBackend(TestCase):
-
     def setUp(self):
         hg_repo = make_test_hg()
         super().setUp()
-        self.eric = User(username='eric')
-        self.eric.set_password('test')
+        self.eric = User(username="eric")
+        self.eric.set_password("test")
         self.eric.save()
         self.project = Project.objects.create(
-            name='Test Project',
-            repo_type='hg',
+            name="Test Project",
+            repo_type="hg",
             # Our top-level checkout
             repo=hg_repo,
         )
@@ -405,7 +404,7 @@ class TestHgBackend(TestCase):
     def test_checkout_invalid_revision(self):
         repo = self.project.vcs_repo(environment=self.build_environment)
         repo.update()
-        version = 'invalid-revision'
+        version = "invalid-revision"
         with self.assertRaises(RepositoryError) as e:
             repo.checkout(version)
         self.assertEqual(
@@ -421,9 +420,9 @@ class TestHgBackend(TestCase):
         1.7.5                          13334:2b2155623ee2
          """
         expected_tags = [
-            ('aa1f3be38ab1', '1.8.1'),
-            ('2616325766e3', '1.8'),
-            ('2b2155623ee2', '1.7.5'),
+            ("aa1f3be38ab1", "1.8.1"),
+            ("2616325766e3", "1.8"),
+            ("2b2155623ee2", "1.7.5"),
         ]
 
         given_ids = [

--- a/readthedocs/rtd_tests/tests/test_build_config.py
+++ b/readthedocs/rtd_tests/tests/test_build_config.py
@@ -8,7 +8,7 @@ from readthedocs.config.tests import utils
 
 V2_SCHEMA = path.join(
     path.dirname(__file__),
-    '../fixtures/spec/v2/schema.yml',
+    "../fixtures/spec/v2/schema.yml",
 )
 
 
@@ -20,9 +20,9 @@ class PathValidator(Validator):
     Checks if the given value is a string and a existing file.
     """
 
-    tag = 'path'
+    tag = "path"
     constraints = []
-    configuration_file = '.'
+    configuration_file = "."
 
     def _is_valid(self, value):
         if isinstance(value, str):
@@ -36,16 +36,16 @@ class PathValidator(Validator):
 
 def create_yaml(tmpdir, content):
     fs = {
-        'environment.yml': '',
-        'mkdocs.yml': '',
-        'rtd.yml': content,
-        'docs': {
-            'conf.py': '',
-            'requirements.txt': '',
+        "environment.yml": "",
+        "mkdocs.yml": "",
+        "rtd.yml": content,
+        "docs": {
+            "conf.py": "",
+            "requirements.txt": "",
         },
     }
     utils.apply_fs(tmpdir, fs)
-    return path.join(tmpdir.strpath, 'rtd.yml')
+    return path.join(tmpdir.strpath, "rtd.yml")
 
 
 def validate_schema(file):
@@ -82,7 +82,7 @@ def test_invalid_version(tmpdir):
     assertInvalidConfig(
         tmpdir,
         'version: "latest"',
-        ['version:', "'latest' not in"],
+        ["version:", "'latest' not in"],
     )
 
 
@@ -90,120 +90,120 @@ def test_invalid_version_1(tmpdir):
     assertInvalidConfig(
         tmpdir,
         'version: "1"',
-        ['version', "'1' not in"],
+        ["version", "'1' not in"],
     )
 
 
 def test_formats(tmpdir):
-    content = '''
+    content = """
 version: "2"
 formats:
   - pdf
-    '''
+    """
     assertValidConfig(tmpdir, content)
 
 
 def test_formats_all(tmpdir):
-    content = '''
+    content = """
 version: "2"
 formats:
   - htmlzip
   - pdf
   - epub
-    '''
+    """
     assertValidConfig(tmpdir, content)
 
 
 def test_formats_key_all(tmpdir):
-    content = '''
+    content = """
 version: "2"
 formats: all
-    '''
+    """
     assertValidConfig(tmpdir, content)
 
 
 def test_formats_invalid(tmpdir):
-    content = '''
+    content = """
 version: "2"
 formats:
   - invalidformat
   - singlehtmllocalmedia
-    '''
+    """
     assertInvalidConfig(
         tmpdir,
         content,
-        ['formats', "'invalidformat' not in"],
+        ["formats", "'invalidformat' not in"],
     )
 
 
 def test_formats_empty(tmpdir):
-    content = '''
+    content = """
 version: "2"
 formats: []
-    '''
+    """
     assertValidConfig(tmpdir, content)
 
 
 def test_conda(tmpdir):
-    content = '''
+    content = """
 version: "2"
 conda:
   environment: environment.yml
-    '''
+    """
     assertValidConfig(tmpdir, content)
 
 
 def test_conda_invalid(tmpdir):
-    content = '''
+    content = """
 version: "2"
 conda:
   environment: environment.yaml
-    '''
+    """
     assertInvalidConfig(
         tmpdir,
         content,
-        ['environment.yaml', 'is not a path'],
+        ["environment.yaml", "is not a path"],
     )
 
 
 def test_conda_missing_key(tmpdir):
-    content = '''
+    content = """
 version: "2"
 conda:
   files: environment.yml
-    '''
+    """
     assertInvalidConfig(
         tmpdir,
         content,
-        ['conda.environment: Required'],
+        ["conda.environment: Required"],
     )
 
 
-@pytest.mark.parametrize('value', ['stable', 'latest'])
+@pytest.mark.parametrize("value", ["stable", "latest"])
 def test_build(tmpdir, value):
-    content = '''
+    content = """
 version: "2"
 build:
   image: "{value}"
-    '''
+    """
     assertValidConfig(tmpdir, content.format(value=value))
 
 
 def test_build_missing_image_key(tmpdir):
-    content = '''
+    content = """
 version: "2"
 build:
   imagine: "2.0"  # note the typo
-    '''
+    """
     assertValidConfig(tmpdir, content)
 
 
 def test_build_invalid(tmpdir):
-    content = '''
+    content = """
 version: "2"
 build:
   image: "9.0"
-    '''
+    """
     assertInvalidConfig(
         tmpdir,
         content,
@@ -211,22 +211,22 @@ build:
     )
 
 
-@pytest.mark.parametrize('value', ['2', '2.7', '3', '3.5', '3.6'])
+@pytest.mark.parametrize("value", ["2", "2.7", "3", "3.5", "3.6"])
 def test_python_version(tmpdir, value):
-    content = '''
+    content = """
 version: "2"
 python:
   version: "{value}"
-    '''
+    """
     assertValidConfig(tmpdir, content.format(value=value))
 
 
 def test_python_version_invalid(tmpdir):
-    content = '''
+    content = """
 version: "2"
 python:
   version: "4"
-    '''
+    """
     assertInvalidConfig(
         tmpdir,
         content,
@@ -235,57 +235,57 @@ python:
 
 
 def test_python_version_no_key(tmpdir):
-    content = '''
+    content = """
 version: "2"
 python:
   guido: true
-    '''
+    """
     assertValidConfig(tmpdir, content)
 
 
 def test_python_requirements(tmpdir):
-    content = '''
+    content = """
 version: "2"
 python:
   install:
     - requirements: docs/requirements.txt
-    '''
+    """
     assertValidConfig(tmpdir, content)
 
 
 def test_python_install_requirements(tmpdir):
-    content = '''
+    content = """
 version: "2"
 python:
   install:
     - requirements: 23
-    '''
+    """
     assertInvalidConfig(
         tmpdir,
         content,
-        ['requirements:', "'23' is not a path"],
+        ["requirements:", "'23' is not a path"],
     )
 
 
-@pytest.mark.parametrize('value', ['pip', 'setuptools'])
+@pytest.mark.parametrize("value", ["pip", "setuptools"])
 def test_python_install(tmpdir, value):
-    content = '''
+    content = """
 version: "2"
 python:
   version: "3.6"
   install:
     - path: .
       method: {value}
-    '''
+    """
     assertValidConfig(tmpdir, content.format(value=value))
 
 
 def test_python_install_invalid(tmpdir):
-    content = '''
+    content = """
 version: "2"
 python:
   install: guido
-    '''
+    """
     assertInvalidConfig(
         tmpdir,
         content,
@@ -294,16 +294,16 @@ python:
 
 
 def test_python_install_null(tmpdir):
-    content = '''
+    content = """
 version: "2"
 python:
   install: null
-    '''
+    """
     assertValidConfig(tmpdir, content)
 
 
 def test_python_install_extra_requirements(tmpdir):
-    content = '''
+    content = """
 version: "2"
 python:
   install:
@@ -311,134 +311,134 @@ python:
       extra_requirements:
         - test
         - dev
-    '''
+    """
     assertValidConfig(tmpdir, content)
 
 
-@pytest.mark.parametrize('value', ['', 'null', '[]'])
+@pytest.mark.parametrize("value", ["", "null", "[]"])
 def test_python_install_extra_requirements_empty(tmpdir, value):
-    content = '''
+    content = """
 version: "2"
 python:
   install:
     - path: .
       extra_requirements: {value}
-    '''
+    """
     assertValidConfig(tmpdir, content.format(value=value))
 
 
 def test_sphinx(tmpdir):
-    content = '''
+    content = """
 version: "2"
 sphinx:
   configuration: docs/conf.py
-    '''
+    """
     assertValidConfig(tmpdir, content)
 
 
 def test_sphinx_default_value(tmpdir):
-    content = '''
+    content = """
 version: "2"
 sphinx:
   file: docs/conf.py  # Default value for configuration key
-    '''
+    """
     assertValidConfig(tmpdir, content)
 
 
-@pytest.mark.parametrize('value', ['2', 'non-existent-file.yml'])
+@pytest.mark.parametrize("value", ["2", "non-existent-file.yml"])
 def test_sphinx_invalid(tmpdir, value):
-    content = '''
+    content = """
 version: "2"
 sphinx:
   configuration: {value}
-    '''
+    """
     assertInvalidConfig(
         tmpdir,
         content,
-        ['is not a path'],
+        ["is not a path"],
     )
 
 
 def test_sphinx_fail_on_warning(tmpdir):
-    content = '''
+    content = """
 version: "2"
 sphinx:
   fail_on_warning: true
-    '''
+    """
     assertValidConfig(tmpdir, content)
 
 
-@pytest.mark.parametrize('value', ['not true', "''", '[]'])
+@pytest.mark.parametrize("value", ["not true", "''", "[]"])
 def test_sphinx_fail_on_warning_invalid(tmpdir, value):
-    content = '''
+    content = """
 version: "2"
 sphinx:
   fail_on_warning: {value}
-    '''
+    """
     assertInvalidConfig(
         tmpdir,
         content.format(value=value),
-        ['is not a bool'],
+        ["is not a bool"],
     )
 
 
 def test_mkdocs(tmpdir):
-    content = '''
+    content = """
 version: "2"
 mkdocs:
   configuration: mkdocs.yml
-    '''
+    """
     assertValidConfig(tmpdir, content)
 
 
 def test_mkdocs_default_value(tmpdir):
-    content = '''
+    content = """
 version: "2"
 mkdocs:
   file: mkdocs.yml  # Default value for configuration key
-    '''
+    """
     assertValidConfig(tmpdir, content)
 
 
-@pytest.mark.parametrize('value', ['2', 'non-existent-file.yml'])
+@pytest.mark.parametrize("value", ["2", "non-existent-file.yml"])
 def test_mkdocs_invalid(tmpdir, value):
-    content = '''
+    content = """
 version: "2"
 mkdocs:
   configuration: {value}
-    '''
+    """
     assertInvalidConfig(
         tmpdir,
         content,
-        ['is not a path'],
+        ["is not a path"],
     )
 
 
 def test_mkdocs_fail_on_warning(tmpdir):
-    content = '''
+    content = """
 version: "2"
 mkdocs:
   fail_on_warning: true
-    '''
+    """
     assertValidConfig(tmpdir, content)
 
 
-@pytest.mark.parametrize('value', ['not true', "''", '[]'])
+@pytest.mark.parametrize("value", ["not true", "''", "[]"])
 def test_mkdocs_fail_on_warning_invalid(tmpdir, value):
-    content = '''
+    content = """
 version: "2"
 mkdocs:
   fail_on_warning: {value}
-    '''
+    """
     assertInvalidConfig(
         tmpdir,
         content.format(value=value),
-        ['is not a bool'],
+        ["is not a bool"],
     )
 
 
 def test_submodules_include(tmpdir):
-    content = '''
+    content = """
 version: "2"
 submodules:
   include:
@@ -446,69 +446,69 @@ submodules:
     - two
     - three
   recursive: false
-    '''
+    """
     assertValidConfig(tmpdir, content)
 
 
 def test_submodules_include_all(tmpdir):
-    content = '''
+    content = """
 version: "2"
 submodules:
 include: all
-    '''
+    """
     assertValidConfig(tmpdir, content)
 
 
 def test_submodules_exclude(tmpdir):
-    content = '''
+    content = """
 version: "2"
 submodules:
 exclude:
   - one
   - two
   - three
-    '''
+    """
     assertValidConfig(tmpdir, content)
 
 
 def test_submodules_exclude_all(tmpdir):
-    content = '''
+    content = """
 version: "2"
 submodules:
   exclude: all
   recursive: true
-    '''
+    """
     assertValidConfig(tmpdir, content)
 
 
 def test_redirects(tmpdir):
-    content = '''
+    content = """
 version: "2"
 redirects:
   page:
     'guides/install.html': 'install.html'
-        '''
+        """
     assertValidConfig(tmpdir, content)
 
 
 def test_redirects_invalid(tmpdir):
-    content = '''
+    content = """
 version: "2"
 redirects:
   page:
     'guides/install.html': true
-    '''
+    """
     assertInvalidConfig(
         tmpdir,
         content,
-        ['is not a str'],
+        ["is not a str"],
     )
 
 
-@pytest.mark.parametrize('value', ['', 'null', '{}'])
+@pytest.mark.parametrize("value", ["", "null", "{}"])
 def test_redirects_empty(tmpdir, value):
-    content = '''
+    content = """
 version: "2"
 redirects: {value}
-    '''
+    """
     assertValidConfig(tmpdir, content.format(value=value))

--- a/readthedocs/rtd_tests/tests/test_core_utils.py
+++ b/readthedocs/rtd_tests/tests/test_core_utils.py
@@ -21,12 +21,13 @@ from readthedocs.subscriptions.products import RTDProductFeature
     ),
 )
 class CoreUtilTests(TestCase):
-
     def setUp(self):
-        self.project = get(Project, container_time_limit=None, main_language_project=None)
+        self.project = get(
+            Project, container_time_limit=None, main_language_project=None
+        )
         self.version = get(Version, project=self.project)
 
-    @mock.patch('readthedocs.projects.tasks.builds.update_docs_task')
+    @mock.patch("readthedocs.projects.tasks.builds.update_docs_task")
     def test_trigger_skipped_project(self, update_docs_task):
         self.project.skip = True
         self.project.save()
@@ -38,18 +39,22 @@ class CoreUtilTests(TestCase):
         self.assertFalse(update_docs_task.signature.called)
         self.assertFalse(update_docs_task.signature().apply_async.called)
 
-    @mock.patch('readthedocs.projects.tasks.builds.update_docs_task')
-    def test_trigger_build_when_version_not_provided_default_version_exist(self, update_docs_task):
-        self.assertFalse(Version.objects.filter(slug='test-default-version').exists())
+    @mock.patch("readthedocs.projects.tasks.builds.update_docs_task")
+    def test_trigger_build_when_version_not_provided_default_version_exist(
+        self, update_docs_task
+    ):
+        self.assertFalse(Version.objects.filter(slug="test-default-version").exists())
 
         project_1 = get(Project)
-        version_1 = get(Version, project=project_1, slug='test-default-version', active=True)
+        version_1 = get(
+            Version, project=project_1, slug="test-default-version", active=True
+        )
 
-        project_1.default_version = 'test-default-version'
+        project_1.default_version = "test-default-version"
         project_1.save()
 
         default_version = project_1.get_default_version()
-        self.assertEqual(default_version, 'test-default-version')
+        self.assertEqual(default_version, "test-default-version")
 
         trigger_build(project=project_1)
 
@@ -59,15 +64,17 @@ class CoreUtilTests(TestCase):
                 mock.ANY,
             ),
             kwargs={
-                'build_commit': None,
+                "build_commit": None,
                 "build_api_key": mock.ANY,
             },
             options=mock.ANY,
             immutable=True,
         )
 
-    @mock.patch('readthedocs.projects.tasks.builds.update_docs_task')
-    def test_trigger_build_when_version_not_provided_default_version_doesnt_exist(self, update_docs_task):
+    @mock.patch("readthedocs.projects.tasks.builds.update_docs_task")
+    def test_trigger_build_when_version_not_provided_default_version_doesnt_exist(
+        self, update_docs_task
+    ):
 
         trigger_build(project=self.project)
         default_version = self.project.get_default_version()
@@ -81,27 +88,24 @@ class CoreUtilTests(TestCase):
                 mock.ANY,
             ),
             kwargs={
-                'build_commit': None,
+                "build_commit": None,
                 "build_api_key": mock.ANY,
             },
             options=mock.ANY,
             immutable=True,
         )
 
-    @pytest.mark.xfail(reason='Fails while we work out Docker time limits', strict=True)
-    @mock.patch('readthedocs.projects.tasks.builds.update_docs_task')
+    @pytest.mark.xfail(reason="Fails while we work out Docker time limits", strict=True)
+    @mock.patch("readthedocs.projects.tasks.builds.update_docs_task")
     def test_trigger_custom_queue(self, update_docs):
         """Use a custom queue when routing the task."""
-        self.project.build_queue = 'build03'
+        self.project.build_queue = "build03"
         trigger_build(project=self.project, version=self.version)
-        kwargs = {
-            'build_pk': mock.ANY,
-            'commit': None
-        }
+        kwargs = {"build_pk": mock.ANY, "commit": None}
         options = {
-            'queue': 'build03',
-            'time_limit': 720,
-            'soft_time_limit': 600,
+            "queue": "build03",
+            "time_limit": 720,
+            "soft_time_limit": 600,
         }
         update_docs.signature.assert_called_with(
             args=(self.version.pk,),
@@ -110,19 +114,16 @@ class CoreUtilTests(TestCase):
             immutable=True,
         )
 
-    @pytest.mark.xfail(reason='Fails while we work out Docker time limits', strict=True)
-    @mock.patch('readthedocs.projects.tasks.builds.update_docs_task')
+    @pytest.mark.xfail(reason="Fails while we work out Docker time limits", strict=True)
+    @mock.patch("readthedocs.projects.tasks.builds.update_docs_task")
     def test_trigger_build_time_limit(self, update_docs):
         """Pass of time limit."""
         trigger_build(project=self.project, version=self.version)
-        kwargs = {
-            'build_pk': mock.ANY,
-            'commit': None
-        }
+        kwargs = {"build_pk": mock.ANY, "commit": None}
         options = {
-            'queue': mock.ANY,
-            'time_limit': 720,
-            'soft_time_limit': 600,
+            "queue": mock.ANY,
+            "time_limit": 720,
+            "soft_time_limit": 600,
         }
         update_docs.signature.assert_called_with(
             args=(self.version.pk,),
@@ -131,20 +132,17 @@ class CoreUtilTests(TestCase):
             immutable=True,
         )
 
-    @pytest.mark.xfail(reason='Fails while we work out Docker time limits', strict=True)
-    @mock.patch('readthedocs.projects.tasks.builds.update_docs_task')
+    @pytest.mark.xfail(reason="Fails while we work out Docker time limits", strict=True)
+    @mock.patch("readthedocs.projects.tasks.builds.update_docs_task")
     def test_trigger_build_invalid_time_limit(self, update_docs):
         """Time limit as string."""
-        self.project.container_time_limit = '200s'
+        self.project.container_time_limit = "200s"
         trigger_build(project=self.project, version=self.version)
-        kwargs = {
-            'build_pk': mock.ANY,
-            'commit': None
-        }
+        kwargs = {"build_pk": mock.ANY, "commit": None}
         options = {
-            'queue': mock.ANY,
-            'time_limit': 720,
-            'soft_time_limit': 600,
+            "queue": mock.ANY,
+            "time_limit": 720,
+            "soft_time_limit": 600,
         }
         update_docs.signature.assert_called_with(
             args=(self.version.pk,),
@@ -153,14 +151,14 @@ class CoreUtilTests(TestCase):
             immutable=True,
         )
 
-    @mock.patch('readthedocs.projects.tasks.builds.update_docs_task')
+    @mock.patch("readthedocs.projects.tasks.builds.update_docs_task")
     def test_trigger_build_rounded_time_limit(self, update_docs):
         """Time limit should round down."""
         self.project.container_time_limit = 3
         trigger_build(project=self.project, version=self.version)
         options = {
-            'time_limit': 3,
-            'soft_time_limit': 3,
+            "time_limit": 3,
+            "soft_time_limit": 3,
         }
         update_docs.signature.assert_called_with(
             args=(
@@ -168,15 +166,15 @@ class CoreUtilTests(TestCase):
                 mock.ANY,
             ),
             kwargs={
-                'build_commit': None,
+                "build_commit": None,
                 "build_api_key": mock.ANY,
             },
             options=options,
             immutable=True,
         )
 
-    @pytest.mark.xfail(reason='Fails while we work out Docker time limits', strict=True)
-    @mock.patch('readthedocs.projects.tasks.builds.update_docs_task')
+    @pytest.mark.xfail(reason="Fails while we work out Docker time limits", strict=True)
+    @mock.patch("readthedocs.projects.tasks.builds.update_docs_task")
     def test_trigger_max_concurrency_reached(self, update_docs):
         max_concurrent_builds = 2
         for _ in range(max_concurrent_builds):
@@ -190,16 +188,13 @@ class CoreUtilTests(TestCase):
         self.project.save()
 
         trigger_build(project=self.project, version=self.version)
-        kwargs = {
-            'build_pk': mock.ANY,
-            'commit': None
-        }
+        kwargs = {"build_pk": mock.ANY, "commit": None}
         options = {
-            'queue': mock.ANY,
-            'time_limit': 720,
-            'soft_time_limit': 600,
-            'countdown': 5 * 60,
-            'max_retries': 25,
+            "queue": mock.ANY,
+            "time_limit": 720,
+            "soft_time_limit": 600,
+            "countdown": 5 * 60,
+            "max_retries": 25,
         }
         update_docs.signature.assert_called_with(
             args=(self.version.pk,),
@@ -208,31 +203,34 @@ class CoreUtilTests(TestCase):
             immutable=True,
         )
         build = self.project.builds.first()
-        self.assertEqual(build.error, BuildMaxConcurrencyError.message.format(limit=max_concurrent_builds))
+        self.assertEqual(
+            build.error,
+            BuildMaxConcurrencyError.message.format(limit=max_concurrent_builds),
+        )
 
     def test_slugify(self):
         """Test additional slugify."""
         self.assertEqual(
-            slugify('This is a test'),
-            'this-is-a-test',
+            slugify("This is a test"),
+            "this-is-a-test",
         )
         self.assertEqual(
-            slugify('project_with_underscores-v.1.0'),
-            'project-with-underscores-v10',
+            slugify("project_with_underscores-v.1.0"),
+            "project-with-underscores-v10",
         )
         self.assertEqual(
-            slugify('__project_with_trailing-underscores---'),
-            'project-with-trailing-underscores',
+            slugify("__project_with_trailing-underscores---"),
+            "project-with-trailing-underscores",
         )
         self.assertEqual(
-            slugify('project_with_underscores-v.1.0', dns_safe=False),
-            'project_with_underscores-v10',
+            slugify("project_with_underscores-v.1.0", dns_safe=False),
+            "project_with_underscores-v10",
         )
         self.assertEqual(
-            slugify('A title_-_with separated parts'),
-            'a-title-with-separated-parts',
+            slugify("A title_-_with separated parts"),
+            "a-title-with-separated-parts",
         )
         self.assertEqual(
-            slugify('A title_-_with separated parts', dns_safe=False),
-            'a-title_-_with-separated-parts',
+            slugify("A title_-_with separated parts", dns_safe=False),
+            "a-title_-_with-separated-parts",
         )

--- a/readthedocs/rtd_tests/tests/test_footer.py
+++ b/readthedocs/rtd_tests/tests/test_footer.py
@@ -19,12 +19,11 @@ from readthedocs.subscriptions.products import RTDProductFeature
 
 
 class BaseTestFooterHTML:
-
     def setUp(self):
         self.pip = get(
             Project,
-            slug='pip',
-            repo='https://github.com/rtfd/readthedocs.org',
+            slug="pip",
+            repo="https://github.com/rtfd/readthedocs.org",
             privacy_level=PUBLIC,
             external_builds_privacy_level=PUBLIC,
             main_language_project=None,
@@ -33,8 +32,8 @@ class BaseTestFooterHTML:
 
         self.latest = self.pip.versions.get(slug=LATEST)
         self.url = (
-            reverse('footer_html') +
-            f'?project={self.pip.slug}&version={self.latest.slug}&page=index&docroot=/'
+            reverse("footer_html")
+            + f"?project={self.pip.slug}&version={self.latest.slug}&page=index&docroot=/"
         )
 
         self.factory = APIRequestFactory()
@@ -44,36 +43,36 @@ class BaseTestFooterHTML:
         return r
 
     def test_footer(self):
-        pip = Project.objects.get(slug='pip')
+        pip = Project.objects.get(slug="pip")
         pip.show_version_warning = True
         pip.save()
 
         r = self.render()
-        self.assertTrue(r.data['version_active'])
-        self.assertTrue(r.data['version_compare']['is_highest'])
-        self.assertTrue(r.data['version_supported'])
-        self.assertTrue(r.data['show_version_warning'])
-        self.assertEqual(r.context['main_project'], self.pip)
+        self.assertTrue(r.data["version_active"])
+        self.assertTrue(r.data["version_compare"]["is_highest"])
+        self.assertTrue(r.data["version_supported"])
+        self.assertTrue(r.data["show_version_warning"])
+        self.assertEqual(r.context["main_project"], self.pip)
         self.assertEqual(r.status_code, 200)
 
         self.latest.active = False
         self.latest.save()
         r = self.render()
-        self.assertFalse(r.data['version_active'])
+        self.assertFalse(r.data["version_active"])
         self.assertEqual(r.status_code, 200)
 
     def test_footer_dont_show_version_warning(self):
-        pip = Project.objects.get(slug='pip')
+        pip = Project.objects.get(slug="pip")
         pip.show_version_warning = False
         pip.save()
 
         r = self.render()
         self.assertEqual(r.status_code, 200)
-        self.assertTrue(r.data['version_active'])
-        self.assertFalse(r.data['version_compare']['is_highest'])
-        self.assertTrue(r.data['version_supported'])
-        self.assertFalse(r.data['show_version_warning'])
-        self.assertEqual(r.context['main_project'], self.pip)
+        self.assertTrue(r.data["version_active"])
+        self.assertFalse(r.data["version_compare"]["is_highest"])
+        self.assertTrue(r.data["version_supported"])
+        self.assertFalse(r.data["show_version_warning"])
+        self.assertEqual(r.context["main_project"], self.pip)
 
     def test_footer_show_explicit_name_for_external_version(self):
         project = Project.objects.get(slug="pip")
@@ -104,138 +103,140 @@ class BaseTestFooterHTML:
 
         r = self.render()
         self.assertEqual(r.status_code, 200)
-        self.assertFalse(r.data['version_compare']['is_highest'])
-        self.assertFalse(r.data['show_version_warning'])
-        self.assertEqual(r.context['main_project'], self.pip)
+        self.assertFalse(r.data["version_compare"]["is_highest"])
+        self.assertFalse(r.data["show_version_warning"])
+        self.assertEqual(r.context["main_project"], self.pip)
 
     def test_footer_uses_version_compare(self):
-        version_compare = 'readthedocs.api.v2.views.footer_views.get_version_compare_data'  # noqa
+        version_compare = (
+            "readthedocs.api.v2.views.footer_views.get_version_compare_data"  # noqa
+        )
         with mock.patch(version_compare) as get_version_compare_data:
             get_version_compare_data.return_value = {
-                'MOCKED': True,
+                "MOCKED": True,
             }
             r = self.render()
             self.assertEqual(r.status_code, 200)
-            self.assertEqual(r.data['version_compare'], {'MOCKED': True})
+            self.assertEqual(r.data["version_compare"], {"MOCKED": True})
 
     def test_pdf_build_mentioned_in_footer(self):
         self.latest.has_pdf = True
         self.latest.save()
 
         response = self.render()
-        self.assertIn('pdf', response.data['html'])
+        self.assertIn("pdf", response.data["html"])
 
     def test_pdf_not_mentioned_in_footer_when_doesnt_exists(self):
         response = self.render()
-        self.assertNotIn('pdf', response.data['html'])
+        self.assertNotIn("pdf", response.data["html"])
 
     def test_epub_build_mentioned_in_footer(self):
         self.latest.has_epub = True
         self.latest.save()
 
         response = self.render()
-        self.assertIn('epub', response.data['html'])
+        self.assertIn("epub", response.data["html"])
 
     def test_epub_not_mentioned_in_footer_when_doesnt_exists(self):
         response = self.render()
-        self.assertNotIn('epub', response.data['html'])
+        self.assertNotIn("epub", response.data["html"])
 
     def test_no_session_logged_out(self):
         mid = ReadTheDocsSessionMiddleware(lambda request: HttpResponse())
 
         # Null session here
-        request = self.factory.get('/api/v2/footer_html/')
+        request = self.factory.get("/api/v2/footer_html/")
         mid.process_request(request)
         self.assertIsInstance(request.session, SessionBase)
         self.assertEqual(list(request.session.keys()), [])
 
         # Proper session here
-        home_request = self.factory.get('/')
+        home_request = self.factory.get("/")
         mid.process_request(home_request)
-        self.assertEqual(home_request.session.TEST_COOKIE_NAME, 'testcookie')
+        self.assertEqual(home_request.session.TEST_COOKIE_NAME, "testcookie")
 
     def test_show_version_warning(self):
         self.pip.show_version_warning = True
         self.pip.save()
         response = self.render()
-        self.assertTrue(response.data['show_version_warning'])
+        self.assertTrue(response.data["show_version_warning"])
 
     def test_show_edit_on_github(self):
         version = self.pip.versions.get(slug=LATEST)
         version.type = BRANCH
         version.save()
         response = self.render()
-        self.assertIn('On GitHub', response.data['html'])
-        self.assertIn('View', response.data['html'])
-        self.assertIn('Edit', response.data['html'])
+        self.assertIn("On GitHub", response.data["html"])
+        self.assertIn("View", response.data["html"])
+        self.assertIn("Edit", response.data["html"])
 
     def test_not_show_edit_on_github(self):
         version = self.pip.versions.get(slug=LATEST)
         version.type = TAG
         version.save()
         response = self.render()
-        self.assertIn('On GitHub', response.data['html'])
-        self.assertIn('View', response.data['html'])
-        self.assertNotIn('Edit', response.data['html'])
+        self.assertIn("On GitHub", response.data["html"])
+        self.assertIn("View", response.data["html"])
+        self.assertNotIn("Edit", response.data["html"])
 
     def test_index_pages_sphinx_htmldir(self):
         version = self.pip.versions.get(slug=LATEST)
-        version.documentation_type = 'sphinx_htmldir'
+        version.documentation_type = "sphinx_htmldir"
         version.save()
 
         # A page with slug 'index' should render like /en/latest/
         self.url = (
-            reverse('footer_html') +
-            f'?project={self.pip.slug}&version={self.latest.slug}&page=index&docroot=/'
+            reverse("footer_html")
+            + f"?project={self.pip.slug}&version={self.latest.slug}&page=index&docroot=/"
         )
         response = self.render()
-        self.assertIn('/en/latest/', response.data['html'])
-        self.assertNotIn('/en/latest/index.html', response.data['html'])
+        self.assertIn("/en/latest/", response.data["html"])
+        self.assertNotIn("/en/latest/index.html", response.data["html"])
 
         # A page with slug 'foo/index' should render like /en/latest/foo/
         self.url = (
-            reverse('footer_html') +
-            f'?project={self.pip.slug}&version={self.latest.slug}&page=foo/index&docroot=/'
+            reverse("footer_html")
+            + f"?project={self.pip.slug}&version={self.latest.slug}&page=foo/index&docroot=/"
         )
         response = self.render()
-        self.assertIn('/en/latest/foo/', response.data['html'])
-        self.assertNotIn('/en/latest/foo.html', response.data['html'])
-        self.assertNotIn('/en/latest/foo/index.html', response.data['html'])
+        self.assertIn("/en/latest/foo/", response.data["html"])
+        self.assertNotIn("/en/latest/foo.html", response.data["html"])
+        self.assertNotIn("/en/latest/foo/index.html", response.data["html"])
 
         # A page with slug 'foo/bar' should render like /en/latest/foo/bar/
         self.url = (
-            reverse('footer_html') +
-            f'?project={self.pip.slug}&version={self.latest.slug}&page=foo/bar&docroot=/'
+            reverse("footer_html")
+            + f"?project={self.pip.slug}&version={self.latest.slug}&page=foo/bar&docroot=/"
         )
         response = self.render()
-        self.assertIn('/en/latest/foo/bar/', response.data['html'])
-        self.assertNotIn('/en/latest/foo/bar.html', response.data['html'])
-        self.assertNotIn('/en/latest/foo/bar/index.html', response.data['html'])
+        self.assertIn("/en/latest/foo/bar/", response.data["html"])
+        self.assertNotIn("/en/latest/foo/bar.html", response.data["html"])
+        self.assertNotIn("/en/latest/foo/bar/index.html", response.data["html"])
 
         # A page with slug 'foo/bar/index' should render like /en/latest/foo/bar/
         self.url = (
-            reverse('footer_html') +
-            f'?project={self.pip.slug}&version={self.latest.slug}&page=foo/bar/index&docroot=/'
+            reverse("footer_html")
+            + f"?project={self.pip.slug}&version={self.latest.slug}&page=foo/bar/index&docroot=/"
         )
         response = self.render()
-        self.assertIn('/en/latest/foo/bar/', response.data['html'])
-        self.assertNotIn('/en/latest/foo/bar.html', response.data['html'])
-        self.assertNotIn('/en/latest/foo/bar/index.html', response.data['html'])
+        self.assertIn("/en/latest/foo/bar/", response.data["html"])
+        self.assertNotIn("/en/latest/foo/bar.html", response.data["html"])
+        self.assertNotIn("/en/latest/foo/bar/index.html", response.data["html"])
 
         # A page with slug 'foo/index/bar' should render like /en/latest/foo/index/bar/
         self.url = (
-            reverse('footer_html') +
-            f'?project={self.pip.slug}&version={self.latest.slug}&page=foo/index/bar&docroot=/'
+            reverse("footer_html")
+            + f"?project={self.pip.slug}&version={self.latest.slug}&page=foo/index/bar&docroot=/"
         )
         response = self.render()
-        self.assertIn('/en/latest/foo/index/bar/', response.data['html'])
-        self.assertNotIn('/en/latest/foo/index/bar.html', response.data['html'])
-        self.assertNotIn('/en/latest/foo/index/bar/index.html', response.data['html'])
+        self.assertIn("/en/latest/foo/index/bar/", response.data["html"])
+        self.assertNotIn("/en/latest/foo/index/bar.html", response.data["html"])
+        self.assertNotIn("/en/latest/foo/index/bar/index.html", response.data["html"])
 
     def test_hidden_versions(self):
         hidden_version = get(
             Version,
-            slug='2.0',
+            slug="2.0",
             hidden=True,
             privacy_level=PUBLIC,
             project=self.pip,
@@ -243,26 +244,26 @@ class BaseTestFooterHTML:
 
         # The hidden version doesn't appear on the footer
         self.url = (
-            reverse('footer_html') +
-            f'?project={self.pip.slug}&version={self.latest.slug}&page=index&docroot=/'
+            reverse("footer_html")
+            + f"?project={self.pip.slug}&version={self.latest.slug}&page=index&docroot=/"
         )
         response = self.render()
-        self.assertIn('/en/latest/', response.data['html'])
-        self.assertNotIn('/en/2.0/', response.data['html'])
+        self.assertIn("/en/latest/", response.data["html"])
+        self.assertNotIn("/en/2.0/", response.data["html"])
 
         # We can access the hidden version, but it doesn't appear on the footer
         self.url = (
-            reverse('footer_html') +
-            f'?project={self.pip.slug}&version={hidden_version.slug}&page=index&docroot=/'
+            reverse("footer_html")
+            + f"?project={self.pip.slug}&version={hidden_version.slug}&page=index&docroot=/"
         )
         response = self.render()
-        self.assertIn('/en/latest/', response.data['html'])
-        self.assertNotIn('/en/2.0/', response.data['html'])
+        self.assertIn("/en/latest/", response.data["html"])
+        self.assertNotIn("/en/2.0/", response.data["html"])
 
     def test_built_versions(self):
         built_version = get(
             Version,
-            slug='2.0',
+            slug="2.0",
             active=True,
             built=True,
             privacy_level=PUBLIC,
@@ -271,26 +272,26 @@ class BaseTestFooterHTML:
 
         # The built versions appears on the footer
         self.url = (
-            reverse('footer_html') +
-            f'?project={self.pip.slug}&version={self.latest.slug}&page=index&docroot=/'
+            reverse("footer_html")
+            + f"?project={self.pip.slug}&version={self.latest.slug}&page=index&docroot=/"
         )
         response = self.render()
-        self.assertIn('/en/latest/', response.data['html'])
-        self.assertIn('/en/2.0/', response.data['html'])
+        self.assertIn("/en/latest/", response.data["html"])
+        self.assertIn("/en/2.0/", response.data["html"])
 
         # We can access the built version, and it appears on the footer
         self.url = (
-            reverse('footer_html') +
-            f'?project={self.pip.slug}&version={built_version.slug}&page=index&docroot=/'
+            reverse("footer_html")
+            + f"?project={self.pip.slug}&version={built_version.slug}&page=index&docroot=/"
         )
         response = self.render()
-        self.assertIn('/en/latest/', response.data['html'])
-        self.assertIn('/en/2.0/', response.data['html'])
+        self.assertIn("/en/latest/", response.data["html"])
+        self.assertIn("/en/2.0/", response.data["html"])
 
     def test_not_built_versions(self):
         not_built_version = get(
             Version,
-            slug='2.0',
+            slug="2.0",
             active=True,
             built=False,
             privacy_level=PUBLIC,
@@ -299,21 +300,21 @@ class BaseTestFooterHTML:
 
         # The un-built version doesn't appear on the footer
         self.url = (
-            reverse('footer_html') +
-            f'?project={self.pip.slug}&version={self.latest.slug}&page=index&docroot=/'
+            reverse("footer_html")
+            + f"?project={self.pip.slug}&version={self.latest.slug}&page=index&docroot=/"
         )
         response = self.render()
-        self.assertIn('/en/latest/', response.data['html'])
-        self.assertNotIn('/en/2.0/', response.data['html'])
+        self.assertIn("/en/latest/", response.data["html"])
+        self.assertNotIn("/en/2.0/", response.data["html"])
 
         # We can access the unbuilt version, but it doesn't appear on the footer
         self.url = (
-            reverse('footer_html') +
-            f'?project={self.pip.slug}&version={not_built_version.slug}&page=index&docroot=/'
+            reverse("footer_html")
+            + f"?project={self.pip.slug}&version={not_built_version.slug}&page=index&docroot=/"
         )
         response = self.render()
-        self.assertIn('/en/latest/', response.data['html'])
-        self.assertNotIn('/en/2.0/', response.data['html'])
+        self.assertIn("/en/latest/", response.data["html"])
+        self.assertNotIn("/en/2.0/", response.data["html"])
 
 
 class TestFooterHTML(BaseTestFooterHTML, TestCase):
@@ -323,15 +324,15 @@ class TestFooterHTML(BaseTestFooterHTML, TestCase):
 
 @override_settings(
     USE_SUBDOMAIN=True,
-    PUBLIC_DOMAIN='readthedocs.io',
+    PUBLIC_DOMAIN="readthedocs.io",
     PUBLIC_DOMAIN_USES_HTTPS=True,
 )
 class TestVersionCompareFooter(TestCase):
 
-    fixtures = ['test_data', 'eric']
+    fixtures = ["test_data", "eric"]
 
     def setUp(self):
-        self.pip = Project.objects.get(slug='pip')
+        self.pip = Project.objects.get(slug="pip")
         self.pip.versions.update(built=True)
         self.pip.show_version_warning = True
         self.pip.save()
@@ -339,23 +340,23 @@ class TestVersionCompareFooter(TestCase):
     def test_highest_version_from_stable(self):
         base_version = self.pip.get_stable_version()
         valid_data = {
-            'project': 'Version 0.8.1 of Pip (19)',
-            'url': 'https://pip.readthedocs.io/en/0.8.1/',
-            'slug': '0.8.1',
-            'version': '0.8.1',
-            'is_highest': True,
+            "project": "Version 0.8.1 of Pip (19)",
+            "url": "https://pip.readthedocs.io/en/0.8.1/",
+            "slug": "0.8.1",
+            "version": "0.8.1",
+            "is_highest": True,
         }
         returned_data = get_version_compare_data(self.pip, base_version)
         self.assertDictEqual(valid_data, returned_data)
 
     def test_highest_version_from_lower(self):
-        base_version = self.pip.versions.get(slug='0.8')
+        base_version = self.pip.versions.get(slug="0.8")
         valid_data = {
-            'project': 'Version 0.8.1 of Pip (19)',
-            'url': 'https://pip.readthedocs.io/en/0.8.1/',
-            'slug': '0.8.1',
-            'version': '0.8.1',
-            'is_highest': False,
+            "project": "Version 0.8.1 of Pip (19)",
+            "url": "https://pip.readthedocs.io/en/0.8.1/",
+            "slug": "0.8.1",
+            "version": "0.8.1",
+            "is_highest": False,
         }
         returned_data = get_version_compare_data(self.pip, base_version)
         self.assertDictEqual(valid_data, returned_data)
@@ -364,11 +365,11 @@ class TestVersionCompareFooter(TestCase):
         self.pip.versions.filter(slug=LATEST).update(built=True)
         base_version = self.pip.versions.get(slug=LATEST)
         valid_data = {
-            'project': 'Version 0.8.1 of Pip (19)',
-            'url': 'https://pip.readthedocs.io/en/0.8.1/',
-            'slug': '0.8.1',
-            'version': '0.8.1',
-            'is_highest': True,
+            "project": "Version 0.8.1 of Pip (19)",
+            "url": "https://pip.readthedocs.io/en/0.8.1/",
+            "slug": "0.8.1",
+            "version": "0.8.1",
+            "is_highest": True,
         }
         returned_data = get_version_compare_data(self.pip, base_version)
         self.assertDictEqual(valid_data, returned_data)
@@ -376,28 +377,28 @@ class TestVersionCompareFooter(TestCase):
     def test_highest_version_over_branches(self):
         Version.objects.create(
             project=self.pip,
-            verbose_name='2.0.0',
-            identifier='2.0.0',
+            verbose_name="2.0.0",
+            identifier="2.0.0",
             type=BRANCH,
             active=True,
         )
 
         version = Version.objects.create(
             project=self.pip,
-            verbose_name='1.0.0',
-            identifier='1.0.0',
+            verbose_name="1.0.0",
+            identifier="1.0.0",
             type=TAG,
             active=True,
             built=True,
         )
 
-        base_version = self.pip.versions.get(slug='0.8.1')
+        base_version = self.pip.versions.get(slug="0.8.1")
         valid_data = {
-            'project': 'Version 1.0.0 of Pip ({})'.format(version.pk),
-            'url': 'https://pip.readthedocs.io/en/1.0.0/',
-            'slug': '1.0.0',
-            'version': '1.0.0',
-            'is_highest': False,
+            "project": "Version 1.0.0 of Pip ({})".format(version.pk),
+            "url": "https://pip.readthedocs.io/en/1.0.0/",
+            "slug": "1.0.0",
+            "version": "1.0.0",
+            "is_highest": False,
         }
         returned_data = get_version_compare_data(self.pip, base_version)
         self.assertDictEqual(valid_data, returned_data)
@@ -405,42 +406,42 @@ class TestVersionCompareFooter(TestCase):
     def test_highest_version_without_tags(self):
         self.pip.versions.filter(type=TAG).update(type=BRANCH)
 
-        base_version = self.pip.versions.get(slug='0.8.1')
+        base_version = self.pip.versions.get(slug="0.8.1")
         valid_data = {
-            'project': 'Version 0.8.1 of Pip (19)',
-            'url': 'https://pip.readthedocs.io/en/0.8.1/',
-            'slug': '0.8.1',
-            'version': '0.8.1',
-            'is_highest': True,
+            "project": "Version 0.8.1 of Pip (19)",
+            "url": "https://pip.readthedocs.io/en/0.8.1/",
+            "slug": "0.8.1",
+            "version": "0.8.1",
+            "is_highest": True,
         }
         returned_data = get_version_compare_data(self.pip, base_version)
         self.assertDictEqual(valid_data, returned_data)
 
-        base_version = self.pip.versions.get(slug='0.8')
+        base_version = self.pip.versions.get(slug="0.8")
         valid_data = {
-            'project': 'Version 0.8.1 of Pip (19)',
-            'url': 'https://pip.readthedocs.io/en/0.8.1/',
-            'slug': '0.8.1',
-            'version': '0.8.1',
-            'is_highest': False,
+            "project": "Version 0.8.1 of Pip (19)",
+            "url": "https://pip.readthedocs.io/en/0.8.1/",
+            "slug": "0.8.1",
+            "version": "0.8.1",
+            "is_highest": False,
         }
         returned_data = get_version_compare_data(self.pip, base_version)
         self.assertDictEqual(valid_data, returned_data)
 
         version = Version.objects.create(
             project=self.pip,
-            verbose_name='2.0.0',
-            identifier='2.0.0',
+            verbose_name="2.0.0",
+            identifier="2.0.0",
             type=BRANCH,
             active=True,
             built=True,
         )
         valid_data = {
-            'project': 'Version 2.0.0 of Pip ({})'.format(version.pk),
-            'url': 'https://pip.readthedocs.io/en/2.0.0/',
-            'slug': '2.0.0',
-            'version': '2.0.0',
-            'is_highest': False,
+            "project": "Version 2.0.0 of Pip ({})".format(version.pk),
+            "url": "https://pip.readthedocs.io/en/2.0.0/",
+            "slug": "2.0.0",
+            "version": "2.0.0",
+            "is_highest": False,
         }
         returned_data = get_version_compare_data(self.pip, base_version)
         self.assertDictEqual(valid_data, returned_data)
@@ -459,56 +460,56 @@ class TestFooterPerformance(TestCase):
     def setUp(self):
         self.pip = get(
             Project,
-            slug='pip',
-            repo='https://github.com/rtfd/readthedocs.org',
+            slug="pip",
+            repo="https://github.com/rtfd/readthedocs.org",
             privacy_level=PUBLIC,
             show_version_warning=True,
             main_language_project=None,
         )
         self.pip.versions.create(
-            verbose_name='0.8.1',
-            identifier='0.8.1',
+            verbose_name="0.8.1",
+            identifier="0.8.1",
             type=TAG,
         )
         self.pip.versions.update(privacy_level=PUBLIC, built=True, active=True)
         self.latest = self.pip.versions.get(slug=LATEST)
 
         self.url = (
-            reverse('footer_html') +
-            f'?project={self.pip.slug}&version={self.latest.slug}&page=index&docroot=/docs/'
+            reverse("footer_html")
+            + f"?project={self.pip.slug}&version={self.latest.slug}&page=index&docroot=/docs/"
         )
-        self.host = 'pip.readthedocs.io'
+        self.host = "pip.readthedocs.io"
 
     def test_version_queries(self):
         with self.assertNumQueries(self.EXPECTED_QUERIES):
             response = self.client.get(self.url, headers={"host": self.host})
-            self.assertContains(response, '0.8.1')
+            self.assertContains(response, "0.8.1")
 
         # Second time we don't create a new page view,
         # this shouldn't impact the number of queries.
         with self.assertNumQueries(self.EXPECTED_QUERIES):
             response = self.client.get(self.url, headers={"host": self.host})
-            self.assertContains(response, '0.8.1')
+            self.assertContains(response, "0.8.1")
 
         # The number of Versions shouldn't impact the number of queries
         for patch in range(3):
-            identifier = '0.99.{}'.format(patch)
+            identifier = "0.99.{}".format(patch)
             self.pip.versions.create(
                 verbose_name=identifier,
                 identifier=identifier,
                 type=TAG,
                 active=True,
-                built=True
+                built=True,
             )
 
         with self.assertNumQueries(self.EXPECTED_QUERIES):
             response = self.client.get(self.url, headers={"host": self.host})
-            self.assertContains(response, '0.99.0')
+            self.assertContains(response, "0.99.0")
 
     def test_domain_queries(self):
-        domain = 'docs.foobar.com'
+        domain = "docs.foobar.com"
         self.pip.domains.create(
-            domain=f'http://{domain}',
+            domain=f"http://{domain}",
             canonical=True,
         )
 

--- a/readthedocs/rtd_tests/tests/test_middleware.py
+++ b/readthedocs/rtd_tests/tests/test_middleware.py
@@ -21,16 +21,16 @@ from readthedocs.subscriptions.products import RTDProductFeature
 
 
 @override_settings(
-    PUBLIC_DOMAIN='readthedocs.io',
+    PUBLIC_DOMAIN="readthedocs.io",
     RTD_DEFAULT_FEATURES=dict([RTDProductFeature(type=TYPE_EMBED_API).to_item()]),
 )
 class TestCORSMiddleware(TestCase):
-
     def setUp(self):
-        self.url = '/api/v2/search'
-        self.owner = create_user(username='owner', password='test')
+        self.url = "/api/v2/search"
+        self.owner = create_user(username="owner", password="test")
         self.project = get(
-            Project, slug='pip',
+            Project,
+            slug="pip",
             users=[self.owner],
             privacy_level=PUBLIC,
             main_language_project=None,
@@ -52,19 +52,19 @@ class TestCORSMiddleware(TestCase):
         )
         self.domain = get(
             Domain,
-            domain='my.valid.domain',
+            domain="my.valid.domain",
             project=self.project,
         )
         self.another_project = get(
             Project,
             privacy_level=PUBLIC,
-            slug='another',
+            slug="another",
         )
         self.another_project.versions.update(privacy_level=PUBLIC)
         self.another_version = self.another_project.versions.get(slug=LATEST)
         self.another_domain = get(
             Domain,
-            domain='another.valid.domain',
+            domain="another.valid.domain",
             project=self.another_project,
         )
 
@@ -244,19 +244,18 @@ class TestCORSMiddleware(TestCase):
 
 
 class TestSessionMiddleware(TestCase):
-
     def setUp(self):
         self.factory = RequestFactory()
         self.middleware = ReadTheDocsSessionMiddleware(lambda request: HttpResponse())
 
-        self.user = create_user(username='owner', password='test')
+        self.user = create_user(username="owner", password="test")
 
     @override_settings(SESSION_COOKIE_SAMESITE=None)
     def test_fallback_cookie(self):
-        request = self.factory.get('/')
+        request = self.factory.get("/")
         response = HttpResponse()
         self.middleware.process_request(request)
-        request.session['test'] = 'value'
+        request.session["test"] = "value"
         response = self.middleware.process_response(request, response)
 
         self.assertTrue(settings.SESSION_COOKIE_NAME in response.cookies)
@@ -264,23 +263,29 @@ class TestSessionMiddleware(TestCase):
 
     @override_settings(SESSION_COOKIE_SAMESITE=None)
     def test_main_cookie_samesite_none(self):
-        request = self.factory.get('/')
+        request = self.factory.get("/")
         response = HttpResponse()
         self.middleware.process_request(request)
-        request.session['test'] = 'value'
+        request.session["test"] = "value"
         response = self.middleware.process_response(request, response)
 
-        self.assertEqual(response.cookies[settings.SESSION_COOKIE_NAME]['samesite'], 'None')
-        self.assertEqual(response.cookies[self.middleware.cookie_name_fallback]['samesite'], '')
+        self.assertEqual(
+            response.cookies[settings.SESSION_COOKIE_NAME]["samesite"], "None"
+        )
+        self.assertEqual(
+            response.cookies[self.middleware.cookie_name_fallback]["samesite"], ""
+        )
 
     def test_main_cookie_samesite_lax(self):
-        request = self.factory.get('/')
+        request = self.factory.get("/")
         response = HttpResponse()
         self.middleware.process_request(request)
-        request.session['test'] = 'value'
+        request.session["test"] = "value"
         response = self.middleware.process_response(request, response)
 
-        self.assertEqual(response.cookies[settings.SESSION_COOKIE_NAME]['samesite'], 'Lax')
+        self.assertEqual(
+            response.cookies[settings.SESSION_COOKIE_NAME]["samesite"], "Lax"
+        )
         self.assertTrue(self.test_main_cookie_samesite_none not in response.cookies)
 
 

--- a/readthedocs/rtd_tests/tests/test_project_forms.py
+++ b/readthedocs/rtd_tests/tests/test_project_forms.py
@@ -28,47 +28,46 @@ from readthedocs.projects.models import EnvironmentVariable, Project, WebHookEve
 
 
 class TestProjectForms(TestCase):
-
     def test_import_repo_url(self):
         """Validate different type of repository URLs on importing a Project."""
 
         common_urls = [
             # Invalid
-            ('./path/to/relative/folder', False),
-            ('../../path/to/relative/folder', False),
-            ('../../path/to/@/folder', False),
-            ('/path/to/local/folder', False),
-            ('/path/to/@/folder', False),
-            ('file:///path/to/local/folder', False),
-            ('file:///path/to/@/folder', False),
-            ('github.com/humitos/foo', False),
-            ('https://github.com/|/foo', False),
-            ('git://github.com/&&/foo', False),
+            ("./path/to/relative/folder", False),
+            ("../../path/to/relative/folder", False),
+            ("../../path/to/@/folder", False),
+            ("/path/to/local/folder", False),
+            ("/path/to/@/folder", False),
+            ("file:///path/to/local/folder", False),
+            ("file:///path/to/@/folder", False),
+            ("github.com/humitos/foo", False),
+            ("https://github.com/|/foo", False),
+            ("git://github.com/&&/foo", False),
             # Valid
-            ('git://github.com/humitos/foo', True),
-            ('http://github.com/humitos/foo', True),
-            ('https://github.com/humitos/foo', True),
-            ('http://gitlab.com/humitos/foo', True),
-            ('http://bitbucket.com/humitos/foo', True),
-            ('ftp://ftpserver.com/humitos/foo', True),
-            ('ftps://ftpserver.com/humitos/foo', True),
-            ('lp:zaraza', True),
+            ("git://github.com/humitos/foo", True),
+            ("http://github.com/humitos/foo", True),
+            ("https://github.com/humitos/foo", True),
+            ("http://gitlab.com/humitos/foo", True),
+            ("http://bitbucket.com/humitos/foo", True),
+            ("ftp://ftpserver.com/humitos/foo", True),
+            ("ftps://ftpserver.com/humitos/foo", True),
+            ("lp:zaraza", True),
         ]
 
         public_urls = [
-            ('git@github.com:humitos/foo', False),
-            ('ssh://git@github.com/humitos/foo', False),
-            ('ssh+git://github.com/humitos/foo', False),
-            ('strangeuser@bitbucket.org:strangeuser/readthedocs.git', False),
-            ('user@one-ssh.domain.com:22/_ssh/docs', False),
+            ("git@github.com:humitos/foo", False),
+            ("ssh://git@github.com/humitos/foo", False),
+            ("ssh+git://github.com/humitos/foo", False),
+            ("strangeuser@bitbucket.org:strangeuser/readthedocs.git", False),
+            ("user@one-ssh.domain.com:22/_ssh/docs", False),
         ] + common_urls
 
         private_urls = [
-            ('git@github.com:humitos/foo', True),
-            ('ssh://git@github.com/humitos/foo', True),
-            ('ssh+git://github.com/humitos/foo', True),
-            ('strangeuser@bitbucket.org:strangeuser/readthedocs.git', True),
-            ('user@one-ssh.domain.com:22/_ssh/docs', True),
+            ("git@github.com:humitos/foo", True),
+            ("ssh://git@github.com/humitos/foo", True),
+            ("ssh+git://github.com/humitos/foo", True),
+            ("strangeuser@bitbucket.org:strangeuser/readthedocs.git", True),
+            ("user@one-ssh.domain.com:22/_ssh/docs", True),
         ] + common_urls
 
         with override_settings(ALLOW_PRIVATE_REPOS=False):
@@ -102,16 +101,16 @@ class TestProjectForms(TestCase):
         }
         form = ProjectBasicsForm(initial)
         self.assertFalse(form.is_valid())
-        self.assertIn('name', form.errors)
+        self.assertIn("name", form.errors)
 
     def test_changing_vcs_should_not_change_latest_is_not_none(self):
         """
         When changing the project's VCS,
         we should respect the custom default branch.
         """
-        project = get(Project, repo_type=REPO_TYPE_HG, default_branch='custom')
+        project = get(Project, repo_type=REPO_TYPE_HG, default_branch="custom")
         latest = project.versions.get(slug=LATEST)
-        self.assertEqual(latest.identifier, 'custom')
+        self.assertEqual(latest.identifier, "custom")
 
         form = ProjectBasicsForm(
             {
@@ -125,27 +124,27 @@ class TestProjectForms(TestCase):
         self.assertTrue(form.is_valid())
         form.save()
         latest.refresh_from_db()
-        self.assertEqual(latest.identifier, 'custom')
+        self.assertEqual(latest.identifier, "custom")
 
     def test_length_of_tags(self):
         data = {
-            'documentation_type': 'sphinx',
-            'language': 'en',
+            "documentation_type": "sphinx",
+            "language": "en",
         }
-        data['tags'] = '{},{}'.format('a'*50, 'b'*99)
+        data["tags"] = "{},{}".format("a" * 50, "b" * 99)
         form = ProjectExtraForm(data)
         self.assertTrue(form.is_valid())
 
-        data['tags'] = '{},{}'.format('a'*90, 'b'*100)
+        data["tags"] = "{},{}".format("a" * 90, "b" * 100)
         form = ProjectExtraForm(data)
         self.assertTrue(form.is_valid())
 
-        data['tags'] = '{},{}'.format('a'*99, 'b'*101)
+        data["tags"] = "{},{}".format("a" * 99, "b" * 101)
         form = ProjectExtraForm(data)
         self.assertFalse(form.is_valid())
-        self.assertTrue(form.has_error('tags'))
-        error_msg = 'Length of each tag must be less than or equal to 100 characters.'
-        self.assertDictEqual(form.errors, {'tags': [error_msg]})
+        self.assertTrue(form.has_error("tags"))
+        error_msg = "Length of each tag must be less than or equal to 100 characters."
+        self.assertDictEqual(form.errors, {"tags": [error_msg]})
 
     def test_strip_repo_url(self):
         form = ProjectBasicsForm(
@@ -158,59 +157,57 @@ class TestProjectForms(TestCase):
         )
         self.assertTrue(form.is_valid())
         self.assertEqual(
-            form.cleaned_data['repo'],
-            'https://github.com/rtfd/readthedocs.org'
+            form.cleaned_data["repo"], "https://github.com/rtfd/readthedocs.org"
         )
 
 
 class TestProjectAdvancedForm(TestCase):
-
     def setUp(self):
         self.project = get(Project, privacy_level=PUBLIC)
         get(
             Version,
             project=self.project,
-            slug='public-1',
+            slug="public-1",
             active=True,
             privacy_level=PUBLIC,
-            identifier='public-1',
-            verbose_name='public-1',
+            identifier="public-1",
+            verbose_name="public-1",
         )
         get(
             Version,
             project=self.project,
-            slug='public-2',
+            slug="public-2",
             active=True,
             privacy_level=PUBLIC,
-            identifier='public-2',
-            verbose_name='public-2',
+            identifier="public-2",
+            verbose_name="public-2",
         )
         get(
             Version,
             project=self.project,
-            slug='public-3',
+            slug="public-3",
             active=False,
             privacy_level=PUBLIC,
-            identifier='public-3',
-            verbose_name='public-3',
+            identifier="public-3",
+            verbose_name="public-3",
         )
         get(
             Version,
             project=self.project,
-            slug='public-4',
+            slug="public-4",
             active=False,
             privacy_level=PUBLIC,
-            identifier='public/4',
-            verbose_name='public/4',
+            identifier="public/4",
+            verbose_name="public/4",
         )
         get(
             Version,
             project=self.project,
-            slug='private',
+            slug="private",
             active=True,
             privacy_level=PRIVATE,
-            identifier='private',
-            verbose_name='private',
+            identifier="private",
+            verbose_name="private",
         )
 
     def test_list_only_active_versions_on_default_version(self):
@@ -218,11 +215,8 @@ class TestProjectAdvancedForm(TestCase):
         # This version is created automatically by the project on save
         self.assertTrue(self.project.versions.filter(slug=LATEST).exists())
         self.assertEqual(
-            {
-                slug
-                for slug, _ in form.fields['default_version'].widget.choices
-            },
-            {'latest', 'public-1', 'public-2', 'private'},
+            {slug for slug, _ in form.fields["default_version"].widget.choices},
+            {"latest", "public-1", "public-2", "private"},
         )
 
     def test_default_version_field_if_no_active_version(self):
@@ -233,17 +227,17 @@ class TestProjectAdvancedForm(TestCase):
         self.assertFalse(project_1.versions.filter(active=True).exists())
 
         form = ProjectAdvancedForm(instance=project_1)
-        self.assertTrue(form.fields['default_version'].widget.attrs['readonly'])
-        self.assertEqual(form.fields['default_version'].initial, 'latest')
+        self.assertTrue(form.fields["default_version"].widget.attrs["readonly"])
+        self.assertEqual(form.fields["default_version"].initial, "latest")
 
     @override_settings(ALLOW_PRIVATE_REPOS=False)
     def test_cant_update_privacy_level(self):
         form = ProjectAdvancedForm(
             {
-                'default_version': LATEST,
-                'documentation_type': SPHINX,
-                'python_interpreter': 'python3',
-                'privacy_level': PRIVATE,
+                "default_version": LATEST,
+                "documentation_type": SPHINX,
+                "python_interpreter": "python3",
+                "privacy_level": PRIVATE,
             },
             instance=self.project,
         )
@@ -255,11 +249,11 @@ class TestProjectAdvancedForm(TestCase):
     def test_can_update_privacy_level(self):
         form = ProjectAdvancedForm(
             {
-                'default_version': LATEST,
-                'documentation_type': SPHINX,
-                'python_interpreter': 'python3',
-                'privacy_level': PRIVATE,
-                'external_builds_privacy_level': PRIVATE,
+                "default_version": LATEST,
+                "documentation_type": SPHINX,
+                "python_interpreter": "python3",
+                "privacy_level": PRIVATE,
+                "external_builds_privacy_level": PRIVATE,
             },
             instance=self.project,
         )
@@ -286,36 +280,36 @@ class TestProjectAdvancedForm(TestCase):
         project = form.save()
         self.assertEqual(project.readthedocs_yaml_path, custom_readthedocs_yaml_path)
 
-class TestProjectAdvancedFormDefaultBranch(TestCase):
 
+class TestProjectAdvancedFormDefaultBranch(TestCase):
     def setUp(self):
         self.project = get(Project)
         user_created_stable_version = get(
             Version,
             project=self.project,
-            slug='stable',
+            slug="stable",
             active=True,
             privacy_level=PUBLIC,
-            identifier='ab96cbff71a8f40a4340aaf9d12e6c10',
-            verbose_name='stable',
+            identifier="ab96cbff71a8f40a4340aaf9d12e6c10",
+            verbose_name="stable",
         )
         get(
             Version,
             project=self.project,
-            slug='public-1',
+            slug="public-1",
             active=True,
             privacy_level=PUBLIC,
-            identifier='public-1',
-            verbose_name='public-1',
+            identifier="public-1",
+            verbose_name="public-1",
         )
         get(
             Version,
             project=self.project,
-            slug='private',
+            slug="private",
             active=True,
             privacy_level=PRIVATE,
-            identifier='private',
-            verbose_name='private',
+            identifier="private",
+            verbose_name="private",
         )
 
     def test_list_only_non_auto_generated_versions_in_default_branch_choices(self):
@@ -327,29 +321,36 @@ class TestProjectAdvancedFormDefaultBranch(TestCase):
         self.assertEqual(
             {
                 identifier
-                for identifier, _ in form.fields['default_branch'].widget.choices
+                for identifier, _ in form.fields["default_branch"].widget.choices
             },
             {
-                None, 'stable', 'public-1', 'private',
+                None,
+                "stable",
+                "public-1",
+                "private",
             },
         )
         # Auto generated version `latest` should not be among the choices
         self.assertNotIn(
             latest.first().verbose_name,
-            [identifier for identifier, _ in form.fields[
-                'default_branch'].widget.choices],
+            [
+                identifier
+                for identifier, _ in form.fields["default_branch"].widget.choices
+            ],
         )
 
-    def test_list_user_created_latest_and_stable_versions_in_default_branch_choices(self):
+    def test_list_user_created_latest_and_stable_versions_in_default_branch_choices(
+        self,
+    ):
         self.project.versions.filter(slug=LATEST).first().delete()
         user_created_latest_version = get(
             Version,
             project=self.project,
-            slug='latest',
+            slug="latest",
             active=True,
             privacy_level=PUBLIC,
-            identifier='ab96cbff71a8f40a4240aaf9d12e6c10',
-            verbose_name='latest',
+            identifier="ab96cbff71a8f40a4240aaf9d12e6c10",
+            verbose_name="latest",
         )
         form = ProjectAdvancedForm(instance=self.project)
         # This version is created by the user
@@ -359,13 +360,17 @@ class TestProjectAdvancedFormDefaultBranch(TestCase):
 
         self.assertIn(
             latest.first().verbose_name,
-            [identifier for identifier, _ in form.fields[
-                'default_branch'].widget.choices],
+            [
+                identifier
+                for identifier, _ in form.fields["default_branch"].widget.choices
+            ],
         )
         self.assertIn(
             stable.first().verbose_name,
-            [identifier for identifier, _ in form.fields[
-                'default_branch'].widget.choices],
+            [
+                identifier
+                for identifier, _ in form.fields["default_branch"].widget.choices
+            ],
         )
 
     def test_commit_name_not_in_default_branch_choices(self):
@@ -378,21 +383,25 @@ class TestProjectAdvancedFormDefaultBranch(TestCase):
         # `commit_name` can not be used as the value for the choices
         self.assertNotIn(
             latest.first().commit_name,
-            [identifier for identifier, _ in form.fields[
-                'default_branch'].widget.choices],
+            [
+                identifier
+                for identifier, _ in form.fields["default_branch"].widget.choices
+            ],
         )
         self.assertNotIn(
             stable.first().commit_name,
-            [identifier for identifier, _ in form.fields[
-                'default_branch'].widget.choices],
+            [
+                identifier
+                for identifier, _ in form.fields["default_branch"].widget.choices
+            ],
         )
 
     def test_external_version_not_in_default_branch_choices(self):
         external_version = get(
             Version,
-            identifier='pr-version',
-            verbose_name='pr-version',
-            slug='pr-9999',
+            identifier="pr-version",
+            verbose_name="pr-version",
+            slug="pr-9999",
             project=self.project,
             active=True,
             type=EXTERNAL,
@@ -402,39 +411,39 @@ class TestProjectAdvancedFormDefaultBranch(TestCase):
 
         self.assertNotIn(
             external_version.verbose_name,
-            [identifier for identifier, _ in form.fields[
-                'default_branch'].widget.choices],
+            [
+                identifier
+                for identifier, _ in form.fields["default_branch"].widget.choices
+            ],
         )
 
 
 class TestTranslationForms(TestCase):
-
     def setUp(self):
         self.user_a = get(User)
-        self.project_a_es = self.get_project(lang='es', users=[self.user_a])
-        self.project_b_en = self.get_project(lang='en', users=[self.user_a])
-        self.project_c_br = self.get_project(lang='br', users=[self.user_a])
-        self.project_d_ar = self.get_project(lang='ar', users=[self.user_a])
-        self.project_e_en = self.get_project(lang='en', users=[self.user_a])
+        self.project_a_es = self.get_project(lang="es", users=[self.user_a])
+        self.project_b_en = self.get_project(lang="en", users=[self.user_a])
+        self.project_c_br = self.get_project(lang="br", users=[self.user_a])
+        self.project_d_ar = self.get_project(lang="ar", users=[self.user_a])
+        self.project_e_en = self.get_project(lang="en", users=[self.user_a])
 
         self.user_b = get(User)
-        self.project_f_ar = self.get_project(lang='ar', users=[self.user_b])
-        self.project_g_ga = self.get_project(lang='ga', users=[self.user_b])
+        self.project_f_ar = self.get_project(lang="ar", users=[self.user_b])
+        self.project_g_ga = self.get_project(lang="ga", users=[self.user_b])
 
         self.project_s_fr = self.get_project(
-            lang='fr',
+            lang="fr",
             users=[self.user_b, self.user_a],
         )
 
     def get_project(self, lang, users, **kwargs):
         return get(
-            Project, language=lang, users=users,
-            main_language_project=None, **kwargs
+            Project, language=lang, users=users, main_language_project=None, **kwargs
         )
 
     def test_list_only_owner_projects(self):
         form = TranslationForm(
-            {'project': self.project_b_en.slug},
+            {"project": self.project_b_en.slug},
             parent=self.project_a_es,
             user=self.user_a,
         )
@@ -447,12 +456,12 @@ class TestTranslationForms(TestCase):
             self.project_s_fr,
         ]
         self.assertEqual(
-            {proj_slug for proj_slug, _ in form.fields['project'].choices},
+            {proj_slug for proj_slug, _ in form.fields["project"].choices},
             {project.slug for project in expected_projects},
         )
 
         form = TranslationForm(
-            {'project': self.project_g_ga.slug},
+            {"project": self.project_g_ga.slug},
             parent=self.project_f_ar,
             user=self.user_b,
         )
@@ -462,7 +471,7 @@ class TestTranslationForms(TestCase):
             self.project_s_fr,
         ]
         self.assertEqual(
-            {proj_slug for proj_slug, _ in form.fields['project'].choices},
+            {proj_slug for proj_slug, _ in form.fields["project"].choices},
             {project.slug for project in expected_projects},
         )
 
@@ -472,7 +481,7 @@ class TestTranslationForms(TestCase):
         self.project_a_es.save()
 
         form = TranslationForm(
-            {'project': self.project_d_ar.slug},
+            {"project": self.project_d_ar.slug},
             parent=self.project_a_es,
             user=self.user_a,
         )
@@ -483,36 +492,36 @@ class TestTranslationForms(TestCase):
             self.project_s_fr,
         ]
         self.assertEqual(
-            {proj_slug for proj_slug, _ in form.fields['project'].choices},
+            {proj_slug for proj_slug, _ in form.fields["project"].choices},
             {project.slug for project in expected_projects},
         )
 
     def test_user_cant_add_other_user_project(self):
         form = TranslationForm(
-            {'project': self.project_f_ar.slug},
+            {"project": self.project_f_ar.slug},
             parent=self.project_b_en,
             user=self.user_a,
         )
         self.assertFalse(form.is_valid())
         self.assertIn(
-            'Select a valid choice',
-            ''.join(form.errors['project']),
+            "Select a valid choice",
+            "".join(form.errors["project"]),
         )
         self.assertNotIn(
             self.project_f_ar,
-            [proj_slug for proj_slug, _ in form.fields['project'].choices],
+            [proj_slug for proj_slug, _ in form.fields["project"].choices],
         )
 
     def test_user_cant_add_project_with_same_lang(self):
         form = TranslationForm(
-            {'project': self.project_b_en.slug},
+            {"project": self.project_b_en.slug},
             parent=self.project_e_en,
             user=self.user_a,
         )
         self.assertFalse(form.is_valid())
         self.assertIn(
-            'Both projects can not have the same language (English).',
-            ''.join(form.errors['project']),
+            "Both projects can not have the same language (English).",
+            "".join(form.errors["project"]),
         )
 
     def test_user_cant_add_project_with_same_lang_of_other_translation(self):
@@ -520,14 +529,14 @@ class TestTranslationForms(TestCase):
         self.project_a_es.save()
 
         form = TranslationForm(
-            {'project': self.project_e_en.slug},
+            {"project": self.project_e_en.slug},
             parent=self.project_a_es,
             user=self.user_a,
         )
         self.assertFalse(form.is_valid())
         self.assertIn(
-            'This project already has a translation for English.',
-            ''.join(form.errors['project']),
+            "This project already has a translation for English.",
+            "".join(form.errors["project"]),
         )
 
     def test_no_nesting_translation(self):
@@ -535,14 +544,14 @@ class TestTranslationForms(TestCase):
         self.project_a_es.save()
 
         form = TranslationForm(
-            {'project': self.project_b_en.slug},
+            {"project": self.project_b_en.slug},
             parent=self.project_c_br,
             user=self.user_a,
         )
         self.assertFalse(form.is_valid())
         self.assertIn(
-            'Select a valid choice',
-            ''.join(form.errors['project']),
+            "Select a valid choice",
+            "".join(form.errors["project"]),
         )
 
     def test_no_nesting_translation_case_2(self):
@@ -550,14 +559,14 @@ class TestTranslationForms(TestCase):
         self.project_a_es.save()
 
         form = TranslationForm(
-            {'project': self.project_a_es.slug},
+            {"project": self.project_a_es.slug},
             parent=self.project_c_br,
             user=self.user_a,
         )
         self.assertFalse(form.is_valid())
         self.assertIn(
-            'A project with existing translations can not',
-            ''.join(form.errors['project']),
+            "A project with existing translations can not",
+            "".join(form.errors["project"]),
         )
 
     def test_not_already_translation(self):
@@ -565,14 +574,14 @@ class TestTranslationForms(TestCase):
         self.project_a_es.save()
 
         form = TranslationForm(
-            {'project': self.project_c_br.slug},
+            {"project": self.project_c_br.slug},
             parent=self.project_b_en,
             user=self.user_a,
         )
         self.assertFalse(form.is_valid())
         self.assertIn(
-            'is already a translation',
-            ''.join(form.errors['project']),
+            "is already a translation",
+            "".join(form.errors["project"]),
         )
 
     def test_cant_change_language_to_translation_lang(self):
@@ -583,44 +592,44 @@ class TestTranslationForms(TestCase):
         # Parent project tries to change lang
         form = UpdateProjectForm(
             {
-                'documentation_type': 'sphinx',
-                'language': 'en',
+                "documentation_type": "sphinx",
+                "language": "en",
             },
             instance=self.project_a_es,
         )
         self.assertFalse(form.is_valid())
         self.assertIn(
             'There is already a "en" translation',
-            ''.join(form.errors['language']),
+            "".join(form.errors["language"]),
         )
 
         # Translation tries to change lang
         form = UpdateProjectForm(
             {
-                'documentation_type': 'sphinx',
-                'language': 'es',
+                "documentation_type": "sphinx",
+                "language": "es",
             },
             instance=self.project_b_en,
         )
         self.assertFalse(form.is_valid())
         self.assertIn(
             'There is already a "es" translation',
-            ''.join(form.errors['language']),
+            "".join(form.errors["language"]),
         )
 
         # Translation tries to change lang
         # to the same as its sibling
         form = UpdateProjectForm(
             {
-                'documentation_type': 'sphinx',
-                'language': 'br',
+                "documentation_type": "sphinx",
+                "language": "br",
             },
             instance=self.project_b_en,
         )
         self.assertFalse(form.is_valid())
         self.assertIn(
             'There is already a "br" translation',
-            ''.join(form.errors['language']),
+            "".join(form.errors["language"]),
         )
 
     def test_can_change_language_to_self_lang(self):
@@ -631,11 +640,11 @@ class TestTranslationForms(TestCase):
         # Parent project tries to change lang
         form = UpdateProjectForm(
             {
-                'repo': 'https://github.com/test/test',
-                'repo_type': self.project_a_es.repo_type,
-                'name': self.project_a_es.name,
-                'documentation_type': 'sphinx',
-                'language': 'es',
+                "repo": "https://github.com/test/test",
+                "repo_type": self.project_a_es.repo_type,
+                "name": self.project_a_es.name,
+                "documentation_type": "sphinx",
+                "language": "es",
             },
             instance=self.project_a_es,
         )
@@ -644,11 +653,11 @@ class TestTranslationForms(TestCase):
         # Translation tries to change lang
         form = UpdateProjectForm(
             {
-                'repo': 'https://github.com/test/test',
-                'repo_type': self.project_b_en.repo_type,
-                'name': self.project_b_en.name,
-                'documentation_type': 'sphinx',
-                'language': 'en',
+                "repo": "https://github.com/test/test",
+                "repo_type": self.project_b_en.repo_type,
+                "name": self.project_b_en.name,
+                "documentation_type": "sphinx",
+                "language": "en",
             },
             instance=self.project_b_en,
         )
@@ -656,7 +665,6 @@ class TestTranslationForms(TestCase):
 
 
 class TestWebhookForm(TestCase):
-
     def setUp(self):
         self.project = get(Project)
 
@@ -664,9 +672,9 @@ class TestWebhookForm(TestCase):
         self.assertEqual(self.project.webhook_notifications.all().count(), 0)
 
         data = {
-            'url': 'http://www.example.com/',
-            'payload': '{}',
-            'events': [WebHookEvent.objects.get(name=WebHookEvent.BUILD_FAILED).id],
+            "url": "http://www.example.com/",
+            "payload": "{}",
+            "events": [WebHookEvent.objects.get(name=WebHookEvent.BUILD_FAILED).id],
         }
         form = WebHookForm(data=data, project=self.project)
         self.assertTrue(form.is_valid())
@@ -674,9 +682,9 @@ class TestWebhookForm(TestCase):
         self.assertEqual(self.project.webhook_notifications.all().count(), 1)
 
         data = {
-            'url': 'https://www.example.com/',
-            'payload': '{}',
-            'events': [WebHookEvent.objects.get(name=WebHookEvent.BUILD_PASSED).id],
+            "url": "https://www.example.com/",
+            "payload": "{}",
+            "events": [WebHookEvent.objects.get(name=WebHookEvent.BUILD_PASSED).id],
         }
         form = WebHookForm(data=data, project=self.project)
         self.assertTrue(form.is_valid())
@@ -687,57 +695,56 @@ class TestWebhookForm(TestCase):
         self.assertEqual(self.project.webhook_notifications.all().count(), 0)
 
         data = {
-            'url': '',
-            'payload': '{}',
-            'events': [WebHookEvent.objects.get(name=WebHookEvent.BUILD_FAILED).id],
+            "url": "",
+            "payload": "{}",
+            "events": [WebHookEvent.objects.get(name=WebHookEvent.BUILD_FAILED).id],
         }
         form = WebHookForm(data=data, project=self.project)
         self.assertFalse(form.is_valid())
-        self.assertDictEqual(form.errors, {'url': ['This field is required.']})
+        self.assertDictEqual(form.errors, {"url": ["This field is required."]})
         self.assertEqual(self.project.webhook_notifications.all().count(), 0)
 
         data = {
-            'url': 'wrong-url',
-            'payload': '{}',
-            'events': [WebHookEvent.objects.get(name=WebHookEvent.BUILD_FAILED).id],
+            "url": "wrong-url",
+            "payload": "{}",
+            "events": [WebHookEvent.objects.get(name=WebHookEvent.BUILD_FAILED).id],
         }
         form = WebHookForm(data=data, project=self.project)
         self.assertFalse(form.is_valid())
-        self.assertDictEqual(form.errors, {'url': ['Enter a valid URL.']})
+        self.assertDictEqual(form.errors, {"url": ["Enter a valid URL."]})
         self.assertEqual(self.project.webhook_notifications.all().count(), 0)
 
         data = {
-            'url': 'https://example.com/webhook/',
-            'payload': '{wrong json object}',
-            'events': [WebHookEvent.objects.get(name=WebHookEvent.BUILD_FAILED).id],
+            "url": "https://example.com/webhook/",
+            "payload": "{wrong json object}",
+            "events": [WebHookEvent.objects.get(name=WebHookEvent.BUILD_FAILED).id],
         }
         form = WebHookForm(data=data, project=self.project)
         self.assertFalse(form.is_valid())
-        self.assertDictEqual(form.errors, {'payload': ['The payload must be a valid JSON object.']})
+        self.assertDictEqual(
+            form.errors, {"payload": ["The payload must be a valid JSON object."]}
+        )
         self.assertEqual(self.project.webhook_notifications.all().count(), 0)
 
         data = {
-            'url': 'https://example.com/webhook/',
-            'payload': '{}',
-            'events': [],
+            "url": "https://example.com/webhook/",
+            "payload": "{}",
+            "events": [],
         }
         form = WebHookForm(data=data, project=self.project)
         self.assertFalse(form.is_valid())
-        self.assertDictEqual(form.errors, {'events': ['This field is required.']})
+        self.assertDictEqual(form.errors, {"events": ["This field is required."]})
         self.assertEqual(self.project.webhook_notifications.all().count(), 0)
 
 
 class TestNotificationForm(TestCase):
-
     def setUp(self):
         self.project = get(Project)
 
     def test_emailhookform(self):
         self.assertEqual(self.project.emailhook_notifications.all().count(), 0)
 
-        data = {
-            'email': 'test@email.com'
-        }
+        data = {"email": "test@email.com"}
         form = EmailHookForm(data=data, project=self.project)
         self.assertTrue(form.is_valid())
         form.save()
@@ -746,104 +753,102 @@ class TestNotificationForm(TestCase):
     def test_wrong_inputs_in_emailhookform(self):
         self.assertEqual(self.project.emailhook_notifications.all().count(), 0)
 
-        data = {
-            'email': 'wrong_email@'
-        }
+        data = {"email": "wrong_email@"}
         form = EmailHookForm(data=data, project=self.project)
         self.assertFalse(form.is_valid())
-        self.assertDictEqual(form.errors, {'email': ['Enter a valid email address.']})
+        self.assertDictEqual(form.errors, {"email": ["Enter a valid email address."]})
         self.assertEqual(self.project.emailhook_notifications.all().count(), 0)
 
-        data = {
-            'email': ''
-        }
+        data = {"email": ""}
         form = EmailHookForm(data=data, project=self.project)
         self.assertFalse(form.is_valid())
-        self.assertDictEqual(form.errors, {'email': ['This field is required.']})
+        self.assertDictEqual(form.errors, {"email": ["This field is required."]})
         self.assertEqual(self.project.emailhook_notifications.all().count(), 0)
 
 
 class TestProjectEnvironmentVariablesForm(TestCase):
-
     def setUp(self):
         self.project = get(Project)
 
     def test_use_invalid_names(self):
         data = {
-            'name': 'VARIABLE WITH SPACES',
-            'value': 'string here',
+            "name": "VARIABLE WITH SPACES",
+            "value": "string here",
         }
         form = EnvironmentVariableForm(data, project=self.project)
         self.assertFalse(form.is_valid())
         self.assertIn(
             "Variable name can't contain spaces",
-            form.errors['name'],
+            form.errors["name"],
         )
 
         data = {
-            'name': 'READTHEDOCS__INVALID',
-            'value': 'string here',
+            "name": "READTHEDOCS__INVALID",
+            "value": "string here",
         }
         form = EnvironmentVariableForm(data, project=self.project)
         self.assertFalse(form.is_valid())
         self.assertIn(
             "Variable name can't start with READTHEDOCS",
-            form.errors['name'],
+            form.errors["name"],
         )
 
         data = {
-            'name': 'INVALID_CHAR*',
-            'value': 'string here',
+            "name": "INVALID_CHAR*",
+            "value": "string here",
         }
         form = EnvironmentVariableForm(data, project=self.project)
         self.assertFalse(form.is_valid())
         self.assertIn(
-            'Only letters, numbers and underscore are allowed',
-            form.errors['name'],
+            "Only letters, numbers and underscore are allowed",
+            form.errors["name"],
         )
 
         data = {
-            'name': '__INVALID',
-            'value': 'string here',
+            "name": "__INVALID",
+            "value": "string here",
         }
         form = EnvironmentVariableForm(data, project=self.project)
         self.assertFalse(form.is_valid())
         self.assertIn(
             "Variable name can't start with __ (double underscore)",
-            form.errors['name'],
+            form.errors["name"],
         )
 
-        get(EnvironmentVariable, name='EXISTENT_VAR', project=self.project)
+        get(EnvironmentVariable, name="EXISTENT_VAR", project=self.project)
         data = {
-            'name': 'EXISTENT_VAR',
-            'value': 'string here',
+            "name": "EXISTENT_VAR",
+            "value": "string here",
         }
         form = EnvironmentVariableForm(data, project=self.project)
         self.assertFalse(form.is_valid())
         self.assertIn(
-            'There is already a variable with this name for this project',
-            form.errors['name'],
+            "There is already a variable with this name for this project",
+            form.errors["name"],
         )
 
     def test_create(self):
         data = {
-            'name': 'MYTOKEN',
-            'value': 'string here',
+            "name": "MYTOKEN",
+            "value": "string here",
         }
         form = EnvironmentVariableForm(data, project=self.project)
         form.save()
 
         self.assertEqual(EnvironmentVariable.objects.count(), 1)
-        self.assertEqual(EnvironmentVariable.objects.latest().name, 'MYTOKEN')
+        self.assertEqual(EnvironmentVariable.objects.latest().name, "MYTOKEN")
         self.assertEqual(EnvironmentVariable.objects.latest().value, "'string here'")
 
         data = {
-            'name': 'ESCAPED',
-            'value': r'string escaped here: #$\1[]{}\|',
+            "name": "ESCAPED",
+            "value": r"string escaped here: #$\1[]{}\|",
         }
         form = EnvironmentVariableForm(data, project=self.project)
         form.save()
 
         self.assertEqual(EnvironmentVariable.objects.count(), 2)
-        self.assertEqual(EnvironmentVariable.objects.latest().name, 'ESCAPED')
-        self.assertEqual(EnvironmentVariable.objects.latest().value, r"'string escaped here: #$\1[]{}\|'")
+        self.assertEqual(EnvironmentVariable.objects.latest().name, "ESCAPED")
+        self.assertEqual(
+            EnvironmentVariable.objects.latest().value,
+            r"'string escaped here: #$\1[]{}\|'",
+        )

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -121,7 +121,7 @@ class TestBasicsForm(WizardTestCase):
 
         proj = Project.objects.get(name="foobar")
         self.assertIsNotNone(proj)
-        for (key, val) in list(self.step_data["basics"].items()):
+        for key, val in list(self.step_data["basics"].items()):
             self.assertEqual(getattr(proj, key), val)
         self.assertEqual(proj.documentation_type, "sphinx")
 

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -21,7 +21,7 @@ from readthedocs.projects.views.public import ProjectBadgeView
 from readthedocs.rtd_tests.base import RequestFactoryTestMixin, WizardTestCase
 
 
-@mock.patch('readthedocs.projects.tasks.builds.update_docs_task', mock.MagicMock())
+@mock.patch("readthedocs.projects.tasks.builds.update_docs_task", mock.MagicMock())
 class TestImportProjectBannedUser(RequestFactoryTestMixin, TestCase):
 
     wizard_class_slug = "import_wizard_view"
@@ -57,15 +57,15 @@ class TestImportProjectBannedUser(RequestFactoryTestMixin, TestCase):
         self.assertTrue(req.user.profile.banned)
         resp = ImportWizardView.as_view()(req)
         self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp['location'], '/')
+        self.assertEqual(resp["location"], "/")
 
 
-@mock.patch('readthedocs.projects.tasks.builds.update_docs_task', mock.MagicMock())
+@mock.patch("readthedocs.projects.tasks.builds.update_docs_task", mock.MagicMock())
 class TestBasicsForm(WizardTestCase):
 
-    wizard_class_slug = 'import_wizard_view'
+    wizard_class_slug = "import_wizard_view"
     wizard_class = ImportWizardView
-    url = '/dashboard/import/manual/'
+    url = "/dashboard/import/manual/"
 
     def setUp(self):
         self.user = get(User)
@@ -80,50 +80,50 @@ class TestBasicsForm(WizardTestCase):
         }
 
     def tearDown(self):
-        Project.objects.filter(slug='foobar').delete()
+        Project.objects.filter(slug="foobar").delete()
 
     def request(self, *args, **kwargs):
-        kwargs['user'] = self.user
+        kwargs["user"] = self.user
         return super().request(*args, **kwargs)
 
     def test_form_import_from_remote_repo(self):
         self.client.force_login(self.user)
 
         data = {
-            'name': 'pipdocs',
-            'repo': 'https://github.com/fail/sauce',
-            'repo_type': 'git',
-            'remote_repository': '1234',
-            'default_branch': 'main',
+            "name": "pipdocs",
+            "repo": "https://github.com/fail/sauce",
+            "repo_type": "git",
+            "remote_repository": "1234",
+            "default_branch": "main",
         }
         resp = self.client.post(
-            '/dashboard/import/',
+            "/dashboard/import/",
             data,
         )
         self.assertEqual(resp.status_code, 200)
 
         # The form is filled with the previous information
         self.assertEqual(
-            resp.context['form'].initial,
+            resp.context["form"].initial,
             data,
         )
 
     def test_form_pass(self):
         """Only submit the basics."""
-        resp = self.post_step('basics')
+        resp = self.post_step("basics")
         self.assertEqual(resp.status_code, 200)
 
         resp = self.post_step("config", session=list(resp._request.session.items()))
 
         self.assertIsInstance(resp, HttpResponseRedirect)
         self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp['location'], '/projects/foobar/')
+        self.assertEqual(resp["location"], "/projects/foobar/")
 
-        proj = Project.objects.get(name='foobar')
+        proj = Project.objects.get(name="foobar")
         self.assertIsNotNone(proj)
-        for (key, val) in list(self.step_data['basics'].items()):
+        for (key, val) in list(self.step_data["basics"].items()):
             self.assertEqual(getattr(proj, key), val)
-        self.assertEqual(proj.documentation_type, 'sphinx')
+        self.assertEqual(proj.documentation_type, "sphinx")
 
     def test_remote_repository_is_added(self):
         remote_repo = get(RemoteRepository, default_branch="default-branch")
@@ -132,35 +132,35 @@ class TestBasicsForm(WizardTestCase):
             RemoteRepositoryRelation,
             remote_repository=remote_repo,
             user=self.user,
-            account=socialaccount
+            account=socialaccount,
         )
-        self.step_data['basics']['remote_repository'] = remote_repo.pk
-        resp = self.post_step('basics')
+        self.step_data["basics"]["remote_repository"] = remote_repo.pk
+        resp = self.post_step("basics")
         self.assertEqual(resp.status_code, 200)
 
         resp = self.post_step("config", session=list(resp._request.session.items()))
         self.assertIsInstance(resp, HttpResponseRedirect)
         self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp['location'], '/projects/foobar/')
+        self.assertEqual(resp["location"], "/projects/foobar/")
 
-        proj = Project.objects.get(name='foobar')
+        proj = Project.objects.get(name="foobar")
         self.assertIsNotNone(proj)
         self.assertEqual(proj.remote_repository, remote_repo)
         self.assertEqual(proj.get_default_branch(), remote_repo.default_branch)
 
     def test_remote_repository_invalid_type(self):
-        self.step_data['basics']['remote_repository'] = 'Invalid id'
-        resp = self.post_step('basics')
+        self.step_data["basics"]["remote_repository"] = "Invalid id"
+        resp = self.post_step("basics")
         self.assertEqual(resp.status_code, 200)
-        form = resp.context_data['form']
-        self.assertIn('remote_repository', form.errors)
+        form = resp.context_data["form"]
+        self.assertIn("remote_repository", form.errors)
 
     def test_remote_repository_invalid_id(self):
-        self.step_data['basics']['remote_repository'] = 9
-        resp = self.post_step('basics')
+        self.step_data["basics"]["remote_repository"] = 9
+        resp = self.post_step("basics")
         self.assertEqual(resp.status_code, 200)
-        form = resp.context_data['form']
-        self.assertIn('remote_repository', form.errors)
+        form = resp.context_data["form"]
+        self.assertIn("remote_repository", form.errors)
 
     def test_remote_repository_is_not_added_for_wrong_user(self):
         user = get(User)
@@ -170,33 +170,32 @@ class TestBasicsForm(WizardTestCase):
             RemoteRepositoryRelation,
             remote_repository=remote_repo,
             user=user,
-            account=socialaccount
+            account=socialaccount,
         )
-        self.step_data['basics']['remote_repository'] = remote_repo.pk
-        resp = self.post_step('basics')
-        self.assertWizardFailure(resp, 'remote_repository')
+        self.step_data["basics"]["remote_repository"] = remote_repo.pk
+        resp = self.post_step("basics")
+        self.assertWizardFailure(resp, "remote_repository")
 
     def test_form_missing(self):
         """Submit form with missing data, expect to get failures."""
-        self.step_data['basics'] = {'advanced': True}
-        resp = self.post_step('basics')
-        self.assertWizardFailure(resp, 'name')
+        self.step_data["basics"] = {"advanced": True}
+        resp = self.post_step("basics")
+        self.assertWizardFailure(resp, "name")
 
 
-@mock.patch('readthedocs.projects.tasks.builds.update_docs_task', mock.MagicMock())
+@mock.patch("readthedocs.projects.tasks.builds.update_docs_task", mock.MagicMock())
 class TestAdvancedForm(TestBasicsForm):
-
     def setUp(self):
         super().setUp()
         self.step_data["basics"]["advanced"] = True
         self.step_data["config"] = {
             "confirm": True,
         }
-        self.step_data['extra'] = {
-            'description': 'Describe foobar',
-            'language': 'en',
-            'documentation_type': 'sphinx',
-            'tags': 'foo, bar, baz',
+        self.step_data["extra"] = {
+            "description": "Describe foobar",
+            "language": "en",
+            "documentation_type": "sphinx",
+            "tags": "foo, bar, baz",
         }
 
     def test_initial_params(self):
@@ -204,20 +203,20 @@ class TestAdvancedForm(TestBasicsForm):
             "confirm": True,
         }
         basic_initial = {
-            'name': 'foobar',
-            'repo': 'https://github.com/foo/bar',
-            'repo_type': 'git',
-            'default_branch': 'main',
-            'remote_repository': '',
+            "name": "foobar",
+            "repo": "https://github.com/foo/bar",
+            "repo_type": "git",
+            "default_branch": "main",
+            "remote_repository": "",
         }
         initial = dict(**config_initial, **basic_initial)
         self.client.force_login(self.user)
 
         # User selects a remote repo to import.
-        resp = self.client.post(reverse('projects_import'), initial)
+        resp = self.client.post(reverse("projects_import"), initial)
 
         # The correct initial data for the basic form is set.
-        form = resp.context_data['form']
+        form = resp.context_data["form"]
         self.assertEqual(form.initial, basic_initial)
 
     def test_form_pass(self):
@@ -227,9 +226,9 @@ class TestAdvancedForm(TestBasicsForm):
         resp = self.post_step("config", session=list(resp._request.session.items()))
         self.assertIsInstance(resp, HttpResponseRedirect)
         self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp['location'], '/projects/foobar/')
+        self.assertEqual(resp["location"], "/projects/foobar/")
 
-        proj = Project.objects.get(name='foobar')
+        proj = Project.objects.get(name="foobar")
         self.assertIsNotNone(proj)
 
     def test_remote_repository_is_added(self):
@@ -239,7 +238,7 @@ class TestAdvancedForm(TestBasicsForm):
             RemoteRepositoryRelation,
             remote_repository=remote_repo,
             user=self.user,
-            account=socialaccount
+            account=socialaccount,
         )
         self.step_data["basics"]["remote_repository"] = remote_repo.pk
         resp = self.post_step("basics")
@@ -247,107 +246,111 @@ class TestAdvancedForm(TestBasicsForm):
         resp = self.post_step("config", session=list(resp._request.session.items()))
         self.assertIsInstance(resp, HttpResponseRedirect)
         self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp['location'], '/projects/foobar/')
+        self.assertEqual(resp["location"], "/projects/foobar/")
 
-        proj = Project.objects.get(name='foobar')
+        proj = Project.objects.get(name="foobar")
         self.assertIsNotNone(proj)
         self.assertEqual(proj.remote_repository, remote_repo)
         self.assertEqual(proj.get_default_branch(), remote_repo.default_branch)
 
 
-@mock.patch('readthedocs.core.utils.trigger_build', mock.MagicMock())
+@mock.patch("readthedocs.core.utils.trigger_build", mock.MagicMock())
 class TestPublicViews(TestCase):
     def setUp(self):
-        self.pip = get(Project, slug='pip', privacy_level=PUBLIC)
+        self.pip = get(Project, slug="pip", privacy_level=PUBLIC)
         self.external_version = get(
             Version,
-            identifier='pr-version',
-            verbose_name='pr-version',
-            slug='pr-9999',
+            identifier="pr-version",
+            verbose_name="pr-version",
+            slug="pr-9999",
             project=self.pip,
             active=True,
-            type=EXTERNAL
+            type=EXTERNAL,
         )
 
     def test_project_detail_view_only_shows_internal_versons(self):
-        url = reverse('projects_detail', args=[self.pip.slug])
+        url = reverse("projects_detail", args=[self.pip.slug])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertNotIn(self.external_version, response.context['versions'])
+        self.assertNotIn(self.external_version, response.context["versions"])
 
     def test_project_downloads_only_shows_internal_versons(self):
-        url = reverse('project_downloads', args=[self.pip.slug])
+        url = reverse("project_downloads", args=[self.pip.slug])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertNotIn(self.external_version, response.context['versions'])
+        self.assertNotIn(self.external_version, response.context["versions"])
 
     def test_project_versions_only_shows_internal_versons(self):
-        url = reverse('project_version_list', args=[self.pip.slug])
+        url = reverse("project_version_list", args=[self.pip.slug])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertNotIn(self.external_version, response.context['active_versions'])
-        self.assertNotIn(self.external_version, response.context['inactive_versions'])
+        self.assertNotIn(self.external_version, response.context["active_versions"])
+        self.assertNotIn(self.external_version, response.context["inactive_versions"])
 
 
-@mock.patch('readthedocs.core.utils.trigger_build', mock.MagicMock())
+@mock.patch("readthedocs.core.utils.trigger_build", mock.MagicMock())
 class TestPrivateViews(TestCase):
     def setUp(self):
-        self.user = new(User, username='eric')
-        self.user.set_password('test')
+        self.user = new(User, username="eric")
+        self.user.set_password("test")
         self.user.save()
-        self.client.login(username='eric', password='test')
-        self.project = get(Project, slug='pip', users=[self.user])
+        self.client.login(username="eric", password="test")
+        self.project = get(Project, slug="pip", users=[self.user])
 
     def test_versions_page(self):
-        self.project.versions.create(verbose_name='1.0')
+        self.project.versions.create(verbose_name="1.0")
 
-        response = self.client.get('/projects/pip/versions/')
+        response = self.client.get("/projects/pip/versions/")
         self.assertEqual(response.status_code, 200)
 
         # Test if the versions page works with a version that contains a slash.
         # That broke in the past, see issue #1176.
-        self.project.versions.create(verbose_name='1.0/with-slash')
+        self.project.versions.create(verbose_name="1.0/with-slash")
 
-        response = self.client.get('/projects/pip/versions/')
+        response = self.client.get("/projects/pip/versions/")
         self.assertEqual(response.status_code, 200)
 
     def test_delete_project(self):
-        response = self.client.get('/dashboard/pip/delete/')
+        response = self.client.get("/dashboard/pip/delete/")
         self.assertEqual(response.status_code, 200)
 
         # Mocked like this because the function is imported inside a class method
         # https://stackoverflow.com/a/22201798
-        with mock.patch('readthedocs.projects.tasks.utils.clean_project_resources') as clean_project_resources:
-            response = self.client.post('/dashboard/pip/delete/')
+        with mock.patch(
+            "readthedocs.projects.tasks.utils.clean_project_resources"
+        ) as clean_project_resources:
+            response = self.client.post("/dashboard/pip/delete/")
             self.assertEqual(response.status_code, 302)
-            self.assertFalse(Project.objects.filter(slug='pip').exists())
+            self.assertFalse(Project.objects.filter(slug="pip").exists())
             clean_project_resources.assert_called_once()
-            self.assertEqual(clean_project_resources.call_args[0][0].slug, self.project.slug)
+            self.assertEqual(
+                clean_project_resources.call_args[0][0].slug, self.project.slug
+            )
 
     def test_delete_superproject(self):
-        sub_proj = get(Project, slug='test-sub-project', users=[self.user])
+        sub_proj = get(Project, slug="test-sub-project", users=[self.user])
 
         self.assertFalse(self.project.subprojects.all().exists())
         self.project.add_subproject(sub_proj)
 
-        response = self.client.get('/dashboard/pip/delete/')
+        response = self.client.get("/dashboard/pip/delete/")
         self.assertEqual(response.status_code, 200)
         self.assertContains(
             response,
             'This project <a href="/dashboard/pip/subprojects/">has subprojects</a> under it. '
-            'Deleting this project will make them to become regular projects. '
-            'This will break the URLs of all its subprojects and they will be served normally as other projects.',
+            "Deleting this project will make them to become regular projects. "
+            "This will break the URLs of all its subprojects and they will be served normally as other projects.",
             count=1,
             html=True,
         )
 
-    @mock.patch('readthedocs.projects.views.private.attach_webhook')
+    @mock.patch("readthedocs.projects.views.private.attach_webhook")
     def test_integration_create(self, attach_webhook):
         response = self.client.post(
-            reverse('projects_integrations_create', args=[self.project.slug]),
+            reverse("projects_integrations_create", args=[self.project.slug]),
             data={
-                'project': self.project.pk,
-                'integration_type': GitHubWebhook.GITHUB_WEBHOOK
+                "project": self.project.pk,
+                "integration_type": GitHubWebhook.GITHUB_WEBHOOK,
             },
         )
         integration = GitHubWebhook.objects.filter(project=self.project)
@@ -357,16 +360,16 @@ class TestPrivateViews(TestCase):
         attach_webhook.assert_called_once_with(
             project_pk=self.project.pk,
             user_pk=self.user.pk,
-            integration=integration.first()
+            integration=integration.first(),
         )
 
-    @mock.patch('readthedocs.projects.views.private.attach_webhook')
+    @mock.patch("readthedocs.projects.views.private.attach_webhook")
     def test_integration_create_generic_webhook(self, attach_webhook):
         response = self.client.post(
-            reverse('projects_integrations_create', args=[self.project.slug]),
+            reverse("projects_integrations_create", args=[self.project.slug]),
             data={
-                'project': self.project.pk,
-                'integration_type': GenericAPIWebhook.API_WEBHOOK
+                "project": self.project.pk,
+                "integration_type": GenericAPIWebhook.API_WEBHOOK,
             },
         )
         integration = GenericAPIWebhook.objects.filter(project=self.project)
@@ -385,10 +388,10 @@ class TestPrivateViews(TestCase):
 
         response = self.client.post(
             reverse(
-                'projects_integrations_webhooks_sync',
+                "projects_integrations_webhooks_sync",
                 kwargs={
-                    'project_slug': self.project.slug,
-                    'integration_pk': integration.pk,
+                    "project_slug": self.project.slug,
+                    "integration_pk": integration.pk,
                 },
             ),
         )
@@ -398,48 +401,47 @@ class TestPrivateViews(TestCase):
         self.assertFalse(self.project.has_valid_webhook)
 
     def test_remove_user(self):
-        user = get(User, username='test')
+        user = get(User, username="test")
         self.project.users.add(user)
 
         self.assertEqual(self.project.users.count(), 2)
         r = self.client.post(
-            reverse('projects_users_delete', args=(self.project.slug,)),
-            data={'username': 'test'}
+            reverse("projects_users_delete", args=(self.project.slug,)),
+            data={"username": "test"},
         )
         self.assertTrue(r.status_code, 302)
         self.assertEqual(self.project.users.count(), 1)
-        self.assertEqual(self.project.users.last().username, 'eric')
+        self.assertEqual(self.project.users.last().username, "eric")
 
     def test_remove_own_user(self):
-        user = get(User, username='test')
+        user = get(User, username="test")
         self.project.users.add(user)
 
         self.assertEqual(self.project.users.count(), 2)
         r = self.client.post(
-            reverse('projects_users_delete', args=(self.project.slug,)),
-            data={'username': 'eric'}
+            reverse("projects_users_delete", args=(self.project.slug,)),
+            data={"username": "eric"},
         )
         self.assertTrue(r.status_code, 302)
         self.assertEqual(self.project.users.count(), 1)
-        self.assertEqual(self.project.users.last().username, 'test')
+        self.assertEqual(self.project.users.last().username, "test")
 
     def test_remove_last_user(self):
         self.assertEqual(self.project.users.count(), 1)
         r = self.client.post(
-            reverse('projects_users_delete', args=(self.project.slug,)),
-            data={'username': 'eric'}
+            reverse("projects_users_delete", args=(self.project.slug,)),
+            data={"username": "eric"},
         )
         self.assertTrue(r.status_code, 400)
         self.assertEqual(self.project.users.count(), 1)
-        self.assertEqual(self.project.users.last().username, 'eric')
+        self.assertEqual(self.project.users.last().username, "eric")
 
 
-@mock.patch('readthedocs.core.utils.trigger_build', mock.MagicMock())
-@mock.patch('readthedocs.projects.tasks.builds.update_docs_task', mock.MagicMock())
+@mock.patch("readthedocs.core.utils.trigger_build", mock.MagicMock())
+@mock.patch("readthedocs.projects.tasks.builds.update_docs_task", mock.MagicMock())
 class TestPrivateMixins(TestCase):
-
     def setUp(self):
-        self.project = get(Project, slug='kong')
+        self.project = get(Project, slug="kong")
         self.domain = get(Domain, project=self.project)
 
     def test_project_relation(self):
@@ -453,38 +455,38 @@ class TestPrivateMixins(TestCase):
                 return Project.objects.all()
 
         view = FoobarView()
-        view.kwargs = {'project_slug': 'kong'}
+        view.kwargs = {"project_slug": "kong"}
         self.assertEqual(view.get_project(), self.project)
         self.assertEqual(view.get_queryset().first(), self.domain)
-        self.assertEqual(view.get_context_data()['project'], self.project)
+        self.assertEqual(view.get_context_data()["project"], self.project)
 
 
 class TestBadges(TestCase):
     """Test a static badge asset is served for each build."""
 
     def setUp(self):
-        self.BADGE_PATH = 'projects/badges/%s-%s.svg'
-        self.project = get(Project, slug='badgey')
+        self.BADGE_PATH = "projects/badges/%s-%s.svg"
+        self.project = get(Project, slug="badgey")
         self.version = Version.objects.get(project=self.project)
-        self.badge_url = reverse('project_badge', args=[self.project.slug])
+        self.badge_url = reverse("project_badge", args=[self.project.slug])
 
     def test_unknown_badge(self):
-        res = self.client.get(self.badge_url, {'version': self.version.slug})
-        self.assertContains(res, 'unknown')
+        res = self.client.get(self.badge_url, {"version": self.version.slug})
+        self.assertContains(res, "unknown")
 
         # Unknown project
-        unknown_project_url = reverse('project_badge', args=['fake-project'])
-        res = self.client.get(unknown_project_url, {'version': 'latest'})
-        self.assertContains(res, 'unknown')
+        unknown_project_url = reverse("project_badge", args=["fake-project"])
+        res = self.client.get(unknown_project_url, {"version": "latest"})
+        self.assertContains(res, "unknown")
 
         # Unknown version
-        res = self.client.get(self.badge_url, {'version': 'fake-version'})
-        self.assertContains(res, 'unknown')
+        res = self.client.get(self.badge_url, {"version": "fake-version"})
+        self.assertContains(res, "unknown")
 
     def test_badge_caching(self):
-        res = self.client.get(self.badge_url, {'version': self.version.slug})
-        self.assertTrue('must-revalidate' in res['Cache-Control'])
-        self.assertTrue('no-cache' in res['Cache-Control'])
+        res = self.client.get(self.badge_url, {"version": self.version.slug})
+        self.assertTrue("must-revalidate" in res["Cache-Control"])
+        self.assertTrue("no-cache" in res["Cache-Control"])
 
     def test_passing_badge(self):
         get(
@@ -539,18 +541,18 @@ class TestBadges(TestCase):
         self.assertContains(res, "passing")
 
         # The social badge (but not the other badges) has this element
-        self.assertContains(res, 'rlink')
+        self.assertContains(res, "rlink")
 
     def test_badge_redirect(self):
         # Test that a project with an underscore redirects
-        badge_url = reverse('project_badge', args=['project_slug'])
-        resp = self.client.get(badge_url, {'version': 'latest'})
+        badge_url = reverse("project_badge", args=["project_slug"])
+        resp = self.client.get(badge_url, {"version": "latest"})
         self.assertEqual(resp.status_code, 302)
-        self.assertTrue('project-slug' in resp['location'])
+        self.assertTrue("project-slug" in resp["location"])
 
     def test_private_version(self):
         # Set version to private
-        self.version.privacy_level = 'private'
+        self.version.privacy_level = "private"
         self.version.save()
 
         # Without a token, badge is unknown
@@ -568,59 +570,57 @@ class TestBadges(TestCase):
         res = self.client.get(
             self.badge_url,
             {
-                'token': ProjectBadgeView.get_project_token('invalid-project'),
-                'version': self.version.slug,
-            }
+                "token": ProjectBadgeView.get_project_token("invalid-project"),
+                "version": self.version.slug,
+            },
         )
-        self.assertContains(res, 'unknown')
+        self.assertContains(res, "unknown")
 
         # With a valid token, the badge should work correctly
         res = self.client.get(
             self.badge_url,
             {
-                'token': ProjectBadgeView.get_project_token(self.project.slug),
-                'version': self.version.slug,
-            }
+                "token": ProjectBadgeView.get_project_token(self.project.slug),
+                "version": self.version.slug,
+            },
         )
-        self.assertContains(res, 'passing')
+        self.assertContains(res, "passing")
 
 
 class TestTags(TestCase):
-
     def test_project_filtering_work_with_tags_with_space_in_name(self):
-        pip = get(Project, slug='pip', privacy_level=PUBLIC)
-        pip.tags.add('tag with space')
-        response = self.client.get('/projects/tags/tag-with-space/')
+        pip = get(Project, slug="pip", privacy_level=PUBLIC)
+        pip.tags.add("tag with space")
+        response = self.client.get("/projects/tags/tag-with-space/")
         self.assertContains(response, '"/projects/pip/"')
 
 
 @override_settings(RTD_ALLOW_ORGANIZATIONS=False)
 class TestWebhooksViews(TestCase):
-
     def setUp(self):
         self.user = get(User)
-        self.project = get(Project, slug='test', users=[self.user])
-        self.version = get(Version, slug='1.0', project=self.project)
+        self.project = get(Project, slug="test", users=[self.user])
+        self.version = get(Version, slug="1.0", project=self.project)
         self.webhook = get(WebHook, project=self.project)
         self.client.force_login(self.user)
 
     def test_list(self):
         resp = self.client.get(
-            reverse('projects_webhooks', args=[self.project.slug]),
+            reverse("projects_webhooks", args=[self.project.slug]),
         )
         self.assertEqual(resp.status_code, 200)
-        queryset = resp.context['object_list']
+        queryset = resp.context["object_list"]
         self.assertEqual(queryset.count(), 1)
         self.assertEqual(queryset.first(), self.webhook)
 
     def test_create(self):
         self.assertEqual(self.project.webhook_notifications.all().count(), 1)
         resp = self.client.post(
-            reverse('projects_webhooks_create', args=[self.project.slug]),
-            data = {
-                'url': 'http://www.example.com/',
-                'payload': '{}',
-                'events': [WebHookEvent.objects.get(name=WebHookEvent.BUILD_FAILED).id],
+            reverse("projects_webhooks_create", args=[self.project.slug]),
+            data={
+                "url": "http://www.example.com/",
+                "payload": "{}",
+                "events": [WebHookEvent.objects.get(name=WebHookEvent.BUILD_FAILED).id],
             },
         )
         self.assertEqual(resp.status_code, 302)
@@ -629,28 +629,33 @@ class TestWebhooksViews(TestCase):
     def test_update(self):
         self.assertEqual(self.project.webhook_notifications.all().count(), 1)
         self.client.post(
-            reverse('projects_webhooks_edit', args=[self.project.slug, self.webhook.pk]),
-            data = {
-                'url': 'http://www.example.com/new',
-                'payload': '{}',
-                'events': [WebHookEvent.objects.get(name=WebHookEvent.BUILD_FAILED).id],
+            reverse(
+                "projects_webhooks_edit", args=[self.project.slug, self.webhook.pk]
+            ),
+            data={
+                "url": "http://www.example.com/new",
+                "payload": "{}",
+                "events": [WebHookEvent.objects.get(name=WebHookEvent.BUILD_FAILED).id],
             },
         )
         self.webhook.refresh_from_db()
-        self.assertEqual(self.webhook.url, 'http://www.example.com/new')
+        self.assertEqual(self.webhook.url, "http://www.example.com/new")
         self.assertEqual(self.project.webhook_notifications.all().count(), 1)
 
     def test_delete(self):
         self.assertEqual(self.project.webhook_notifications.all().count(), 1)
         self.client.post(
-            reverse('projects_webhooks_delete', args=[self.project.slug, self.webhook.pk]),
+            reverse(
+                "projects_webhooks_delete", args=[self.project.slug, self.webhook.pk]
+            ),
         )
         self.assertEqual(self.project.webhook_notifications.all().count(), 0)
 
 
 @override_settings(RTD_ALLOW_ORGANIZATIONS=True)
 class TestWebhooksViewsWithOrganizations(TestWebhooksViews):
-
     def setUp(self):
         super().setUp()
-        self.organization = get(Organization, owners=[self.user], projects=[self.project])
+        self.organization = get(
+            Organization, owners=[self.user], projects=[self.project]
+        )

--- a/readthedocs/rtd_tests/tests/test_resolver.py
+++ b/readthedocs/rtd_tests/tests/test_resolver.py
@@ -875,20 +875,20 @@ class TestSubprojectsWithTranslations(TestCase):
         self.assertEqual(
             url,
             (
-                'http://{project.slug}.readthedocs.io/projects/'
-                '{subproject.slug}/en/latest/'
+                "http://{project.slug}.readthedocs.io/projects/"
+                "{subproject.slug}/en/latest/"
             ).format(
                 project=self.superproject_en,
                 subproject=self.subproject_en,
             ),
         )
 
-        url = resolve(self.subproject_es, filename='')
+        url = resolve(self.subproject_es, filename="")
         self.assertEqual(
             url,
             (
-                'http://{project.slug}.readthedocs.io/projects/'
-                '{subproject.slug}/es/latest/'
+                "http://{project.slug}.readthedocs.io/projects/"
+                "{subproject.slug}/es/latest/"
             ).format(
                 project=self.superproject_en,
                 subproject=self.subproject_en,
@@ -914,24 +914,18 @@ class TestSubprojectsWithTranslations(TestCase):
         url = resolve(self.superproject_es, filename="")
         self.assertEqual(url, "http://docs.example.com/es/latest/")
 
-        url = resolve(self.subproject_en, filename='')
+        url = resolve(self.subproject_en, filename="")
         self.assertEqual(
             url,
-            (
-                'http://docs.example.com/projects/'
-                '{subproject.slug}/en/latest/'
-            ).format(
+            ("http://docs.example.com/projects/" "{subproject.slug}/en/latest/").format(
                 subproject=self.subproject_en,
             ),
         )
 
-        url = resolve(self.subproject_es, filename='')
+        url = resolve(self.subproject_es, filename="")
         self.assertEqual(
             url,
-            (
-                'http://docs.example.com/projects/'
-                '{subproject.slug}/es/latest/'
-            ).format(
+            ("http://docs.example.com/projects/" "{subproject.slug}/es/latest/").format(
                 subproject=self.subproject_en,
             ),
         )

--- a/readthedocs/rtd_tests/tests/test_sync_versions.py
+++ b/readthedocs/rtd_tests/tests/test_sync_versions.py
@@ -16,21 +16,21 @@ from readthedocs.organizations.models import Organization, OrganizationOwner
 from readthedocs.projects.models import Project
 
 
-@mock.patch('readthedocs.core.utils.trigger_build', mock.MagicMock())
-@mock.patch('readthedocs.builds.tasks.trigger_build', mock.MagicMock())
+@mock.patch("readthedocs.core.utils.trigger_build", mock.MagicMock())
+@mock.patch("readthedocs.builds.tasks.trigger_build", mock.MagicMock())
 class TestSyncVersions(TestCase):
-    fixtures = ['eric', 'test_data']
+    fixtures = ["eric", "test_data"]
 
     def setUp(self):
-        self.user = User.objects.get(username='eric')
+        self.user = User.objects.get(username="eric")
         self.client.force_login(self.user)
-        self.pip = Project.objects.get(slug='pip')
+        self.pip = Project.objects.get(slug="pip")
 
         # Run tests for .com
         if settings.ALLOW_PRIVATE_REPOS:
             self.org = get(
                 Organization,
-                name='testorg',
+                name="testorg",
             )
             OrganizationOwner.objects.create(
                 owner=self.user,
@@ -40,16 +40,16 @@ class TestSyncVersions(TestCase):
 
         Version.objects.create(
             project=self.pip,
-            identifier='origin/master',
-            verbose_name='master',
+            identifier="origin/master",
+            verbose_name="master",
             active=True,
             machine=True,
             type=BRANCH,
         )
         Version.objects.create(
             project=self.pip,
-            identifier='to_delete',
-            verbose_name='to_delete',
+            identifier="to_delete",
+            verbose_name="to_delete",
             active=False,
             type=TAG,
         )
@@ -59,18 +59,18 @@ class TestSyncVersions(TestCase):
     def test_proper_url_no_slash(self):
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
             {
-                'identifier': 'origin/to_add',
-                'verbose_name': 'to_add',
+                "identifier": "origin/to_add",
+                "verbose_name": "to_add",
             },
         ]
 
         self.assertEqual(
-            set(self.pip.versions.all().values_list('slug', flat=True)),
-            {'master', 'latest', 'stable', '0.8.1', '0.8', 'to_delete'},
+            set(self.pip.versions.all().values_list("slug", flat=True)),
+            {"master", "latest", "stable", "0.8.1", "0.8", "to_delete"},
         )
         sync_versions_task(
             self.pip.pk,
@@ -78,37 +78,37 @@ class TestSyncVersions(TestCase):
             tags_data=[],
         )
         self.assertEqual(
-            set(self.pip.versions.all().values_list('slug', flat=True)),
-            {'master', 'latest', 'stable', '0.8.1', '0.8', 'to_add'},
+            set(self.pip.versions.all().values_list("slug", flat=True)),
+            {"master", "latest", "stable", "0.8.1", "0.8", "to_add"},
         )
 
     def test_new_tag_update_active(self):
         Version.objects.create(
             project=self.pip,
-            identifier='0.8.3',
-            verbose_name='0.8.3',
+            identifier="0.8.3",
+            verbose_name="0.8.3",
             active=True,
         )
         self.pip.update_stable_version()
 
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
             {
-                'identifier': 'origin/to_add',
-                'verbose_name': 'to_add',
+                "identifier": "origin/to_add",
+                "verbose_name": "to_add",
             },
         ]
         tags_data = [
             {
-                'identifier': '0.9',
-                'verbose_name': '0.9',
+                "identifier": "0.9",
+                "verbose_name": "0.9",
             },
             {
-                'identifier': '0.8.3',
-                'verbose_name': '0.8.3',
+                "identifier": "0.8.3",
+                "verbose_name": "0.8.3",
             },
         ]
 
@@ -117,7 +117,7 @@ class TestSyncVersions(TestCase):
             branches_data=branches_data,
             tags_data=tags_data,
         )
-        version_9 = Version.objects.get(slug='0.9')
+        version_9 = Version.objects.get(slug="0.9")
         self.assertTrue(version_9.active)
 
         # Version 0.9 becomes the stable version
@@ -129,8 +129,8 @@ class TestSyncVersions(TestCase):
     def test_new_tag_dont_update_inactive(self):
         Version.objects.create(
             project=self.pip,
-            identifier='0.8.3',
-            verbose_name='0.8.3',
+            identifier="0.8.3",
+            verbose_name="0.8.3",
             type=TAG,
             active=False,
         )
@@ -138,22 +138,22 @@ class TestSyncVersions(TestCase):
 
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
             {
-                'identifier': 'origin/to_add',
-                'verbose_name': 'to_add',
+                "identifier": "origin/to_add",
+                "verbose_name": "to_add",
             },
         ]
         tags_data = [
             {
-                'identifier': '0.9',
-                'verbose_name': '0.9',
+                "identifier": "0.9",
+                "verbose_name": "0.9",
             },
             {
-                'identifier': '0.8.3',
-                'verbose_name': '0.8.3',
+                "identifier": "0.8.3",
+                "verbose_name": "0.8.3",
             },
         ]
 
@@ -163,7 +163,7 @@ class TestSyncVersions(TestCase):
             tags_data=tags_data,
         )
         # Version 0.9 becomes the stable version, but it's inactive
-        version_9 = self.pip.versions.get(slug='0.9')
+        version_9 = self.pip.versions.get(slug="0.9")
         self.assertEqual(
             version_9.identifier,
             self.pip.get_stable_version().identifier,
@@ -171,21 +171,21 @@ class TestSyncVersions(TestCase):
         self.assertFalse(version_9.active)
 
         # Version 0.8.3 is still inactive
-        version_8 = Version.objects.get(slug='0.8.3')
+        version_8 = Version.objects.get(slug="0.8.3")
         self.assertFalse(version_8.active)
 
     def test_delete_version(self):
         Version.objects.create(
             project=self.pip,
-            identifier='0.8.3',
-            verbose_name='0.8.3',
+            identifier="0.8.3",
+            verbose_name="0.8.3",
             active=False,
         )
 
         Version.objects.create(
             project=self.pip,
-            identifier='external',
-            verbose_name='external',
+            identifier="external",
+            verbose_name="external",
             type=EXTERNAL,
             active=False,
         )
@@ -194,13 +194,13 @@ class TestSyncVersions(TestCase):
 
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
         ]
 
         self.assertTrue(
-            Version.objects.filter(slug='0.8.3').exists(),
+            Version.objects.filter(slug="0.8.3").exists(),
         )
 
         sync_versions_task(
@@ -211,12 +211,12 @@ class TestSyncVersions(TestCase):
 
         # There isn't a v0.8.3
         self.assertFalse(
-            Version.objects.filter(slug='0.8.3').exists(),
+            Version.objects.filter(slug="0.8.3").exists(),
         )
 
         # The inactive external version isn't deleted
         self.assertTrue(
-            Version.objects.filter(slug='external').exists(),
+            Version.objects.filter(slug="external").exists(),
         )
 
     def test_update_stable_version_type(self):
@@ -317,8 +317,8 @@ class TestSyncVersions(TestCase):
         """
         version8 = Version.objects.create(
             project=self.pip,
-            identifier='0.8.3',
-            verbose_name='0.8.3',
+            identifier="0.8.3",
+            verbose_name="0.8.3",
             type=TAG,
             active=False,
             machine=False,
@@ -335,19 +335,19 @@ class TestSyncVersions(TestCase):
 
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
         ]
         tags_data = [
             # User new stable
             {
-                'identifier': '1abc2def3',
-                'verbose_name': 'stable',
+                "identifier": "1abc2def3",
+                "verbose_name": "stable",
             },
             {
-                'identifier': '0.8.3',
-                'verbose_name': '0.8.3',
+                "identifier": "0.8.3",
+                "verbose_name": "0.8.3",
             },
         ]
 
@@ -359,21 +359,21 @@ class TestSyncVersions(TestCase):
 
         current_stable = self.pip.get_stable_version()
         self.assertEqual(
-            '1abc2def3',
+            "1abc2def3",
             current_stable.identifier,
         )
 
         # Deleting the tag should return the RTD's stable
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
         ]
         tags_data = [
             {
-                'identifier': '0.8.3',
-                'verbose_name': '0.8.3',
+                "identifier": "0.8.3",
+                "verbose_name": "0.8.3",
             },
         ]
 
@@ -387,7 +387,7 @@ class TestSyncVersions(TestCase):
         # The stable isn't stuck with the previous commit
         current_stable = self.pip.get_stable_version()
         self.assertEqual(
-            '0.8.3',
+            "0.8.3",
             current_stable.identifier,
         )
         self.assertTrue(current_stable.machine)
@@ -401,25 +401,25 @@ class TestSyncVersions(TestCase):
         is back (set to machine=True).
         """
         # There isn't a stable version yet
-        self.pip.versions.exclude(slug='master').delete()
+        self.pip.versions.exclude(slug="master").delete()
         current_stable = self.pip.get_stable_version()
         self.assertIsNone(current_stable)
 
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
         ]
         tags_data = [
             # User stable
             {
-                'identifier': '1abc2def3',
-                'verbose_name': 'stable',
+                "identifier": "1abc2def3",
+                "verbose_name": "stable",
             },
             {
-                'identifier': '0.8.3',
-                'verbose_name': '0.8.3',
+                "identifier": "0.8.3",
+                "verbose_name": "0.8.3",
             },
         ]
 
@@ -431,7 +431,7 @@ class TestSyncVersions(TestCase):
 
         current_stable = self.pip.get_stable_version()
         self.assertEqual(
-            '1abc2def3',
+            "1abc2def3",
             current_stable.identifier,
         )
 
@@ -442,14 +442,14 @@ class TestSyncVersions(TestCase):
         # Deleting the tag should return the RTD's stable
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
         ]
         tags_data = [
             {
-                'identifier': '0.8.3',
-                'verbose_name': '0.8.3',
+                "identifier": "0.8.3",
+                "verbose_name": "0.8.3",
             },
         ]
 
@@ -463,7 +463,7 @@ class TestSyncVersions(TestCase):
         # The stable isn't stuck with the previous commit
         current_stable = self.pip.get_stable_version()
         self.assertEqual(
-            '0.8.3',
+            "0.8.3",
             current_stable.identifier,
         )
         self.assertTrue(current_stable.machine)
@@ -480,8 +480,8 @@ class TestSyncVersions(TestCase):
         self.pip.versions.filter(type=TAG).delete()
         Version.objects.create(
             project=self.pip,
-            identifier='0.8.3',
-            verbose_name='0.8.3',
+            identifier="0.8.3",
+            verbose_name="0.8.3",
             type=BRANCH,
             active=False,
             machine=False,
@@ -491,24 +491,24 @@ class TestSyncVersions(TestCase):
 
         # 0.8.3 is the current stable
         self.assertEqual(
-            '0.8.3',
+            "0.8.3",
             current_stable.identifier,
         )
         self.assertTrue(current_stable.machine)
 
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
             # User new stable
             {
-                'identifier': 'origin/stable',
-                'verbose_name': 'stable',
+                "identifier": "origin/stable",
+                "verbose_name": "stable",
             },
             {
-                'identifier': 'origin/0.8.3',
-                'verbose_name': '0.8.3',
+                "identifier": "origin/0.8.3",
+                "verbose_name": "0.8.3",
             },
         ]
 
@@ -520,19 +520,19 @@ class TestSyncVersions(TestCase):
 
         current_stable = self.pip.get_stable_version()
         self.assertEqual(
-            'origin/stable',
+            "origin/stable",
             current_stable.identifier,
         )
 
         # Deleting the branch should return the RTD's stable
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
             {
-                'identifier': 'origin/0.8.3',
-                'verbose_name': '0.8.3',
+                "identifier": "origin/0.8.3",
+                "verbose_name": "0.8.3",
             },
         ]
 
@@ -546,35 +546,37 @@ class TestSyncVersions(TestCase):
         # The stable isn't stuck with the previous branch
         current_stable = self.pip.get_stable_version()
         self.assertEqual(
-            'origin/0.8.3',
+            "origin/0.8.3",
             current_stable.identifier,
         )
         self.assertTrue(current_stable.machine)
 
-    def test_machine_attr_when_user_define_stable_branch_and_delete_it_new_project(self):
+    def test_machine_attr_when_user_define_stable_branch_and_delete_it_new_project(
+        self,
+    ):
         """The user imports a new project with a branch named ``stable``, when
         syncing the versions, the RTD's ``stable`` is lost (set to
         machine=False) and doesn't update automatically anymore, when the branch
         is deleted on the user repository, the RTD's ``stable`` is back (set to
         machine=True)."""
         # There isn't a stable version yet
-        self.pip.versions.exclude(slug='master').delete()
+        self.pip.versions.exclude(slug="master").delete()
         current_stable = self.pip.get_stable_version()
         self.assertIsNone(current_stable)
 
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
             # User stable
             {
-                'identifier': 'origin/stable',
-                'verbose_name': 'stable',
+                "identifier": "origin/stable",
+                "verbose_name": "stable",
             },
             {
-                'identifier': 'origin/0.8.3',
-                'verbose_name': '0.8.3',
+                "identifier": "origin/0.8.3",
+                "verbose_name": "0.8.3",
             },
         ]
 
@@ -586,7 +588,7 @@ class TestSyncVersions(TestCase):
 
         current_stable = self.pip.get_stable_version()
         self.assertEqual(
-            'origin/stable',
+            "origin/stable",
             current_stable.identifier,
         )
 
@@ -597,12 +599,12 @@ class TestSyncVersions(TestCase):
         # Deleting the branch should return the RTD's stable
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
             {
-                'identifier': 'origin/0.8.3',
-                'verbose_name': '0.8.3',
+                "identifier": "origin/0.8.3",
+                "verbose_name": "0.8.3",
             },
         ]
 
@@ -616,7 +618,7 @@ class TestSyncVersions(TestCase):
         # The stable isn't stuck with the previous commit
         current_stable = self.pip.get_stable_version()
         self.assertEqual(
-            'origin/0.8.3',
+            "origin/0.8.3",
             current_stable.identifier,
         )
         self.assertTrue(current_stable.machine)
@@ -630,15 +632,15 @@ class TestSyncVersions(TestCase):
 
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
         ]
         tags_data = [
             # User new stable
             {
-                'identifier': '1abc2def3',
-                'verbose_name': 'latest',
+                "identifier": "1abc2def3",
+                "verbose_name": "latest",
             },
         ]
 
@@ -649,17 +651,17 @@ class TestSyncVersions(TestCase):
         )
 
         # The tag is the new latest
-        version_latest = self.pip.versions.get(slug='latest')
+        version_latest = self.pip.versions.get(slug="latest")
         self.assertEqual(
-            '1abc2def3',
+            "1abc2def3",
             version_latest.identifier,
         )
 
         # Deleting the tag should return the RTD's latest
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
         ]
 
@@ -670,9 +672,9 @@ class TestSyncVersions(TestCase):
         )
 
         # The latest isn't stuck with the previous commit
-        version_latest = self.pip.versions.get(slug='latest')
+        version_latest = self.pip.versions.get(slug="latest")
         self.assertEqual(
-            'master',
+            "master",
             version_latest.identifier,
         )
         self.assertTrue(version_latest.machine)
@@ -685,13 +687,13 @@ class TestSyncVersions(TestCase):
                                                                          machine=True)."""
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
             # User new latest
             {
-                'identifier': 'origin/latest',
-                'verbose_name': 'latest',
+                "identifier": "origin/latest",
+                "verbose_name": "latest",
             },
         ]
 
@@ -702,17 +704,17 @@ class TestSyncVersions(TestCase):
         )
 
         # The branch is the new latest
-        version_latest = self.pip.versions.get(slug='latest')
+        version_latest = self.pip.versions.get(slug="latest")
         self.assertEqual(
-            'origin/latest',
+            "origin/latest",
             version_latest.identifier,
         )
 
         # Deleting the branch should return the RTD's latest
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
         ]
 
@@ -723,9 +725,9 @@ class TestSyncVersions(TestCase):
         )
 
         # The latest isn't stuck with the previous branch
-        version_latest = self.pip.versions.get(slug='latest')
+        version_latest = self.pip.versions.get(slug="latest")
         self.assertEqual(
-            'master',
+            "master",
             version_latest.identifier,
         )
         self.assertTrue(version_latest.machine)
@@ -733,14 +735,14 @@ class TestSyncVersions(TestCase):
     def test_deletes_version_with_same_identifier(self):
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
         ]
         tags_data = [
             {
-                'identifier': '1234',
-                'verbose_name': 'one',
+                "identifier": "1234",
+                "verbose_name": "one",
             },
         ]
 
@@ -752,25 +754,25 @@ class TestSyncVersions(TestCase):
 
         # We only have one version with an identifier `1234`
         self.assertEqual(
-            self.pip.versions.filter(identifier='1234').count(),
+            self.pip.versions.filter(identifier="1234").count(),
             1,
         )
 
         # We add a new tag with the same identifier
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
         ]
         tags_data = [
             {
-                'identifier': '1234',
-                'verbose_name': 'two',
+                "identifier": "1234",
+                "verbose_name": "two",
             },
             {
-                'identifier': '1234',
-                'verbose_name': 'one',
+                "identifier": "1234",
+                "verbose_name": "one",
             },
         ]
 
@@ -782,21 +784,21 @@ class TestSyncVersions(TestCase):
 
         # We have two versions with an identifier `1234`
         self.assertEqual(
-            self.pip.versions.filter(identifier='1234').count(),
+            self.pip.versions.filter(identifier="1234").count(),
             2,
         )
 
         # We delete one version with identifier `1234`
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
         ]
         tags_data = [
             {
-                'identifier': '1234',
-                'verbose_name': 'one',
+                "identifier": "1234",
+                "verbose_name": "one",
             },
         ]
 
@@ -808,7 +810,7 @@ class TestSyncVersions(TestCase):
 
         # We have only one version with an identifier `1234`
         self.assertEqual(
-            self.pip.versions.filter(identifier='1234').count(),
+            self.pip.versions.filter(identifier="1234").count(),
             1,
         )
 
@@ -862,35 +864,36 @@ class TestSyncVersions(TestCase):
             1,
         )
 
-
-    @mock.patch('readthedocs.builds.tasks.run_automation_rules')
-    def test_automation_rules_are_triggered_for_new_versions(self, run_automation_rules):
+    @mock.patch("readthedocs.builds.tasks.run_automation_rules")
+    def test_automation_rules_are_triggered_for_new_versions(
+        self, run_automation_rules
+    ):
         Version.objects.create(
             project=self.pip,
-            identifier='0.8.3',
-            verbose_name='0.8.3',
+            identifier="0.8.3",
+            verbose_name="0.8.3",
             active=True,
             type=TAG,
         )
 
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
             {
-                'identifier': 'origin/new_branch',
-                'verbose_name': 'new_branch',
+                "identifier": "origin/new_branch",
+                "verbose_name": "new_branch",
             },
         ]
         tags_data = [
             {
-                'identifier': 'new_tag',
-                'verbose_name': 'new_tag',
+                "identifier": "new_tag",
+                "verbose_name": "new_tag",
             },
             {
-                'identifier': '0.8.3',
-                'verbose_name': '0.8.3',
+                "identifier": "0.8.3",
+                "verbose_name": "0.8.3",
             },
         ]
         sync_versions_task(
@@ -900,56 +903,54 @@ class TestSyncVersions(TestCase):
         )
         run_automation_rules.assert_called_with(
             self.pip,
-            {'new_branch', 'new_tag'},
-            {'0.8', '0.8.1'},
+            {"new_branch", "new_tag"},
+            {"0.8", "0.8.1"},
         )
 
-    @mock.patch('readthedocs.builds.automation_actions.trigger_build', mock.MagicMock())
+    @mock.patch("readthedocs.builds.automation_actions.trigger_build", mock.MagicMock())
     def test_automation_rule_activate_version(self):
         tags_data = [
             {
-                'identifier': 'new_tag',
-                'verbose_name': 'new_tag',
+                "identifier": "new_tag",
+                "verbose_name": "new_tag",
             },
             {
-                'identifier': '0.8.3',
-                'verbose_name': '0.8.3',
+                "identifier": "0.8.3",
+                "verbose_name": "0.8.3",
             },
         ]
         RegexAutomationRule.objects.create(
             project=self.pip,
             priority=0,
-            match_arg=r'^new_tag$',
+            match_arg=r"^new_tag$",
             action=VersionAutomationRule.ACTIVATE_VERSION_ACTION,
             version_type=TAG,
         )
-        self.assertFalse(
-            self.pip.versions.filter(verbose_name='new_tag').exists()
-        )
+        self.assertFalse(self.pip.versions.filter(verbose_name="new_tag").exists())
         sync_versions_task(
             self.pip.pk,
             branches_data=[],
             tags_data=tags_data,
         )
-        new_tag = self.pip.versions.get(verbose_name='new_tag')
+        new_tag = self.pip.versions.get(verbose_name="new_tag")
         self.assertTrue(new_tag.active)
 
-    @mock.patch('readthedocs.builds.automation_actions.trigger_build', mock.MagicMock())
+    @mock.patch("readthedocs.builds.automation_actions.trigger_build", mock.MagicMock())
     def test_automation_rule_set_default_version(self):
         tags_data = [
             {
-                'identifier': 'new_tag',
-                'verbose_name': 'new_tag',
+                "identifier": "new_tag",
+                "verbose_name": "new_tag",
             },
             {
-                'identifier': '0.8.3',
-                'verbose_name': '0.8.3',
+                "identifier": "0.8.3",
+                "verbose_name": "0.8.3",
             },
         ]
         RegexAutomationRule.objects.create(
             project=self.pip,
             priority=0,
-            match_arg=r'^new_tag$',
+            match_arg=r"^new_tag$",
             action=VersionAutomationRule.SET_DEFAULT_VERSION_ACTION,
             version_type=TAG,
         )
@@ -960,24 +961,24 @@ class TestSyncVersions(TestCase):
             tags_data=tags_data,
         )
         self.pip.refresh_from_db()
-        self.assertEqual(self.pip.get_default_version(), 'new_tag')
+        self.assertEqual(self.pip.get_default_version(), "new_tag")
 
     def test_automation_rule_delete_version(self):
         tags_data = [
             {
-                'identifier': 'new_tag',
-                'verbose_name': 'new_tag',
+                "identifier": "new_tag",
+                "verbose_name": "new_tag",
             },
             {
-                'identifier': '0.8.3',
-                'verbose_name': '0.8.3',
+                "identifier": "0.8.3",
+                "verbose_name": "0.8.3",
             },
         ]
-        version_slug = '0.8'
+        version_slug = "0.8"
         RegexAutomationRule.objects.create(
             project=self.pip,
             priority=0,
-            match_arg=r'^0\.8$',
+            match_arg=r"^0\.8$",
             action=VersionAutomationRule.DELETE_VERSION_ACTION,
             version_type=TAG,
         )
@@ -994,19 +995,19 @@ class TestSyncVersions(TestCase):
     def test_automation_rule_dont_delete_default_version(self):
         tags_data = [
             {
-                'identifier': 'new_tag',
-                'verbose_name': 'new_tag',
+                "identifier": "new_tag",
+                "verbose_name": "new_tag",
             },
             {
-                'identifier': '0.8.3',
-                'verbose_name': '0.8.3',
+                "identifier": "0.8.3",
+                "verbose_name": "0.8.3",
             },
         ]
-        version_slug = '0.8'
+        version_slug = "0.8"
         RegexAutomationRule.objects.create(
             project=self.pip,
             priority=0,
-            match_arg=r'^0\.8$',
+            match_arg=r"^0\.8$",
             action=VersionAutomationRule.DELETE_VERSION_ACTION,
             version_type=TAG,
         )
@@ -1023,21 +1024,22 @@ class TestSyncVersions(TestCase):
         )
         self.assertTrue(self.pip.versions.filter(slug=version_slug).exists())
 
-@mock.patch('readthedocs.core.utils.trigger_build', mock.MagicMock())
-@mock.patch('readthedocs.builds.tasks.trigger_build', mock.MagicMock())
+
+@mock.patch("readthedocs.core.utils.trigger_build", mock.MagicMock())
+@mock.patch("readthedocs.builds.tasks.trigger_build", mock.MagicMock())
 class TestStableVersion(TestCase):
-    fixtures = ['eric', 'test_data']
+    fixtures = ["eric", "test_data"]
 
     def setUp(self):
-        self.user = User.objects.get(username='eric')
+        self.user = User.objects.get(username="eric")
         self.client.force_login(self.user)
-        self.pip = Project.objects.get(slug='pip')
+        self.pip = Project.objects.get(slug="pip")
 
         # Run tests for .com
         if settings.ALLOW_PRIVATE_REPOS:
             self.org = get(
                 Organization,
-                name='testorg',
+                name="testorg",
             )
             OrganizationOwner.objects.create(
                 owner=self.user,
@@ -1045,26 +1047,25 @@ class TestStableVersion(TestCase):
             )
             self.org.projects.add(self.pip)
 
-
     def test_stable_versions(self):
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
             {
-                'identifier': 'origin/to_add',
-                'verbose_name': 'to_add',
+                "identifier": "origin/to_add",
+                "verbose_name": "to_add",
             },
         ]
         tags_data = [
             {
-                'identifier': '0.9',
-                'verbose_name': '0.9',
+                "identifier": "0.9",
+                "verbose_name": "0.9",
             },
             {
-                'identifier': '0.8',
-                'verbose_name': '0.8',
+                "identifier": "0.8",
+                "verbose_name": "0.8",
             },
         ]
 
@@ -1080,15 +1081,15 @@ class TestStableVersion(TestCase):
         )
         version_stable = Version.objects.get(slug=STABLE)
         self.assertTrue(version_stable.active)
-        self.assertEqual(version_stable.identifier, '0.9')
+        self.assertEqual(version_stable.identifier, "0.9")
 
     def test_pre_release_are_not_stable(self):
         tags_data = [
-            {'identifier': '1.0a1', 'verbose_name': '1.0a1'},
-            {'identifier': '0.9', 'verbose_name': '0.9'},
-            {'identifier': '0.9b1', 'verbose_name': '0.9b1'},
-            {'identifier': '0.8', 'verbose_name': '0.8'},
-            {'identifier': '0.8rc2', 'verbose_name': '0.8rc2'},
+            {"identifier": "1.0a1", "verbose_name": "1.0a1"},
+            {"identifier": "0.9", "verbose_name": "0.9"},
+            {"identifier": "0.9b1", "verbose_name": "0.9b1"},
+            {"identifier": "0.8", "verbose_name": "0.8"},
+            {"identifier": "0.8rc2", "verbose_name": "0.8rc2"},
         ]
 
         sync_versions_task(
@@ -1098,12 +1099,12 @@ class TestStableVersion(TestCase):
         )
         version_stable = Version.objects.get(slug=STABLE)
         self.assertTrue(version_stable.active)
-        self.assertEqual(version_stable.identifier, '0.9')
+        self.assertEqual(version_stable.identifier, "0.9")
 
     def test_post_releases_are_stable(self):
         tags_data = [
-            {'identifier': '1.0', 'verbose_name': '1.0'},
-            {'identifier': '1.0.post1', 'verbose_name': '1.0.post1'},
+            {"identifier": "1.0", "verbose_name": "1.0"},
+            {"identifier": "1.0.post1", "verbose_name": "1.0.post1"},
         ]
 
         sync_versions_task(
@@ -1113,15 +1114,15 @@ class TestStableVersion(TestCase):
         )
         version_stable = Version.objects.get(slug=STABLE)
         self.assertTrue(version_stable.active)
-        self.assertEqual(version_stable.identifier, '1.0.post1')
+        self.assertEqual(version_stable.identifier, "1.0.post1")
 
     def test_invalid_version_numbers_are_not_stable(self):
         self.pip.versions.all().delete()
 
         tags_data = [
             {
-                'identifier': 'this.is.invalid',
-                'verbose_name': 'this.is.invalid',
+                "identifier": "this.is.invalid",
+                "verbose_name": "this.is.invalid",
             },
         ]
 
@@ -1134,12 +1135,12 @@ class TestStableVersion(TestCase):
 
         tags_data = [
             {
-                'identifier': '1.0',
-                'verbose_name': '1.0',
+                "identifier": "1.0",
+                "verbose_name": "1.0",
             },
             {
-                'identifier': 'this.is.invalid',
-                'verbose_name': 'this.is.invalid',
+                "identifier": "this.is.invalid",
+                "verbose_name": "this.is.invalid",
             },
         ]
 
@@ -1150,23 +1151,23 @@ class TestStableVersion(TestCase):
         )
         version_stable = Version.objects.get(slug=STABLE)
         self.assertTrue(version_stable.active)
-        self.assertEqual(version_stable.identifier, '1.0')
+        self.assertEqual(version_stable.identifier, "1.0")
 
     def test_update_stable_version(self):
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
         ]
         tags_data = [
             {
-                'identifier': '0.9',
-                'verbose_name': '0.9',
+                "identifier": "0.9",
+                "verbose_name": "0.9",
             },
             {
-                'identifier': '0.8',
-                'verbose_name': '0.8',
+                "identifier": "0.8",
+                "verbose_name": "0.8",
             },
         ]
 
@@ -1179,12 +1180,12 @@ class TestStableVersion(TestCase):
 
         version_stable = self.pip.versions.get(slug=STABLE)
         self.assertTrue(version_stable.active)
-        self.assertEqual(version_stable.identifier, '0.9')
+        self.assertEqual(version_stable.identifier, "0.9")
 
         tags_data = [
             {
-                'identifier': '1.0.0',
-                'verbose_name': '1.0.0',
+                "identifier": "1.0.0",
+                "verbose_name": "1.0.0",
             },
         ]
 
@@ -1196,12 +1197,12 @@ class TestStableVersion(TestCase):
 
         version_stable = self.pip.versions.get(slug=STABLE)
         self.assertTrue(version_stable.active)
-        self.assertEqual(version_stable.identifier, '1.0.0')
+        self.assertEqual(version_stable.identifier, "1.0.0")
 
         tags_data = [
             {
-                'identifier': '0.7',
-                'verbose_name': '0.7',
+                "identifier": "0.7",
+                "verbose_name": "0.7",
             },
         ]
 
@@ -1213,19 +1214,19 @@ class TestStableVersion(TestCase):
 
         version_stable = self.pip.versions.get(slug=STABLE)
         self.assertTrue(version_stable.active)
-        self.assertEqual(version_stable.identifier, '1.0.0')
+        self.assertEqual(version_stable.identifier, "1.0.0")
 
     def test_update_inactive_stable_version(self):
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
         ]
         tags_data = [
             {
-                'identifier': '0.9',
-                'verbose_name': '0.9',
+                "identifier": "0.9",
+                "verbose_name": "0.9",
             },
         ]
 
@@ -1237,14 +1238,16 @@ class TestStableVersion(TestCase):
         )
 
         version_stable = Version.objects.get(slug=STABLE)
-        self.assertEqual(version_stable.identifier, '0.9')
+        self.assertEqual(version_stable.identifier, "0.9")
         version_stable.active = False
         version_stable.save()
 
-        tags_data.append({
-            'identifier': '1.0.0',
-            'verbose_name': '1.0.0',
-        })
+        tags_data.append(
+            {
+                "identifier": "1.0.0",
+                "verbose_name": "1.0.0",
+            }
+        )
 
         sync_versions_task(
             self.pip.pk,
@@ -1256,17 +1259,17 @@ class TestStableVersion(TestCase):
         # but the version is still not active
         version_stable = Version.objects.get(slug=STABLE)
         self.assertFalse(version_stable.active)
-        self.assertEqual(version_stable.identifier, '1.0.0')
+        self.assertEqual(version_stable.identifier, "1.0.0")
 
     def test_stable_version_tags_over_branches(self):
         branches_data = [
             # 2.0 development
-            {'identifier': 'origin/2.0', 'verbose_name': '2.0'},
-            {'identifier': 'origin/0.9.1rc1', 'verbose_name': '0.9.1rc1'},
+            {"identifier": "origin/2.0", "verbose_name": "2.0"},
+            {"identifier": "origin/0.9.1rc1", "verbose_name": "0.9.1rc1"},
         ]
         tags_data = [
-            {'identifier': '1.0rc1', 'verbose_name': '1.0rc1'},
-            {'identifier': '0.9', 'verbose_name': '0.9'},
+            {"identifier": "1.0rc1", "verbose_name": "1.0rc1"},
+            {"identifier": "0.9", "verbose_name": "0.9"},
         ]
         self.pip.update_stable_version()
 
@@ -1280,12 +1283,14 @@ class TestStableVersion(TestCase):
         # over the branches to select the stable version
         version_stable = Version.objects.get(slug=STABLE)
         self.assertTrue(version_stable.active)
-        self.assertEqual(version_stable.identifier, '0.9')
+        self.assertEqual(version_stable.identifier, "0.9")
 
-        tags_data.append({
-            'identifier': '1.0',
-            'verbose_name': '1.0',
-        })
+        tags_data.append(
+            {
+                "identifier": "1.0",
+                "verbose_name": "1.0",
+            }
+        )
 
         sync_versions_task(
             self.pip.pk,
@@ -1295,17 +1300,17 @@ class TestStableVersion(TestCase):
 
         version_stable = Version.objects.get(slug=STABLE)
         self.assertTrue(version_stable.active)
-        self.assertEqual(version_stable.identifier, '1.0')
+        self.assertEqual(version_stable.identifier, "1.0")
 
     def test_stable_version_same_id_tag_branch(self):
         branches_data = [
             # old 1.0 development branch
-            {'identifier': 'origin/1.0', 'verbose_name': '1.0'},
+            {"identifier": "origin/1.0", "verbose_name": "1.0"},
         ]
         tags_data = [
             # tagged 1.0 final version
-            {'identifier': '1.0', 'verbose_name': '1.0'},
-            {'identifier': '0.9', 'verbose_name': '0.9'},
+            {"identifier": "1.0", "verbose_name": "1.0"},
+            {"identifier": "0.9", "verbose_name": "0.9"},
         ]
 
         self.pip.update_stable_version()
@@ -1317,12 +1322,12 @@ class TestStableVersion(TestCase):
 
         version_stable = Version.objects.get(slug=STABLE)
         self.assertTrue(version_stable.active)
-        self.assertEqual(version_stable.identifier, '1.0')
-        self.assertEqual(version_stable.type, 'tag')
+        self.assertEqual(version_stable.identifier, "1.0")
+        self.assertEqual(version_stable.type, "tag")
 
     def test_unicode(self):
         tags_data = [
-            {'identifier': 'foo-£', 'verbose_name': 'foo-£'},
+            {"identifier": "foo-£", "verbose_name": "foo-£"},
         ]
 
         sync_versions_task(
@@ -1335,40 +1340,40 @@ class TestStableVersion(TestCase):
     def test_user_defined_stable_version_tag_with_tags(self):
         Version.objects.create(
             project=self.pip,
-            identifier='0.8.3',
-            verbose_name='0.8.3',
+            identifier="0.8.3",
+            verbose_name="0.8.3",
             active=True,
         )
 
         # A pre-existing active stable tag that was machine created
         Version.objects.create(
             project=self.pip,
-            identifier='foo',
+            identifier="foo",
             type=TAG,
-            verbose_name='stable',
+            verbose_name="stable",
             active=True,
             machine=True,
         )
 
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
         ]
         tags_data = [
             # A new user-defined stable tag
             {
-                'identifier': '1abc2def3',
-                'verbose_name': 'stable',
+                "identifier": "1abc2def3",
+                "verbose_name": "stable",
             },
             {
-                'identifier': '0.9',
-                'verbose_name': '0.9',
+                "identifier": "0.9",
+                "verbose_name": "0.9",
             },
             {
-                'identifier': '0.8.3',
-                'verbose_name': '0.8.3',
+                "identifier": "0.8.3",
+                "verbose_name": "0.8.3",
             },
         ]
 
@@ -1379,21 +1384,21 @@ class TestStableVersion(TestCase):
         )
 
         # Didn't update to newest tag
-        version_9 = self.pip.versions.get(slug='0.9')
+        version_9 = self.pip.versions.get(slug="0.9")
         self.assertFalse(version_9.active)
 
         # Did update to user-defined stable version
-        version_stable = self.pip.versions.get(slug='stable')
+        version_stable = self.pip.versions.get(slug="stable")
         self.assertFalse(version_stable.machine)
         self.assertTrue(version_stable.active)
         self.assertEqual(
-            '1abc2def3',
+            "1abc2def3",
             self.pip.get_stable_version().identifier,
         )
 
         # There aren't others stable slugs like stable_a
         other_stable = self.pip.versions.filter(
-            slug__startswith='stable_',
+            slug__startswith="stable_",
         )
         self.assertFalse(other_stable.exists())
 
@@ -1404,32 +1409,32 @@ class TestStableVersion(TestCase):
             tags_data=tags_data,
         )
 
-        version_stable = self.pip.versions.get(slug='stable')
+        version_stable = self.pip.versions.get(slug="stable")
         self.assertFalse(version_stable.machine)
         self.assertTrue(version_stable.active)
         self.assertEqual(
-            '1abc2def3',
+            "1abc2def3",
             self.pip.get_stable_version().identifier,
         )
         other_stable = self.pip.versions.filter(
-            slug__startswith='stable_',
+            slug__startswith="stable_",
         )
         self.assertFalse(other_stable.exists())
 
     def test_user_defined_stable_version_branch_with_tags(self):
         Version.objects.create(
             project=self.pip,
-            identifier='0.8.3',
-            verbose_name='0.8.3',
+            identifier="0.8.3",
+            verbose_name="0.8.3",
             active=True,
         )
 
         # A pre-existing active stable branch that was machine created
         Version.objects.create(
             project=self.pip,
-            identifier='foo',
+            identifier="foo",
             type=BRANCH,
-            verbose_name='stable',
+            verbose_name="stable",
             active=True,
             machine=True,
         )
@@ -1437,23 +1442,23 @@ class TestStableVersion(TestCase):
 
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
             # A new user-defined stable branch
             {
-                'identifier': 'origin/stable',
-                'verbose_name': 'stable',
+                "identifier": "origin/stable",
+                "verbose_name": "stable",
             },
         ]
         tags_data = [
             {
-                'identifier': '0.9',
-                'verbose_name': '0.9',
+                "identifier": "0.9",
+                "verbose_name": "0.9",
             },
             {
-                'identifier': '0.8.3',
-                'verbose_name': '0.8.3',
+                "identifier": "0.8.3",
+                "verbose_name": "0.8.3",
             },
         ]
 
@@ -1464,20 +1469,20 @@ class TestStableVersion(TestCase):
         )
 
         # Didn't update to newest tag
-        version_9 = self.pip.versions.get(slug='0.9')
+        version_9 = self.pip.versions.get(slug="0.9")
         self.assertFalse(version_9.active)
 
         # Did update to user-defined stable version
-        version_stable = self.pip.versions.get(slug='stable')
+        version_stable = self.pip.versions.get(slug="stable")
         self.assertFalse(version_stable.machine)
         self.assertTrue(version_stable.active)
         self.assertEqual(
-            'origin/stable',
+            "origin/stable",
             self.pip.get_stable_version().identifier,
         )
         # There aren't others stable slugs like stable_a
         other_stable = self.pip.versions.filter(
-            slug__startswith='stable_',
+            slug__startswith="stable_",
         )
         self.assertFalse(other_stable.exists())
 
@@ -1488,34 +1493,34 @@ class TestStableVersion(TestCase):
             tags_data=tags_data,
         )
 
-        version_stable = self.pip.versions.get(slug='stable')
+        version_stable = self.pip.versions.get(slug="stable")
         self.assertFalse(version_stable.machine)
         self.assertTrue(version_stable.active)
         self.assertEqual(
-            'origin/stable',
+            "origin/stable",
             self.pip.get_stable_version().identifier,
         )
         other_stable = self.pip.versions.filter(
-            slug__startswith='stable_',
+            slug__startswith="stable_",
         )
         self.assertFalse(other_stable.exists())
 
 
-@mock.patch('readthedocs.core.utils.trigger_build', mock.MagicMock())
-@mock.patch('readthedocs.builds.tasks.trigger_build', mock.MagicMock())
+@mock.patch("readthedocs.core.utils.trigger_build", mock.MagicMock())
+@mock.patch("readthedocs.builds.tasks.trigger_build", mock.MagicMock())
 class TestLatestVersion(TestCase):
-    fixtures = ['eric', 'test_data']
+    fixtures = ["eric", "test_data"]
 
     def setUp(self):
-        self.user = User.objects.get(username='eric')
+        self.user = User.objects.get(username="eric")
         self.client.force_login(self.user)
-        self.pip = Project.objects.get(slug='pip')
+        self.pip = Project.objects.get(slug="pip")
 
         # Run tests for .com
         if settings.ALLOW_PRIVATE_REPOS:
             self.org = get(
                 Organization,
-                name='testorg',
+                name="testorg",
             )
             OrganizationOwner.objects.create(
                 owner=self.user,
@@ -1525,8 +1530,8 @@ class TestLatestVersion(TestCase):
 
         Version.objects.create(
             project=self.pip,
-            identifier='origin/master',
-            verbose_name='master',
+            identifier="origin/master",
+            verbose_name="master",
             active=True,
             machine=True,
             type=BRANCH,
@@ -1541,15 +1546,15 @@ class TestLatestVersion(TestCase):
         # ``latest_a`` version.
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
         ]
         tags_data = [
             # A new user-defined latest tag
             {
-                'identifier': '1abc2def3',
-                'verbose_name': 'latest',
+                "identifier": "1abc2def3",
+                "verbose_name": "latest",
             },
         ]
 
@@ -1560,17 +1565,17 @@ class TestLatestVersion(TestCase):
         )
 
         # Did update to user-defined latest version
-        version_latest = self.pip.versions.get(slug='latest')
+        version_latest = self.pip.versions.get(slug="latest")
         self.assertFalse(version_latest.machine)
         self.assertTrue(version_latest.active)
         self.assertEqual(
-            '1abc2def3',
+            "1abc2def3",
             version_latest.identifier,
         )
 
         # There aren't others latest slugs like latest_a
         other_latest = self.pip.versions.filter(
-            slug__startswith='latest_',
+            slug__startswith="latest_",
         )
         self.assertFalse(other_latest.exists())
 
@@ -1581,28 +1586,28 @@ class TestLatestVersion(TestCase):
             tags_data=tags_data,
         )
 
-        version_latest = self.pip.versions.get(slug='latest')
+        version_latest = self.pip.versions.get(slug="latest")
         self.assertFalse(version_latest.machine)
         self.assertTrue(version_latest.active)
         self.assertEqual(
-            '1abc2def3',
+            "1abc2def3",
             version_latest.identifier,
         )
         other_latest = self.pip.versions.filter(
-            slug__startswith='latest_',
+            slug__startswith="latest_",
         )
         self.assertFalse(other_latest.exists())
 
     def test_user_defined_latest_version_branch(self):
         branches_data = [
             {
-                'identifier': 'origin/master',
-                'verbose_name': 'master',
+                "identifier": "origin/master",
+                "verbose_name": "master",
             },
             # A new user-defined latest branch
             {
-                'identifier': 'origin/latest',
-                'verbose_name': 'latest',
+                "identifier": "origin/latest",
+                "verbose_name": "latest",
             },
         ]
 
@@ -1613,17 +1618,17 @@ class TestLatestVersion(TestCase):
         )
 
         # Did update to user-defined latest version
-        version_latest = self.pip.versions.get(slug='latest')
+        version_latest = self.pip.versions.get(slug="latest")
         self.assertFalse(version_latest.machine)
         self.assertTrue(version_latest.active)
         self.assertEqual(
-            'origin/latest',
+            "origin/latest",
             version_latest.identifier,
         )
 
         # There aren't others latest slugs like latest_a
         other_latest = self.pip.versions.filter(
-            slug__startswith='latest_',
+            slug__startswith="latest_",
         )
         self.assertFalse(other_latest.exists())
 
@@ -1634,14 +1639,14 @@ class TestLatestVersion(TestCase):
             tags_data=[],
         )
 
-        version_latest = self.pip.versions.get(slug='latest')
+        version_latest = self.pip.versions.get(slug="latest")
         self.assertFalse(version_latest.machine)
         self.assertTrue(version_latest.active)
         self.assertEqual(
-            'origin/latest',
+            "origin/latest",
             version_latest.identifier,
         )
         other_latest = self.pip.versions.filter(
-            slug__startswith='latest_',
+            slug__startswith="latest_",
         )
         self.assertFalse(other_latest.exists())

--- a/readthedocs/rtd_tests/utils.py
+++ b/readthedocs/rtd_tests/utils.py
@@ -22,6 +22,7 @@ def get_readthedocs_app_path():
 
     try:
         import readthedocs
+
         path = readthedocs.__path__[0]
     except (IndexError, ImportError):
         raise Exception('Unable to find "readthedocs" path module')
@@ -31,7 +32,9 @@ def get_readthedocs_app_path():
 
 def check_output(command, env=None):
     output = subprocess.Popen(
-        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         env=env,
     ).communicate()[0]
     log.info(output)
@@ -43,29 +46,33 @@ def make_test_git():
     directory = mkdtemp()
     directory = make_git_repo(directory)
     env = environ.copy()
-    env['GIT_DIR'] = pjoin(directory, '.git')
+    env["GIT_DIR"] = pjoin(directory, ".git")
     chdir(directory)
 
     # Add fake repo as submodule. We need to fake this here because local path
     # URL are not allowed and using a real URL will require Internet to clone
     # the repo
-    check_output(['git', 'checkout', '-b', 'submodule', 'master'], env=env)
+    check_output(["git", "checkout", "-b", "submodule", "master"], env=env)
     add_git_submodule_without_cloning(
-        directory, 'foobar', 'https://foobar.com/git',
+        directory,
+        "foobar",
+        "https://foobar.com/git",
     )
-    check_output(['git', 'add', '.'], env=env)
-    check_output(['git', 'commit', '-m"Add submodule"'], env=env)
+    check_output(["git", "add", "."], env=env)
+    check_output(["git", "commit", '-m"Add submodule"'], env=env)
 
     # Add an invalid submodule URL in the invalidsubmodule branch
-    check_output(['git', 'checkout', '-b', 'invalidsubmodule', 'master'], env=env)
+    check_output(["git", "checkout", "-b", "invalidsubmodule", "master"], env=env)
     add_git_submodule_without_cloning(
-        directory, 'invalid', 'git@github.com:rtfd/readthedocs.org.git',
+        directory,
+        "invalid",
+        "git@github.com:rtfd/readthedocs.org.git",
     )
-    check_output(['git', 'add', '.'], env=env)
-    check_output(['git', 'commit', '-m"Add invalid submodule"'], env=env)
+    check_output(["git", "add", "."], env=env)
+    check_output(["git", "commit", '-m"Add invalid submodule"'], env=env)
 
     # Checkout to master branch again
-    check_output(['git', 'checkout', 'master'], env=env)
+    check_output(["git", "checkout", "master"], env=env)
 
     # Add something unique to the master branch (so we can verify it's correctly checked out)
     open("only-on-default-branch", "w").write(
@@ -95,63 +102,70 @@ def add_git_submodule_without_cloning(directory, submodule, url):
     :type url: str
     """
     env = environ.copy()
-    env['GIT_DIR'] = pjoin(directory, '.git')
+    env["GIT_DIR"] = pjoin(directory, ".git")
     chdir(directory)
 
     mkdir(pjoin(directory, submodule))
-    gitmodules_path = pjoin(directory, '.gitmodules')
-    with open(gitmodules_path, 'w+') as fh:
-        content = textwrap.dedent('''
+    gitmodules_path = pjoin(directory, ".gitmodules")
+    with open(gitmodules_path, "w+") as fh:
+        content = textwrap.dedent(
+            """
             [submodule "{submodule}"]
                 path = {submodule}
                 url = {url}
-        ''')
+        """
+        )
         fh.write(content.format(submodule=submodule, url=url))
     check_output(
         [
-            'git', 'update-index', '--add', '--cacheinfo', '160000',
-            '233febf4846d7a0aeb95b6c28962e06e21d13688', submodule,
+            "git",
+            "update-index",
+            "--add",
+            "--cacheinfo",
+            "160000",
+            "233febf4846d7a0aeb95b6c28962e06e21d13688",
+            submodule,
         ],
         env=env,
     )
 
 
 @restoring_chdir
-def make_git_repo(directory, name='sample_repo'):
+def make_git_repo(directory, name="sample_repo"):
     path = get_readthedocs_app_path()
-    sample = abspath(pjoin(path, 'rtd_tests/fixtures/sample_repo'))
+    sample = abspath(pjoin(path, "rtd_tests/fixtures/sample_repo"))
     directory = pjoin(directory, name)
     copytree(sample, directory)
     env = environ.copy()
-    env['GIT_DIR'] = pjoin(directory, '.git')
+    env["GIT_DIR"] = pjoin(directory, ".git")
     chdir(directory)
 
     # Initialize and configure
-    check_output(['git', 'init'] + [directory], env=env)
+    check_output(["git", "init"] + [directory], env=env)
     check_output(
-        ['git', 'config', 'user.email', 'dev@readthedocs.org'],
+        ["git", "config", "user.email", "dev@readthedocs.org"],
         env=env,
     )
     check_output(
-        ['git', 'config', 'user.name', 'Read the Docs'],
+        ["git", "config", "user.name", "Read the Docs"],
         env=env,
     )
 
     # Set up the actual repository
-    check_output(['git', 'add', '.'], env=env)
-    check_output(['git', 'commit', '-m"init"'], env=env)
+    check_output(["git", "add", "."], env=env)
+    check_output(["git", "commit", '-m"init"'], env=env)
     return directory
 
 
 @restoring_chdir
 def create_git_tag(directory, tag, annotated=False):
     env = environ.copy()
-    env['GIT_DIR'] = pjoin(directory, '.git')
+    env["GIT_DIR"] = pjoin(directory, ".git")
     chdir(directory)
 
-    command = ['git', 'tag']
+    command = ["git", "tag"]
     if annotated:
-        command.extend(['-a', '-m', 'Some tag'])
+        command.extend(["-a", "-m", "Some tag"])
     command.append(tag)
     check_output(command, env=env)
 
@@ -159,20 +173,20 @@ def create_git_tag(directory, tag, annotated=False):
 @restoring_chdir
 def delete_git_tag(directory, tag):
     env = environ.copy()
-    env['GIT_DIR'] = pjoin(directory, '.git')
+    env["GIT_DIR"] = pjoin(directory, ".git")
     chdir(directory)
 
-    command = ['git', 'tag', '--delete', tag]
+    command = ["git", "tag", "--delete", tag]
     check_output(command, env=env)
 
 
 @restoring_chdir
 def create_git_branch(directory, branch):
     env = environ.copy()
-    env['GIT_DIR'] = pjoin(directory, '.git')
+    env["GIT_DIR"] = pjoin(directory, ".git")
     chdir(directory)
 
-    command = ['git', 'branch', branch]
+    command = ["git", "branch", branch]
     check_output(command, env=env)
 
 
@@ -189,28 +203,30 @@ def get_git_latest_commit_hash(directory, branch):
 @restoring_chdir
 def delete_git_branch(directory, branch):
     env = environ.copy()
-    env['GIT_DIR'] = pjoin(directory, '.git')
+    env["GIT_DIR"] = pjoin(directory, ".git")
     chdir(directory)
 
-    command = ['git', 'branch', '-D', branch]
+    command = ["git", "branch", "-D", branch]
     check_output(command, env=env)
 
 
 @restoring_chdir
 def create_git_submodule(
-    directory, submodule,
-    msg='Add realative submodule', branch='master',
+    directory,
+    submodule,
+    msg="Add realative submodule",
+    branch="master",
 ):
     env = environ.copy()
-    env['GIT_DIR'] = pjoin(directory, '.git')
+    env["GIT_DIR"] = pjoin(directory, ".git")
     chdir(directory)
 
-    command = ['git', 'branch', '-D', branch]
+    command = ["git", "branch", "-D", branch]
     check_output(command, env=env)
-    command = ['git', 'submodule', 'add', '-b', branch, './', submodule]
+    command = ["git", "submodule", "add", "-b", branch, "./", submodule]
     check_output(command, env=env)
-    check_output(['git', 'add', '.'], env=env)
-    check_output(['git', 'commit', '-m', '"{}"'.format(msg)], env=env)
+    check_output(["git", "add", "."], env=env)
+    check_output(["git", "commit", "-m", '"{}"'.format(msg)], env=env)
 
 
 @restoring_chdir
@@ -227,14 +243,14 @@ def get_current_commit(directory):
 def make_test_hg():
     directory = mkdtemp()
     path = get_readthedocs_app_path()
-    sample = abspath(pjoin(path, 'rtd_tests/fixtures/sample_repo'))
-    directory = pjoin(directory, 'sample_repo')
+    sample = abspath(pjoin(path, "rtd_tests/fixtures/sample_repo"))
+    directory = pjoin(directory, "sample_repo")
     copytree(sample, directory)
     chdir(directory)
-    hguser = 'Test User <test-user@readthedocs.org>'
-    log.info(check_output(['hg', 'init'] + [directory]))
-    log.info(check_output(['hg', 'add', '.']))
-    log.info(check_output(['hg', 'commit', '-u', hguser, '-m"init"']))
+    hguser = "Test User <test-user@readthedocs.org>"
+    log.info(check_output(["hg", "init"] + [directory]))
+    log.info(check_output(["hg", "add", "."]))
+    log.info(check_output(["hg", "commit", "-u", hguser, '-m"init"']))
     return directory
 
 

--- a/readthedocs/subscriptions/forms.py
+++ b/readthedocs/subscriptions/forms.py
@@ -27,5 +27,5 @@ class PlanForm(forms.Form):
         ]
         self.fields["plan"].help_text = _(
             'Check our <a href="https://about.readthedocs.com/pricing/">pricing page</a> '
-            'for more information about each plan.'
+            "for more information about each plan."
         )

--- a/readthedocs/vcs_support/backends/__init__.py
+++ b/readthedocs/vcs_support/backends/__init__.py
@@ -2,8 +2,8 @@
 from . import bzr, git, hg, svn
 
 backend_cls = {
-    'bzr': bzr.Backend,
-    'svn': svn.Backend,
-    'git': git.Backend,
-    'hg': hg.Backend,
+    "bzr": bzr.Backend,
+    "svn": svn.Backend,
+    "git": git.Backend,
+    "hg": hg.Backend,
 }

--- a/readthedocs/vcs_support/backends/bzr.py
+++ b/readthedocs/vcs_support/backends/bzr.py
@@ -13,7 +13,7 @@ class Backend(BaseVCS):
     """Bazaar VCS backend."""
 
     supports_tags = True
-    fallback_branch = ''
+    fallback_branch = ""
 
     def clone(self):
         self.make_clean_working_dir()
@@ -25,7 +25,7 @@ class Backend(BaseVCS):
     @property
     def tags(self):
         try:
-            code, stdout, stderr = self.run('bzr', 'tags', record_as_success=True)
+            code, stdout, stderr = self.run("bzr", "tags", record_as_success=True)
             return self.parse_tags(stdout)
         except RepositoryError:
             # error (or no tags found)
@@ -52,19 +52,19 @@ class Backend(BaseVCS):
         # StringIO below is expecting Unicode data, so ensure that it gets it.
         if not isinstance(data, str):
             data = str(data)
-        squashed_data = re.sub(r' +', ' ', data)
-        raw_tags = csv.reader(StringIO(squashed_data), delimiter=' ')
+        squashed_data = re.sub(r" +", " ", data)
+        raw_tags = csv.reader(StringIO(squashed_data), delimiter=" ")
         vcs_tags = []
         for row in raw_tags:
-            name = ' '.join(row[:-1])
+            name = " ".join(row[:-1])
             commit = row[-1]
-            if commit != '?':
+            if commit != "?":
                 vcs_tags.append(VCSVersion(self, commit, name))
         return vcs_tags
 
     @property
     def commit(self):
-        _, stdout, _ = self.run('bzr', 'revno')
+        _, stdout, _ = self.run("bzr", "revno")
         return stdout.strip()
 
     def checkout(self, identifier=None):
@@ -74,7 +74,7 @@ class Backend(BaseVCS):
             return self.up()
 
         try:
-            code, stdout, stderr = self.run('bzr', 'switch', identifier)
+            code, stdout, stderr = self.run("bzr", "switch", identifier)
             return code, stdout, stderr
         except RepositoryError:
             raise RepositoryError(

--- a/readthedocs/vcs_support/backends/hg.py
+++ b/readthedocs/vcs_support/backends/hg.py
@@ -1,4 +1,3 @@
-
 """Mercurial-related utilities."""
 from readthedocs.projects.exceptions import RepositoryError
 from readthedocs.vcs_support.base import BaseVCS, VCSVersion
@@ -10,7 +9,7 @@ class Backend(BaseVCS):
 
     supports_tags = True
     supports_branches = True
-    fallback_branch = 'default'
+    fallback_branch = "default"
 
     def update(self):
         super().update()
@@ -35,9 +34,9 @@ class Backend(BaseVCS):
     def branches(self):
         try:
             _, stdout, _ = self.run(
-                'hg',
-                'branches',
-                '--quiet',
+                "hg",
+                "branches",
+                "--quiet",
                 record_as_success=True,
             )
             return self.parse_branches(stdout)
@@ -64,7 +63,7 @@ class Backend(BaseVCS):
     @property
     def tags(self):
         try:
-            _, stdout, _ = self.run('hg', 'tags', record_as_success=True)
+            _, stdout, _ = self.run("hg", "tags", record_as_success=True)
             return self.parse_tags(stdout)
         except RepositoryError:
             # error (or no tags found)
@@ -94,27 +93,27 @@ class Backend(BaseVCS):
             if len(row) != 2:
                 continue
             name, commit = row
-            if name == 'tip':
+            if name == "tip":
                 continue
-            _, commit_hash = commit.split(':')
+            _, commit_hash = commit.split(":")
             vcs_tags.append(VCSVersion(self, commit_hash, name))
         return vcs_tags
 
     @property
     def commit(self):
-        _, stdout = self.run('hg', 'identify', '--id')[:2]
+        _, stdout = self.run("hg", "identify", "--id")[:2]
         return stdout.strip()
 
     def checkout(self, identifier=None):
         super().checkout()
         if not identifier:
-            identifier = 'tip'
+            identifier = "tip"
 
         try:
             code, stdout, stderr = self.run(
-                'hg',
-                'update',
-                '--clean',
+                "hg",
+                "update",
+                "--clean",
                 identifier,
             )
             return code, stdout, stderr

--- a/readthedocs/vcs_support/backends/svn.py
+++ b/readthedocs/vcs_support/backends/svn.py
@@ -12,14 +12,14 @@ class Backend(BaseVCS):
     """Subversion VCS backend."""
 
     supports_tags = False
-    fallback_branch = '/trunk/'
+    fallback_branch = "/trunk/"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if self.repo_url[-1] != '/':
+        if self.repo_url[-1] != "/":
             self.base_url = self.repo_url
-            self.repo_url += '/'
-        elif self.repo_url.endswith('/trunk/'):
+            self.repo_url += "/"
+        elif self.repo_url.endswith("/trunk/"):
             self.supports_tags = True
             self.base_url = self.repo_url[:-7]
         else:
@@ -35,7 +35,7 @@ class Backend(BaseVCS):
             url = self.get_url(self.base_url, identifier)
         else:
             url = self.repo_url
-        retcode, out, err = self.run('svn', 'checkout', url, '.')
+        retcode, out, err = self.run("svn", "checkout", url, ".")
         if retcode != 0:
             raise RepositoryError(RepositoryError.CLONE_ERROR())
         return retcode, out, err
@@ -43,9 +43,9 @@ class Backend(BaseVCS):
     @property
     def tags(self):
         retcode, stdout = self.run(
-            'svn',
-            'list',
-            '%s/tags/' % self.base_url,
+            "svn",
+            "list",
+            "%s/tags/" % self.base_url,
             record_as_success=True,
         )[:2]
         # error (or no tags found)
@@ -70,15 +70,15 @@ class Backend(BaseVCS):
         # StringIO below is expecting Unicode data, so ensure that it gets it.
         if not isinstance(data, str):
             data = str(data)
-        raw_tags = csv.reader(StringIO(data), delimiter='/')
+        raw_tags = csv.reader(StringIO(data), delimiter="/")
         vcs_tags = []
         for name, _ in raw_tags:
-            vcs_tags.append(VCSVersion(self, '/tags/%s/' % name, name))
+            vcs_tags.append(VCSVersion(self, "/tags/%s/" % name, name))
         return vcs_tags
 
     @property
     def commit(self):
-        _, stdout = self.run('svnversion')[:2]
+        _, stdout = self.run("svnversion")[:2]
         return stdout.strip()
 
     def checkout(self, identifier=None):
@@ -86,7 +86,7 @@ class Backend(BaseVCS):
         return self.co(identifier)
 
     def get_url(self, base_url, identifier):
-        base = base_url.rstrip('/')
-        tag = identifier.lstrip('/')
-        url = '{}/{}'.format(base, tag)
+        base = base_url.rstrip("/")
+        tag = identifier.lstrip("/")
+        url = "{}/{}".format(base, tag)
         return url

--- a/readthedocs/vcs_support/base.py
+++ b/readthedocs/vcs_support/base.py
@@ -27,7 +27,7 @@ class VCSVersion:
         self.verbose_name = verbose_name
 
     def __repr__(self):
-        return '<VCSVersion: {}:{}'.format(
+        return "<VCSVersion: {}:{}".format(
             self.repository.repo_url,
             self.verbose_name,
         )
@@ -93,10 +93,12 @@ class BaseVCS:
         self.check_working_dir()
 
     def run(self, *cmd, **kwargs):
-        kwargs.update({
-            'cwd': self.working_dir,
-            'shell': False,
-        })
+        kwargs.update(
+            {
+                "cwd": self.working_dir,
+                "shell": False,
+            }
+        )
 
         try:
             build_cmd = self.environment.run(*cmd, **kwargs)


### PR DESCRIPTION
Same method as last time. It seems darker and black do not always agree for some
reason though, not sure why.

Output:

```
reformatted readthedocs/api/v3/permissions.py
reformatted readthedocs/api/v3/tests/test_builds.py
reformatted readthedocs/api/v2/serializers.py
reformatted readthedocs/builds/tests/test_build_queryset.py
reformatted readthedocs/builds/tasks.py
reformatted readthedocs/core/resolver.py
reformatted readthedocs/core/utils/filesystem.py
reformatted readthedocs/doc_builder/exceptions.py
reformatted readthedocs/integrations/migrations/0007_update-provider-data.py
reformatted readthedocs/doc_builder/environments.py
reformatted readthedocs/organizations/tests/test_views.py
reformatted readthedocs/projects/tasks/mixins.py
reformatted readthedocs/projects/views/mixins.py
reformatted readthedocs/proxito/tests/test_middleware.py
reformatted readthedocs/redirects/querysets.py
reformatted readthedocs/proxito/views/mixins.py
reformatted readthedocs/rtd_tests/files/conf.py
reformatted readthedocs/proxito/tests/test_custom_path_prefixes.py
reformatted readthedocs/proxito/tests/test_redirects.py
reformatted readthedocs/rtd_tests/tests/test_build_config.py
reformatted readthedocs/rtd_tests/tests/test_backend.py
reformatted readthedocs/rtd_tests/tests/test_core_utils.py
reformatted readthedocs/rtd_tests/tests/test_middleware.py
reformatted readthedocs/rtd_tests/tests/test_footer.py
reformatted readthedocs/rtd_tests/tests/test_project_views.py
reformatted readthedocs/rtd_tests/tests/test_project_forms.py
reformatted readthedocs/rtd_tests/utils.py
reformatted readthedocs/rtd_tests/tests/test_resolver.py
reformatted readthedocs/rtd_tests/tests/test_sync_versions.py
reformatted readthedocs/subscriptions/forms.py
reformatted readthedocs/vcs_support/backends/__init__.py
reformatted readthedocs/vcs_support/backends/bzr.py
reformatted readthedocs/vcs_support/backends/hg.py
reformatted readthedocs/vcs_support/base.py
reformatted readthedocs/vcs_support/backends/svn.py

All done! ✨ 🍰 ✨
35 files reformatted, 677 files left unchanged.
```

Getting very close too, another pass of the whole directory after this shows:

```
...
64 files reformatted, 729 files left unchanged.
```