### PR TITLE
Requirements: revert upgrade to `psycopg==3.x`

### DIFF
--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -96,7 +96,7 @@ dj-pagination==2.5.0
     # via -r requirements/pip.txt
 dj-stripe==2.6.3
     # via -r requirements/pip.txt
-django==4.2.4
+django==4.2.5
     # via
     #   -r requirements/pip.txt
     #   dj-stripe
@@ -265,16 +265,8 @@ prompt-toolkit==3.0.39
     #   -r requirements/pip.txt
     #   click-repl
     #   ipython
-psycopg[binary,pool]==3.1.10
+psycopg2==2.9.7
     # via -r requirements/pip.txt
-psycopg-binary==3.1.10
-    # via
-    #   -r requirements/pip.txt
-    #   psycopg
-psycopg-pool==3.1.7
-    # via
-    #   -r requirements/pip.txt
-    #   psycopg
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
@@ -385,8 +377,6 @@ typing-extensions==4.7.1
     #   -r requirements/pip.txt
     #   asgiref
     #   filelock
-    #   psycopg
-    #   psycopg-pool
 tzdata==2023.3
     # via
     #   -r requirements/pip.txt

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -12,7 +12,7 @@ asgiref==3.7.2
     # via
     #   -r requirements/pip.txt
     #   django
-asttokens==2.3.0
+asttokens==2.4.0
     # via stack-data
 async-timeout==4.0.3
     # via
@@ -24,11 +24,11 @@ billiard==3.6.4.0
     # via
     #   -r requirements/pip.txt
     #   celery
-boto3==1.28.40
+boto3==1.28.45
     # via
     #   -r requirements/pip.txt
     #   django-storages
-botocore==1.31.40
+botocore==1.31.45
     # via
     #   -r requirements/pip.txt
     #   boto3
@@ -155,13 +155,13 @@ django-polymorphic==3.1.0
     # via -r requirements/pip.txt
 django-simple-history==3.0.0
     # via -r requirements/pip.txt
-django-storages[boto3]==1.13.2
+django-storages[boto3]==1.14
     # via -r requirements/pip.txt
 django-structlog==2.2.0
     # via -r requirements/pip.txt
 django-taggit==4.0.0
     # via -r requirements/pip.txt
-django-timezone-field==6.0
+django-timezone-field==6.0.1
     # via
     #   -r requirements/pip.txt
     #   django-celery-beat
@@ -242,7 +242,7 @@ oauthlib==3.2.2
     # via
     #   -r requirements/pip.txt
     #   requests-oauthlib
-orjson==3.9.5
+orjson==3.9.7
     # via -r requirements/pip.txt
 packaging==23.1
     # via
@@ -299,7 +299,7 @@ python3-openid==3.2.0
     # via
     #   -r requirements/pip.txt
     #   django-allauth
-pytz==2023.3
+pytz==2023.3.post1
     # via
     #   -r requirements/pip.txt
     #   celery
@@ -407,13 +407,13 @@ vine==5.0.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.24.4
+virtualenv==20.24.5
     # via -r requirements/pip.txt
 wcwidth==0.2.6
     # via
     #   -r requirements/pip.txt
     #   prompt-toolkit
-websocket-client==1.6.2
+websocket-client==1.6.3
     # via
     #   -r requirements/pip.txt
     #   docker

--- a/requirements/docker.in
+++ b/requirements/docker.in
@@ -2,6 +2,9 @@
 
 -r pip.txt
 
+# https://www.psycopg.org/docs/install.html#psycopg-vs-psycopg-binary
+psycopg2-binary
+
 # run tests
 tox
 

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -12,7 +12,7 @@ asgiref==3.7.2
     # via
     #   -r requirements/pip.txt
     #   django
-asttokens==2.3.0
+asttokens==2.4.0
     # via stack-data
 async-timeout==4.0.3
     # via
