### PR TITLE
Allow override of env settings from host

### DIFF
--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -206,6 +206,7 @@ class DockerBaseSettings(CommunityBaseSettings):
     STRIPE_SECRET = os.environ.get("RTD_STRIPE_SECRET")
     STRIPE_PUBLISHABLE = os.environ.get("RTD_STRIPE_PUBLISHABLE")
     STRIPE_TEST_SECRET_KEY = STRIPE_SECRET
+    DJSTRIPE_WEBHOOK_SECRET = os.environ.get("RTD_DJSTRIPE_WEBHOOK_SECRET")
 
     RTD_SAVE_BUILD_COMMANDS_TO_STORAGE = True
     RTD_BUILD_COMMANDS_STORAGE = "readthedocs.storage.s3_storage.S3BuildCommandsStorage"

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -203,6 +203,10 @@ class DockerBaseSettings(CommunityBaseSettings):
     AWS_S3_ENDPOINT_URL = "http://storage:9000/"
     AWS_QUERYSTRING_AUTH = False
 
+    STRIPE_SECRET = os.environ.get("RTD_STRIPE_SECRET")
+    STRIPE_PUBLISHABLE = os.environ.get("RTD_STRIPE_PUBLISHABLE")
+    STRIPE_TEST_SECRET_KEY = STRIPE_SECRET
+
     RTD_SAVE_BUILD_COMMANDS_TO_STORAGE = True
     RTD_BUILD_COMMANDS_STORAGE = "readthedocs.storage.s3_storage.S3BuildCommandsStorage"
     BUILD_COLD_STORAGE_URL = "http://storage:9000/builds"


### PR DESCRIPTION
This is to avoid stashing/unstashing settings and to push this towards a local .envrc file instead, where the secrets can be encrypted. Keeping unencrypted settings in stash history is a pattern to avoid.

- Requires https://github.com/readthedocs/common/pull/191