### PR TITLE
Keep Ad Customization in the docs

### DIFF
--- a/docs/user/advertising/index.rst
+++ b/docs/user/advertising/index.rst
@@ -37,3 +37,4 @@ please consider :doc:`Read the Docs for Business </commercial/index>`.
     ethical-advertising
     advertising-details
     ad-blocking
+    ad-customization


### PR DESCRIPTION
Not sure why this wasn't linked previously.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10843.org.readthedocs.build/en/10843/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10843.org.readthedocs.build/en/10843/

<!-- readthedocs-preview dev end -->