### PR TITLE
pip-compile fixes

### DIFF
--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -395,7 +395,7 @@ stripe==4.2.0
     # via
     #   -r requirements/pip.txt
     #   dj-stripe
-structlog==23.3.0
+structlog==23.2.0
     # via
     #   -r requirements/pip.txt
     #   django-structlog

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -403,7 +403,7 @@ stripe==4.2.0
     # via
     #   -r requirements/pip.txt
     #   dj-stripe
-structlog==23.3.0
+structlog==23.2.0
     # via
     #   -r requirements/pip.txt
     #   django-structlog


### PR DESCRIPTION
In #11003 we downgrade structlog, but we didn't update all the requirement files.