### PR TITLE
NGINX: inject the proper `readthedocs-version-slug`

### DIFF
--- a/dockerfiles/nginx/proxito.conf.template
+++ b/dockerfiles/nginx/proxito.conf.template
@@ -113,7 +113,7 @@ server {
 
         # Inject our own script dynamically and project/version slugs into the HTML to emulate what CF worker does
         # TODO: find a way to make this work _without_ running `npm run dev` from the `addons` repository
-        sub_filter '</head>' '<script async language="javascript" src="http://localhost:8000/readthedocs-addons.js"></script>\n<meta name="readthedocs-project-slug" content="$rtd_project" />\n<meta name="readthedocs-version-slug" content="latest" />\n</head>';
+        sub_filter '</head>' '<script async language="javascript" src="http://localhost:8000/readthedocs-addons.js"></script>\n<meta name="readthedocs-project-slug" content="$rtd_project" />\n<meta name="readthedocs-version-slug" content="$rtd_version" />\n</head>';
         sub_filter_types text/html;
         sub_filter_last_modified on;
         sub_filter_once on;


### PR DESCRIPTION
I made a mistake and hardcoded `latest` when testing this, but it should be `$rtd_version` which is grabbed from the HTTP header sent from the app.