### PR TITLE
APIv3: return `single_version` field on `Project` resource

### DIFF
--- a/docs/user/api/v3.rst
+++ b/docs/user/api/v3.rst
@@ -279,6 +279,7 @@ Project details
             },
             "privacy_level": "public",
             "external_builds_privacy_level": "public",
+            "single_version": false,
             "_links": {
                 "_self": "/api/v3/projects/pip/",
                 "versions": "/api/v3/projects/pip/versions/",

--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -638,6 +638,7 @@ class ProjectSerializer(FlexFieldsModelSerializer):
             "tags",
             "privacy_level",
             "external_builds_privacy_level",
+            "single_version",
             # NOTE: ``expandable_fields`` must not be included here. Otherwise,
             # they will be tried to be rendered and fail
             # 'active_versions',

--- a/readthedocs/api/v3/tests/responses/projects-detail.json
+++ b/readthedocs/api/v3/tests/responses/projects-detail.json
@@ -107,5 +107,6 @@
         }
     ],
     "privacy_level": "public",
-    "external_builds_privacy_level": "public"
+    "external_builds_privacy_level": "public",
+    "single_version": false
 }

--- a/readthedocs/api/v3/tests/responses/projects-list.json
+++ b/readthedocs/api/v3/tests/responses/projects-list.json
@@ -53,7 +53,8 @@
                 "translations": "https://readthedocs.org/api/v3/projects/project/translations/"
             },
             "privacy_level": "public",
-            "external_builds_privacy_level": "public"
+            "external_builds_privacy_level": "public",
+            "single_version": false
         }
     ]
 }

--- a/readthedocs/api/v3/tests/responses/projects-list_POST.json
+++ b/readthedocs/api/v3/tests/responses/projects-list_POST.json
@@ -44,5 +44,6 @@
         }
     ],
     "privacy_level": "public",
-    "external_builds_privacy_level": "public"
+    "external_builds_privacy_level": "public",
+    "single_version": false
 }

--- a/readthedocs/api/v3/tests/responses/projects-subprojects-detail.json
+++ b/readthedocs/api/v3/tests/responses/projects-subprojects-detail.json
@@ -49,6 +49,7 @@
             }
         ],
         "privacy_level": "public",
-        "external_builds_privacy_level": "public"
+        "external_builds_privacy_level": "public",
+        "single_version": false
     }
 }

--- a/readthedocs/api/v3/tests/responses/projects-subprojects-list.json
+++ b/readthedocs/api/v3/tests/responses/projects-subprojects-list.json
@@ -54,7 +54,8 @@
                     }
                 ],
                 "privacy_level": "public",
-                "external_builds_privacy_level": "public"
+                "external_builds_privacy_level": "public",
+                "single_version": false
             }
         }
     ]

--- a/readthedocs/api/v3/tests/responses/projects-subprojects-list_POST.json
+++ b/readthedocs/api/v3/tests/responses/projects-subprojects-list_POST.json
@@ -49,6 +49,7 @@
             }
         ],
         "privacy_level": "public",
-        "external_builds_privacy_level": "public"
+        "external_builds_privacy_level": "public",
+        "single_version": false
     }
 }

--- a/readthedocs/api/v3/tests/responses/projects-superproject.json
+++ b/readthedocs/api/v3/tests/responses/projects-superproject.json
@@ -48,5 +48,6 @@
         }
     ],
     "privacy_level": "public",
-    "external_builds_privacy_level": "public"
+    "external_builds_privacy_level": "public",
+    "single_version": false
 }

--- a/readthedocs/api/v3/tests/responses/projects-versions-builds-list_POST.json
+++ b/readthedocs/api/v3/tests/responses/projects-versions-builds-list_POST.json
@@ -74,7 +74,8 @@
             }
         ],
         "privacy_level": "public",
-        "external_builds_privacy_level": "public"
+        "external_builds_privacy_level": "public",
+        "single_version": false
     },
     "triggered": true,
     "version": {

--- a/readthedocs/api/v3/tests/responses/remoterepositories-list.json
+++ b/readthedocs/api/v3/tests/responses/remoterepositories-list.json
@@ -49,7 +49,8 @@
         },
         "users": [{ "username": "testuser" }],
         "privacy_level": "public",
-        "external_builds_privacy_level": "public"
+        "external_builds_privacy_level": "public",
+        "single_version": false
       }],
       "remote_organization": {
           "avatar_url": "https://avatars.githubusercontent.com/u/366329?v=4",

--- a/readthedocs/proxito/tests/responses/v0.json
+++ b/readthedocs/proxito/tests/responses/v0.json
@@ -23,6 +23,7 @@
         "type": "git",
         "url": "https://github.com/readthedocs/project"
       },
+      "single_version": false,
       "slug": "project",
       "subproject_of": null,
       "tags": ["project", "tag", "test"],


### PR DESCRIPTION
For some reason we weren't returning this field in the API response. I understand there is no reason to not do it.

I added `single_version` field in the response API so we can make some decisions from the addons based on its value.

Required by https://github.com/readthedocs/addons/issues/140

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10758.org.readthedocs.build/en/10758/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10758.org.readthedocs.build/en/10758/

<!-- readthedocs-preview dev end -->