### PR TITLE
Test ES upgrade to 7.17.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
         environment:
           TOX_POSARGS: ''
           PYTEST_COVERAGE: --cov-report=xml --cov-config .coveragerc --cov=. --cov-append
-      - image: 'docker.elastic.co/elasticsearch/elasticsearch:7.14.0'
+      - image: 'docker.elastic.co/elasticsearch/elasticsearch:7.17.13'
         name: search
         environment:
           discovery.type: single-node


### PR DESCRIPTION
Before upgrading to 8.x, we need to upgrade to 7.17.13.

This is mainly so we can test the upgrade process
outside the ES cluster.