### PR TITLE
Build: use tag name for checkout

### DIFF
--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -225,7 +225,7 @@ class BuildDirector:
         log.info("Cloning and fetching.")
         self.vcs_repository.update()
 
-        identifier = self.data.build_commit or self.data.version.identifier
+        identifier = self.data.build_commit or self.data.version.commit_name
         log.info("Checking out.", identifier=identifier)
         self.vcs_repository.checkout(identifier)
 


### PR DESCRIPTION
Instead of relying on the commit, we can just use the name of the tag, this solves the problem where we are using an old commit when a tag is force pushed.

Fixes https://github.com/readthedocs/readthedocs.org/issues/10838