### PR TITLE
Clarify that 404 analytics is only available on Read the Docs for Business

### DIFF
--- a/docs/user/reference/analytics.rst
+++ b/docs/user/reference/analytics.rst
@@ -12,7 +12,8 @@ Traffic analytics
 
 Read the Docs aggregates statistics about visits to your documentation.
 This is mainly information about how often pages are viewed,
-and which return a `404 Not Found` error code.
+and which return a `404 Not Found` error code (available on Read the Docs for
+Business only).
 
 Traffic Analytics lets you see *which* documents your users are reading.
 This allows you to understand how your documentation is being used,


### PR DESCRIPTION
It would be nice to have this documented, as otherwise it’s not clear what to expect from the platform. I was hoping to use this data as part of designing a custom 404 page for my project, but it looks like it’s a Business feature only. I figured this out based on #9131.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10967.org.readthedocs.build/en/10967/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10967.org.readthedocs.build/en/10967/

<!-- readthedocs-preview dev end -->