### PR TITLE
Proxito: always use subdomain for serving docs

### DIFF
--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -346,7 +346,7 @@ Docker for builds
 
 Serve documentation under a subdomain
     There are a number of resolution bugs and cross-domain behavior that can
-    only be caught by using `USE_SUBDOMAIN` setting.
+    only be caught by using a ``PUBLIC_DOMAIN`` setting different from the ``PRODUCTION_DOMAIN`` setting.
 
 PostgreSQL as a database
     It is recommended that Postgres be used as the default database whenever

--- a/docs/dev/settings.rst
+++ b/docs/dev/settings.rst
@@ -22,7 +22,7 @@ memory
 PRODUCTION_DOMAIN
 ------------------
 
-This is the domain that is used by the main application (not documentation pages).
+This is the domain that is used by the main application dashboard (not documentation pages).
 
 RTD_INTERSPHINX_URL
 -------------------

--- a/docs/dev/settings.rst
+++ b/docs/dev/settings.rst
@@ -19,18 +19,10 @@ memory
     Examples: '200m' for 200MB of total memory, or '2g' for 2GB of
     total memory.
 
-USE_SUBDOMAIN
----------------
-
-Whether to use subdomains in URLs on the site, or the Django-served content.
-When used in production, this should be ``True``, as Nginx will serve this content.
-During development and other possible deployments, this might be ``False``.
-
 PRODUCTION_DOMAIN
 ------------------
 
-This is the domain that gets linked to throughout the site when used in production.
-It depends on `USE_SUBDOMAIN`, otherwise it isn't used.
+This is the domain that is used by the main application (not documentation pages).
 
 RTD_INTERSPHINX_URL
 -------------------

--- a/readthedocs/api/v3/tests/mixins.py
+++ b/readthedocs/api/v3/tests/mixins.py
@@ -21,7 +21,6 @@ from readthedocs.redirects.models import Redirect
 @override_settings(
     PUBLIC_DOMAIN="readthedocs.io",
     PRODUCTION_DOMAIN="readthedocs.org",
-    USE_SUBDOMAIN=True,
     RTD_BUILD_MEDIA_STORAGE="readthedocs.rtd_tests.storage.BuildMediaFileSystemStorageTest",
     RTD_ALLOW_ORGANIZATIONS=False,
 )

