### PR TITLE
Integrations: better error message for integrations without a secret

### DIFF
--- a/readthedocs/api/v2/views/integrations.py
+++ b/readthedocs/api/v2/views/integrations.py
@@ -31,7 +31,7 @@ from readthedocs.projects.models import Project
 
 log = structlog.get_logger(__name__)
 
-GITHUB_EVENT_HEADER = "GitHub-Event"
+GITHUB_EVENT_HEADER = "X-GitHub-Event"
 GITHUB_SIGNATURE_HEADER = "X-Hub-Signature-256"
 GITHUB_PING = "ping"
 GITHUB_PUSH = "push"


### PR DESCRIPTION
This also fixes https://github.com/readthedocs/readthedocs.org/issues/10902, the github event header name was missing the `X-`