### PR TITLE
Docs: update example for AsciiDoc to simplify it a little

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -480,6 +480,5 @@ Here is an example configuration file:
      tools:
        nodejs: "20"
      commands:
-       - npm i -g asciidoctor
-       - asciidoctor index.asciidoc
-       - mkdir -pv $READTHEDOCS_OUTPUT/html/ && mv index.html $READTHEDOCS_OUTPUT/html/
+       - npm install -g asciidoctor
+       - asciidoctor -D $READTHEDOCS_OUTPUT/html index.asciidoc


### PR DESCRIPTION
I created a version on `test-builds` for this and it works fine: https://test-builds.readthedocs.io/en/asciidoctor/

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10763.org.readthedocs.build/en/10763/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10763.org.readthedocs.build/en/10763/

<!-- readthedocs-preview dev end -->