--- a/readthedocs/core/context_processors.py
+++ b/readthedocs/core/context_processors.py
@@ -7,7 +7,6 @@ def readthedocs_processor(request):
     exports = {
         "PUBLIC_DOMAIN": settings.PUBLIC_DOMAIN,
         "PRODUCTION_DOMAIN": settings.PRODUCTION_DOMAIN,
-        "USE_SUBDOMAIN": settings.USE_SUBDOMAIN,
         "GLOBAL_ANALYTICS_CODE": settings.GLOBAL_ANALYTICS_CODE,
         "DASHBOARD_ANALYTICS_CODE": settings.DASHBOARD_ANALYTICS_CODE,
         "SITE_ROOT": settings.SITE_ROOT + "/",

--- a/readthedocs/core/resolver.py
+++ b/readthedocs/core/resolver.py
@@ -147,10 +147,7 @@ class ResolverBase:
             if domain:
                 return domain.domain
 
-        if self._use_subdomain():
-            return self._get_project_subdomain(canonical_project)
-
-        return settings.PRODUCTION_DOMAIN
+        return self._get_project_subdomain(canonical_project)
 
     def resolve(
         self,
@@ -176,10 +173,8 @@ class ResolverBase:
             domain = self._get_external_subdomain(canonical_project, version_slug)
         elif use_custom_domain:
             domain = custom_domain.domain
-        elif self._use_subdomain():
-            domain = self._get_project_subdomain(canonical_project)
         else:
-            domain = settings.PRODUCTION_DOMAIN
+            domain = self._get_project_subdomain(canonical_project)
 
         use_https_protocol = any(
             [
@@ -366,10 +361,6 @@ class ResolverBase:
         :type custom_domain: readthedocs.projects.models.Domain
         """
         return custom_domain is not None
-
-    def _use_subdomain(self):
-        """Make decision about whether to use a subdomain to serve docs."""
-        return settings.PUBLIC_DOMAIN is not None
 
     def _use_cname(self, project):
         """Test if to allow direct serving for project on CNAME."""

--- a/readthedocs/core/resolver.py
+++ b/readthedocs/core/resolver.py
@@ -62,8 +62,6 @@ class ResolverBase:
         language=None,
         single_version=None,
         project_relationship=None,
-        subdomain=None,
-        cname=None,
         custom_prefix=None,
     ):
         """
@@ -77,12 +75,7 @@ class ResolverBase:
         the path will be prefixed with the subproject prefix
         (defaults to ``/projects/<subproject-slug>/``).
         """
-        # Only support `/docs/project' URLs outside our normal environment. Normally
-        # the path should always have a subdomain or CNAME domain
-        if subdomain or cname or self._use_subdomain():
-            path = "/"
-        else:
-            path = "/docs/{project}/"
+        path = "/"
 
         if project_relationship:
             path = unsafe_join_url_path(path, project_relationship.subproject_prefix)
@@ -112,8 +105,6 @@ class ResolverBase:
         version_slug=None,
         language=None,
         single_version=None,
-        subdomain=None,
-        cname=None,
     ):
         """Resolve a URL with a subset of fields defined."""
         version_slug = version_slug or project.get_default_version()
@@ -122,11 +113,6 @@ class ResolverBase:
         filename = self._fix_filename(filename)
 
         parent_project, project_relationship = self._get_canonical_project_data(project)
-        cname = (
-            cname
-            or self._use_subdomain()
-            or parent_project.get_canonical_custom_domain()
-        )
         single_version = bool(project.single_version or single_version)
 
         # If the project is a subproject, we use the custom prefix
@@ -145,8 +131,6 @@ class ResolverBase:
             language=language,
             single_version=single_version,
             project_relationship=project_relationship,
-            cname=cname,
-            subdomain=subdomain,
             custom_prefix=custom_prefix,
         )
 
@@ -385,7 +369,7 @@ class ResolverBase:
 
     def _use_subdomain(self):
         """Make decision about whether to use a subdomain to serve docs."""
-        return settings.USE_SUBDOMAIN and settings.PUBLIC_DOMAIN is not None
+        return settings.PUBLIC_DOMAIN is not None
 
     def _use_cname(self, project):
         """Test if to allow direct serving for project on CNAME."""

--- a/readthedocs/embed/tests/test_api.py
+++ b/readthedocs/embed/tests/test_api.py
@@ -33,7 +33,6 @@ class BaseTestEmbedAPI:
         self.version.privacy_level = PUBLIC
         self.version.save()
 
-        settings.USE_SUBDOMAIN = True
         settings.PUBLIC_DOMAIN = "readthedocs.io"
         settings.RTD_DEFAULT_FEATURES = dict(
             [RTDProductFeature(TYPE_EMBED_API).to_item()]

--- a/readthedocs/embed/v3/tests/test_access.py
+++ b/readthedocs/embed/v3/tests/test_access.py
@@ -17,7 +17,6 @@ from readthedocs.subscriptions.products import RTDProductFeature
 
 
 @override_settings(
-    USE_SUBDOMAIN=True,
     PUBLIC_DOMAIN="readthedocs.io",
     RTD_ALLOW_ORGAZATIONS=False,
     RTD_DEFAULT_FEATURES=dict([RTDProductFeature(TYPE_EMBED_API).to_item()]),

--- a/readthedocs/embed/v3/tests/test_basics.py
+++ b/readthedocs/embed/v3/tests/test_basics.py
@@ -9,7 +9,6 @@ from django.urls import reverse
 class TestEmbedAPIv3Basics:
     @pytest.fixture(autouse=True)
     def setup_method(self, settings):
-        settings.USE_SUBDOMAIN = True
         settings.PUBLIC_DOMAIN = "readthedocs.io"
         settings.RTD_EMBED_API_EXTERNAL_DOMAINS = ["docs.project.com"]
 

--- a/readthedocs/embed/v3/tests/test_external_pages.py
+++ b/readthedocs/embed/v3/tests/test_external_pages.py
@@ -13,7 +13,6 @@ from .utils import get_anchor_link_title, srcdir
 class TestEmbedAPIv3ExternalPages:
     @pytest.fixture(autouse=True)
     def setup_method(self, settings):
-        settings.USE_SUBDOMAIN = True
         settings.PUBLIC_DOMAIN = "readthedocs.io"
         settings.RTD_EMBED_API_EXTERNAL_DOMAINS = ["docs.project.com"]
 

--- a/readthedocs/embed/v3/tests/test_internal_pages.py
+++ b/readthedocs/embed/v3/tests/test_internal_pages.py
@@ -20,7 +20,6 @@ from .utils import get_anchor_link_title, srcdir
 class TestEmbedAPIv3InternalPages:
     @pytest.fixture(autouse=True)
     def setup_method(self, settings):
-        settings.USE_SUBDOMAIN = True
         settings.PUBLIC_DOMAIN = "readthedocs.io"
         settings.RTD_EMBED_API_EXTERNAL_DOMAINS = []
         settings.RTD_DEFAULT_FEATURES = dict(

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -755,11 +755,7 @@ class DomainList(DomainMixin, ListViewWithForm):
         ctx = super().get_context_data(**kwargs)
 
         # Get the default docs domain
-        ctx['default_domain'] = (
-            settings.PUBLIC_DOMAIN
-            if settings.USE_SUBDOMAIN
-            else settings.PRODUCTION_DOMAIN
-        )
+        ctx['default_domain'] = settings.PUBLIC_DOMAIN
 
         return ctx
 

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -755,7 +755,7 @@ class DomainList(DomainMixin, ListViewWithForm):
         ctx = super().get_context_data(**kwargs)
 
         # Get the default docs domain
-        ctx['default_domain'] = settings.PUBLIC_DOMAIN
+        ctx["default_domain"] = settings.PUBLIC_DOMAIN
 
         return ctx
 

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -200,12 +200,7 @@ class ProxitoMiddleware(MiddlewareMixin):
         request.unresolved_domain = None
 
         skip = any(request.path.startswith(reverse(view)) for view in self.skip_views)
-        if (
-            skip
-            or not settings.USE_SUBDOMAIN
-            or "localhost" in request.get_host()
-            or "testserver" in request.get_host()
-        ):
+        if skip:
             log.debug("Not processing Proxito middleware")
             return None
 

--- a/readthedocs/proxito/tests/test_old_redirects.py
+++ b/readthedocs/proxito/tests/test_old_redirects.py
@@ -6,7 +6,6 @@ Most of this code is copied from:
 and adapted to use:
 
  * El Proxito
- * USE_SUBDOMAIN=True always
 """
 
 import django_dynamic_fixture as fixture

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -65,6 +65,7 @@ from readthedocs.subscriptions.constants import TYPE_CONCURRENT_BUILDS
 from readthedocs.subscriptions.products import RTDProductFeature
 
 
+@override_settings(PUBLIC_DOMAIN='readthedocs.io')
 class APIBuildTests(TestCase):
     fixtures = ['eric.json', 'test_data.json']
 
@@ -253,10 +254,7 @@ class APIBuildTests(TestCase):
         resp = client.get('/api/v2/build/{build}/'.format(build=build.pk))
         self.assertEqual(resp.status_code, 200)
         build = resp.data
-        docs_url = 'http://readthedocs.org/docs/{project}/en/{version}/'.format(
-            project=project.slug,
-            version=version.slug,
-        )
+        docs_url = f'http://{project.slug}.readthedocs.io/en/{version.slug}/'
         self.assertEqual(build['state'], 'finished')
         self.assertEqual(build['error'], '')
         self.assertEqual(build['exit_code'], 0)
@@ -3108,6 +3106,7 @@ class IntegrationsTests(TestCase):
         self.assertEqual(resp.data['versions'], ['v1.0'])
 
 
+@override_settings(PUBLIC_DOMAIN='readthedocs.io')
 class APIVersionTests(TestCase):
     fixtures = ['eric', 'test_data']
     maxDiff = None  # So we get an actual diff when it fails
@@ -3139,11 +3138,11 @@ class APIVersionTests(TestCase):
             "built": False,
             "id": 18,
             "active": True,
-            "canonical_url": "http://readthedocs.org/docs/pip/en/0.8/",
+            "canonical_url": "http://pip.readthedocs.io/en/0.8/",
             "project": {
                 "analytics_code": None,
                 "analytics_disabled": False,
-                "canonical_url": "http://readthedocs.org/docs/pip/en/latest/",
+                "canonical_url": "http://pip.readthedocs.io/en/latest/",
                 "cdn_enabled": False,
                 "conf_py_file": "",
                 "container_image": None,
@@ -3203,7 +3202,7 @@ class APIVersionTests(TestCase):
             'active': 'true',
         }
         url = reverse("version-list")
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             resp = self.client.get(url, data)
 
         self.assertEqual(resp.status_code, 200)
@@ -3213,7 +3212,7 @@ class APIVersionTests(TestCase):
         data.update({
             'active': 'false',
         })
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             resp = self.client.get(url, data)
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.data['count'], pip.versions.filter(active=False).count())
@@ -3221,7 +3220,7 @@ class APIVersionTests(TestCase):
     def test_project_get_active_versions(self):
         pip = Project.objects.get(slug="pip")
         url = reverse("project-active-versions", args=[pip.pk])
-        with self.assertNumQueries(6):
+        with self.assertNumQueries(5):
             resp = self.client.get(url)
         self.assertEqual(
             len(resp.data["versions"]), pip.versions.filter(active=True).count()

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -65,7 +65,7 @@ from readthedocs.subscriptions.constants import TYPE_CONCURRENT_BUILDS
 from readthedocs.subscriptions.products import RTDProductFeature
 
 
-@override_settings(PUBLIC_DOMAIN='readthedocs.io')
+@override_settings(PUBLIC_DOMAIN="readthedocs.io")
 class APIBuildTests(TestCase):
     fixtures = ['eric.json', 'test_data.json']
 
@@ -254,12 +254,12 @@ class APIBuildTests(TestCase):
         resp = client.get('/api/v2/build/{build}/'.format(build=build.pk))
         self.assertEqual(resp.status_code, 200)
         build = resp.data
-        docs_url = f'http://{project.slug}.readthedocs.io/en/{version.slug}/'
-        self.assertEqual(build['state'], 'finished')
-        self.assertEqual(build['error'], '')
-        self.assertEqual(build['exit_code'], 0)
-        self.assertEqual(build['success'], True)
-        self.assertEqual(build['docs_url'], docs_url)
+        docs_url = f"http://{project.slug}.readthedocs.io/en/{version.slug}/"
+        self.assertEqual(build["state"], "finished")
+        self.assertEqual(build["error"], "")
+        self.assertEqual(build["exit_code"], 0)
+        self.assertEqual(build["success"], True)
+        self.assertEqual(build["docs_url"], docs_url)
         # Verify the path is trimmed
         self.assertEqual(
             build["commands"][0]["command"],
@@ -3106,7 +3106,7 @@ class IntegrationsTests(TestCase):
         self.assertEqual(resp.data['versions'], ['v1.0'])
 
 
-@override_settings(PUBLIC_DOMAIN='readthedocs.io')
+@override_settings(PUBLIC_DOMAIN="readthedocs.io")
 class APIVersionTests(TestCase):
     fixtures = ['eric', 'test_data']
     maxDiff = None  # So we get an actual diff when it fails

--- a/readthedocs/rtd_tests/tests/test_build_notifications.py
+++ b/readthedocs/rtd_tests/tests/test_build_notifications.py
@@ -25,7 +25,6 @@ from readthedocs.projects.models import (
 @override_settings(
     PRODUCTION_DOMAIN="readthedocs.org",
     PUBLIC_DOMAIN="readthedocs.io",
-    USE_SUBDOMAIN=True,
 )
 class BuildNotificationsTests(TestCase):
     def setUp(self):

--- a/readthedocs/rtd_tests/tests/test_core_tags.py
+++ b/readthedocs/rtd_tests/tests/test_core_tags.py
@@ -7,12 +7,12 @@ from readthedocs.core.templatetags import core_tags
 from readthedocs.projects.models import Project
 
 
-@override_settings(USE_SUBDOMAIN=False, PRODUCTION_DOMAIN="readthedocs.org")
+@override_settings(PRODUCTION_DOMAIN="readthedocs.org", PUBLIC_DOMAIN="readthedocs.org")
 class CoreTagsTests(TestCase):
     fixtures = ["eric", "test_data"]
 
     def setUp(self):
-        url_base = "http://{domain}/docs/pip{{version}}".format(
+        url_base = "http://pip.{domain}{{version}}".format(
             domain=settings.PRODUCTION_DOMAIN,
         )
 

--- a/readthedocs/rtd_tests/tests/test_footer.py
+++ b/readthedocs/rtd_tests/tests/test_footer.py
@@ -325,7 +325,6 @@ class TestFooterHTML(BaseTestFooterHTML, TestCase):
 
 
 @override_settings(
-    USE_SUBDOMAIN=True,
     PUBLIC_DOMAIN="readthedocs.io",
     PUBLIC_DOMAIN_USES_HTTPS=True,
 )

--- a/readthedocs/rtd_tests/tests/test_notifications.py
+++ b/readthedocs/rtd_tests/tests/test_notifications.py
@@ -71,7 +71,6 @@ class NotificationTests(TestCase):
                 "SUPPORT_EMAIL": "support@readthedocs.org",
                 "TEMPLATE_ROOT": mock.ANY,
                 "USE_PROMOS": mock.ANY,
-                "USE_SUBDOMAIN": mock.ANY,
                 "USE_ORGANIZATIONS": mock.ANY,
             },
         )
@@ -236,7 +235,6 @@ class SiteNotificationTests(TestCase):
             "SUPPORT_EMAIL": "support@readthedocs.org",
             "TEMPLATE_ROOT": mock.ANY,
             "USE_PROMOS": mock.ANY,
-            "USE_SUBDOMAIN": mock.ANY,
             "USE_ORGANIZATIONS": mock.ANY,
         }
         self.assertEqual(self.n.get_context_data(), context)

--- a/readthedocs/rtd_tests/tests/test_privacy.py
+++ b/readthedocs/rtd_tests/tests/test_privacy.py
@@ -227,7 +227,6 @@ class PrivacyTests(TestCase):
     @override_settings(
         DEFAULT_PRIVACY_LEVEL="private",
         PUBLIC_DOMAIN="readthedocs.io",
-        USE_SUBDOMAIN=True,
     )
     def test_private_download_filename(self):
         self._create_kong("private", "private")
@@ -270,7 +269,6 @@ class PrivacyTests(TestCase):
     @override_settings(
         DEFAULT_PRIVACY_LEVEL="public",
         PUBLIC_DOMAIN="readthedocs.io",
-        USE_SUBDOMAIN=True,
     )
     def test_public_repo_downloading(self):
         self._create_kong("public", "public")
@@ -308,7 +306,6 @@ class PrivacyTests(TestCase):
     @override_settings(
         DEFAULT_PRIVACY_LEVEL="public",
         PUBLIC_DOMAIN="readthedocs.io",
-        USE_SUBDOMAIN=True,
     )
     def test_public_private_repo_downloading(self):
         self._create_kong("private", "private")
@@ -338,7 +335,6 @@ class PrivacyTests(TestCase):
     @override_settings(
         DEFAULT_PRIVACY_LEVEL="public",
         PUBLIC_DOMAIN="readthedocs.io",
-        USE_SUBDOMAIN=True,
     )
     def test_public_download_filename(self):
         self._create_kong("public", "public")

--- a/readthedocs/rtd_tests/tests/test_resolver.py
+++ b/readthedocs/rtd_tests/tests/test_resolver.py
@@ -59,71 +59,55 @@ class ResolverBase(TestCase):
 
 class SmartResolverPathTests(ResolverBase):
     def test_resolver_filename(self):
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_path(project=self.pip, filename="/foo/bar/blah.html")
-            self.assertEqual(url, "/docs/pip/en/latest/foo/bar/blah.html")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve_path(project=self.pip, filename="/foo/bar/blah.html")
-            self.assertEqual(url, "/en/latest/foo/bar/blah.html")
+        url = resolve_path(project=self.pip, filename="/foo/bar/blah.html")
+        self.assertEqual(url, "/en/latest/foo/bar/blah.html")
 
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_path(project=self.pip, filename="")
-            self.assertEqual(url, "/docs/pip/en/latest/")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve_path(project=self.pip, filename="")
-            self.assertEqual(url, "/en/latest/")
+        url = resolve_path(project=self.pip, filename="")
+        self.assertEqual(url, "/en/latest/")
 
     def test_resolver_filename_index(self):
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_path(project=self.pip, filename="foo/bar/index.html")
-            self.assertEqual(url, "/docs/pip/en/latest/foo/bar/index.html")
-            url = resolve_path(
-                project=self.pip,
-                filename="foo/index/index.html",
-            )
-            self.assertEqual(url, "/docs/pip/en/latest/foo/index/index.html")
+        url = resolve_path(project=self.pip, filename="foo/bar/index.html")
+        self.assertEqual(url, "/en/latest/foo/bar/index.html")
+        url = resolve_path(
+            project=self.pip,
+            filename="foo/index/index.html",
+        )
+        self.assertEqual(url, "/en/latest/foo/index/index.html")
 
     def test_resolver_filename_false_index(self):
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_path(project=self.pip, filename="foo/foo_index.html")
-            self.assertEqual(url, "/docs/pip/en/latest/foo/foo_index.html")
-            url = resolve_path(
-                project=self.pip,
-                filename="foo_index/foo_index.html",
-            )
-            self.assertEqual(
-                url,
-                "/docs/pip/en/latest/foo_index/foo_index.html",
-            )
+        url = resolve_path(project=self.pip, filename="foo/foo_index.html")
+        self.assertEqual(url, "/en/latest/foo/foo_index.html")
+        url = resolve_path(
+            project=self.pip,
+            filename="foo_index/foo_index.html",
+        )
+        self.assertEqual(
+            url,
+            "/en/latest/foo_index/foo_index.html",
+        )
 
     def test_resolver_filename_sphinx(self):
         self.pip.documentation_type = "sphinx"
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_path(project=self.pip, filename="foo/bar")
-            self.assertEqual(url, "/docs/pip/en/latest/foo/bar")
+        url = resolve_path(project=self.pip, filename="foo/bar")
+        self.assertEqual(url, "/en/latest/foo/bar")
 
-            url = resolve_path(project=self.pip, filename="foo/index")
-            self.assertEqual(url, "/docs/pip/en/latest/foo/index")
+        url = resolve_path(project=self.pip, filename="foo/index")
+        self.assertEqual(url, "/en/latest/foo/index")
 
     def test_resolver_filename_mkdocs(self):
         self.pip.documentation_type = "mkdocs"
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_path(project=self.pip, filename="foo/bar")
-            self.assertEqual(url, "/docs/pip/en/latest/foo/bar")
+        url = resolve_path(project=self.pip, filename="foo/bar")
+        self.assertEqual(url, "/en/latest/foo/bar")
 
-            url = resolve_path(project=self.pip, filename="foo/index.html")
-            self.assertEqual(url, "/docs/pip/en/latest/foo/index.html")
+        url = resolve_path(project=self.pip, filename="foo/index.html")
+        self.assertEqual(url, "/en/latest/foo/index.html")
 
-            url = resolve_path(project=self.pip, filename="foo/bar.html")
-            self.assertEqual(url, "/docs/pip/en/latest/foo/bar.html")
+        url = resolve_path(project=self.pip, filename="foo/bar.html")
+        self.assertEqual(url, "/en/latest/foo/bar.html")
 
     def test_resolver_subdomain(self):
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_path(project=self.pip, filename="index.html")
-            self.assertEqual(url, "/docs/pip/en/latest/index.html")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve_path(project=self.pip, filename="index.html")
-            self.assertEqual(url, "/en/latest/index.html")
+        url = resolve_path(project=self.pip, filename="index.html")
+        self.assertEqual(url, "/en/latest/index.html")
 
     def test_resolver_domain_object(self):
         self.domain = fixture.get(
@@ -133,12 +117,8 @@ class SmartResolverPathTests(ResolverBase):
             canonical=True,
             https=False,
         )
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_path(project=self.pip, filename="index.html")
-            self.assertEqual(url, "/en/latest/index.html")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve_path(project=self.pip, filename="index.html")
-            self.assertEqual(url, "/en/latest/index.html")
+        url = resolve_path(project=self.pip, filename="index.html")
+        self.assertEqual(url, "/en/latest/index.html")
 
     def test_resolver_domain_object_not_canonical(self):
         self.domain = fixture.get(
@@ -148,47 +128,27 @@ class SmartResolverPathTests(ResolverBase):
             canonical=False,
             https=False,
         )
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_path(project=self.pip, filename="")
-            self.assertEqual(url, "/docs/pip/en/latest/")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve_path(project=self.pip, filename="")
-            self.assertEqual(url, "/en/latest/")
+        url = resolve_path(project=self.pip, filename="")
+        self.assertEqual(url, "/en/latest/")
 
     def test_resolver_subproject_subdomain(self):
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_path(project=self.subproject, filename="index.html")
-            self.assertEqual(url, "/docs/pip/projects/sub/ja/latest/index.html")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve_path(project=self.subproject, filename="index.html")
-            self.assertEqual(url, "/projects/sub/ja/latest/index.html")
+        url = resolve_path(project=self.subproject, filename="index.html")
+        self.assertEqual(url, "/projects/sub/ja/latest/index.html")
 
     def test_resolver_subproject_single_version(self):
         self.subproject.single_version = True
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_path(project=self.subproject, filename="index.html")
-            self.assertEqual(url, "/docs/pip/projects/sub/index.html")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve_path(project=self.subproject, filename="index.html")
-            self.assertEqual(url, "/projects/sub/index.html")
+        url = resolve_path(project=self.subproject, filename="index.html")
+        self.assertEqual(url, "/projects/sub/index.html")
 
     def test_resolver_subproject_both_single_version(self):
         self.pip.single_version = True
         self.subproject.single_version = True
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_path(project=self.subproject, filename="index.html")
-            self.assertEqual(url, "/docs/pip/projects/sub/index.html")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve_path(project=self.subproject, filename="index.html")
-            self.assertEqual(url, "/projects/sub/index.html")
+        url = resolve_path(project=self.subproject, filename="index.html")
+        self.assertEqual(url, "/projects/sub/index.html")
 
     def test_resolver_translation(self):
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_path(project=self.translation, filename="index.html")
-            self.assertEqual(url, "/docs/pip/ja/latest/index.html")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve_path(project=self.translation, filename="index.html")
-            self.assertEqual(url, "/ja/latest/index.html")
+        url = resolve_path(project=self.translation, filename="index.html")
+        self.assertEqual(url, "/ja/latest/index.html")
 
 
 class ResolverPathOverrideTests(ResolverBase):
@@ -197,105 +157,37 @@ class ResolverPathOverrideTests(ResolverBase):
 
     def test_resolver_force_single_version(self):
         self.pip.single_version = False
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_path(
-                project=self.pip,
-                filename="index.html",
-                single_version=True,
-            )
-            self.assertEqual(url, "/docs/pip/index.html")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve_path(
-                project=self.pip,
-                filename="index.html",
-                single_version=True,
-            )
-            self.assertEqual(url, "/index.html")
-
-    def test_resolver_force_domain(self):
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_path(
-                project=self.pip,
-                filename="index.html",
-                cname=True,
-            )
-            self.assertEqual(url, "/en/latest/index.html")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve_path(
-                project=self.pip,
-                filename="index.html",
-                cname=True,
-            )
-            self.assertEqual(url, "/en/latest/index.html")
-
-    def test_resolver_force_domain_single_version(self):
-        self.pip.single_version = False
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_path(
-                project=self.pip,
-                filename="index.html",
-                single_version=True,
-                cname=True,
-            )
-            self.assertEqual(url, "/index.html")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve_path(
-                project=self.pip,
-                filename="index.html",
-                single_version=True,
-                cname=True,
-            )
-            self.assertEqual(url, "/index.html")
+        url = resolve_path(
+            project=self.pip,
+            filename="index.html",
+            single_version=True,
+        )
+        self.assertEqual(url, "/index.html")
 
     def test_resolver_force_language(self):
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_path(
-                project=self.pip,
-                filename="index.html",
-                language="cz",
-            )
-            self.assertEqual(url, "/docs/pip/cz/latest/index.html")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve_path(
-                project=self.pip,
-                filename="index.html",
-                language="cz",
-            )
-            self.assertEqual(url, "/cz/latest/index.html")
+        url = resolve_path(
+            project=self.pip,
+            filename="index.html",
+            language="cz",
+        )
+        self.assertEqual(url, "/cz/latest/index.html")
 
     def test_resolver_force_version(self):
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_path(
-                project=self.pip,
-                filename="index.html",
-                version_slug="foo",
-            )
-            self.assertEqual(url, "/docs/pip/en/foo/index.html")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve_path(
-                project=self.pip,
-                filename="index.html",
-                version_slug="foo",
-            )
-            self.assertEqual(url, "/en/foo/index.html")
+        url = resolve_path(
+            project=self.pip,
+            filename="index.html",
+            version_slug="foo",
+        )
+        self.assertEqual(url, "/en/foo/index.html")
 
     def test_resolver_force_language_version(self):
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_path(
-                project=self.pip,
-                filename="index.html",
-                language="cz",
-                version_slug="foo",
-            )
-            self.assertEqual(url, "/docs/pip/cz/foo/index.html")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve_path(
-                project=self.pip,
-                filename="index.html",
-                language="cz",
-                version_slug="foo",
-            )
-            self.assertEqual(url, "/cz/foo/index.html")
+        url = resolve_path(
+            project=self.pip,
+            filename="index.html",
+            language="cz",
+            version_slug="foo",
+        )
+        self.assertEqual(url, "/cz/foo/index.html")
 
 
 class ResolverCanonicalProject(TestCase):
@@ -382,12 +274,8 @@ class ResolverCanonicalProject(TestCase):
 class ResolverDomainTests(ResolverBase):
     @override_settings(PRODUCTION_DOMAIN="readthedocs.org")
     def test_domain_resolver(self):
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_domain(project=self.pip)
-            self.assertEqual(url, "readthedocs.org")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve_domain(project=self.pip)
-            self.assertEqual(url, "pip.readthedocs.org")
+        url = resolve_domain(project=self.pip)
+        self.assertEqual(url, "pip.readthedocs.org")
 
     @override_settings(
         PRODUCTION_DOMAIN="readthedocs.org",
@@ -401,30 +289,22 @@ class ResolverDomainTests(ResolverBase):
             canonical=True,
             https=False,
         )
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_domain(project=self.pip)
-            self.assertEqual(url, "docs.foobar.com")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve_domain(project=self.pip)
-            self.assertEqual(url, "docs.foobar.com")
+        url = resolve_domain(project=self.pip)
+        self.assertEqual(url, "docs.foobar.com")
 
-            url = resolve_domain(project=self.pip, use_canonical_domain=False)
-            self.assertEqual(url, "pip.readthedocs.io")
+        url = resolve_domain(project=self.pip, use_canonical_domain=False)
+        self.assertEqual(url, "pip.readthedocs.io")
 
     @override_settings(
         PRODUCTION_DOMAIN="readthedocs.org",
         PUBLIC_DOMAIN="readthedocs.io",
     )
     def test_domain_resolver_subproject(self):
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_domain(project=self.subproject)
-            self.assertEqual(url, "readthedocs.org")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve_domain(project=self.subproject)
-            self.assertEqual(url, "pip.readthedocs.io")
+        url = resolve_domain(project=self.subproject)
+        self.assertEqual(url, "pip.readthedocs.io")
 
-            url = resolve_domain(project=self.subproject, use_canonical_domain=False)
-            self.assertEqual(url, "pip.readthedocs.io")
+        url = resolve_domain(project=self.subproject, use_canonical_domain=False)
+        self.assertEqual(url, "pip.readthedocs.io")
 
     @override_settings(PRODUCTION_DOMAIN="readthedocs.org")
     def test_domain_resolver_subproject_itself(self):
@@ -440,27 +320,19 @@ class ResolverDomainTests(ResolverBase):
         # add the project as subproject of itself
         self.pip.add_subproject(self.pip)
 
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_domain(project=self.pip)
-            self.assertEqual(url, "readthedocs.org")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve_domain(project=self.pip)
-            self.assertEqual(url, "pip.readthedocs.org")
+        url = resolve_domain(project=self.pip)
+        self.assertEqual(url, "pip.readthedocs.org")
 
     @override_settings(
         PRODUCTION_DOMAIN="readthedocs.org",
         PUBLIC_DOMAIN="readthedocs.io",
     )
     def test_domain_resolver_translation(self):
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_domain(project=self.translation)
-            self.assertEqual(url, "readthedocs.org")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve_domain(project=self.translation)
-            self.assertEqual(url, "pip.readthedocs.io")
+        url = resolve_domain(project=self.translation)
+        self.assertEqual(url, "pip.readthedocs.io")
 
-            url = resolve_domain(project=self.translation, use_canonical_domain=False)
-            self.assertEqual(url, "pip.readthedocs.io")
+        url = resolve_domain(project=self.translation, use_canonical_domain=False)
+        self.assertEqual(url, "pip.readthedocs.io")
 
     @override_settings(PRODUCTION_DOMAIN="readthedocs.org")
     def test_domain_resolver_translation_itself(self):
@@ -476,34 +348,25 @@ class ResolverDomainTests(ResolverBase):
         # add the project as subproject of itself
         self.pip.translations.add(self.pip)
 
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_domain(project=self.pip)
-            self.assertEqual(url, "readthedocs.org")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve_domain(project=self.pip)
-            self.assertEqual(url, "pip.readthedocs.org")
+        url = resolve_domain(project=self.pip)
+        self.assertEqual(url, "pip.readthedocs.org")
 
     @override_settings(
         PRODUCTION_DOMAIN="readthedocs.org",
         PUBLIC_DOMAIN="public.readthedocs.org",
     )
     def test_domain_public(self):
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve_domain(project=self.translation)
-            self.assertEqual(url, "readthedocs.org")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve_domain(project=self.translation)
-            self.assertEqual(url, "pip.public.readthedocs.org")
+        url = resolve_domain(project=self.translation)
+        self.assertEqual(url, "pip.public.readthedocs.org")
 
-            url = resolve_domain(project=self.translation, use_canonical_domain=False)
-            self.assertEqual(url, "pip.public.readthedocs.org")
+        url = resolve_domain(project=self.translation, use_canonical_domain=False)
+        self.assertEqual(url, "pip.public.readthedocs.org")
 
     @override_settings(
         PRODUCTION_DOMAIN="readthedocs.org",
         PUBLIC_DOMAIN="public.readthedocs.org",
         RTD_EXTERNAL_VERSION_DOMAIN="dev.readthedocs.build",
         PUBLIC_DOMAIN_USES_HTTPS=True,
-        USE_SUBDOMAIN=True,
     )
     def test_domain_external(self):
         latest = self.pip.versions.first()
@@ -520,12 +383,8 @@ class ResolverDomainTests(ResolverBase):
 class ResolverTests(ResolverBase):
     @override_settings(PRODUCTION_DOMAIN="readthedocs.org")
     def test_resolver(self):
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve(project=self.pip)
-            self.assertEqual(url, "http://readthedocs.org/docs/pip/en/latest/")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve(project=self.pip)
-            self.assertEqual(url, "http://pip.readthedocs.org/en/latest/")
+        url = resolve(project=self.pip)
+        self.assertEqual(url, "http://pip.readthedocs.org/en/latest/")
 
     @override_settings(PRODUCTION_DOMAIN="readthedocs.org")
     def test_resolver_domain(self):
@@ -536,12 +395,8 @@ class ResolverTests(ResolverBase):
             canonical=True,
             https=False,
         )
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve(project=self.pip)
-            self.assertEqual(url, "http://docs.foobar.com/en/latest/")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve(project=self.pip)
-            self.assertEqual(url, "http://docs.foobar.com/en/latest/")
+        url = resolve(project=self.pip)
+        self.assertEqual(url, "http://docs.foobar.com/en/latest/")
 
     @override_settings(PRODUCTION_DOMAIN="readthedocs.org")
     def test_resolver_domain_https(self):
@@ -552,36 +407,21 @@ class ResolverTests(ResolverBase):
             https=True,
             canonical=True,
         )
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve(project=self.pip)
-            self.assertEqual(url, "https://docs.foobar.com/en/latest/")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve(project=self.pip)
-            self.assertEqual(url, "https://docs.foobar.com/en/latest/")
+        url = resolve(project=self.pip)
+        self.assertEqual(url, "https://docs.foobar.com/en/latest/")
 
     @override_settings(PRODUCTION_DOMAIN="readthedocs.org")
     def test_resolver_subproject(self):
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve(project=self.subproject)
-            self.assertEqual(
-                url,
-                "http://readthedocs.org/docs/pip/projects/sub/ja/latest/",
-            )
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve(project=self.subproject)
-            self.assertEqual(
-                url,
-                "http://pip.readthedocs.org/projects/sub/ja/latest/",
-            )
+        url = resolve(project=self.subproject)
+        self.assertEqual(
+            url,
+            "http://pip.readthedocs.org/projects/sub/ja/latest/",
+        )
 
     @override_settings(PRODUCTION_DOMAIN="readthedocs.org")
     def test_resolver_translation(self):
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve(project=self.translation)
-            self.assertEqual(url, "http://readthedocs.org/docs/pip/ja/latest/")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve(project=self.translation)
-            self.assertEqual(url, "http://pip.readthedocs.org/ja/latest/")
+        url = resolve(project=self.translation)
+        self.assertEqual(url, "http://pip.readthedocs.org/ja/latest/")
 
     @override_settings(PRODUCTION_DOMAIN="readthedocs.org")
     def test_resolver_nested_translation_of_a_subproject(self):
@@ -594,18 +434,11 @@ class ResolverTests(ResolverBase):
             main_language_project=self.subproject,
         )
 
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve(project=translation)
-            self.assertEqual(
-                url,
-                "http://readthedocs.org/docs/pip/projects/sub/es/latest/",
-            )
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve(project=translation)
-            self.assertEqual(
-                url,
-                "http://pip.readthedocs.org/projects/sub/es/latest/",
-            )
+        url = resolve(project=translation)
+        self.assertEqual(
+            url,
+            "http://pip.readthedocs.org/projects/sub/es/latest/",
+        )
 
     @pytest.mark.xfail(reason="We do not support this for now", strict=True)
     @override_settings(PRODUCTION_DOMAIN="readthedocs.org")
@@ -635,102 +468,69 @@ class ResolverTests(ResolverBase):
         )
         translation.add_subproject(subproject)
 
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve(project=subproject)
-            self.assertEqual(
-                url, "http://readthedocs.org/docs/docs-es/projects/api-es/es/latest/"
-            )
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve(project=subproject)
-            self.assertEqual(
-                url, "http://docs-es.readthedocs.org/projects/api-es/es/latest/"
-            )
+        url = resolve(project=subproject)
+        self.assertEqual(
+            url, "http://docs-es.readthedocs.org/projects/api-es/es/latest/"
+        )
 
     @override_settings(PRODUCTION_DOMAIN="readthedocs.org")
     def test_resolver_single_version(self):
         self.pip.single_version = True
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve(project=self.pip)
-            self.assertEqual(url, "http://readthedocs.org/docs/pip/")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve(project=self.pip)
-            self.assertEqual(url, "http://pip.readthedocs.org/")
+        url = resolve(project=self.pip)
+        self.assertEqual(url, "http://pip.readthedocs.org/")
 
     @override_settings(PRODUCTION_DOMAIN="readthedocs.org")
     def test_resolver_subproject_alias(self):
         relation = self.pip.subprojects.first()
         relation.alias = "sub_alias"
         relation.save()
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve(project=self.subproject)
-            self.assertEqual(
-                url,
-                "http://pip.readthedocs.org/projects/sub_alias/ja/latest/",
-            )
+        url = resolve(project=self.subproject)
+        self.assertEqual(
+            url,
+            "http://pip.readthedocs.org/projects/sub_alias/ja/latest/",
+        )
 
     @override_settings(PRODUCTION_DOMAIN="readthedocs.org")
     def test_resolver_private_project(self):
         self.pip.privacy_level = PRIVATE
         self.pip.save()
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve(project=self.pip)
-            self.assertEqual(url, "http://readthedocs.org/docs/pip/en/latest/")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve(project=self.pip)
-            self.assertEqual(url, "http://pip.readthedocs.org/en/latest/")
+        url = resolve(project=self.pip)
+        self.assertEqual(url, "http://pip.readthedocs.org/en/latest/")
 
     @override_settings(PRODUCTION_DOMAIN="readthedocs.org")
     def test_resolver_private_project_override(self):
         self.pip.privacy_level = PRIVATE
         self.pip.save()
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve(project=self.pip)
-            self.assertEqual(url, "http://readthedocs.org/docs/pip/en/latest/")
-            url = resolve(project=self.pip)
-            self.assertEqual(url, "http://readthedocs.org/docs/pip/en/latest/")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve(project=self.pip)
-            self.assertEqual(url, "http://pip.readthedocs.org/en/latest/")
-            url = resolve(project=self.pip)
-            self.assertEqual(url, "http://pip.readthedocs.org/en/latest/")
+        url = resolve(project=self.pip)
+        self.assertEqual(url, "http://pip.readthedocs.org/en/latest/")
+        url = resolve(project=self.pip)
+        self.assertEqual(url, "http://pip.readthedocs.org/en/latest/")
 
     @override_settings(PRODUCTION_DOMAIN="readthedocs.org")
     def test_resolver_private_version_override(self):
         latest = self.pip.versions.first()
         latest.privacy_level = PRIVATE
         latest.save()
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve(project=self.pip)
-            self.assertEqual(url, "http://readthedocs.org/docs/pip/en/latest/")
-            url = resolve(project=self.pip)
-            self.assertEqual(url, "http://readthedocs.org/docs/pip/en/latest/")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve(project=self.pip)
-            self.assertEqual(url, "http://pip.readthedocs.org/en/latest/")
-            url = resolve(project=self.pip)
-            self.assertEqual(url, "http://pip.readthedocs.org/en/latest/")
+        url = resolve(project=self.pip)
+        self.assertEqual(url, "http://pip.readthedocs.org/en/latest/")
+        url = resolve(project=self.pip)
+        self.assertEqual(url, "http://pip.readthedocs.org/en/latest/")
 
     @override_settings(
         PRODUCTION_DOMAIN="readthedocs.org",
         PUBLIC_DOMAIN="public.readthedocs.org",
     )
     def test_resolver_public_domain_overrides(self):
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve(project=self.pip)
-            self.assertEqual(url, "http://readthedocs.org/docs/pip/en/latest/")
-            url = resolve(project=self.pip)
-            self.assertEqual(url, "http://readthedocs.org/docs/pip/en/latest/")
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve(project=self.pip)
-            self.assertEqual(
-                url,
-                "http://pip.public.readthedocs.org/en/latest/",
-            )
-            url = resolve(project=self.pip)
-            self.assertEqual(
-                url,
-                "http://pip.public.readthedocs.org/en/latest/",
-            )
+        url = resolve(project=self.pip)
+        self.assertEqual(
+            url,
+            "http://pip.public.readthedocs.org/en/latest/",
+        )
+        url = resolve(project=self.pip)
+        self.assertEqual(
+            url,
+            "http://pip.public.readthedocs.org/en/latest/",
+        )
 
         # Domain overrides PUBLIC_DOMAIN
         self.domain = fixture.get(
@@ -740,21 +540,14 @@ class ResolverTests(ResolverBase):
             canonical=True,
             https=False,
         )
