### PR TITLE
Redirects: fix prefix redirects

### DIFF
--- a/readthedocs/proxito/tests/test_old_redirects.py
+++ b/readthedocs/proxito/tests/test_old_redirects.py
@@ -251,6 +251,13 @@ class UserRedirectTests(MockStorageMixin, BaseDocServing):
             "http://project.dev.readthedocs.io/en/latest/faq.html",
         )
 
+        # Prefix redirects should match the whole path.
+        with self.assertRaises(Http404):
+            self.client.get(
+                "/en/latest/woot/faq.html",
+                headers={"host": "project.dev.readthedocs.io"},
+            )
+
     def test_redirect_page(self):
         Redirect.objects.create(
             project=self.project,

--- a/readthedocs/redirects/querysets.py
+++ b/readthedocs/redirects/querysets.py
@@ -64,7 +64,7 @@ class RedirectQuerySet(models.QuerySet):
         )
         prefix = Q(
             redirect_type="prefix",
-            path__startswith=F("from_url"),
+            full_path__startswith=F("from_url"),
         )
         page = Q(
             redirect_type="page",


### PR DESCRIPTION
We were using the path (filename) to match
prefix redirects, but we should be using the full_path.