### PR TITLE
Addons: resolve versions/translations URLs properly

### DIFF
--- a/readthedocs/proxito/tests/responses/v0.json
+++ b/readthedocs/proxito/tests/responses/v0.json
@@ -110,7 +110,7 @@
     "flyout": {
       "enabled": true,
       "translations": [],
-      "versions": [{ "slug": "latest", "url": "/en/latest/" }],
+      "versions": [{ "slug": "latest", "url": "https://project.dev.readthedocs.io/en/latest/" }],
       "downloads": []
     },
     "search": {

--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -282,8 +282,11 @@ class TestReadTheDocsConfigJson(TestCase):
         assert r.status_code == 200
 
         expected = [
-            {"slug": "latest", "url": "/en/latest/"},
-            {"slug": "public-built", "url": "/en/public-built/"},
+            {"slug": "latest", "url": "https://project.dev.readthedocs.io/en/latest/"},
+            {
+                "slug": "public-built",
+                "url": "https://project.dev.readthedocs.io/en/public-built/",
+            },
         ]
         assert r.json()["addons"]["flyout"]["versions"] == expected
 
@@ -310,7 +313,7 @@ class TestReadTheDocsConfigJson(TestCase):
         assert r.status_code == 200
 
         expected = [
-            {"slug": "ja", "url": "/ja/"},
+            {"slug": "ja", "url": "https://project.dev.readthedocs.io/ja/latest/"},
         ]
         assert r.json()["addons"]["flyout"]["translations"] == expected
 
@@ -426,3 +429,68 @@ class TestReadTheDocsConfigJson(TestCase):
             r.json()["projects"]["current"]["repository"]["url"]
             == "https://github.com/readthedocs/subproject"
         )
+
+    def test_flyout_subproject_urls(self):
+        translation = fixture.get(
+            Project,
+            slug="translation",
+            language="es",
+            repo="https://github.com/readthedocs/subproject",
+        )
+        translation.versions.update(
+            built=True,
+            active=True,
+        )
+        subproject = fixture.get(
+            Project, slug="subproject", repo="https://github.com/readthedocs/subproject"
+        )
+        self.project.add_subproject(subproject)
+        subproject.translations.add(translation)
+        subproject.save()
+
+        fixture.get(Version, slug="v1", project=subproject)
+        fixture.get(Version, slug="v2.3", project=subproject)
+        subproject.versions.update(
+            privacy_level=PUBLIC,
+            built=True,
+            active=True,
+            hidden=False,
+        )
+
+        r = self.client.get(
+            reverse("proxito_readthedocs_docs_addons"),
+            {
+                "url": "https://project.dev.readthedocs.io/projects/subproject/en/latest/",
+                "client-version": "0.6.0",
+                "api-version": "0.1.0",
+            },
+            secure=True,
+            headers={
+                "host": "project.dev.readthedocs.io",
+            },
+        )
+        assert r.status_code == 200
+
+        expected_versions = [
+            {
+                "slug": "latest",
+                "url": "https://project.dev.readthedocs.io/projects/subproject/en/latest/",
+            },
+            {
+                "slug": "v1",
+                "url": "https://project.dev.readthedocs.io/projects/subproject/en/v1/",
+            },
+            {
+                "slug": "v2.3",
+                "url": "https://project.dev.readthedocs.io/projects/subproject/en/v2.3/",
+            },
+        ]
+        assert r.json()["addons"]["flyout"]["versions"] == expected_versions
+
+        expected_translations = [
+            {
+                "slug": "es",
+                "url": "https://project.dev.readthedocs.io/projects/subproject/es/latest/",
+            },
+        ]
+        assert r.json()["addons"]["flyout"]["translations"] == expected_translations

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -326,7 +326,12 @@ class AddonsResponse:
                         {
                             # TODO: name this field "display_name"
                             "slug": translation.language,
-                            "url": f"/{translation.language}/",
+                            "url": resolver.resolve(
+                                project=project,
+                                version_slug=version.slug,
+                                language=translation.language,
+                                external=False,
+                            ),
                         }
                         for translation in project_translations
                     ],
@@ -334,7 +339,11 @@ class AddonsResponse:
                         {
                             # TODO: name this field "display_name"
                             "slug": version.slug,
-                            "url": f"/{project.language}/{version.slug}/",
+                            "url": resolver.resolve(
+                                project=project,
+                                version_slug=version.slug,
+                                external=False,
+                            ),
                         }
                         for version in versions_active_built_not_hidden
                     ],


### PR DESCRIPTION
Use our `Resolver.resolve` logic to resolve versions/translations URLs for the
flyout menu. This makes it work URLs for subprojects and translations as well.

Closes readthedocs/addons#158