### PR TITLE
Search: index in small chunks

### DIFF
--- a/readthedocs/projects/tasks/search.py
+++ b/readthedocs/projects/tasks/search.py
@@ -215,6 +215,9 @@ def _create_imported_files_and_search_index(
             document=PageDocument,
             objects=html_files_to_index,
             index_name=search_index_name,
+            # Pages are indexed in small chunks to avoid a
+            # large payload that will probably timeout ES.
+            chunk_size=25,
         )
 
     # Remove old HTMLFiles from ElasticSearch

--- a/readthedocs/projects/tasks/search.py
+++ b/readthedocs/projects/tasks/search.py
@@ -217,7 +217,7 @@ def _create_imported_files_and_search_index(
             index_name=search_index_name,
             # Pages are indexed in small chunks to avoid a
             # large payload that will probably timeout ES.
-            chunk_size=25,
+            chunk_size=100,
         )
 
     # Remove old HTMLFiles from ElasticSearch

--- a/readthedocs/search/utils.py
+++ b/readthedocs/search/utils.py
@@ -10,7 +10,7 @@ from readthedocs.search.documents import PageDocument
 log = structlog.get_logger(__name__)
 
 
-def index_objects(document, objects, index_name=None):
+def index_objects(document, objects, index_name=None, chunk_size=500):
     if not DEDConfig.autosync_enabled():
         log.info("Autosync disabled, skipping searh indexing.")
         return
@@ -21,7 +21,7 @@ def index_objects(document, objects, index_name=None):
     if index_name:
         document._index._name = index_name
 
-    document().update(objects)
+    document().update(objects, chunk_size=chunk_size)
 
     # Restore the old index name.
     if index_name:


### PR DESCRIPTION
The default is 500 documents, our documents have nested objects, that can make the final document huge, and timeout ES.

closes https://github.com/readthedocs/readthedocs.org/issues/10911

Ref https://github.com/readthedocs/readthedocs.org/issues/10911#issuecomment-1819688230