### PR TITLE
Proxito: update CORS settings

### DIFF
--- a/readthedocs/embed/v3/tests/test_access.py
+++ b/readthedocs/embed/v3/tests/test_access.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from unittest import mock
 
 import pytest
+from corsheaders.middleware import ACCESS_CONTROL_ALLOW_ORIGIN
 from django.contrib.auth.models import User
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -67,6 +68,7 @@ class TestEmbedAPIV3Access(TestCase):
         resp = self.get(self.url)
         self.assertEqual(resp.status_code, 200)
         self.assertIn("Content", resp.json()["content"])
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_ORIGIN, resp.headers)
 
     def test_get_content_private_version_anonymous_user(self, storage_mock):
         self._mock_storage(storage_mock)
@@ -85,6 +87,7 @@ class TestEmbedAPIV3Access(TestCase):
         resp = self.get(self.url)
         self.assertEqual(resp.status_code, 200)
         self.assertIn("Content", resp.json()["content"])
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_ORIGIN, resp.headers)
 
     def test_get_content_private_version_logged_in_user(self, storage_mock):
         self._mock_storage(storage_mock)
@@ -96,6 +99,7 @@ class TestEmbedAPIV3Access(TestCase):
         resp = self.get(self.url)
         self.assertEqual(resp.status_code, 200)
         self.assertIn("Content", resp.json()["content"])
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_ORIGIN, resp.headers)
 
     @mock.patch.object(EmbedAPIBase, "_download_page_content")
     def test_get_content_allowed_external_page(
@@ -108,6 +112,7 @@ class TestEmbedAPIV3Access(TestCase):
         )
         self.assertEqual(resp.status_code, 200)
         self.assertIn("Content", resp.json()["content"])
+        self.assertNotIn(ACCESS_CONTROL_ALLOW_ORIGIN, resp.headers)
 
     def test_get_content_not_allowed_external_page(self, storage_mock):
         resp = self.get(reverse("embed_api_v3") + "?url=https://example.com/en/latest/")

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -327,12 +327,12 @@ class ProxitoMiddleware(MiddlewareMixin):
 
         project_slug = getattr(request, "path_project_slug", "")
         version_slug = getattr(request, "path_version_slug", "")
-        host = request.get_host()
+        origin = request.headers.get("origin")
 
         if (
             project_slug
             and version_slug
-            and host.endswith(settings.RTD_EXTERNAL_VERSION_DOMAIN)
+            and origin.endswith(settings.RTD_EXTERNAL_VERSION_DOMAIN)
         ):
             allow_cors = Version.objects.filter(
                 project__slug=project_slug,
@@ -340,7 +340,7 @@ class ProxitoMiddleware(MiddlewareMixin):
                 privacy_level=PUBLIC,
             ).exists()
             if allow_cors:
-                response.headers["Access-Control-Allow-Origin"] = host
+                response.headers["Access-Control-Allow-Origin"] = origin
                 response.headers["Access-Control-Allow-Methods"] = "OPTIONS, GET"
                 patch_vary_headers(response, ("origin",))
 

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -341,6 +341,7 @@ class ProxitoMiddleware(MiddlewareMixin):
             if allow_cors:
                 response.headers["Access-Control-Allow-Origin"] = host
                 response.headers["Access-Control-Allow-Methods"] = "OPTIONS, GET"
+                response.headers["Vary"] = "Origin"
 
         return response
 

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -13,6 +13,7 @@ from django.conf import settings
 from django.core.exceptions import SuspiciousOperation
 from django.shortcuts import redirect
 from django.urls import reverse
+from django.utils.cache import patch_vary_headers
 from django.utils.deprecation import MiddlewareMixin
 
 from readthedocs.builds.models import Version
@@ -341,7 +342,7 @@ class ProxitoMiddleware(MiddlewareMixin):
             if allow_cors:
                 response.headers["Access-Control-Allow-Origin"] = host
                 response.headers["Access-Control-Allow-Methods"] = "OPTIONS, GET"
-                response.headers["Vary"] = "Origin"
+                patch_vary_headers(response, ("origin",))
 
         return response
 

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -9,11 +9,14 @@ import re
 from urllib.parse import urlparse
 
 import structlog
+from corsheaders.middleware import (
+    ACCESS_CONTROL_ALLOW_METHODS,
+    ACCESS_CONTROL_ALLOW_ORIGIN,
+)
 from django.conf import settings
 from django.core.exceptions import SuspiciousOperation
 from django.shortcuts import redirect
 from django.urls import reverse
-from django.utils.cache import patch_vary_headers
 from django.utils.deprecation import MiddlewareMixin
 
 from readthedocs.builds.models import Version
@@ -309,7 +312,7 @@ class ProxitoMiddleware(MiddlewareMixin):
 
     def add_cors_headers(self, request, response):
         """
-        Add CORS headers only on PUBLIC versions.
+        Add CORS headers only to files from PUBLIC versions.
 
         DocDiff addons requires making a request from
         ``RTD_EXTERNAL_VERSION_DOMAIN`` to ``PUBLIC_DOMAIN`` to be able to
@@ -318,6 +321,12 @@ class ProxitoMiddleware(MiddlewareMixin):
         This request needs ``Access-Control-Allow-Origin`` HTTP headers to be
         accepted by browsers. However, we cannot expose these headers for
         documentation that's not PUBLIC.
+
+        We set this header to `*`, since the allowed versions are public only,
+        we don't care about the origin of the request. And we don't have the
+        need nor want to allow passing credentials from cross-origin requests.
+
+        See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin.
         """
 
         # Disable CORS on "Read the Docs for Business" for now.
