### PR TITLE
Design: small update to add a PATCH endpoint

### DIFF
--- a/docs/dev/design/new-notifications-system.rst
+++ b/docs/dev/design/new-notifications-system.rst
@@ -425,6 +425,30 @@ Notification create
    we want to attach a ``Notification`` (e.g. ``User``, ``Organization``, etc)
 
 
+Notification update
+~~~~~~~~~~~~~~~~~~~
+
+
+.. http:patch:: /api/v3/projects/(str:project_slug)/builds/(int:build_id)/notifications/(int:notification_id)/
+
+    Update an existing notification.
+    Mainly used to change the state from the front-end.
+
+    **Example request**:
+
+    .. sourcecode:: json
+
+        {
+            "state": "read",
+        }
+
+
+.. note::
+
+   Similar API endpoints will be created for each of the resources
+   we want to attach a ``Notification`` (e.g. ``User``, ``Organization``, etc)
+
+
 Backward compatibility
 ----------------------
 


### PR DESCRIPTION
Endpoint to update a notification.
This will be used by the front-end to mark a notification as read, for example.

Ref: https://github.com/readthedocs/readthedocs.org/pull/10890#discussion_r1403203545

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10919.org.readthedocs.build/en/10919/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10919.org.readthedocs.build/en/10919/

<!-- readthedocs-preview dev end -->