### PR TITLE
Development: update steps for testing subscriptions

### DIFF
--- a/docs/dev/subscriptions.rst
+++ b/docs/dev/subscriptions.rst
@@ -9,11 +9,10 @@ Local testing
 -------------
 
 To test subscriptions locally, you need to have access to the Stripe account,
-and define the following settings with the keys from Stripe test mode:
+and define the following environment variables with the keys from Stripe test mode:
 
-- ``STRIPE_SECRET``: https://dashboard.stripe.com/test/apikeys
-- ``STRIPE_TEST_SECRET_KEY``: https://dashboard.stripe.com/test/apikeys
-- ``DJSTRIPE_WEBHOOK_SECRET``: https://dashboard.stripe.com/test/webhooks
+- ``RTD_STRIPE_SECRET``: https://dashboard.stripe.com/test/apikeys
+- ``RTD_DJSTRIPE_WEBHOOK_SECRET``: https://dashboard.stripe.com/test/webhooks
 
 To test the webhook locally, you need to run your local instance with ngrok, for example:
 

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -203,7 +203,7 @@ class DockerBaseSettings(CommunityBaseSettings):
     AWS_S3_ENDPOINT_URL = "http://storage:9000/"
     AWS_QUERYSTRING_AUTH = False
 
-    STRIPE_SECRET = os.environ.get("RTD_STRIPE_SECRET")
+    STRIPE_SECRET = os.environ.get("RTD_STRIPE_SECRET", "sk_test_x")
     STRIPE_PUBLISHABLE = os.environ.get("RTD_STRIPE_PUBLISHABLE")
     STRIPE_TEST_SECRET_KEY = STRIPE_SECRET
     DJSTRIPE_WEBHOOK_SECRET = os.environ.get("RTD_DJSTRIPE_WEBHOOK_SECRET")


### PR DESCRIPTION
- Mention the use of environment variables for testing
- Add a default for the stripe key (otherwise the instance won't start)

Hit this today while spinning up my dev environment

Ref https://github.com/readthedocs/readthedocs.org/pull/10959

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10992.org.readthedocs.build/en/10992/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--10992.org.readthedocs.build/en/10992/

<!-- readthedocs-preview dev end -->