### PR TITLE
Addons: move the HTTP header to a GET parameter

### DIFF
--- a/readthedocs/proxito/tests/responses/v2.json
+++ b/readthedocs/proxito/tests/responses/v2.json
@@ -1,3 +1,3 @@
 {
-    "error": "The version specified in 'X-RTD-Hosting-Integrations-Version' is currently not supported"
+    "error": "The version specified in 'api-version' is currently not supported"
 }

--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -80,11 +80,13 @@ class TestReadTheDocsConfigJson(TestCase):
     def test_get_config_v0(self):
         r = self.client.get(
             reverse("proxito_readthedocs_docs_addons"),
-            {"url": "https://project.dev.readthedocs.io/en/latest/"},
+            {
+                "url": "https://project.dev.readthedocs.io/en/latest/",
+                "api-version": "0.1.0",
+            },
             secure=True,
             headers={
                 "host": "project.dev.readthedocs.io",
-                "x-rtd-hosting-integrations-version": "0.1.0",
             },
         )
         assert r.status_code == 200
@@ -95,11 +97,13 @@ class TestReadTheDocsConfigJson(TestCase):
     def test_get_config_v1(self):
         r = self.client.get(
             reverse("proxito_readthedocs_docs_addons"),
-            {"url": "https://project.dev.readthedocs.io/en/latest/"},
+            {
+                "url": "https://project.dev.readthedocs.io/en/latest/",
+                "api-version": "1.0.0",
+            },
             secure=True,
             headers={
                 "host": "project.dev.readthedocs.io",
-                "x-rtd-hosting-integrations-version": "1.0.0",
             },
         )
         assert r.status_code == 200
@@ -108,11 +112,13 @@ class TestReadTheDocsConfigJson(TestCase):
     def test_get_config_unsupported_version(self):
         r = self.client.get(
             reverse("proxito_readthedocs_docs_addons"),
-            {"url": "https://project.dev.readthedocs.io/en/latest/"},
+            {
+                "url": "https://project.dev.readthedocs.io/en/latest/",
+                "api-version": "2.0.0",
+            },
             secure=True,
             headers={
                 "host": "project.dev.readthedocs.io",
-                "x-rtd-hosting-integrations-version": "2.0.0",
             },
         )
         assert r.status_code == 400

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -31,13 +31,9 @@ ADDONS_VERSIONS_SUPPORTED = (0, 1)
 
 class ClientError(Exception):
     VERSION_NOT_CURRENTLY_SUPPORTED = (
-        "The version specified in 'X-RTD-Hosting-Integrations-Version'"
-        " is currently not supported"
+        "The version specified in 'api-version' is currently not supported"
     )
-    VERSION_INVALID = "'X-RTD-Hosting-Integrations-Version' header version is invalid"
-    VERSION_HEADER_MISSING = (
-        "'X-RTD-Hosting-Integrations-Version' header attribute is required"
-    )
+    VERSION_INVALID = "The version specifified in 'api-version' is invalid"
 
 
 class BaseReadTheDocsConfigJson(CDNCacheTagsMixin, APIView):
@@ -52,6 +48,8 @@ class BaseReadTheDocsConfigJson(CDNCacheTagsMixin, APIView):
 
       url (required): absolute URL from where the request is performed
         (e.g. ``window.location.href``)
+
+      api-version (required): API JSON structure version (e.g. ``0``, ``1``, ``2``).
     """
 
     http_method_names = ["get"]
@@ -112,12 +110,10 @@ class BaseReadTheDocsConfigJson(CDNCacheTagsMixin, APIView):
                 status=400,
             )
 
-        addons_version = request.headers.get("X-RTD-Hosting-Integrations-Version")
+        addons_version = request.GET.get("api-version")
         if not addons_version:
             return JsonResponse(
-                {
-                    "error": ClientError.VERSION_HEADER_MISSING,
-                },
+                {"error": "'api-version' GET attribute is required"},
                 status=400,
             )
         try:


### PR DESCRIPTION
Move `X-RTD-Hosting-Integration-Version` header to `api-version` querystring parameter. This has some benefits:

- make links to this URL clickable (there is no need to use a browser extension to send a specific header in the request)
- easier to cache using the default strategy supported by CF

Related #10536