### PR TITLE
Notifications: initialize exception properly

### DIFF
--- a/readthedocs/projects/exceptions.py
+++ b/readthedocs/projects/exceptions.py
@@ -30,3 +30,5 @@ class RepositoryError(BuildUserError):
 class SyncRepositoryLocked(BuildAppError):
 
     """Error risen when there is another sync_repository_task already running."""
+
+    REPOSITORY_LOCKED = "project:repository:locked"

--- a/readthedocs/projects/notifications.py
+++ b/readthedocs/projects/notifications.py
@@ -3,11 +3,12 @@ import textwrap
 
 from django.utils.translation import gettext_noop as _
 
-from readthedocs.notifications.constants import ERROR, INFO
+from readthedocs.notifications.constants import ERROR, INFO, WARNING
 from readthedocs.notifications.messages import Message, registry
 from readthedocs.projects.exceptions import (
     ProjectConfigurationError,
     RepositoryError,
+    SyncRepositoryLocked,
     UserFileNotFound,
 )
 
@@ -130,6 +131,19 @@ messages = [
             ).strip(),
         ),
         type=ERROR,
+    ),
+    Message(
+        id=SyncRepositoryLocked.REPOSITORY_LOCKED,
+        header=_("Repository locked"),
+        body=_(
+            textwrap.dedent(
+                """
+                We can't perform the versions/branches synchronize at the moment.
+                There is another sync already running.
+            """
+            ).strip(),
+        ),
+        type=WARNING,
     ),
 ]
 registry.add(messages)

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -259,7 +259,7 @@ def sync_repository_task(self, version_id, *, build_api_key, **kwargs):
         # by a different worker.
         # See https://github.com/readthedocs/readthedocs.org/pull/9021/files#r828509016
         if not lock_acquired:
-            raise SyncRepositoryLocked
+            raise SyncRepositoryLocked(SyncRepositoryLocked.REPOSITORY_LOCKED)
 
         self.execute()
 


### PR DESCRIPTION
Required `message_id` was missing when initializing the exception.

Closes https://read-the-docs.sentry.io/issues/4839350524/