-        with override_settings(USE_SUBDOMAIN=True):
-            url = resolve(project=self.pip)
-            self.assertEqual(url, "http://docs.foobar.com/en/latest/")
-            url = resolve(project=self.pip)
-            self.assertEqual(url, "http://docs.foobar.com/en/latest/")
-        with override_settings(USE_SUBDOMAIN=False):
-            url = resolve(project=self.pip)
-            self.assertEqual(url, "http://docs.foobar.com/en/latest/")
-            url = resolve(project=self.pip)
-            self.assertEqual(url, "http://docs.foobar.com/en/latest/")
+        url = resolve(project=self.pip)
+        self.assertEqual(url, "http://docs.foobar.com/en/latest/")
+        url = resolve(project=self.pip)
+        self.assertEqual(url, "http://docs.foobar.com/en/latest/")
 
     @override_settings(
         PRODUCTION_DOMAIN="readthedocs.org",
         PUBLIC_DOMAIN="readthedocs.io",
-        USE_SUBDOMAIN=True,
     )
     def test_resolver_domain_https(self):
         with override_settings(PUBLIC_DOMAIN_USES_HTTPS=True):
@@ -818,7 +611,7 @@ class ResolverTestsAlt(ResolverAltSetUp, ResolverTests):
     pass
 
 
