### PR TITLE
Revert "Build (python): default 3 to 3.11"

### DIFF
--- a/readthedocs/builds/constants_docker.py
+++ b/readthedocs/builds/constants_docker.py
@@ -38,9 +38,7 @@ RTD_DOCKER_BUILD_SETTINGS = {
             "3.11": "3.11.6",
             "3.12": "3.12.0",
             # Always point to the latest stable release.
-            # Pin to 3.11 till we fix an issue with 3.12
-            # https://github.com/readthedocs/readthedocs.org/issues/10832.
-            "3": "3.11.6",
+            "3": "3.12.0",
             "miniconda3-4.7": "miniconda3-4.7.12",
             "mambaforge-4.10": "mambaforge-4.10.3-10",
             "mambaforge-22.9": "mambaforge-22.9.0-3",


### PR DESCRIPTION
Reverts readthedocs/readthedocs.org#10833

Builds using python 3.12 are fixed now. Ref https://github.com/readthedocs/readthedocs.org/pull/10844.