### PR TITLE
Make Ubuntu callout correct

### DIFF
--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -354,7 +354,7 @@ build.apt_packages
 ``````````````````
 
 List of `APT packages`_ to install.
-Our build servers run Ubuntu 18.04, with the default set of package repositories installed.
+Our build servers run various Ubuntu LTS versions with the default set of package repositories installed.
 We don't currently support PPA's or other custom repositories.
 
 .. _APT packages: https://packages.ubuntu.com/


### PR DESCRIPTION


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10883.org.readthedocs.build/en/10883/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10883.org.readthedocs.build/en/10883/

<!-- readthedocs-preview dev end -->