-@override_settings(USE_SUBDOMAIN=True, PUBLIC_DOMAIN="readthedocs.io")
+@override_settings(PUBLIC_DOMAIN="readthedocs.io")
 class TestSubprojectsWithTranslations(TestCase):
     def setUp(self):
         self.subproject_en = fixture.get(
@@ -932,7 +725,6 @@ class TestSubprojectsWithTranslations(TestCase):
 
 
 @override_settings(
-    USE_SUBDOMAIN=True,
     PUBLIC_DOMAIN="readthedocs.io",
     RTD_EXTERNAL_VERSION_DOMAIN="readthedocs.build",
 )

--- a/readthedocs/rtd_tests/tests/test_single_version.py
+++ b/readthedocs/rtd_tests/tests/test_single_version.py
@@ -6,7 +6,6 @@ from readthedocs.projects.models import Project
 
 
 @override_settings(
-    USE_SUBDOMAIN=True,
     PUBLIC_DOMAIN="public.readthedocs.org",
     SERVE_PUBLIC_DOCS=True,
 )
@@ -17,25 +16,13 @@ class RedirectSingleVersionTests(TestCase):
         )
 
     def test_docs_url_generation(self):
-        with override_settings(USE_SUBDOMAIN=False):
-            self.assertEqual(
-                self.pip.get_docs_url(),
-                "http://readthedocs.org/docs/pip/",
-            )
-        with override_settings(USE_SUBDOMAIN=True):
-            self.assertEqual(
-                self.pip.get_docs_url(),
-                "http://pip.public.readthedocs.org/",
-            )
+        self.assertEqual(
+            self.pip.get_docs_url(),
+            "http://pip.public.readthedocs.org/",
+        )
 
         self.pip.single_version = False
