### PR TITLE
Clarify admin permission

### DIFF
--- a/docs/user/guides/setup-single-sign-on-github-gitlab-bitbucket.rst
+++ b/docs/user/guides/setup-single-sign-on-github-gitlab-bitbucket.rst
@@ -47,7 +47,7 @@ Having **read** permissions to the git repository translates to having **view** 
 Grant access to administer a project
 ------------------------------------
 
-By granting **write** permission to a user in the git repository,
+By granting **admin** permission to a user in the git repository,
 you are giving the user access to read the documentation *and* to be an administrator of the associated project on Read the Docs.
 
 Grant access to import a project


### PR DESCRIPTION
Had a user ask about this, and we're checking for `admin` on the API response:

https://github.com/readthedocs/readthedocs.org/blob/14c6a9c546e096e1ebf97775e88248eb92972fde/readthedocs/oauth/services/github.py#L163-L165

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10822.org.readthedocs.build/en/10822/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10822.org.readthedocs.build/en/10822/

<!-- readthedocs-preview dev end -->