### PR TITLE
Notification: oauth typo on URL name

### DIFF
--- a/readthedocs/oauth/tasks.py
+++ b/readthedocs/oauth/tasks.py
@@ -238,7 +238,7 @@ def attach_webhook(project_pk, user_pk, integration=None):
             format_values={
                 "provider_name": provider.name,
                 "url_connect_account": reverse(
-                    "project_integrations",
+                    "projects_integrations",
                     args=[project.slug],
                 ),
             },


### PR DESCRIPTION
I found this on production at
https://read-the-docs.sentry.io/issues/4838793200/?project=148442&query=is%3Aunresolved+%21message%3A%22%21message%3A%22%21message%3A%22SystemExit%22+%21message%3A%22frame-ancestors%22&referrer=issue-stream&statsPeriod=14d&stream_index=3