### PR TITLE
Search: fix default for search.ranking when indexing

### DIFF
--- a/readthedocs/projects/tasks/search.py
+++ b/readthedocs/projects/tasks/search.py
@@ -45,7 +45,7 @@ def index_build(build_id):
 
     build_config = build.config or {}
     search_config = build_config.get("search", {})
-    search_ranking = search_config.get("ranking", [])
+    search_ranking = search_config.get("ranking", {})
     search_ignore = search_config.get("ignore", [])
 
     try:


### PR DESCRIPTION
This only happens if the project doesn't have a configuration file attached to it (even the default one we create when the project doesn't have one). So, this actually happening is very rare, probably the build wasn't updated before the search index was triggered.

Ref https://read-the-docs.sentry.io/issues/4701432554/?project=148442&query=is%3Aunresolved+firstSeen%3A-4h&referrer=issue-stream&statsPeriod=24h&stream_index=0