### PR TITLE
Build: remove browndates for config file

### DIFF
--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -10,11 +10,9 @@ It "directs" all of the high-level build jobs:
 import os
 import tarfile
 
-import pytz
 import structlog
 import yaml
 from django.conf import settings
-from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from readthedocs.builds.constants import EXTERNAL
@@ -249,47 +247,18 @@ class BuildDirector:
         self.data.build["config"] = self.data.config.as_dict()
         self.data.build["readthedocs_yaml_path"] = custom_config_file
 
-        now = timezone.now()
-        pdt = pytz.timezone("America/Los_Angeles")
-
-        # fmt: off
-        # These browndates matches https://blog.readthedocs.com/use-build-os-config/
-        browndates = any([
-            timezone.datetime(2023, 7, 14, 0, 0, 0, tzinfo=pdt) < now < timezone.datetime(2023, 7, 14, 12, 0, 0, tzinfo=pdt),  # First, 12hs
-            timezone.datetime(2023, 8, 14, 0, 0, 0, tzinfo=pdt) < now < timezone.datetime(2023, 8, 15, 0, 0, 0, tzinfo=pdt),  # Second, 24hs
-            timezone.datetime(2023, 9, 4, 0, 0, 0, tzinfo=pdt) < now < timezone.datetime(2023, 9, 6, 0, 0, 0, tzinfo=pdt),  # Third, 24hs
-            timezone.datetime(2023, 9, 25, 0, 0, 0, tzinfo=pdt) < now,  # Fully removal
-        ])
-        # fmt: on
-
         # Raise a build error if the project is not using a config file or using v1
-        if (
-            settings.RTD_ENFORCE_BROWNOUTS_FOR_DEPRECATIONS
-            and browndates
-            and self.data.config.version not in ("2", 2)
-        ):
+        if self.data.config.version not in ("2", 2):
             raise BuildUserError(BuildUserError.NO_CONFIG_FILE_DEPRECATED)
 
         # Raise a build error if the project is using "build.image" on their config file
+        build_config_key = self.data.config.source_config.get("build", {})
+        if "image" in build_config_key:
+            raise BuildUserError(BuildUserError.BUILD_IMAGE_CONFIG_KEY_DEPRECATED)
 
-        # fmt: off
-        # These browndates matches https://blog.readthedocs.com/use-build-os-config/
-        browndates = any([
-            timezone.datetime(2023, 8, 28, 0, 0, 0, tzinfo=pdt) < now < timezone.datetime(2023, 8, 28, 12, 0, 0, tzinfo=pdt),  # First, 12hs
-            timezone.datetime(2023, 9, 18, 0, 0, 0, tzinfo=pdt) < now < timezone.datetime(2023, 9, 19, 0, 0, 0, tzinfo=pdt),  # Second, 24hs
-            timezone.datetime(2023, 10, 2, 0, 0, 0, tzinfo=pdt) < now < timezone.datetime(2023, 10, 4, 0, 0, 0, tzinfo=pdt),  # Third, 48hs
-            timezone.datetime(2023, 10, 16, 0, 0, 0, tzinfo=pdt) < now,  # Fully removal
-        ])
-        # fmt: on
-
-        if settings.RTD_ENFORCE_BROWNOUTS_FOR_DEPRECATIONS and browndates:
-            build_config_key = self.data.config.source_config.get("build", {})
-            if "image" in build_config_key:
-                raise BuildUserError(BuildUserError.BUILD_IMAGE_CONFIG_KEY_DEPRECATED)
-
-            # TODO: move this validation to the Config object once we are settled here
-            if "image" not in build_config_key and "os" not in build_config_key:
-                raise BuildUserError(BuildUserError.BUILD_OS_REQUIRED)
+        # TODO: move this validation to the Config object once we are settled here
+        if "image" not in build_config_key and "os" not in build_config_key:
+            raise BuildUserError(BuildUserError.BUILD_OS_REQUIRED)
 
         if self.vcs_repository.supports_submodules:
             self.vcs_repository.update_submodules(self.data.config)


### PR DESCRIPTION
We are ahead of the dates for these deprecations, so they became the default path now and we have to always check for them.