### PR TITLE
Tests: set privacy level explicitly

### DIFF
--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -410,6 +410,7 @@ class TestReadTheDocsConfigJson(TestCase):
             repo="https://github.com/readthedocs/subproject",
             privacy_level=PUBLIC,
         )
+        subproject.versions.update(privacy_level=PUBLIC, built=True, active=True)
         self.project.add_subproject(subproject)
 
         r = self.client.get(


### PR DESCRIPTION
In https://github.com/readthedocs/readthedocs.org/pull/10852 I forgot that we actually need to set the privacy level of the version, not the project.