### PR TITLE
docs: Document how to fetch additional branches

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -88,7 +88,8 @@ we recommend you use them as a starting point.
 Unshallow git clone
 ^^^^^^^^^^^^^^^^^^^
 
-Read the Docs does not perform a full clone on ``checkout`` job to reduce network data and speed up the build process.
+Read the Docs does not perform a full clone in the ``checkout`` job in order to reduce network data and speed up the build process.
+Instead, it performs a `shallow clone <https://git-scm.com/docs/shallow>`_ and only fetches the branch or tag that you are building documentation for.
 Because of this, extensions that depend on the full Git history will fail.
 To avoid this, it's possible to unshallow the :program:`git clone`:
 
@@ -103,6 +104,22 @@ To avoid this, it's possible to unshallow the :program:`git clone`:
      jobs:
        post_checkout:
          - git fetch --unshallow || true
+
+If your build also relies on the contents of other branches, it may also be necessary to re-configure git to fetch these:
+
+.. code-block:: yaml
+   :caption: .readthedocs.yaml
+
+   version: 2
+   build:
+     os: "ubuntu-20.04"
+     tools:
+       python: "3.10"
+     jobs:
+       post_checkout:
+         - git fetch --unshallow || true
+         - git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*' || true
+         - git fetch --all --tags || true
 
 
 Cancel build based on a condition


### PR DESCRIPTION
Tools like reno depend on a complete git history. Simply unshallowing a clone is not sufficient, as we specifically fetch from the branch or tag that we are building docs for, e.g.:

    git fetch origin --force --prune --prune-tags --depth 50 refs/heads/main:refs/remotes/origin/main

Add documentation describing how you can correct this if necessary.


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10795.org.readthedocs.build/en/10795/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10795.org.readthedocs.build/en/10795/

<!-- readthedocs-preview dev end -->