### PR TITLE
Notifications: use `instance.slug` instead of `instance.name`

### DIFF
--- a/readthedocs/oauth/notifications.py
+++ b/readthedocs/oauth/notifications.py
@@ -23,7 +23,7 @@ messages = [
         body=_(
             textwrap.dedent(
                 """
-            Could not add webhook for {instance.name}.
+            Could not add webhook for "{instance.slug}".
             Please <a href="{url_connect_account}">connect your {provider_name} account</a>.
             """
             ).strip(),
@@ -36,7 +36,7 @@ messages = [
         body=_(
             textwrap.dedent(
                 """
-            Could not add webhook for {instance.name}.
+            Could not add webhook for "{instance.slug}".
             Make sure <a href="{url_docs_webhook}">you have the correct {provider_name} permissions</a>.
             """
             ).strip(),
@@ -49,7 +49,7 @@ messages = [
         body=_(
             textwrap.dedent(
                 """
-        The project {instance.name} doesn't have a valid webhook set up,
+        The project "{instance.slug}" doesn't have a valid webhook set up,
         commits won't trigger new builds for this project.
         See <a href='{url_integrations}'>the project integrations</a> for more information.
             """
@@ -63,7 +63,7 @@ messages = [
         body=_(
             textwrap.dedent(
                 """
-        Could not send {provider_name} build status report for {instance.name}.
+        Could not send {provider_name} build status report for "{instance.slug}".
         Make sure you have the correct {provider_name} repository permissions</a> and
         your <a href="{url_connect_account}">{provider_name} account</a>
         is connected to Read the Docs.

--- a/readthedocs/subscriptions/notifications.py
+++ b/readthedocs/subscriptions/notifications.py
@@ -93,7 +93,7 @@ messages = [
         body=_(
             textwrap.dedent(
                 """
-            The organization "{instance.name}" is currently disabled. You need to <a href="{subscription_url}">renew your subscription</a> to keep using Read the Docs
+            The organization "{instance.slug}" is currently disabled. You need to <a href="{subscription_url}">renew your subscription</a> to keep using Read the Docs
             """
             ).strip(),
         ),


### PR DESCRIPTION
We need to `escape()` some of the values that are controlled by the user before being able to format them.

Related #11016