### PR TITLE
Remove addons response for last build

### DIFF
--- a/readthedocs/proxito/tests/responses/v0.json
+++ b/readthedocs/proxito/tests/responses/v0.json
@@ -52,21 +52,7 @@
     }
   },
   "builds": {
-    "current": {
-      "commit": "a1b2c3",
-      "created": "2019-04-29T10:00:00Z",
-      "duration": 60,
-      "error": "",
-      "finished": "2019-04-29T10:01:00Z",
-      "id": 1,
-      "project": "project",
-      "state": {
-        "code": "finished",
-        "name": "Finished"
-      },
-      "success": true,
-      "version": "latest"
-    }
+    "current": null
   },
   "domains": {
     "dashboard": "readthedocs.org"

--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -73,8 +73,11 @@ class TestReadTheDocsConfigJson(TestCase):
     def _normalize_datetime_fields(self, obj):
         obj["projects"]["current"]["created"] = "2019-04-29T10:00:00Z"
         obj["projects"]["current"]["modified"] = "2019-04-29T12:00:00Z"
-        obj["builds"]["current"]["created"] = "2019-04-29T10:00:00Z"
-        obj["builds"]["current"]["finished"] = "2019-04-29T10:01:00Z"
+        # TODO remove this conditional, it's not required when build.current is
+        # a mandatory response attribute.
+        if obj["builds"]["current"] is not None:
+            obj["builds"]["current"]["created"] = "2019-04-29T10:00:00Z"
+            obj["builds"]["current"]["finished"] = "2019-04-29T10:01:00Z"
         return obj
 
     def test_get_config_v0(self):

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -77,7 +77,11 @@ class BaseReadTheDocsConfigJson(CDNCacheTagsMixin, APIView):
             project = unresolved_url.project
             version = unresolved_url.version
             filename = unresolved_url.filename
-            build = version.builds.last()
+            # TODO build listing is disabled for now as it caused a big jump in
+            # query time, consider adding it back in:
+            # https://github.com/readthedocs/readthedocs.org/issues/10830
+            # build = version.builds.last()
+            build = None
 
         except UnresolverError as exc:
             # If an exception is raised and there is a ``project`` in the


### PR DESCRIPTION
We noticed a big spike in time spent in build table queries today and
traced the query back to the addons response. The addons data structure
includes a list of the latest builds for each version.

I've disabled that for now, but it's not yet clear why this became an
issue on Fri, or why the cache doesn't seem to be helping much here.

cc @humitos in case you have some more input here