-        with override_settings(USE_SUBDOMAIN=False):
-            self.assertEqual(
-                self.pip.get_docs_url(),
-                "http://readthedocs.org/docs/pip/en/latest/",
-            )
-        with override_settings(USE_SUBDOMAIN=True):
-            self.assertEqual(
-                self.pip.get_docs_url(),
-                "http://pip.public.readthedocs.org/en/latest/",
-            )
+        self.assertEqual(
+            self.pip.get_docs_url(),
+            "http://pip.public.readthedocs.org/en/latest/",
+        )

--- a/readthedocs/rtd_tests/tests/test_version.py
+++ b/readthedocs/rtd_tests/tests/test_version.py
@@ -92,7 +92,6 @@ class TestVersionModel(VersionMixin, TestCase):
     @override_settings(
         PRODUCTION_DOMAIN="readthedocs.org",
         PUBLIC_DOMAIN="readthedocs.io",
-        USE_SUBDOMAIN=True,
     )
     def test_get_downloads(self):
         version = self.branch_version
@@ -110,7 +109,6 @@ class TestVersionModel(VersionMixin, TestCase):
     @override_settings(
         PRODUCTION_DOMAIN="readthedocs.org",
         PUBLIC_DOMAIN="readthedocs.io",
-        USE_SUBDOMAIN=True,
     )
     def test_get_downloads_subproject(self):
         version = self.subproject.versions.get(slug=LATEST)
