### PR TITLE
Remove _level_to_color call that doesn't exist

### DIFF
--- a/readthedocs/core/logs.py
+++ b/readthedocs/core/logs.py
@@ -112,7 +112,6 @@ class SysLogRenderer(structlog.dev.ConsoleRenderer):
         if level is not None:
             sio.write(
                 "["
-                + self._level_to_color.get(level, "")
                 + _pad(level, self._longest_level)
                 + self._styles.reset
                 + "] "


### PR DESCRIPTION
Fixes https://github.com/readthedocs/readthedocs.org/issues/10990