### PR TITLE
Fix broken link syntax

### DIFF
--- a/docs/user/guides/best-practice/links.rst
+++ b/docs/user/guides/best-practice/links.rst
@@ -53,7 +53,7 @@ you most likely want users clicking on incoming links to see the latest version 
 Good practice ✅
 ~~~~~~~~~~~~~~~~
 
-* Use `page redirects <user-defined-redirects:Page redirects>`_ if you are linking to the page in the :term:`default version` of the default language. This allows links to continue working even if those defaults change.
+* Use :ref:`page redirects <user-defined-redirects:Page redirects>` if you are linking to the page in the :term:`default version` of the default language. This allows links to continue working even if those defaults change.
 * If you move a page that likely has incoming references, :doc:`create a custom redirect rule </guides/redirects>`.
 * Links to other Sphinx projects should use :doc:`intersphinx </guides/intersphinx>`.
 * Use minimal filenames that don't require renaming often.


### PR DESCRIPTION


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10837.org.readthedocs.build/en/10837/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10837.org.readthedocs.build/en/10837/

<!-- readthedocs-preview dev end -->