@@ -24,11 +24,11 @@ billiard==3.6.4.0
     # via
     #   -r requirements/pip.txt
     #   celery
-boto3==1.28.40
+boto3==1.28.45
     # via
     #   -r requirements/pip.txt
     #   django-storages
-botocore==1.31.40
+botocore==1.31.45
     # via
     #   -r requirements/pip.txt
     #   boto3
@@ -164,13 +164,13 @@ django-polymorphic==3.1.0
     # via -r requirements/pip.txt
 django-simple-history==3.0.0
     # via -r requirements/pip.txt
-django-storages[boto3]==1.13.2
+django-storages[boto3]==1.14
     # via -r requirements/pip.txt
 django-structlog==2.2.0
     # via -r requirements/pip.txt
 django-taggit==4.0.0
     # via -r requirements/pip.txt
-django-timezone-field==6.0
+django-timezone-field==6.0.1
     # via
     #   -r requirements/pip.txt
     #   django-celery-beat
@@ -258,7 +258,7 @@ oauthlib==3.2.2
     # via
     #   -r requirements/pip.txt
     #   requests-oauthlib
-orjson==3.9.5
+orjson==3.9.7
     # via -r requirements/pip.txt
 packaging==23.1
     # via
@@ -330,7 +330,7 @@ python3-openid==3.2.0
     # via
     #   -r requirements/pip.txt
     #   django-allauth
-pytz==2023.3
+pytz==2023.3.post1
     # via
     #   -r requirements/pip.txt
     #   celery
@@ -399,7 +399,7 @@ tomli==2.0.1
     #   ipdb
     #   pyproject-api
     #   tox
-tox==4.11.1
+tox==4.11.3
     # via -r requirements/docker.in
 traitlets==5.9.0
     # via
@@ -439,7 +439,7 @@ vine==5.0.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.24.4
+virtualenv==20.24.5
     # via
     #   -r requirements/pip.txt
     #   tox
@@ -447,7 +447,7 @@ wcwidth==0.2.6
     # via
     #   -r requirements/pip.txt
     #   prompt-toolkit
-websocket-client==1.6.2
+websocket-client==1.6.3
     # via
     #   -r requirements/pip.txt
     #   docker

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -105,7 +105,7 @@ dj-pagination==2.5.0
     # via -r requirements/pip.txt
 dj-stripe==2.6.3
     # via -r requirements/pip.txt
-django==4.2.4
+django==4.2.5
     # via
     #   -r requirements/pip.txt
     #   dj-stripe
@@ -288,16 +288,10 @@ prompt-toolkit==3.0.39
     #   -r requirements/pip.txt
     #   click-repl
     #   ipython
-psycopg[binary,pool]==3.1.10
+psycopg2==2.9.7
     # via -r requirements/pip.txt
-psycopg-binary==3.1.10
-    # via
-    #   -r requirements/pip.txt
-    #   psycopg
-psycopg-pool==3.1.7
-    # via
-    #   -r requirements/pip.txt
-    #   psycopg
+psycopg2-binary==2.9.7
+    # via -r requirements/docker.in
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
@@ -416,8 +410,6 @@ typing-extensions==4.7.1
     #   -r requirements/pip.txt
     #   asgiref
     #   filelock
-    #   psycopg
-    #   psycopg-pool
 tzdata==2023.3
     # via
     #   -r requirements/pip.txt

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -49,7 +49,7 @@ markdown-it-py==3.0.0
     #   myst-parser
 markupsafe==2.1.3
     # via jinja2
-matplotlib==3.7.2
+matplotlib==3.7.3
     # via sphinxext-opengraph
 mdit-py-plugins==0.4.0
     # via myst-parser
@@ -74,7 +74,7 @@ pygments==2.16.1
     #   sphinx
     #   sphinx-prompt
     #   sphinx-tabs
