### PR TITLE
Addons: normalize search filters

### DIFF
--- a/readthedocs/proxito/tests/responses/v0.json
+++ b/readthedocs/proxito/tests/responses/v0.json
@@ -117,10 +117,9 @@
     "search": {
       "enabled": true,
       "api_endpoint": "/_/api/v3/search/",
-      "default_filter": "subprojects:project/latest",
+      "default_filter": "project:project/latest",
       "filters": [
-        ["Search only in this project", "project:project/latest"],
-        ["Search subprojects", "subprojects:project/latest"]
+        ["Include subprojects", "subprojects:project/latest"]
       ],
       "project": "project",
       "version": "latest"

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -398,17 +398,13 @@ class AddonsResponse:
                     # TODO: figure it out where this data comes from
                     "filters": [
                         [
-                            "Search only in this project",
-                            f"project:{project.slug}/{version.slug}",
-                        ],
-                        [
-                            "Search subprojects",
+                            "Include subprojects",
                             f"subprojects:{project.slug}/{version.slug}",
                         ],
                     ]
                     if version
                     else [],
-                    "default_filter": f"subprojects:{project.slug}/{version.slug}"
+                    "default_filter": f"project:{project.slug}/{version.slug}"
                     if version
                     else None,
                 },


### PR DESCRIPTION
Currently, we have two filters on shown by default in the search modal. However, they are not super useful to work together.

I changed this behavior (for now) to be:

* Default: search on the current project
* Include subprojects: also include results from subprojects

Note this will be configurable by the user once we expose the addons admin page in https://github.com/readthedocs/ext-theme/issues/211

Closes https://github.com/readthedocs/addons/issues/209