### PR TITLE
Add organization view UI filters

### DIFF
--- a/readthedocs/core/filters.py
+++ b/readthedocs/core/filters.py
@@ -38,10 +38,10 @@ class FilteredModelChoiceFilter(ModelChoiceFilter):
         return super().get_queryset(request)
 
 
-class FilterMixin(views.FilterMixin):
+class FilterContextMixin(views.FilterMixin):
 
     """
-    Django-filter filterset mixin class.
+    Django-filter filterset mixin class for context data.
 
     Django-filter gives two classes for constructing views:
 
@@ -49,7 +49,8 @@ class FilterMixin(views.FilterMixin):
     - :py:class:`~django_filters.views.FilterMixin`
 
     These aren't quite yet usable, as some of our views still support our legacy
-    dashboard. For now, this class will aim to be an intermediate step, but
+    dashboard. For now, this class will aim to be an intermediate step. It will
+    expect these methods to be called from ``get_context_data()``, but will
     maintain some level of compatibility with the native mixin/view classes.
     """
 

--- a/readthedocs/core/filters.py
+++ b/readthedocs/core/filters.py
@@ -32,7 +32,8 @@ class FilteredModelChoiceFilter(ModelChoiceFilter):
     def get_queryset(self, request):
         if self.queryset_method:
             fn = getattr(self.parent, self.queryset_method, None)
-            assert callable(fn)
+            if not callable(fn):
+                raise ValueError(f"Method {self.queryset_method} is not callable")
             return fn()
         return super().get_queryset(request)
 

--- a/readthedocs/core/filters.py
+++ b/readthedocs/core/filters.py
@@ -1,0 +1,25 @@
+"""Extended classes for django-filter."""
+
+from django_filters import ModelChoiceFilter
+
+
+class FilteredModelChoiceFilter(ModelChoiceFilter):
+
+    """
+    A model choice field for customizing choice querysets at initialization.
+
+    This extends the model choice field queryset lookup to include executing a
+    method from the parent filter set. This allows for use of ``self`` on the
+    filterset, allowing better support for view time filtering.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.queryset_method = kwargs.pop("queryset_method", None)
+        super().__init__(*args, **kwargs)
+
+    def get_queryset(self, request):
+        if self.queryset_method:
+            fn = getattr(self.parent, self.queryset_method, None)
+            assert callable(fn)
+            return fn()
+        return super().get_queryset(request)

--- a/readthedocs/core/filters.py
+++ b/readthedocs/core/filters.py
@@ -9,8 +9,20 @@ class FilteredModelChoiceFilter(ModelChoiceFilter):
     A model choice field for customizing choice querysets at initialization.
 
     This extends the model choice field queryset lookup to include executing a
-    method from the parent filter set. This allows for use of ``self`` on the
-    filterset, allowing better support for view time filtering.
+    method from the parent filter set. Normally, ModelChoiceFilter will use the
+    underlying model manager ``all()`` method to populate choices. This of
+    course is not correct as we need to worry about permissions to organizations
+    and teams.
+
+    Using a method on the parent filterset, the queryset can be filtered using
+    attributes on the FilterSet instance, which for now is view time parameters
+    like ``organization``.
+
+    Additional parameters from this class:
+
+    :param queryset_method: Name of method on parent FilterSet to call to build
+                            queryset for choice population.
+    :type queryset_method: str
     """
 
     def __init__(self, *args, **kwargs):

--- a/readthedocs/organizations/filters.py
+++ b/readthedocs/organizations/filters.py
@@ -1,10 +1,28 @@
-"""Filters used in organization dashboard."""
+"""
+Filters used in the organization dashboard.
+
+Some of the below filters instantiate with multiple querysets as django-filter
+doesn't use the supplied queryset for filter field choices. By default the
+``all()`` manager method is used from the filter field model. ``FilterSet`` is
+mostly instantiated at class definition time, not per-instance, so we need to
+pass in related querysets at view time.
+"""
 
 import structlog
 from django.db.models import F
 from django.forms.widgets import HiddenInput
 from django.utils.translation import gettext_lazy as _
-from django_filters import CharFilter, FilterSet, OrderingFilter
+from django_filters import (
+    CharFilter,
+    ChoiceFilter,
+    FilterSet,
+    ModelChoiceFilter,
+    OrderingFilter,
+)
+
+from readthedocs.organizations.constants import ACCESS_LEVELS
+from readthedocs.organizations.models import Team
+from readthedocs.projects.models import Project
 
 log = structlog.get_logger(__name__)
 
@@ -63,3 +81,195 @@ class OrganizationListFilterSet(FilterSet):
         field_name="sort",
         label=_("Sort by"),
     )