-pyparsing==3.0.9
+pyparsing==3.1.1
     # via matplotlib
 python-dateutil==2.8.2
     # via matplotlib

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -7,8 +7,9 @@ django-extensions
 django-polymorphic
 django-autoslug
 
-# https://www.psycopg.org/psycopg3/docs/basic/install.html
-psycopg[binary,pool]
+# NOTE: we cannot use ``psycopg`` (3.x), even if it's supported by Django 4.2
+# because New Relic agent is not sending the data of the database to their servers.
+psycopg2
 
 # 3.1.0 includes changes that require running `makemigrations`
 # https://django-simple-history.readthedocs.io/en/latest/#changes

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -12,9 +12,9 @@ async-timeout==4.0.3
     # via redis
 billiard==3.6.4.0
     # via celery
-boto3==1.28.40
+boto3==1.28.45
     # via django-storages
-botocore==1.31.40
+botocore==1.31.45
     # via
     #   boto3
     #   s3transfer
@@ -113,13 +113,13 @@ django-polymorphic==3.1.0
     # via -r requirements/pip.in
 django-simple-history==3.0.0
     # via -r requirements/pip.in
-django-storages[boto3]==1.13.2
+django-storages[boto3]==1.14
     # via -r requirements/pip.in
 django-structlog==2.2.0
     # via -r requirements/pip.in
 django-taggit==4.0.0
     # via -r requirements/pip.in
-django-timezone-field==6.0
+django-timezone-field==6.0.1
     # via django-celery-beat
 django-vanilla-views==3.0.0
     # via -r requirements/pip.in
@@ -173,7 +173,7 @@ markdown==3.4.4
     # via -r requirements/pip.in
 oauthlib==3.2.2
     # via requests-oauthlib
-orjson==3.9.5
+orjson==3.9.7
     # via -r requirements/pip.in
 packaging==23.1
     # via
@@ -205,7 +205,7 @@ python-dateutil==2.8.2
     #   python-crontab
 python3-openid==3.2.0
     # via django-allauth
-pytz==2023.3
+pytz==2023.3.post1
     # via
     #   -r requirements/pip.in
     #   celery
@@ -287,11 +287,11 @@ vine==5.0.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.24.4
+virtualenv==20.24.5
     # via -r requirements/pip.in
 wcwidth==0.2.6
     # via prompt-toolkit
-websocket-client==1.6.2
+websocket-client==1.6.3
     # via docker
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -56,7 +56,7 @@ dj-pagination==2.5.0
     # via -r requirements/pip.in
 dj-stripe==2.6.3
     # via -r requirements/pip.in
-django==4.2.4
+django==4.2.5
     # via
     #   -r requirements/pip.in
     #   dj-stripe
@@ -185,12 +185,8 @@ platformdirs==3.10.0
     # via virtualenv
 prompt-toolkit==3.0.39
     # via click-repl
-psycopg[binary,pool]==3.1.10
+psycopg2==2.9.7
     # via -r requirements/pip.in
-psycopg-binary==3.1.10
-    # via psycopg
-psycopg-pool==3.1.7
-    # via psycopg
 pycparser==2.21
     # via cffi
 pygments==2.16.1
@@ -268,8 +264,6 @@ typing-extensions==4.7.1
     # via
     #   asgiref
     #   filelock
-    #   psycopg
-    #   psycopg-pool
 tzdata==2023.3
     # via
     #   -r requirements/pip.in

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -24,11 +24,11 @@ billiard==3.6.4.0
     # via
     #   -r requirements/pip.txt
     #   celery
-boto3==1.28.40
+boto3==1.28.45
     # via
     #   -r requirements/pip.txt
     #   django-storages
-botocore==1.31.40
+botocore==1.31.45
     # via
     #   -r requirements/pip.txt
     #   boto3
@@ -69,7 +69,7 @@ click-repl==0.3.0
     # via
     #   -r requirements/pip.txt
     #   celery
