### PR TITLE
Version: don't use default_branch when getting the commit name

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -341,10 +341,10 @@ class Version(TimeStampedModel):
         """
         # LATEST is special as it is usually a branch but does not contain the
         # name in verbose_name.
-        if self.slug == LATEST:
-            return self.project.get_default_branch()
+        if self.slug == LATEST and self.machine:
+            return self.identifier
 
-        if self.slug == STABLE:
+        if self.slug == STABLE and self.machine:
             if self.type == BRANCH:
                 # Special case, as we do not store the original branch name
                 # that the stable version works on. We can only interpolate the
@@ -356,7 +356,7 @@ class Version(TimeStampedModel):
             return self.identifier
 
         # By now we must have handled all special versions.
-        if self.slug in NON_REPOSITORY_VERSIONS:
+        if self.machine and self.slug in NON_REPOSITORY_VERSIONS:
             # pylint: disable=broad-exception-raised
             raise Exception('All special versions must be handled by now.')
 


### PR DESCRIPTION
The name of the branch used is already in the version itself, we don't need to depend on the project's `get_default_branch`.

This doesn't work on the builders, because we use
the APIProject object, which doesn't have access to the DB nor has the remote_repository relationship in it.

https://github.com/readthedocs/readthedocs.org/blob/fe7e976dbf989f1eee04368df3427086edfb89c9/readthedocs/projects/models.py#L1262-L1263

In cases where users have `project.default_branh = None`, this was returning master instead of the GitHub's default.