### PR TITLE
Notifications: render `Organization` notifications on details page

### DIFF
--- a/readthedocs/organizations/models.py
+++ b/readthedocs/organizations/models.py
@@ -2,6 +2,7 @@
 import structlog
 from autoslug import AutoSlugField
 from django.contrib.auth.models import User
+from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.urls import reverse
@@ -12,6 +13,7 @@ from djstripe.enums import SubscriptionStatus
 from readthedocs.core.history import ExtraHistoricalRecords
 from readthedocs.core.permissions import AdminPermission
 from readthedocs.core.utils import slugify
+from readthedocs.notifications.models import Notification
 
 from . import constants
 from .managers import TeamManager, TeamMemberManager
@@ -116,6 +118,13 @@ class Organization(models.Model):
         related_name="rtd_organization",
         null=True,
         blank=True,
+    )
+
+    notifications = GenericRelation(
+        Notification,
+        related_query_name="organization",
+        content_type_field="attached_to_content_type",
+        object_id_field="attached_to_id",
     )
 
     # Managers

--- a/readthedocs/organizations/templates/organizations/organization_detail.html
+++ b/readthedocs/organizations/templates/organizations/organization_detail.html
@@ -9,6 +9,16 @@
 {% block organization-bar-details %}active{% endblock %}
 
 {% block content %}
+  {% if organization.notifications.exists %}
+    <ul class="notifications">
+    {% for notification in organization.notifications.all %}
+      <li class="notification">
+        {{ notification.get_message.get_rendered_body|safe }}
+      </li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+
   <div class="col-major organization-major">
     <div class="module organization organization-detail">
       {% if projects|length == 0 %}


### PR DESCRIPTION
This work was missed when implementing the new notification system.

![Screenshot_2024-01-10_10-56-20](https://github.com/readthedocs/readthedocs.org/assets/244656/d55aebb5-6d4c-416d-9611-f23faca35e2a)


Related https://github.com/readthedocs/ext-theme/issues/260