### PR TITLE
Search: check for build being None

### DIFF
--- a/readthedocs/projects/tasks/search.py
+++ b/readthedocs/projects/tasks/search.py
@@ -141,8 +141,10 @@ def _create_imported_files_and_search_index(
     # it's used to differentiate the files from the current sync from the previous one.
     # This is useful to easily delete the previous files from the DB and ES.
     # See https://github.com/readthedocs/readthedocs.org/issues/10734.
-    imported_file = version.imported_files.first()
-    sync_id = imported_file.build + 1 if imported_file else 1
+    imported_file_build_id = version.imported_files.values_list(
+        "build", flat=True
+    ).first()
+    sync_id = imported_file_build_id + 1 if imported_file_build_id else 1
 
     log.debug(
         "Using sync ID for search indexing",


### PR DESCRIPTION
Looks like some imported files have their build id set to None, probably some old data.

Ref https://read-the-docs.sentry.io/issues/4491624505/?project=148442&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=13