### PR TITLE
Build: typo on `on_retry`

### DIFF
--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -684,7 +684,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
                 project_slug=self.data.project.slug,
                 version_slug=self.data.version.slug,
             )
-            self.data.director.attach_notification(
+            self.data.build_director.attach_notification(
                 BuildMaxConcurrencyError.LIMIT_REACHED
             )
             self.update_build(state=BUILD_STATE_TRIGGERED)


### PR DESCRIPTION
I found this on production.

https://read-the-docs.sentry.io/issues/4838648613/?project=148442&query=is%3Aunresolved+%21message%3A%22%21message%3A%22%21message%3A%22SystemExit%22+%21message%3A%22frame-ancestors%22&referrer=issue-stream&statsPeriod=14d&stream_index=0