### PR TITLE
Allow empty project list on organization team form

### DIFF
--- a/readthedocs/organizations/forms.py
+++ b/readthedocs/organizations/forms.py
@@ -208,6 +208,7 @@ class OrganizationTeamProjectForm(forms.ModelForm):
         self.fields["projects"] = forms.ModelMultipleChoiceField(
             queryset=self.organization.projects,
             widget=forms.CheckboxSelectMultiple,
+            required=False,
         )
 
 


### PR DESCRIPTION
This allows the field/widget in the form to be empty on submit.

- Fixes #10934