@@ -128,7 +126,6 @@ class TestVersionModel(VersionMixin, TestCase):
     @override_settings(
         PRODUCTION_DOMAIN="readthedocs.org",
         PUBLIC_DOMAIN="readthedocs.io",
-        USE_SUBDOMAIN=True,
     )
     def test_get_downloads_translation_subproject(self):
         version = self.translation_subproject.versions.get(slug=LATEST)

--- a/readthedocs/search/api/v3/tests/test_api.py
+++ b/readthedocs/search/api/v3/tests/test_api.py
@@ -355,7 +355,7 @@ class SearchAPITest(SearchTestBase):
 
 
 @pytest.mark.proxito
-@override_settings(PUBLIC_DOMAIN="readthedocs.io", USE_SUBDOMAIN=True)
+@override_settings(PUBLIC_DOMAIN="readthedocs.io")
 class ProxiedSearchAPITest(SearchAPITest):
     host = "project.readthedocs.io"
 

--- a/readthedocs/search/tests/test_api.py
+++ b/readthedocs/search/tests/test_api.py
@@ -36,7 +36,6 @@ class BaseTestDocumentSearch:
     @pytest.fixture(autouse=True)
     def setup_settings(self, settings):
         settings.PUBLIC_DOMAIN = "readthedocs.io"
