### PR TITLE
Development: define `SUPPORT_EMAIL` setting

### DIFF
--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -220,7 +220,7 @@ class DockerBaseSettings(CommunityBaseSettings):
     # Remove the checks on the number of fields being submitted
     # This limit is mostly hit on large forms in the Django admin
     DATA_UPLOAD_MAX_NUMBER_FIELDS = None
-    SUPPORT_EMAIL = "example@company.com"
+    SUPPORT_EMAIL = "support@example.com"
 
 
 DockerBaseSettings.load_settings(__name__)

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -220,6 +220,7 @@ class DockerBaseSettings(CommunityBaseSettings):
     # Remove the checks on the number of fields being submitted
     # This limit is mostly hit on large forms in the Django admin
     DATA_UPLOAD_MAX_NUMBER_FIELDS = None
+    SUPPORT_EMAIL = "example@company.com"
 
 
 DockerBaseSettings.load_settings(__name__)


### PR DESCRIPTION
We had it set to `None` to avoid spam in our own addresses. However, it makes sense to have a valid email here so we can see templates rendered properly when doing development.