+
+
+class OrganizationProjectListFilterSet(FilterSet):
+
+    """
+    Filter and sorting set for organization project listing page.
+
+    This filter set creates the following filters in the organization project
+    listing UI:
+
+    Project
+        A list of project names that the user has permissions to, using ``slug``
+        as a lookup field. This is used when linking directly to a project in
+        this filter list, and also for quick lookup in the list UI.
+
+    Team
+        A list of team names that the user has access to, using ``slug`` as a
+        lookup field. This filter is linked to directly by the team listing
+        view, as a shortcut for listing projects managed by the team.
+
+    This filter set takes an additional argument, used to limit the model choice
+    filter field values:
+
+    :param team_queryset: Organization team list queryset
+    """
+
+    slug = ModelChoiceFilter(
+        label=_("Project"),
+        empty_label=_("All projects"),
+        to_field_name="slug",
+        queryset=Project.objects.none(),
+        method="get_project",
+    )
+
+    teams__slug = ModelChoiceFilter(
+        label=_("Team"),
+        empty_label=_("All teams"),
+        field_name="teams",
+        to_field_name="slug",
+        # Queryset is required, give an empty queryset from the correct model
+        queryset=Team.objects.none(),
+    )
+
+    def __init__(
+        self,
+        data=None,
+        queryset=None,
+        *,
+        request=None,
+        prefix=None,
+        teams_queryset=None,
+    ):
+        super().__init__(data, queryset, request=request, prefix=prefix)
+        # Redefine the querysets used for the filter fields using the querysets
+        # defined at view time. This populates the filter field with only the
+        # correct related objects for the user. Otherwise, the default for model
+        # choice filter fields is ``<Model>.objects.all()``.
+        self.filters["slug"].field.queryset = self.queryset.all()
+        self.filters["teams__slug"].field.queryset = teams_queryset.all()
+
+    def get_project(self, queryset, field_name, project):
+        return queryset.filter(slug=project.slug)
+
+
+class OrganizationTeamListFilterSet(FilterSet):
+
+    """
+    Filter and sorting for organization team listing page.
+
+    This filter set creates the following filters in the organization team
+    listing UI:
+
+    Team
+        A list of team names that the user has access to, using ``slug`` as a
+        lookup field. This filter is used mostly for direct linking to a
+        specific team in the listing UI, but can be used for quick filtering
+        with the dropdown too.
+    """
+
+    slug = ModelChoiceFilter(
+        label=_("Team"),
+        empty_label=_("All teams"),
+        field_name="teams",
+        to_field_name="slug",
+        # Queryset is required, give an empty queryset from the correct model
+        queryset=Team.objects.none(),
+        method="get_team",
+    )
+
+    def __init__(
+        self,
+        data=None,
+        queryset=None,
+        *,
+        request=None,
+        prefix=None,
+        teams_queryset=None,
+    ):
+        super().__init__(data, queryset, request=request, prefix=prefix)
+        # Redefine the querysets used for the filter fields using the querysets
+        # defined at view time. This populates the filter field with only the
+        # correct related objects for the user/organization. Otherwise, the
+        # default for model choice filter fields is ``<Model>.objects.all()``.
+        self.filters["slug"].field.queryset = queryset.all()
+
+    def get_team(self, queryset, field_name, team):
+        return queryset.filter(slug=team.slug)
+
+
+class OrganizationTeamMemberListFilterSet(FilterSet):
+
+    """
+    Filter and sorting set for organization member listing page.
+
+    This filter set's underlying queryset from the member listing view is the
+    manager method ``Organization.members``. The model described in this filter
+    is effectively ``User``, but through a union of ``TeamMembers.user`` and
+    ``Organizations.owners``.
+
+    This filter set will result in the following filters in the UI:
+
+    Team
+       A list of ``Team`` names, using ``Team.slug`` as the lookup field. This
+       is linked to directly from the team listing page, to show the users that
+       are members of a particular team.
+
+    Access
+       This is an extension of ``Team.access`` in a way, but with a new option
+       (``ACCESS_OWNER``) to describe ownership privileges through organization
+       ownership.
+
+       Our modeling is not ideal here, so instead of aiming for model purity and
+       a confusing UI/UX, this aims for hiding confusing modeling from the user
+       with clear UI/UX. Otherwise, two competing filters are required for "user
+       has privileges granted through a team" and "user has privileges granted
+       through ownership".
+    """
+
+    ACCESS_OWNER = "owner"
+
+    teams__slug = ModelChoiceFilter(
+        label=_("Team"),
+        empty_label=_("All teams"),
+        # teams__slug refers to User.teams.slug.
+        field_name="teams__slug",
+        queryset=Team.objects.none(),
+    )
+
+    access = ChoiceFilter(
+        label=_("Access"),
+        empty_label=_("All access levels"),
+        choices=ACCESS_LEVELS + ((ACCESS_OWNER, _("Owner")),),
+        method="get_access",
+    )
+
+    def __init__(
+        self, data=None, queryset=None, *, request=None, prefix=None, organization=None
+    ):
+        """
+        Organization members filter set.
+
+        This filter set requires the following additional parameters:
+
+        :param organization: Organization for field ``filter()`` and used to
+                             check for organization owner access.
+        """
+        super().__init__(data, queryset, request=request, prefix=prefix)
+        self.organization = organization
+        # Redefine the querysets used for the filter fields using the querysets
+        # defined at view time. This populates the filter field with only the
+        # correct related objects for the user/organization. Otherwise, the
+        # default for model choice filter fields is ``<Model>.objects.all()``.
+        filter_with_user_relationship = True
+        team_queryset = self.organization.teams
+        if filter_with_user_relationship:
+            # XXX remove this conditional and decide which one of these is most
+            # correct There are reasons for both showing all the teams here and
+            # only the team that the user has access to.
+            team_queryset = Team.objects.member(request.user).filter(
+                organization=self.organization,
+            )
+        self.filters["teams__slug"].field.queryset = team_queryset.all()
+
+    def get_access(self, queryset, field_name, value):
+        # Note: the queryset here is effectively against the ``User`` model, and
+        # is from Organization.members, a union of TeamMember.user and
+        # Organization.owners.
+        if value == self.ACCESS_OWNER:
+            return queryset.filter(owner_organizations=self.organization)
+        if value is not None:
+            return queryset.filter(teams__access=value)
+        return queryset