-        settings.USE_SUBDOMAIN = True
 
     def get_search(self, api_client, search_params):
         return api_client.get(self.url, search_params)

--- a/readthedocs/search/tests/test_views.py
+++ b/readthedocs/search/tests/test_views.py
@@ -264,7 +264,7 @@ class TestPageSearch:
         assert results[1]["version"] == {"slug": "latest"}
         for result in results:
             assert result["project"] == {"alias": None, "slug": "kuma"}
-            assert result["domain"] == "http://readthedocs.org"
+            assert result["domain"] == "http://kuma.readthedocs.io"
             assert result["path"].endswith("/documentation.html")
 
         blocks = results[0]["blocks"]

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -75,7 +75,6 @@ class CommunityBaseSettings(Settings):
     PRODUCTION_DOMAIN = 'readthedocs.org'
     PUBLIC_DOMAIN = None
     PUBLIC_DOMAIN_USES_HTTPS = False
-    USE_SUBDOMAIN = False
     PUBLIC_API_URL = 'https://{}'.format(PRODUCTION_DOMAIN)
     RTD_INTERSPHINX_URL = 'https://{}'.format(PRODUCTION_DOMAIN)
     RTD_EXTERNAL_VERSION_DOMAIN = 'external-builds.readthedocs.io'

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -15,7 +15,6 @@ class DockerBaseSettings(CommunityBaseSettings):
     RTD_DOCKER_COMPOSE_VOLUME = "community_build-user-builds"
     RTD_DOCKER_USER = f"{os.geteuid()}:{os.getegid()}"
     DOCKER_LIMITS = {"memory": "1g", "time": 900}
