### PR TITLE
Fix ref to the "new addons integrations" blog post @ custom build doc

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -390,7 +390,7 @@ Override the build process
 .. warning::
 
    This feature is in *beta* and could change without warning.
-   We are currently testing `the new addons integrations we are building <rtd-blog:addons-flyout-menu-beta>`_
+   We are currently testing :ref:`the new addons integrations we are building <rtd-blog:addons-flyout-menu-beta>`
    on projects using ``build.commands`` configuration key.
 
 If your project requires full control of the build process,


### PR DESCRIPTION

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--10997.org.readthedocs.build/en/10997/build-customization.html#override-the-build-process

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- ~Developer's documentation (`dev`): https://dev--10997.org.readthedocs.build/en/10997/~

<!-- readthedocs-preview dev end -->