--- a/readthedocs/organizations/filters.py
+++ b/readthedocs/organizations/filters.py
@@ -1,12 +1,4 @@
-"""
-Filters used in the organization dashboard.
-
-Some of the below filters instantiate with multiple querysets as django-filter
-doesn't use the supplied queryset for filter field choices. By default the
-``all()`` manager method is used from the filter field model. ``FilterSet`` is
-mostly instantiated at class definition time, not per-instance, so we need to
-pass in related querysets at view time.
-"""
+"""Filters used in the organization dashboard views."""
 
 import structlog
 from django.db.models import F
@@ -25,8 +17,8 @@ class OrganizationFilterSet(FilterSet):
     """
     Organization base filter set.
 
-    Adds some object attributes that are used for orgaization related queries
-    and common base querysets for filter fields.
+    Adds some methods that are used for organization related queries and common
+    base querysets for filter fields.
 
     Note, the querysets here are also found in the organization base views and
     mixin classes. These are redefined here instead of passing in the querysets
@@ -131,11 +123,6 @@ class OrganizationProjectListFilterSet(OrganizationFilterSet):
         A list of team names that the user has access to, using ``slug`` as a
         lookup field. This filter is linked to directly by the team listing
         view, as a shortcut for listing projects managed by the team.
-
-    This filter set takes an additional argument, used to limit the model choice
-    filter field values:
-
-    :param team_queryset: Organization team list queryset
     """
 
     slug = FilteredModelChoiceFilter(

--- a/readthedocs/organizations/filters.py
+++ b/readthedocs/organizations/filters.py
@@ -248,8 +248,8 @@ class OrganizationTeamMemberListFilterSet(FilterSet):
     teams__slug = ModelChoiceFilter(
         label=_("Team"),
         empty_label=_("All teams"),
-        # teams__slug refers to User.teams.slug.
-        field_name="teams__slug",
+        field_name="teams",
+        to_field_name="slug",
         queryset=Team.objects.none(),
     )
 

--- a/readthedocs/organizations/filters.py
+++ b/readthedocs/organizations/filters.py
@@ -27,8 +27,8 @@ class OrganizationFilterSet(FilterSet):
     :param organization: Organization instance for current view
     """
 
-    def __init__(self, *args, **kwargs):
-        self.organization = kwargs.pop("organization", None)
+    def __init__(self, *args, organization=None, **kwargs):
+        self.organization = organization
         super().__init__(*args, **kwargs)
 
     def get_organization_queryset(self):

--- a/readthedocs/organizations/filters.py
+++ b/readthedocs/organizations/filters.py
@@ -11,11 +11,7 @@ pass in related querysets at view time.
 import structlog
 from django.db.models import F
 from django.utils.translation import gettext_lazy as _
-from django_filters import (
-    ChoiceFilter,
-    FilterSet,
-    OrderingFilter,
-)
+from django_filters import ChoiceFilter, FilterSet, OrderingFilter
 
 from readthedocs.core.filters import FilteredModelChoiceFilter
 from readthedocs.organizations.constants import ACCESS_LEVELS

--- a/readthedocs/organizations/filters.py
+++ b/readthedocs/organizations/filters.py
@@ -40,6 +40,11 @@ class OrganizationFilterSet(FilterSet):
             organization=self.organization,
         ).prefetch_related("organization")
 
+    def is_valid(self):
+        # This differs from the default logic as we want to consider unbound
+        # data as a valid filterset state.
+        return (self.is_bound is False) or self.form.is_valid()
+
 
 class OrganizationSortOrderingFilter(OrderingFilter):
 

--- a/readthedocs/organizations/tests/test_filters.py
+++ b/readthedocs/organizations/tests/test_filters.py
@@ -78,32 +78,32 @@ def filter_data(request):
 
 @pytest.fixture
 def user(request, filter_data):
-    return filter_data.get("users", {}).get(request.param)
+    return filter_data["users"][request.param]
 
 
 @pytest.fixture
 def organization(request, filter_data):
-    return filter_data.get("organizations", {}).get(request.param)
+    return filter_data["organizations"][request.param]
 
 
 @pytest.fixture
 def team(request, filter_data):
-    return filter_data.get("teams", {}).get(request.param)
+    return filter_data["teams"][request.param]
 
 
 @pytest.fixture
 def teams(request, filter_data):
-    return [filter_data.get("teams", {}).get(key) for key in request.param]
+    return [filter_data["teams"][key] for key in request.param]
 
 
 @pytest.fixture
 def project(request, filter_data):
-    return filter_data.get("projects", {}).get(request.param)
+    return filter_data["projects"][request.param]
 
 
 @pytest.fixture
 def users(request, filter_data):
-    return [filter_data.get("users", {}).get(key) for key in request.param]
+    return [filter_data["users"][key] for key in request.param]
 
 
 @pytest.mark.parametrize(
@@ -119,7 +119,6 @@ def users(request, filter_data):
 class TestOrganizationFilterSet(OrganizationFilterTestCase):
     def get_filterset_for_user(self, user, organization, data=None, **kwargs):
         self.client.force_login(user)
-        # url = reverse("organization_detail", kwargs={"slug": organization.slug})
         url = reverse("organization_list")
         resp = self.client.get(url, data=data)
         return resp.context_data.get("filter")
@@ -286,7 +285,7 @@ class TestOrganizationProjectFilterSet(OrganizationFilterTestCase):
         )
         assertQuerySetEqual(
             filter.qs,
-            [filter_data.get("projects").get(key) for key in projects],
+            [filter_data["projects"][key] for key in projects],
             transform=lambda o: o,
             ordered=False,
         )
@@ -355,7 +354,7 @@ class TestOrganizationProjectFilterSet(OrganizationFilterTestCase):
             user,
             organization,
         )
-        choices = [filter_data.get("teams").get(key).slug for key in teams]
+        choices = [filter_data["teams"][key].slug for key in teams]
         choices.insert(0, "")
         assert list(dict(filter.filters["teams__slug"].field.choices).keys()) == choices
 

--- a/readthedocs/organizations/tests/test_filters.py
+++ b/readthedocs/organizations/tests/test_filters.py
@@ -1,0 +1,624 @@
+import django_dynamic_fixture as fixture
+import pytest
+from django.contrib.auth.models import User
+from django.test.client import RequestFactory
+from pytest_django.asserts import assertQuerySetEqual
+
+from readthedocs.organizations.filters import (
+    OrganizationListFilterSet,
+    OrganizationProjectListFilterSet,
+    OrganizationTeamListFilterSet,
+    OrganizationTeamMemberListFilterSet,
+)
+from readthedocs.organizations.models import Organization, Team
+from readthedocs.projects.models import Project
+
+
+@pytest.mark.django_db
+class OrganizationFilterTestCase:
+    @pytest.fixture(autouse=True)
+    def set_up(self, settings):
+        settings.RTD_ALLOW_ORGANIZATIONS = True
+
+        self.owner = fixture.get(User)
+        self.user = fixture.get(User)
+        self.project = fixture.get(Project)
+
+        self.organization = fixture.get(
+            Organization,
+            owners=[self.owner],
+            projects=[self.project],
+        )
+        self.team = fixture.get(
+            Team,
+            access="admin",
+            organization=self.organization,
+            members=[self.user],
+            projects=[self.project],
+        )
+        self.team_empty = fixture.get(
+            Team,
+            access="readonly",
+            organization=self.organization,
+            members=[],
+            projects=[],
+        )
+
+        # Create extra objects just to ensure there are no extra objects in our
+        # filter querysets
+        self.other_owner = fixture.get(User)
+        self.other_user = fixture.get(User)
+        self.other_project = fixture.get(Project)
+        self.other_organization = fixture.get(
+            Organization,
+            owners=[self.other_owner],
+            projects=[self.other_project],
+        )
+        self.other_team = fixture.get(
+            Team,
+            access="admin",
+            organization=self.other_organization,
+            members=[self.other_user],
+            projects=[self.other_project],
+        )
+
+        self.set_up_extra()
+
+    def set_up_extra(self):
+        pass
+
+
+class TestOrganizationFilterSet(OrganizationFilterTestCase):
+    def get_filterset_for_user(self, user, *args, **kwargs):
+        request = RequestFactory().get("")
+        request.user = user
+        queryset = Organization.objects.for_user(user)
+        kwargs.update(
+            {
+                "queryset": queryset,
+                "request": request,
+            }
+        )
+        return OrganizationListFilterSet(*args, **kwargs)
+
+    @pytest.mark.parametrize(
+        "get_params",
+        [
+            lambda self: (self.user, self.organization),
+            lambda self: (self.owner, self.organization),
+            lambda self: (self.other_user, self.other_organization),
+            lambda self: (self.other_owner, self.other_organization),
+        ],
+    )
+    def test_unfiltered_queryset(self, get_params):
+        """No active filters returns full queryset."""
+        (user, organization) = get_params(self)
+        filter = self.get_filterset_for_user(user, organization=organization)
+        assertQuerySetEqual(
+            filter.qs,
+            [organization],
+            transform=lambda o: o,
+            ordered=False,
+        )
+
+    @pytest.mark.parametrize(
+        "get_params",
+        [
+            lambda self: (self.user, self.organization),
+            lambda self: (self.owner, self.organization),
+            lambda self: (self.other_user, self.other_organization),
+            lambda self: (self.other_owner, self.other_organization),
+        ],
+    )
+    def test_filtered_queryset_choice(self, get_params):
+        """Valid project choice returns expected results."""
+        (user, organization) = get_params(self)
+        request = RequestFactory().get("")
+        request.user = user
+        queryset = Organization.objects.for_user(user)
+        filter = OrganizationListFilterSet(
+            {"slug": organization.slug},
+            queryset=queryset,
+            request=request,
+            organization=organization,
+        )
+        assertQuerySetEqual(
+            filter.qs,
+            [organization],
+            transform=lambda o: o,
+            ordered=False,
+        )
+
+    @pytest.mark.parametrize(
+        "get_params",
+        [
+            lambda self: (self.user, self.organization, self.other_organization),
+            lambda self: (self.owner, self.organization, self.other_organization),
+            lambda self: (self.other_user, self.other_organization, self.organization),
+            lambda self: (self.other_owner, self.other_organization, self.organization),
+        ],
+    )
+    def test_filtered_queryset_invalid_choice(self, get_params):
+        """Invalid project choice returns the original queryset."""
+        (user, organization, wrong_organization) = get_params(self)
+        filter = self.get_filterset_for_user(
+            user,
+            {"slug": wrong_organization.slug},
+            organization=organization,
+        )
+        assertQuerySetEqual(
+            filter.qs,
+            [organization],
+            transform=lambda o: o,
+            ordered=False,
+        )
+
+    @pytest.mark.parametrize(
+        "get_params",
+        [
+            lambda self: (self.user, self.organization),
+            lambda self: (self.owner, self.organization),
+            lambda self: (self.other_user, self.other_organization),
+            lambda self: (self.other_owner, self.other_organization),
+        ],
+    )
+    def test_organization_filter_choices(self, get_params):
+        (user, organization) = get_params(self)
+        filter = self.get_filterset_for_user(
+            user,
+            organization=organization,
+        )
+        assert list(dict(filter.filters["slug"].field.choices).keys()) == [
+            "",
+            organization.slug,
+        ]
+
+
+class TestOrganizationProjectFilterSet(OrganizationFilterTestCase):
+    def get_filterset_for_user(self, user, *args, **kwargs):
+        request = RequestFactory().get("")
+        request.user = user
+        queryset = Project.objects.for_user(user).filter(
+            organizations=kwargs.get("organization", self.organization)
+        )
+        kwargs.update(
+            {
+                "queryset": queryset,
+                "request": request,
+            }
+        )
+        return OrganizationProjectListFilterSet(*args, **kwargs)
+
+    @pytest.mark.parametrize(
+        "get_params",
+        [
+            lambda self: (self.user, self.organization, self.project),
+            lambda self: (self.owner, self.organization, self.project),
+            lambda self: (self.other_user, self.other_organization, self.other_project),
+            lambda self: (
+                self.other_owner,
+                self.other_organization,
+                self.other_project,
+            ),
+        ],
+    )
+    def test_unfiltered_queryset(self, get_params):
+        """No active filters returns full queryset."""
+        (user, organization, project) = get_params(self)
+        filter = self.get_filterset_for_user(user, organization=organization)
+        assertQuerySetEqual(
+            filter.qs,
+            [project],
+            transform=lambda o: o,
+            ordered=False,
+        )
+
+    @pytest.mark.parametrize(
+        "get_params",
+        [
+            lambda self: (self.user, self.organization, self.project),
+            lambda self: (self.owner, self.organization, self.project),
+            lambda self: (self.other_user, self.other_organization, self.other_project),
+            lambda self: (
+                self.other_owner,
+                self.other_organization,
+                self.other_project,
+            ),
+        ],
+    )
+    def test_filtered_queryset_project_choice(self, get_params):
+        """Valid project choice returns expected results."""
+        (user, organization, project) = get_params(self)
+        filter = self.get_filterset_for_user(
+            user,
+            {"slug": project.slug},
+            organization=organization,
+        )
+        assertQuerySetEqual(
+            filter.qs,
+            [project],
+            transform=lambda o: o,
+            ordered=False,
+        )
+
+    def test_filtered_queryset_project_invalid_choice(self):
+        """Invalid project choice returns the original queryset."""
+        filter = self.get_filterset_for_user(
+            self.user,
+            {"slug": self.other_project.slug},
+            organization=self.organization,
+        )
+        assertQuerySetEqual(
+            filter.qs,
+            [self.project],
+            transform=lambda o: o,
+            ordered=False,
+        )
+
+    @pytest.mark.parametrize(
+        "get_params",
+        [
+            lambda self: (self.user, self.organization, self.team, [self.project]),
+            lambda self: (self.owner, self.organization, self.team, [self.project]),
+            # This is an invalid slug choice, so the default queryset is returned
+            lambda self: (
+                self.user,
+                self.organization,
+                self.team_empty,
+                [self.project],
+            ),
+            lambda self: (self.owner, self.organization, self.team_empty, []),
+        ],
+    )
+    def test_filtered_queryset_team_choice(self, get_params):
+        """Valid team choice returns expected results."""
+        (user, organization, team, projects) = get_params(self)
+        filter = self.get_filterset_for_user(
+            user,
+            {"teams__slug": team.slug},
+            organization=organization,
+        )
+        assertQuerySetEqual(
+            filter.qs,
+            projects,
+            transform=lambda o: o,
+            ordered=False,
+        )
+
+    def test_filtered_queryset_team_invalid_choice(self):
+        """Invalid team choice returns the original queryset."""
+        filter = self.get_filterset_for_user(
+            self.user,
+            {"teams__slug": self.other_team.slug},
+            organization=self.organization,
+        )
+        assertQuerySetEqual(
+            filter.qs,
+            [self.project],
+            transform=lambda o: o,
+            ordered=False,
+        )
+
+    @pytest.mark.parametrize(
+        "get_params",
+        [
+            lambda self: (self.user, self.organization, ["", self.project.slug]),
+            lambda self: (self.owner, self.organization, ["", self.project.slug]),
+            lambda self: (
+                self.other_user,
+                self.other_organization,
+                ["", self.other_project.slug],
+            ),
+            lambda self: (
+                self.other_owner,
+                self.other_organization,
+                ["", self.other_project.slug],
+            ),
+        ],
+    )
+    def test_project_filter_choices(self, get_params):
+        """Project filter choices limited to organization projects."""
+        (user, organization, projects) = get_params(self)
+        filter = self.get_filterset_for_user(
+            user,
+            organization=organization,
+        )
+        assert list(dict(filter.filters["slug"].field.choices).keys()) == projects
+
+    @pytest.mark.parametrize(
+        "get_params",
+        [
+            lambda self: (self.user, self.organization, ["", self.team.slug]),
+            lambda self: (
+                self.owner,
+                self.organization,
+                ["", self.team.slug, self.team_empty.slug],
+            ),
+            lambda self: (
+                self.other_user,
+                self.other_organization,
+                ["", self.other_team.slug],
+            ),
+            lambda self: (
+                self.other_owner,
+                self.other_organization,
+                ["", self.other_team.slug],
+            ),
+        ],
+    )
+    def test_team_filter_choices(self, get_params):
+        """Team filter choices limited to organization teams."""
+        (user, organization, teams) = get_params(self)
+        filter = self.get_filterset_for_user(
+            user,
+            organization=organization,
+        )
+        assert list(dict(filter.filters["teams__slug"].field.choices).keys()) == teams
+
+
+class TestOrganizationTeamListFilterSet(OrganizationFilterTestCase):
+    def get_filterset_for_user(self, user, *args, **kwargs):
+        request = RequestFactory().get("")
+        request.user = user
+        queryset = Team.objects.member(user).filter(
+            organization=kwargs.get("organization", self.organization),
+        )
+        kwargs.update(
+            {
+                "queryset": queryset,
+                "request": request,
+            }
+        )
+        return OrganizationTeamListFilterSet(*args, **kwargs)
+
+    @pytest.mark.parametrize(
+        "get_params",
+        [
+            lambda self: (self.user, self.organization, [self.team]),
+            lambda self: (
+                self.owner,
+                self.organization,
+                [self.team, self.team_empty],
+            ),
+            lambda self: (
+                self.other_user,
+                self.other_organization,
+                [self.other_team],
+            ),
+            lambda self: (
+                self.other_owner,
+                self.other_organization,
+                [self.other_team],
+            ),
+        ],
+    )
+    def test_unfiltered_queryset(self, get_params):
+        """No active filters returns full queryset."""
+        (user, organization, teams) = get_params(self)
+        filter = self.get_filterset_for_user(
+            user,
+            organization=organization,
+        )
+        assertQuerySetEqual(
+            filter.qs,
+            teams,
+            transform=lambda o: o,
+            ordered=False,
+        )
+
+    @pytest.mark.parametrize(
+        "get_params",
+        [
+            lambda self: (self.user, self.organization, self.team),
+            lambda self: (self.owner, self.organization, self.team_empty),
+            lambda self: (self.other_user, self.other_organization, self.other_team),
+            lambda self: (self.other_owner, self.other_organization, self.other_team),
+        ],
+    )
+    def test_filtered_queryset_team_choice(self, get_params):
+        """Valid team choice returns expected results."""
+        (user, organization, team) = get_params(self)
+        filter = self.get_filterset_for_user(
+            user,
+            {"slug": team.slug},
+            organization=organization,
+        )
+        assertQuerySetEqual(
+            filter.qs,
+            [team],
+            transform=lambda o: o,
+            ordered=False,
+        )
+
+    def test_filtered_queryset_team_invalid_choice(self):
+        """Invalid team choice returns the original queryset."""
+        filter = self.get_filterset_for_user(
+            self.user,
+            {"slug": self.other_team.slug},
+            organization=self.organization,
+        )
+        assertQuerySetEqual(
+            filter.qs,
+            [self.team],
+            transform=lambda o: o,
+            ordered=False,
+        )
+
+    @pytest.mark.parametrize(
+        "get_params",
+        [
+            lambda self: (self.user, self.organization, ["", self.team.slug]),
+            lambda self: (
+                self.owner,
+                self.organization,
+                ["", self.team.slug, self.team_empty.slug],
+            ),
+            lambda self: (
+                self.other_user,
+                self.other_organization,
+                ["", self.other_team.slug],
+            ),
+            lambda self: (
+                self.other_owner,
+                self.other_organization,
+                ["", self.other_team.slug],
+            ),
+        ],
+    )
+    def test_team_filter_choices(self, get_params):
+        """Team filter choices limited to organization teams."""
+        (user, organization, teams) = get_params(self)
+        filter = self.get_filterset_for_user(
+            user,
+            organization=organization,
+        )
+        assert list(dict(filter.filters["slug"].field.choices).keys()) == teams
+
+
+class TestOrganizationTeamMemberFilterSet(OrganizationFilterTestCase):
+    def get_filterset_for_user(self, user, *args, **kwargs):
+        request = RequestFactory().get("")
+        request.user = user
+        organization = kwargs.get("organization", self.organization)
+        queryset = organization.members
+        kwargs.update(
+            {
+                "queryset": queryset,
+                "request": request,
+            }
+        )
+        return OrganizationTeamMemberListFilterSet(*args, **kwargs)
+
+    @pytest.mark.parametrize(
+        "get_params",
+        [
+            lambda self: (self.user, self.organization, [self.user, self.owner]),
+            lambda self: (self.owner, self.organization, [self.user, self.owner]),
+            lambda self: (
+                self.other_user,
+                self.other_organization,
+                [self.other_user, self.other_owner],
+            ),
+            lambda self: (
+                self.other_owner,
+                self.other_organization,
+                [self.other_user, self.other_owner],
+            ),
+        ],
+    )
+    def test_unfiltered_queryset(self, get_params):
+        """No active filters returns full queryset."""
+        (user, organization, members) = get_params(self)
+        filter = self.get_filterset_for_user(
+            user,
+            organization=organization,
+        )
+        assertQuerySetEqual(
+            filter.qs,
+            members,
+            transform=lambda o: o,
+            ordered=False,
+        )
+
+    @pytest.mark.parametrize(
+        "get_params",
+        [
+            lambda self: (self.user, self.organization, self.team, [self.user]),
+            lambda self: (self.owner, self.organization, self.team, [self.user]),
+            lambda self: (self.owner, self.organization, self.team_empty, []),
+        ],
+    )
+    def test_filtered_queryset_team_choice(self, get_params):
+        """Valid team choice returns expected results."""
+        (user, organization, team, members) = get_params(self)
+        filter = self.get_filterset_for_user(
+            user,
+            {"teams__slug": team.slug},
+            organization=organization,
+        )
+        assertQuerySetEqual(
+            filter.qs,
+            members,
+            transform=lambda o: o,
+            ordered=False,
+        )
+
+    @pytest.mark.parametrize(
+        "get_params",
+        [
+            lambda self: (self.user, self.organization, "readonly", []),
+            lambda self: (self.user, self.organization, "admin", [self.user]),
+            lambda self: (self.user, self.organization, "owner", [self.owner]),
+        ],
+    )
+    def test_filtered_queryset_access_choice(self, get_params):
+        """Valid access choice returns expected results."""
+        (user, organization, access, members) = get_params(self)
+        filter = self.get_filterset_for_user(
+            user,
+            {"access": access},
+            organization=organization,
+        )
+        assertQuerySetEqual(
+            filter.qs,
+            members,
+            transform=lambda o: o,
+            ordered=False,
+        )
+
+    def test_filtered_queryset_team_invalid_choice(self):
+        """Invalid team choice returns the original queryset."""
+        filter = self.get_filterset_for_user(
+            self.user,
+            {"teams__slug": self.other_team.slug},
+            organization=self.organization,
+        )
+        assertQuerySetEqual(
+            filter.qs,
+            [self.owner, self.user],
+            transform=lambda o: o,
+            ordered=False,
+        )
+
+    @pytest.mark.parametrize(
+        "get_params",
+        [
+            lambda self: (self.user, self.organization, ["", self.team.slug]),
+            lambda self: (
+                self.owner,
+                self.organization,
+                ["", self.team.slug, self.team_empty.slug],
+            ),
+            lambda self: (
+                self.other_user,
+                self.other_organization,
+                ["", self.other_team.slug],
+            ),
+            lambda self: (
+                self.other_owner,
+                self.other_organization,
+                ["", self.other_team.slug],
+            ),
+        ],
+    )
+    def test_team_filter_choices(self, get_params):
+        """Team filter choices limited to organization teams with permisisons."""
+        (user, organization, choices) = get_params(self)
+        filter = self.get_filterset_for_user(
+            user,
+            organization=organization,
+        )
+        assert list(dict(filter.filters["teams__slug"].field.choices).keys()) == choices
+
+    def test_access_filter_choices(self):
+        """Access filter choices are correct."""
+        filter = self.get_filterset_for_user(
+            self.user,
+            organization=self.organization,
+        )
+        assert list(dict(filter.filters["access"].field.choices).keys()) == [
+            "",
+            "readonly",
+            "admin",
+            "owner",
+        ]

--- a/readthedocs/organizations/views/private.py
+++ b/readthedocs/organizations/views/private.py
@@ -65,8 +65,10 @@ class CreateOrganizationSignup(PrivateViewMixin, OrganizationView, CreateView):
         )
 
 
-class ListOrganization(FilterContextMixin, PrivateViewMixin, OrganizationView, ListView):
-    template_name = 'organizations/organization_list.html'
+class ListOrganization(
+    FilterContextMixin, PrivateViewMixin, OrganizationView, ListView
+):
+    template_name = "organizations/organization_list.html"
     admin_only = False
 
     filterset_class = OrganizationListFilterSet

--- a/readthedocs/organizations/views/private.py
+++ b/readthedocs/organizations/views/private.py
@@ -13,7 +13,7 @@ from vanilla import CreateView, DeleteView, FormView, ListView, UpdateView
 
 from readthedocs.audit.filters import OrganizationSecurityLogFilter
 from readthedocs.audit.models import AuditLog
-from readthedocs.core.filters import FilterMixin
+from readthedocs.core.filters import FilterContextMixin
 from readthedocs.core.history import UpdateChangeReasonPostView
 from readthedocs.core.mixins import PrivateViewMixin
 from readthedocs.invitations.models import Invitation
@@ -65,7 +65,7 @@ class CreateOrganizationSignup(PrivateViewMixin, OrganizationView, CreateView):
         )
 
 
-class ListOrganization(FilterMixin, PrivateViewMixin, OrganizationView, ListView):
+class ListOrganization(FilterContextMixin, PrivateViewMixin, OrganizationView, ListView):
     template_name = 'organizations/organization_list.html'
     admin_only = False
 

--- a/readthedocs/organizations/views/private.py
+++ b/readthedocs/organizations/views/private.py
@@ -75,7 +75,9 @@ class ListOrganization(PrivateViewMixin, OrganizationView, ListView):
         context = super().get_context_data(**kwargs)
         if settings.RTD_EXT_THEME_ENABLED:
             filter = OrganizationListFilterSet(
-                self.request.GET, queryset=self.get_queryset()
+                self.request.GET,
+                queryset=self.get_queryset(),
+                request=self.request,
             )
             context["filter"] = filter
             context["organization_list"] = filter.qs

--- a/readthedocs/organizations/views/public.py
+++ b/readthedocs/organizations/views/public.py
@@ -1,11 +1,17 @@
 """Views that don't require login."""
 # pylint: disable=too-many-ancestors
 import structlog
+from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.urls import reverse, reverse_lazy
 from django.views.generic.base import TemplateView
 from vanilla import DetailView, GenericView, ListView
 
+from readthedocs.organizations.filters import (
+    OrganizationProjectListFilterSet,
+    OrganizationTeamListFilterSet,
+    OrganizationTeamMemberListFilterSet,
+)
 from readthedocs.organizations.models import Team
 from readthedocs.organizations.views.base import (
     CheckOrganizationsEnabled,
@@ -36,27 +42,56 @@ class DetailOrganization(OrganizationView, DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         org = self.get_object()
-        context['projects'] = (
+        projects = (
             Project.objects
             .for_user(self.request.user)
             .filter(organizations=org)
             .all()
         )
-        context['teams'] = (
+        teams = (
             Team.objects
             .member(self.request.user, organization=org)
             .prefetch_related('organization')
             .all()
         )
-        context['owners'] = org.owners.all()
+        if settings.RTD_EXT_THEME_ENABLED:
+            filter = OrganizationProjectListFilterSet(
+                self.request.GET,
+                request=self.request,
+                queryset=projects,
+                teams_queryset=teams,
+            )
+            context["filter"] = filter
+            projects = filter.qs
+        context["projects"] = projects
+        context["teams"] = teams
+        context["owners"] = org.owners.all()
         return context
 
 
 # Member Views
 class ListOrganizationMembers(OrganizationMixin, ListView):
-    template_name = 'organizations/member_list.html'
-    context_object_name = 'members'
+    template_name = "organizations/member_list.html"
+    context_object_name = "members"
     admin_only = False
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        team_members = self.get_queryset()
+        if settings.RTD_EXT_THEME_ENABLED:
+            # Because of the split between TeamMember and Organization.owners,
+            # we have to pass in two querysets here. This is what makes it
+            # possible to list the available organization Teams in
+            filter = OrganizationTeamMemberListFilterSet(
+                self.request.GET,
+                queryset=team_members,
+                organization=self.get_organization(),
+                request=self.request,
+            )
+            context["filter"] = filter
+            team_members = filter.qs
+        context["members"] = team_members
+        return context
 
     def get_queryset(self):
         return self.get_organization().members
@@ -78,6 +113,18 @@ class ListOrganizationTeams(OrganizationTeamView, ListView):
         context = super().get_context_data(**kwargs)
         org = self.get_organization()
         context['owners'] = org.owners.all()
+
+        # Note, the team queryset defines sorting at the parent class. Sorting
+        # should happen in the filter instead so it can be controlled in the UI.
+        teams = self.get_team_queryset()
+        if settings.RTD_EXT_THEME_ENABLED:
+            filter = OrganizationTeamListFilterSet(
+                self.request.GET,
+                queryset=teams,
+            )
+            context["filter"] = filter
+            teams = filter.qs
+        context["teams"] = teams
         return context
 
 
@@ -96,7 +143,6 @@ class RedirectRedeemTeamInvitation(CheckOrganizationsEnabled, GenericView):
 
     """Redirect invitation links to the new view."""
 
-    # pylint: disable=unused-argument
     def get(self, request, *args, **kwargs):
         return HttpResponseRedirect(
             reverse("invitations_redeem", args=[kwargs["hash"]])

--- a/readthedocs/organizations/views/public.py
+++ b/readthedocs/organizations/views/public.py
@@ -7,7 +7,7 @@ from django.urls import reverse, reverse_lazy
 from django.views.generic.base import TemplateView
 from vanilla import DetailView, GenericView, ListView
 
-from readthedocs.core.filters import FilterMixin
+from readthedocs.core.filters import FilterContextMixin
 from readthedocs.organizations.filters import (
     OrganizationProjectListFilterSet,
     OrganizationTeamListFilterSet,
@@ -34,7 +34,7 @@ class OrganizationTemplateView(CheckOrganizationsEnabled, TemplateView):
 # Organization
 
 
-class DetailOrganization(FilterMixin, OrganizationView, DetailView):
+class DetailOrganization(FilterContextMixin, OrganizationView, DetailView):
 
     """Display information about an organization."""
 
@@ -73,7 +73,7 @@ class DetailOrganization(FilterMixin, OrganizationView, DetailView):
 
 
 # Member Views
-class ListOrganizationMembers(FilterMixin, OrganizationMixin, ListView):
+class ListOrganizationMembers(FilterContextMixin, OrganizationMixin, ListView):
     template_name = "organizations/member_list.html"
     context_object_name = "members"
     admin_only = False
@@ -101,7 +101,7 @@ class ListOrganizationMembers(FilterMixin, OrganizationMixin, ListView):
 
 
 # Team Views
-class ListOrganizationTeams(FilterMixin, OrganizationTeamView, ListView):
+class ListOrganizationTeams(FilterContextMixin, OrganizationTeamView, ListView):
     template_name = 'organizations/team_list.html'
     context_object_name = 'teams'
     admin_only = False

--- a/readthedocs/organizations/views/public.py
+++ b/readthedocs/organizations/views/public.py
@@ -80,9 +80,6 @@ class ListOrganizationMembers(OrganizationMixin, ListView):
         context = super().get_context_data(**kwargs)
         team_members = self.get_queryset()
         if settings.RTD_EXT_THEME_ENABLED:
-            # Because of the split between TeamMember and Organization.owners,
-            # we have to pass in two querysets here. This is what makes it
-            # possible to list the available organization Teams in
             filter = OrganizationTeamMemberListFilterSet(
                 self.request.GET,
                 queryset=team_members,


### PR DESCRIPTION
This filters are used for the new dashboard UI, they are not API filters.

These were a challenge to create, as django-filter is really opinionated
about the way it should work, and doesn't quite agree with use cases
that need to use filtered querysets (such as limiting the field choices
to objects the organization is related to).

I went through many permutations of this code, trying to find a pattern
that was not obtuse or awful. Unfortunately, I don't quite like the
patterns here, but because all of the django-filter magic happens at the
class level instead of at instantiation time, every direction required
hacks to obtain something reasonable.

Given the use we have for filters in our UI, I wouldn't mind making
these into a more generalized filter solution.

I think I'd like to replace some of the existing filters that currently
hit the API with frontend code and replace those with proper filters
too. These are mostly the project/version listing elements.