-coverage[toml]==7.3.0
+coverage[toml]==7.3.1
     # via pytest-cov
 cron-descriptor==1.4.0
     # via
@@ -156,13 +156,13 @@ django-polymorphic==3.1.0
     # via -r requirements/pip.txt
 django-simple-history==3.0.0
     # via -r requirements/pip.txt
-django-storages[boto3]==1.13.2
+django-storages[boto3]==1.14
     # via -r requirements/pip.txt
 django-structlog==2.2.0
     # via -r requirements/pip.txt
 django-taggit==4.0.0
     # via -r requirements/pip.txt
-django-timezone-field==6.0
+django-timezone-field==6.0.1
     # via
     #   -r requirements/pip.txt
     #   django-celery-beat
@@ -239,13 +239,13 @@ markdown==3.4.4
     # via -r requirements/pip.txt
 markupsafe==2.1.3
     # via jinja2
-mercurial==6.5.1
+mercurial==6.5.2
     # via -r requirements/testing.in
 oauthlib==3.2.2
     # via
     #   -r requirements/pip.txt
     #   requests-oauthlib
-orjson==3.9.5
+orjson==3.9.7
     # via -r requirements/pip.txt
 packaging==23.1
     # via
@@ -281,7 +281,7 @@ pyjwt[crypto]==2.8.0
     #   django-allauth
 pyquery==2.0.0
     # via -r requirements/pip.txt
-pytest==7.4.1
+pytest==7.4.2
     # via
     #   -r requirements/testing.in
     #   pytest-cov
@@ -310,7 +310,7 @@ python3-openid==3.2.0
     # via
     #   -r requirements/pip.txt
     #   django-allauth
-pytz==2023.3
+pytz==2023.3.post1
     # via
     #   -r requirements/pip.txt
     #   celery
@@ -436,13 +436,13 @@ vine==5.0.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.24.4
+virtualenv==20.24.5
     # via -r requirements/pip.txt
 wcwidth==0.2.6
     # via
     #   -r requirements/pip.txt
     #   prompt-toolkit
-websocket-client==1.6.2
+websocket-client==1.6.3
     # via
     #   -r requirements/pip.txt
     #   docker

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -95,7 +95,7 @@ dj-pagination==2.5.0
     # via -r requirements/pip.txt
 dj-stripe==2.6.3
     # via -r requirements/pip.txt
-django==4.2.4
+django==4.2.5
     # via
     #   -r requirements/pip.txt
     #   dj-stripe
@@ -265,16 +265,8 @@ prompt-toolkit==3.0.39
     # via
     #   -r requirements/pip.txt
     #   click-repl
-psycopg[binary,pool]==3.1.10
+psycopg2==2.9.7
     # via -r requirements/pip.txt
-psycopg-binary==3.1.10
-    # via
-    #   -r requirements/pip.txt
-    #   psycopg
-psycopg-pool==3.1.7
-    # via
-    #   -r requirements/pip.txt
-    #   psycopg
 pycparser==2.21
     # via
     #   -r requirements/pip.txt
@@ -415,8 +407,6 @@ typing-extensions==4.7.1
     #   -r requirements/pip.txt
     #   asgiref
     #   filelock
-    #   psycopg
-    #   psycopg-pool
 tzdata==2023.3
     # via
     #   -r requirements/pip.txt


### PR DESCRIPTION
This package works fine and the upgrade was transparent. However, it seems that New Relic agent is not prepared to collect data from v3.x and send it to their servers.

https://docs.newrelic.com/docs/apm/agents/python-agent/getting-started/instrumented-python-packages/#instance-details

> The Python agent should be able to track database queries for any Python
> DB-API 2.0 compliant modules

`psycopg3` is compatible with DB-API 2.0, but for some reason doesn't work. I'm reverting it for now and we can take a look later.

Note this commit also upgrades Django, due to a security issue that was reported:

https://docs.djangoproject.com/en/4.2/releases/4.2.5/

Reverts #10667