### PR TITLE
Fix a typo in the word 'Sphinx'

### DIFF
--- a/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
+++ b/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
@@ -270,7 +270,7 @@
       "additionalProperties": false
     },
     "sphinx": {
-      "title": "Sphix",
+      "title": "Sphinx",
       "description": "Configuration for sphinx documentation.",
       "type": "object",
       "properties": {


### PR DESCRIPTION
Noticed this while reading the schema.

Thanks for your work on ReadtheDocs!