### PR TITLE
Feature flag: remove `CDN_ENABLED` which is not used anymore

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1921,7 +1921,6 @@ class Feature(models.Model):
     API_LARGE_DATA = "api_large_data"
     CONDA_APPEND_CORE_REQUIREMENTS = "conda_append_core_requirements"
     ALL_VERSIONS_IN_HTML_CONTEXT = "all_versions_in_html_context"
-    CDN_ENABLED = "cdn_enabled"
     RECORD_404_PAGE_VIEWS = "record_404_page_views"
     ALLOW_FORCED_REDIRECTS = "allow_forced_redirects"
     DISABLE_PAGEVIEWS = "disable_pageviews"
@@ -1986,13 +1985,6 @@ class Feature(models.Model):
             _(
                 "Sphinx: Pass all versions (including private) into the html context "
                 "when building with Sphinx"
-            ),
-        ),
-        (
-            CDN_ENABLED,
-            _(
-                "Proxito: CDN support for a project's public versions when privacy levels "
-                "are enabled."
             ),
         ),
         (

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -1695,14 +1695,6 @@ class TestAdditionalDocViews(BaseDocServing):
 )
 class TestCDNCache(BaseDocServing):
 
-    def setUp(self):
-        super().setUp()
-        get(
-            Feature,
-            feature_id=Feature.CDN_ENABLED,
-            projects=list(Project.objects.all()),
-        )
-
     def _test_cache_control_header_project(self, expected_value, host=None):
         """
         Test the CDN-Cache-Control header on requests for `self.project`.


### PR DESCRIPTION
Small code cleaning to continue removing old feature flags.