-    USE_SUBDOMAIN = True
 
     PRODUCTION_DOMAIN = os.environ.get("RTD_PRODUCTION_DOMAIN", "devthedocs.org")
     PUBLIC_DOMAIN = os.environ.get("RTD_PUBLIC_DOMAIN", "devthedocs.org")

--- a/readthedocs/settings/proxito/base.py
+++ b/readthedocs/settings/proxito/base.py
@@ -12,7 +12,6 @@ log = structlog.get_logger(__name__)
 
 class CommunityProxitoSettingsMixin:
     ROOT_URLCONF = "readthedocs.proxito.urls"
-    USE_SUBDOMAIN = True
     SECURE_REFERRER_POLICY = "no-referrer-when-downgrade"
 
     # Allow cookies from cross-site requests on subdomains for now.

--- a/readthedocs/settings/test.py
+++ b/readthedocs/settings/test.py
@@ -11,6 +11,7 @@ class CommunityTestSettings(CommunityBaseSettings):
 
     # A bunch of our tests check this value in a returned URL/Domain
     PRODUCTION_DOMAIN = "readthedocs.org"
+    PUBLIC_DOMAIN = "readthedocs.io"
     DONT_HIT_DB = False
 
     # Disable password validators on tests


### PR DESCRIPTION
Closes https://github.com/readthedocs/readthedocs.org/issues/10767

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10799.org.readthedocs.build/en/10799/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10799.org.readthedocs.build/en/10799/

<!-- readthedocs-preview dev end -->