### PR TITLE
Fix YAML indentation in example `.readthedocs.yaml`

### DIFF
--- a/readthedocs/templates/projects/import_config.html
+++ b/readthedocs/templates/projects/import_config.html
@@ -39,7 +39,7 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-   configuration: docs/conf.py
+  configuration: docs/conf.py
 
 # Optionally build your docs in additional formats such as PDF and ePub
 # formats:


### PR DESCRIPTION
Had 3 spaces.