### PR TITLE
Docs: update root language redirect docs

### DIFF
--- a/docs/user/user-defined-redirects.rst
+++ b/docs/user/user-defined-redirects.rst
@@ -88,13 +88,7 @@ Root language redirect at ``/<lang>/``
 A link to the root language of your documentation (``<slug>.readthedocs.io/en/``)
 will redirect to the  :term:`default version` of that language.
 
-.. TODO: Remove this once the feature is default on .com
-
-This redirect is currently only active on |org_brand| (``<slug>.readthedocs.io`` and :doc:`custom domains </custom-domains>`).
-
-Root language redirects on |com_brand| can be enabled by contacting :doc:`support </support>`.
-
-For example, accessing the English language of the project will redirect you to the its version (``stable``)::
+For example, accessing the English language of the project will redirect you to the its default version (``stable``)::
 
    https://docs.readthedocs.io/en/ -> https://docs.readthedocs.io/en/stable/
 


### PR DESCRIPTION
The new implementation of proxito is the default now.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10817.org.readthedocs.build/en/10817/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10817.org.readthedocs.build/en/10817/

<!-- readthedocs-preview dev end -->