### PR TITLE
Notifications: bugfix when passing `instance` to the render method

### DIFF
--- a/readthedocs/notifications/messages.py
+++ b/readthedocs/notifications/messages.py
@@ -46,11 +46,17 @@ class Message:
         If we want to support other types or nested dictionaries,
         we will need to iterate recursively to apply the ``escape`` function.
         """
-        return {
+        result = {
             key: escape(value)
             for key, value in format_values.items()
             if isinstance(value, (str, int))
         }
+
+        # TODO: improve this code; I need to hotfix it for now.
+        # We need to keep passing the "instance" that comes from the notification object itself.
+        if "instance" in format_values:
+            result["instance"] = format_values["instance"]
+        return result
 
     def set_format_values(self, format_values):
         self.format_values = self._escape_format_values(format_values)


### PR DESCRIPTION
I found this while doing the deploy:
https://read-the-docs.sentry.io/issues/4838646997/?project=148442&query=is%3Aunresolved+%21message%3A%22%21message%3A%22%21message%3A%22SystemExit%22+%21message%3A%22frame-ancestors%22&referrer=issue-stream&statsPeriod=14d&stream_index=1