### PR TITLE
Footer API: include current user in queryset

### DIFF
--- a/readthedocs/api/v2/views/footer_views.py
+++ b/readthedocs/api/v2/views/footer_views.py
@@ -27,7 +27,7 @@ from readthedocs.projects.version_handling import (
 log = structlog.get_logger(__name__)
 
 
-def get_version_compare_data(project, user=None, base_version=None):
+def get_version_compare_data(project, base_version=None, user=None):
     """
     Retrieve metadata about the highest version available for this project.
 
@@ -209,7 +209,7 @@ class BaseFooterHTML(CDNCacheTagsMixin, APIView):
         version = self._get_version()
         version_compare_data = get_version_compare_data(
             project,
-            version,
+            base_version=version,
             user=request.user,
         )
 

--- a/readthedocs/api/v2/views/footer_views.py
+++ b/readthedocs/api/v2/views/footer_views.py
@@ -27,7 +27,7 @@ from readthedocs.projects.version_handling import (
 log = structlog.get_logger(__name__)
 
 
-def get_version_compare_data(project, base_version=None):
+def get_version_compare_data(project, user=None, base_version=None):
     """
     Retrieve metadata about the highest version available for this project.
 
@@ -40,9 +40,8 @@ def get_version_compare_data(project, base_version=None):
     ):
         return {'is_highest': False}
 
-    versions_qs = (
-        Version.internal.public(project=project)
-        .filter(built=True, active=True)
+    versions_qs = Version.internal.public(project=project, user=user).filter(
+        built=True, active=True
     )
 
     # Take preferences over tags only if the project has at least one tag
@@ -211,6 +210,7 @@ class BaseFooterHTML(CDNCacheTagsMixin, APIView):
         version_compare_data = get_version_compare_data(
             project,
             version,
+            user=request.user,
         )
 
         context = self._get_context()

--- a/readthedocs/rtd_tests/tests/test_footer.py
+++ b/readthedocs/rtd_tests/tests/test_footer.py
@@ -12,7 +12,7 @@ from readthedocs.api.v2.views.footer_views import get_version_compare_data
 from readthedocs.builds.constants import BRANCH, EXTERNAL, LATEST, TAG
 from readthedocs.builds.models import Version
 from readthedocs.core.middleware import ReadTheDocsSessionMiddleware
-from readthedocs.projects.constants import GITHUB_BRAND, GITLAB_BRAND, PUBLIC
+from readthedocs.projects.constants import GITHUB_BRAND, GITLAB_BRAND, PRIVATE, PUBLIC
 from readthedocs.projects.models import Project
 from readthedocs.subscriptions.constants import TYPE_CNAME
 from readthedocs.subscriptions.products import RTDProductFeature
@@ -446,6 +446,22 @@ class TestVersionCompareFooter(TestCase):
         returned_data = get_version_compare_data(self.pip, base_version)
         self.assertDictEqual(valid_data, returned_data)
 
+    def test_private_highest_version(self):
+        self.pip.versions.update(privacy_level=PRIVATE)
+        owner = self.pip.users.first()
+        base_version = self.pip.versions.get(slug="0.8")
+        returned_data = get_version_compare_data(self.pip, base_version)
+        self.assertTrue(returned_data["is_highest"])
+
+        returned_data = get_version_compare_data(self.pip, base_version, user=owner)
+        valid_data = {
+            "project": "Version 0.8.1 of Pip (19)",
+            "url": "https://pip.readthedocs.io/en/0.8.1/",
+            "slug": "0.8.1",
+            "version": "0.8.1",
+            "is_highest": False,
+        }
+        self.assertDictEqual(valid_data, returned_data)
 
 @pytest.mark.proxito
 @override_settings(


### PR DESCRIPTION
The current queryset includes public versions only, but this is a problem on .com, since we have private versions there.

Including the user in the queryset will include
private versions the user has access to.