### PR TITLE
Notifications: save `format_values` when `on_retry` exception

### DIFF
--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -684,8 +684,12 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
                 project_slug=self.data.project.slug,
                 version_slug=self.data.version.slug,
             )
+
+            # Grab the format values from the exception in case it contains
+            format_values = exc.format_values if hasattr(exc, "format_values") else None
             self.data.director.attach_notification(
-                BuildMaxConcurrencyError.LIMIT_REACHED
+                BuildMaxConcurrencyError.LIMIT_REACHED,
+                format_values=format_values,
             )
             self.update_build(state=BUILD_STATE_TRIGGERED)
 


### PR DESCRIPTION
Sentry issue: https://read-the-docs.sentry.io/issues/4841607731/