### PR TITLE
Build: don't pre-install pip and setuptools in images

### DIFF
--- a/scripts/compile_version_upload_s3.sh
+++ b/scripts/compile_version_upload_s3.sh
@@ -108,18 +108,14 @@ docker exec $CONTAINER_ID asdf reshim $TOOL
 # for now to avoid changing versions.
 if [[ $TOOL == "python" ]] && [[ ! $VERSION =~ (^miniconda.*|^mambaforge.*) ]]
 then
-    RTD_PIP_VERSION=21.2.4
-    RTD_SETUPTOOLS_VERSION=57.4.0
     RTD_VIRTUALENV_VERSION=20.7.2
 
     if [[ $VERSION == "2.7.18" ]]
     then
         # Pin to the latest versions supported on Python 2.7
-        RTD_PIP_VERSION=20.3.4
-        RTD_SETUPTOOLS_VERSION=44.1.1
         RTD_VIRTUALENV_VERSION=20.7.2
     fi
-    docker exec $CONTAINER_ID $TOOL -m pip install -U pip==$RTD_PIP_VERSION setuptools==$RTD_SETUPTOOLS_VERSION virtualenv==$RTD_VIRTUALENV_VERSION
+    docker exec $CONTAINER_ID $TOOL -m pip install -U virtualenv==$RTD_VIRTUALENV_VERSION
 fi
 
 # Compress it as a .tar.gz without include the full path in the compressed file


### PR DESCRIPTION
We hit a problem with Python 3.12 and the outdated version of pip that we have pre-installed.

Python ships with a vendored version of pip,
and we install the latest version of pip and setuptools on each build before installing the requirements.

The only breaking change here would be for projects using build.commands, setuptools won't be available anymore, pip is vendored by Python, so that shouldn't be a problem. I think we are fine not installing setuptools,
build.commands is in beta, so we can get away with this :)

Fixes https://github.com/readthedocs/readthedocs.org/issues/10832

We may even consider not installing virtualenv on python3.x and just use venv.