@@ -325,24 +334,22 @@ class ProxitoMiddleware(MiddlewareMixin):
         if settings.ALLOW_PRIVATE_REPOS:
             return
 
+        # TODO: se should add these headers to files from docs only,
+        # proxied APIs and other endpoints should not have CORS headers.
+        # These attributes aren't currently set for proxied APIs, but we shuold
+        # find a better way to do this.
         project_slug = getattr(request, "path_project_slug", "")
         version_slug = getattr(request, "path_version_slug", "")
-        origin = request.headers.get("origin")
 
-        if (
-            project_slug
-            and version_slug
-            and origin.endswith(settings.RTD_EXTERNAL_VERSION_DOMAIN)
-        ):
+        if project_slug and version_slug:
             allow_cors = Version.objects.filter(
                 project__slug=project_slug,
                 slug=version_slug,
                 privacy_level=PUBLIC,
             ).exists()
             if allow_cors:
-                response.headers["Access-Control-Allow-Origin"] = origin
-                response.headers["Access-Control-Allow-Methods"] = "OPTIONS, GET"
-                patch_vary_headers(response, ("origin",))
+                response.headers[ACCESS_CONTROL_ALLOW_ORIGIN] = "*"
+                response.headers[ACCESS_CONTROL_ALLOW_METHODS] = "HEAD, OPTIONS, GET"
 
         return response
 

--- a/readthedocs/proxito/tests/test_headers.py
+++ b/readthedocs/proxito/tests/test_headers.py
@@ -196,6 +196,7 @@ class ProxitoHeaderTests(BaseDocServing):
         self.assertEqual(r.status_code, 200)
         self.assertIsNone(r.get("Access-Control-Allow-Origin"))
         self.assertIsNone(r.get("Access-Control-Allow-Methods"))
+        self.assertIsNone(r.get("Vary"))
 
     def test_cors_headers_public_version(self):
         fixture.get(
@@ -217,6 +218,7 @@ class ProxitoHeaderTests(BaseDocServing):
             r["Access-Control-Allow-Origin"], "project--111.dev.readthedocs.build"
         )
         self.assertEqual(r["Access-Control-Allow-Methods"], "OPTIONS, GET")
+        self.assertEqual(r["Vary"], "Origin")
 
     @override_settings(ALLOW_PRIVATE_REPOS=True)
     def test_cors_headers_public_version_allow_private_repositories(self):

--- a/readthedocs/proxito/tests/test_headers.py
+++ b/readthedocs/proxito/tests/test_headers.py
@@ -191,7 +191,7 @@ class ProxitoHeaderTests(BaseDocServing):
         r = self.client.get(
             "/en/111/",
             secure=True,
-            headers={"host": "project--111.dev.readthedocs.build"},
+            headers={"origin": "project--111.dev.readthedocs.build"},
         )
         self.assertEqual(r.status_code, 200)
         self.assertIsNone(r.get("Access-Control-Allow-Origin"))
@@ -211,7 +211,7 @@ class ProxitoHeaderTests(BaseDocServing):
         r = self.client.get(
             "/en/111/",
             secure=True,
-            headers={"host": "project--111.dev.readthedocs.build"},
+            headers={"origin": "project--111.dev.readthedocs.build"},
         )
         self.assertEqual(r.status_code, 200)
         self.assertEqual(
@@ -234,7 +234,7 @@ class ProxitoHeaderTests(BaseDocServing):
         r = self.client.get(
             "/en/111/",
             secure=True,
-            headers={"host": "project--111.dev.readthedocs.build"},
+            headers={"origin": "project--111.dev.readthedocs.build"},
         )
         self.assertEqual(r.status_code, 200)
         self.assertIsNone(r.get("Access-Control-Allow-Origin"))

--- a/readthedocs/search/tests/test_proxied_api.py
+++ b/readthedocs/search/tests/test_proxied_api.py
@@ -1,4 +1,5 @@
 import pytest
+from corsheaders.middleware import ACCESS_CONTROL_ALLOW_ORIGIN
 
 from readthedocs.search.tests.test_api import BaseTestDocumentSearch
 
@@ -25,3 +26,4 @@ class TestProxiedSearchAPI(BaseTestDocumentSearch):
             f"{project.slug},{project.slug}:{version.slug},{project.slug}:rtd-search"
         )
         assert resp["Cache-Tag"] == cache_tags
+        assert ACCESS_CONTROL_ALLOW_ORIGIN not in resp.headers


### PR DESCRIPTION
- Only add CORS headers on community site
- Explicit host on `Access-Control-Allow-Origin`
- Only query the database if the host ends with `RTD_EXTERNAL_VERSION_DOMAIN`
- Add more tests

Continuation of #10737