### PR TITLE
Add link to docs in error message

### DIFF
--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -100,7 +100,8 @@ class DefaultConfigFileNotFound(ConfigError):
 
     def __init__(self):
         super().__init__(
-            "No default configuration file found at repository's root.",
+            "No default configuration file found at repository's root. "
+            "See https://blog.readthedocs.com/migrate-configuration-v2/",
             CONFIG_FILE_REQUIRED,
         )
 

--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -101,7 +101,7 @@ class DefaultConfigFileNotFound(ConfigError):
     def __init__(self):
         super().__init__(
             "No default configuration file found at repository's root. "
-            "See https://blog.readthedocs.com/migrate-configuration-v2/",
+            "See https://docs.readthedocs.io/en/stable/config-file/",
             CONFIG_FILE_REQUIRED,
         )
 


### PR DESCRIPTION
When a build fails due to a missing config file, it's not always clear what action should be taken. For example: 

https://github.com/python/pythondotorg/pull/2327#issuecomment-1817764006

I suggest including a link to a webpage that explains what action is needed. Perhaps this blog post?

https://blog.readthedocs.com/migrate-configuration-v2/