### PR TITLE
Build: install compatible version of virtualenv in images

### DIFF
--- a/scripts/compile_version_upload_s3.sh
+++ b/scripts/compile_version_upload_s3.sh
@@ -108,11 +108,14 @@ docker exec $CONTAINER_ID asdf reshim $TOOL
 # for now to avoid changing versions.
 if [[ $TOOL == "python" ]] && [[ ! $VERSION =~ (^miniconda.*|^mambaforge.*) ]]
 then
-    RTD_VIRTUALENV_VERSION=20.7.2
+    # Virtualenv 20.21.1 is the latest version that supports Python 3.7 till 3.12.
+    # When adding a new version of Python, we need to pin a compatible version of
+    # virtualenv for that version of Python.
+    RTD_VIRTUALENV_VERSION=20.21.1
 
-    if [[ $VERSION == "2.7.18" ]]
+    if [[ $VERSION == 2.7.* || $VERSION == 3.6.* ]]
     then
-        # Pin to the latest versions supported on Python 2.7
+        # Pin to the latest versions supported on Python 2.7 and 3.6.
         RTD_VIRTUALENV_VERSION=20.7.2
     fi
     docker exec $CONTAINER_ID $TOOL -m pip install -U virtualenv==$RTD_VIRTUALENV_VERSION


### PR DESCRIPTION
https://github.com/readthedocs/readthedocs.org/pull/10834 didn't solve https://github.com/readthedocs/readthedocs.org/issues/10832.

Having an outdated version of pip is still the main problem, but the outdated version of pip didn't come from the python installation, but from the virtualenv creation.

When creating the environment, virtualenv installs some specfic/outdated versions of pip/setuptools/wheels.

https://github.com/pypa/virtualenv/blob/20.7.2/src/virtualenv/seed/wheels/embed/__init__.py