### PR TITLE
Remove leftovers from `django-messages-extends`

### DIFF
--- a/readthedocs/templates/base.html
+++ b/readthedocs/templates/base.html
@@ -120,16 +120,11 @@
 
         <!-- BEGIN notify -->
         {% block notify %}
-          {# TODO: migrate these notifications to new system #}
+          {# These are regular one-time Django message attached to the request. #}
           {% if messages %}
             <ul class="notifications">
               {% for message in messages %}
-                <li class="notification notification-{{ message.level }}" {% if message.pk %}data-dismiss-url="{% url 'message_mark_read' message.pk %}{% endif %}">
-                  {% if message.pk %}
-                  <a class="notification-action" href="{% url 'message_mark_read' message.pk %}">
-                    <span class="icon close" aria-label="{% trans 'Close notification' %}"></span>
-                  </a>
-                  {% endif %}
+                <li class="notification notification-{{ message.level }}">
                   {{ message }}
                 </li>
               {% endfor %}


### PR DESCRIPTION
Keep rendering regular one-time Django messages attached to the request, but remove the logic used for sticky/permanent messages from `django-messages-extends`.

Closes #10988
Related https://github.com/readthedocs/ext-theme/issues/259