### PR TITLE
docs: update documentation around version warning banner

### DIFF
--- a/docs/user/versions.rst
+++ b/docs/user/versions.rst
@@ -149,14 +149,14 @@ Version Control Support Matrix
 Version warning
 ---------------
 
-A banner can be automatically displayed to notify viewers that there may be 
+A banner can be automatically displayed to notify viewers that there may be
 a more stable version of the documentation available. Specifically:
 
-- When the ``latest`` version is being shown, and there's also a ``stable`` version available, 
-  then the banner will remind the viewer that some of the documented features may not yet be 
+- When the ``latest`` version is being shown, and there's also a ``stable`` version available,
+  then the banner will remind the viewer that some of the documented features may not yet be
   available, and suggest that the viewer switch to the ``stable`` version.
-- When a version is being shown that is not the ``stable`` version, and there's a ``stable`` 
-  version available, then the banner will suggest that the viewer switch to the ``stable`` version 
+- When a version is being shown that is not the ``stable`` version, and there's a ``stable``
+  version available, then the banner will suggest that the viewer switch to the ``stable`` version
   to see the newest documentation.
 
 
@@ -165,7 +165,7 @@ you can enable it in the admin section of your docs (:guilabel:`Admin` > :guilab
 
 .. note::
 
-   An older version of this feature is currently only available to projects that have already enabled it. 
+   An older version of this feature is currently only available to projects that have already enabled it.
    When the updated feature development is finished the toggle setting will be enabled for all projects.
 
 .. note::

--- a/docs/user/versions.rst
+++ b/docs/user/versions.rst
@@ -149,25 +149,38 @@ Version Control Support Matrix
 Version warning
 ---------------
 
-This is a banner that appears on the top of every page of your docs that aren't stable or latest.
-This banner has a text with a link redirecting the users to the latest version of your docs.
+A banner can be automatically displayed to notify viewers that there may be 
+a more stable version of the documentation available. Specifically:
+
+- When the ``latest`` version is being shown, and there's also a ``stable`` version available, 
+  then the banner will remind the viewer that some of the documented features may not yet be 
+  available, and suggest that the viewer switch to the ``stable`` version.
+- When a version is being shown that is not the ``stable`` version, and there's a ``stable`` 
+  version available, then the banner will suggest that the viewer switch to the ``stable`` version 
+  to see the newest documentation.
+
 
 This feature is disabled by default on new projects,
 you can enable it in the admin section of your docs (:guilabel:`Admin` > :guilabel:`Advanced Settings`).
 
 .. note::
 
-   The banner will be injected in an HTML element with the ``main`` role or in the ``main`` tag.
-   For example:
+    An older version of this feature is currently only available to projects that have already enabled it. 
+    When the updated feature development is finished the toggle setting will be enabled for all projects.
 
-   .. code-block:: html
+.. note::
+  
+    The banner will be injected in an HTML element with the ``main`` role or in the ``main`` tag.
+    For example:
+
+    .. code-block:: html
 
       <div role="main">
         <!-- The banner would be injected here -->
         ...
       </div>
 
-   .. code-block:: html
+    .. code-block:: html
 
       <main>
         <!-- The banner would be injected here -->

--- a/docs/user/versions.rst
+++ b/docs/user/versions.rst
@@ -160,8 +160,8 @@ a more stable version of the documentation available. Specifically:
   to see the newest documentation.
 
 
-This feature is disabled by default on new projects,
-you can enable it in the admin section of your docs (:guilabel:`Admin` > :guilabel:`Advanced Settings`).
+This feature is enabled by default on projects using the new beta addons.
+The beta addons can be enabled by using ``build.commands`` config key or via the new beta dashboard (https://beta.readthedocs.org) going to the admin section of your docs (:guilabel:`Admin` > :guilabel:`Advanced Settings`)
 
 .. note::
 

--- a/docs/user/versions.rst
+++ b/docs/user/versions.rst
@@ -168,26 +168,6 @@ The beta addons can be enabled by using ``build.commands`` config key or via the
    An older version of this feature is currently only available to projects that have already enabled it.
    When the updated feature development is finished the toggle setting will be enabled for all projects.
 
-.. note::
-
-   The banner will be injected in an HTML element with the ``main`` role or in the ``main`` tag.
-   For example:
-
-   .. code-block:: html
-
-      <div role="main">
-        <!-- The banner would be injected here -->
-        ...
-      </div>
-
-   .. code-block:: html
-
-      <main>
-        <!-- The banner would be injected here -->
-        ...
-      </main>
-
-
 Redirects on root URLs
 ----------------------
 

--- a/docs/user/versions.rst
+++ b/docs/user/versions.rst
@@ -152,7 +152,7 @@ Version warning
 A banner can be automatically displayed to notify viewers that there may be
 a more stable version of the documentation available. Specifically:
 
-- When the ``latest`` version is being shown, and there's also a ``stable`` version available,
+- When the ``latest`` version is being shown, and there's also a ``stable`` version active and not hidden,
   then the banner will remind the viewer that some of the documented features may not yet be
   available, and suggest that the viewer switch to the ``stable`` version.
 - When a version is being shown that is not the ``stable`` version, and there's a ``stable``

--- a/docs/user/versions.rst
+++ b/docs/user/versions.rst
@@ -165,22 +165,22 @@ you can enable it in the admin section of your docs (:guilabel:`Admin` > :guilab
 
 .. note::
 
-    An older version of this feature is currently only available to projects that have already enabled it. 
-    When the updated feature development is finished the toggle setting will be enabled for all projects.
+   An older version of this feature is currently only available to projects that have already enabled it. 
+   When the updated feature development is finished the toggle setting will be enabled for all projects.
 
 .. note::
-  
-    The banner will be injected in an HTML element with the ``main`` role or in the ``main`` tag.
-    For example:
 
-    .. code-block:: html
+   The banner will be injected in an HTML element with the ``main`` role or in the ``main`` tag.
+   For example:
+
+   .. code-block:: html
 
       <div role="main">
         <!-- The banner would be injected here -->
         ...
       </div>
 
-    .. code-block:: html
+   .. code-block:: html
 
       <main>
         <!-- The banner would be injected here -->


### PR DESCRIPTION
Relates to issue: https://github.com/readthedocs/readthedocs.org/issues/8789#issuecomment-1783302709
Closes #6096
Closes #8789

This updates the *Version warning* doc section to communicate the new functionality in an upcoming addon PR (https://github.com/readthedocs/addons/pull/174) and also notes that the feature toggle is currently not visible to all projects.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10877.org.readthedocs.build/en/10877/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10877.org.readthedocs.build/en/10877/

<!-- readthedocs-preview dev end -->