### PR TITLE
Addons: include `hotkeys` in API response

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1806,6 +1806,7 @@ class Feature(models.Model):
         "addons_non_latest_version_warning_disabled"
     )
     ADDONS_SEARCH_DISABLED = "addons_search_disabled"
+    ADDONS_HOTKEYS_DISABLED = "addons_hotkeys_disabled"
 
     FEATURES = (
         (
@@ -1950,6 +1951,10 @@ class Feature(models.Model):
         (
             ADDONS_SEARCH_DISABLED,
             _("Addons: Disable Search."),
+        ),
+        (
+            ADDONS_HOTKEYS_DISABLED,
+            _("Addons: Disable Hotkeys."),
         ),
     )
 

--- a/readthedocs/proxito/tests/responses/v0.json
+++ b/readthedocs/proxito/tests/responses/v0.json
@@ -82,6 +82,17 @@
     "external_version_warning": {
       "enabled": true
     },
+    "hotkeys": {
+      "enabled": true,
+      "doc_diff": {
+        "enabled": true,
+        "trigger": "KeyD"
+      },
+      "search": {
+        "enabled": true,
+        "trigger": "Slash"
+      }
+    },
     "non_latest_version_warning": {
       "enabled": true,
       "versions": ["latest"]

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -379,6 +379,17 @@ class AddonsResponse:
                     if version
                     else None,
                 },
+                "hotkeys": {
+                    "enabled": Feature.ADDONS_HOTKEYS_DISABLED not in project_features,
+                    "doc_diff": {
+                        "enabled": True,
+                        "trigger": "KeyD",  # Could be something like "Ctrl + D"
+                    },
+                    "search": {
+                        "enabled": True,
+                        "trigger": "Slash",  # Could be something like "Ctrl + D"
+                    },
+                },
             },
         }
 


### PR DESCRIPTION
Required for https://github.com/readthedocs/addons/pull/118