### PR TITLE
Addons: update form to show all the options

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -542,6 +542,12 @@ class AddonsConfigForm(forms.ModelForm):
         )
         labels = {
             "enabled": _("Enable Addons"),
+            "external_version_warning_enabled": _(
+                "Show a notification on builds from pull requests"
+            ),
+            "stable_latest_version_warning_enabled": _(
+                "Show a notification on non-stable and latest versions"
+            ),
         }
 
     def __init__(self, *args, **kwargs):

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -540,6 +540,9 @@ class AddonsConfigForm(forms.ModelForm):
             "search_enabled",
             "stable_latest_version_warning_enabled",
         )
+        labels = {
+            "enabled": _("Enable Addons"),
+        }
 
     def __init__(self, *args, **kwargs):
         self.project = kwargs.pop("project", None)

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -529,7 +529,17 @@ class AddonsConfigForm(forms.ModelForm):
 
     class Meta:
         model = AddonsConfig
-        fields = ("enabled", "project")
+        fields = (
+            "enabled",
+            "project",
+            "analytics_enabled",
+            "doc_diff_enabled",
+            "external_version_warning_enabled",
+            "flyout_enabled",
+            "hotkeys_enabled",
+            "search_enabled",
+            "stable_latest_version_warning_enabled",
+        )
 
     def __init__(self, *args, **kwargs):
         self.project = kwargs.pop("project", None)
@@ -540,6 +550,72 @@ class AddonsConfigForm(forms.ModelForm):
             self.fields["enabled"].initial = self.project.addons.enabled
         except AddonsConfig.DoesNotExist:
             self.fields["enabled"].initial = False
+
+        fieldsets = [
+            Fieldset(
+                _("Global"),
+                "enabled",
+            ),
+            Fieldset(
+                _("Analytics"),
+                HTML(
+                    "<p>Analytics addon allows you to store traffic analytics in your project.</p>"
+                ),
+                *[field for field in self.fields if field.startswith("analytics_")],
+            ),
+            Fieldset(
+                _("DocDiff"),
+                HTML(
+                    "<p>DocDicc addon helps you to review changes from PR by visually showing the differences.</p>"
+                ),
+                *[field for field in self.fields if field.startswith("doc_diff_")],
+            ),
+            Fieldset(
+                _("Flyout"),
+                HTML(
+                    "<p>Flyout addon shows a small menu at bottom-right of each page with useful links to switch between versions and translations.</p>"
+                ),
+                *[field for field in self.fields if field.startswith("flyout_")],
+            ),
+            Fieldset(
+                _("Hotkeys"),
+                HTML(
+                    "<p>Hotkeys addon enables keyboard shortcuts to access other addons quickly.</p>"
+                ),
+                *[field for field in self.fields if field.startswith("hotkeys_")],
+            ),
+            Fieldset(
+                _("Search"),
+                HTML(
+                    "<p>Search addon improves your search experience with the search-as-you-type feature.</p>"
+                ),
+                *[field for field in self.fields if field.startswith("search_")],
+            ),
+            Fieldset(
+                _("Warning on PR previews"),
+                HTML("<p>Shows a warning notification on PR previews.</p>"),
+                *[
+                    field
+                    for field in self.fields
+                    if field.startswith("external_version_warning_")
+                ],
+            ),
+            Fieldset(
+                _("Warning on non-stable/latest versions"),
+                HTML(
+                    "<p>Shows a warning notification stable and latest versions letting the user know they may be reading an outdated page or a non-released one.</p>"
+                ),
+                *[
+                    field
+                    for field in self.fields
+                    if field.startswith("stable_latest_version_warning_")
+                ],
+            ),
+        ]
+
+        self.helper = FormHelper()
+        self.helper.layout = Layout(*fieldsets)
+        self.helper.add_input(Submit("save", _("Save")))
 
     def clean_project(self):
         return self.project

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -550,6 +550,10 @@ class AddonsConfigForm(forms.ModelForm):
             self.fields["enabled"].initial = self.project.addons.enabled
         except AddonsConfig.DoesNotExist:
             self.fields["enabled"].initial = False
+        addons, created = AddonsConfig.objects.get_or_create(project=self.project)
+        if created:
+            addons.enabled = False
+            addons.save()
 
         fieldsets = [
             Fieldset(

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -543,83 +543,13 @@ class AddonsConfigForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         self.project = kwargs.pop("project", None)
-        kwargs["instance"] = getattr(self.project, "addons", None)
-        super().__init__(*args, **kwargs)
-
-        try:
-            self.fields["enabled"].initial = self.project.addons.enabled
-        except AddonsConfig.DoesNotExist:
-            self.fields["enabled"].initial = False
         addons, created = AddonsConfig.objects.get_or_create(project=self.project)
         if created:
             addons.enabled = False
             addons.save()
 
-        fieldsets = [
-            Fieldset(
-                _("Global"),
-                "enabled",
-            ),
-            Fieldset(
-                _("Analytics"),
-                HTML(
-                    "<p>Analytics addon allows you to store traffic analytics in your project.</p>"
-                ),
-                *[field for field in self.fields if field.startswith("analytics_")],
-            ),
-            Fieldset(
-                _("DocDiff"),
-                HTML(
-                    "<p>DocDicc addon helps you to review changes from PR by visually showing the differences.</p>"
-                ),
-                *[field for field in self.fields if field.startswith("doc_diff_")],
-            ),
-            Fieldset(
-                _("Flyout"),
-                HTML(
-                    "<p>Flyout addon shows a small menu at bottom-right of each page with useful links to switch between versions and translations.</p>"
-                ),
-                *[field for field in self.fields if field.startswith("flyout_")],
-            ),
-            Fieldset(
-                _("Hotkeys"),
-                HTML(
-                    "<p>Hotkeys addon enables keyboard shortcuts to access other addons quickly.</p>"
-                ),
-                *[field for field in self.fields if field.startswith("hotkeys_")],
-            ),
-            Fieldset(
-                _("Search"),
-                HTML(
-                    "<p>Search addon improves your search experience with the search-as-you-type feature.</p>"
-                ),
-                *[field for field in self.fields if field.startswith("search_")],
-            ),
-            Fieldset(
-                _("Warning on PR previews"),
-                HTML("<p>Shows a warning notification on PR previews.</p>"),
-                *[
-                    field
-                    for field in self.fields
-                    if field.startswith("external_version_warning_")
-                ],
-            ),
-            Fieldset(
-                _("Warning on non-stable/latest versions"),
-                HTML(
-                    "<p>Shows a warning notification stable and latest versions letting the user know they may be reading an outdated page or a non-released one.</p>"
-                ),
-                *[
-                    field
-                    for field in self.fields
-                    if field.startswith("stable_latest_version_warning_")
-                ],
-            ),
-        ]
-
-        self.helper = FormHelper()
-        self.helper.layout = Layout(*fieldsets)
-        self.helper.add_input(Submit("save", _("Save")))
+        kwargs["instance"] = addons
+        super().__init__(*args, **kwargs)
 
     def clean_project(self):
         return self.project

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1977,25 +1977,6 @@ class Feature(models.Model):
     # Build related features
     SCALE_IN_PROTECTION = "scale_in_prtection"
 
-    # Addons related features
-    HOSTING_INTEGRATIONS = "hosting_integrations"
-    # NOTE: this is mainly temporal while we are rolling these features out.
-    # The idea here is to have more control over particular projects and do some testing.
-    # All these features will be enabled by default to all projects,
-    # and we can disable them if we want to
-    ADDONS_ANALYTICS_DISABLED = "addons_analytics_disabled"
-    ADDONS_DOC_DIFF_DISABLED = "addons_doc_diff_disabled"
-    ADDONS_ETHICALADS_DISABLED = "addons_ethicalads_disabled"
-    ADDONS_EXTERNAL_VERSION_WARNING_DISABLED = (
-        "addons_external_version_warning_disabled"
-    )
-    ADDONS_FLYOUT_DISABLED = "addons_flyout_disabled"
-    ADDONS_NON_LATEST_VERSION_WARNING_DISABLED = (
-        "addons_non_latest_version_warning_disabled"
-    )
-    ADDONS_SEARCH_DISABLED = "addons_search_disabled"
-    ADDONS_HOTKEYS_DISABLED = "addons_hotkeys_disabled"
-
     FEATURES = (
         (
             MKDOCS_THEME_RTD,
@@ -2092,45 +2073,6 @@ class Feature(models.Model):
         (
             SCALE_IN_PROTECTION,
             _("Build: Set scale-in protection before/after building."),
-        ),
-        # Addons related features.
-        (
-            HOSTING_INTEGRATIONS,
-            _(
-                "Proxito: Inject 'readthedocs-addons.js' as <script> HTML tag in responses."
-            ),
-        ),
-        (
-            ADDONS_ANALYTICS_DISABLED,
-            _("Addons: Disable Analytics."),
-        ),
-        (
-            ADDONS_DOC_DIFF_DISABLED,
-            _("Addons: Disable Doc Diff."),
-        ),
-        (
-            ADDONS_ETHICALADS_DISABLED,
-            _("Addons: Disable EthicalAds."),
-        ),
-        (
-            ADDONS_EXTERNAL_VERSION_WARNING_DISABLED,
-            _("Addons: Disable External version warning."),
-        ),
-        (
-            ADDONS_FLYOUT_DISABLED,
-            _("Addons: Disable Flyout."),
-        ),
-        (
-            ADDONS_NON_LATEST_VERSION_WARNING_DISABLED,
-            _("Addons: Disable Non latest version warning."),
-        ),
-        (
-            ADDONS_SEARCH_DISABLED,
-            _("Addons: Disable Search."),
-        ),
-        (
-            ADDONS_HOTKEYS_DISABLED,
-            _("Addons: Disable Hotkeys."),
         ),
     )
 

--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -17,7 +17,7 @@ from readthedocs.projects.constants import (
     PUBLIC,
     SINGLE_VERSION_WITHOUT_TRANSLATIONS,
 )
-from readthedocs.projects.models import Domain, Project
+from readthedocs.projects.models import AddonsConfig, Domain, Project
 
 
 @override_settings(

--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -131,7 +131,7 @@ class TestReadTheDocsConfigJson(TestCase):
     def test_disabled_addons_via_addons_config(self):
         addons = fixture.get(
             AddonsConfig,
-            projects=[self.project],
+            project=self.project,
         )
         addons.analytics_enabled = False
         addons.doc_diff_enabled = False

--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -141,6 +141,7 @@ class TestReadTheDocsConfigJson(TestCase):
         addons.hotkeys_enabled = False
         addons.search_enabled = False
         addons.stable_latest_version_warning_enabled = False
+        addons.save()
 
         r = self.client.get(
             reverse("proxito_readthedocs_docs_addons"),

--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -17,7 +17,7 @@ from readthedocs.projects.constants import (
     PUBLIC,
     SINGLE_VERSION_WITHOUT_TRANSLATIONS,
 )
-from readthedocs.projects.models import Domain, Feature, Project
+from readthedocs.projects.models import Domain, Project
 
 
 @override_settings(
@@ -128,42 +128,19 @@ class TestReadTheDocsConfigJson(TestCase):
         assert r.status_code == 400
         assert r.json() == self._get_response_dict("v2")
 
-    def test_disabled_addons_via_feature_flags(self):
-        fixture.get(
-            Feature,
+    def test_disabled_addons_via_addons_config(self):
+        addons = fixture.get(
+            AddonsConfig,
             projects=[self.project],
-            feature_id=Feature.ADDONS_ANALYTICS_DISABLED,
         )
-        fixture.get(
-            Feature,
-            projects=[self.project],
-            feature_id=Feature.ADDONS_EXTERNAL_VERSION_WARNING_DISABLED,
-        )
-        fixture.get(
-            Feature,
-            projects=[self.project],
-            feature_id=Feature.ADDONS_NON_LATEST_VERSION_WARNING_DISABLED,
-        )
-        fixture.get(
-            Feature,
-            projects=[self.project],
-            feature_id=Feature.ADDONS_DOC_DIFF_DISABLED,
-        )
-        fixture.get(
-            Feature,
-            projects=[self.project],
-            feature_id=Feature.ADDONS_FLYOUT_DISABLED,
-        )
-        fixture.get(
-            Feature,
-            projects=[self.project],
-            feature_id=Feature.ADDONS_SEARCH_DISABLED,
-        )
-        fixture.get(
-            Feature,
-            projects=[self.project],
-            feature_id=Feature.ADDONS_HOTKEYS_DISABLED,
-        )
+        addons.analytics_enabled = False
+        addons.doc_diff_enabled = False
+        addons.external_version_warning_enabled = False
+        addons.ethicalads_enabled = False
+        addons.flyout_enabled = False
+        addons.hotkeys_enabled = False
+        addons.search_enabled = False
+        addons.stable_latest_version_warning_enabled = False
 
         r = self.client.get(
             reverse("proxito_readthedocs_docs_addons"),
@@ -678,7 +655,7 @@ class TestReadTheDocsConfigJson(TestCase):
                 active=True,
             )
 
-        with self.assertNumQueries(17):
+        with self.assertNumQueries(20):
             r = self.client.get(
                 reverse("proxito_readthedocs_docs_addons"),
                 {
@@ -707,7 +684,7 @@ class TestReadTheDocsConfigJson(TestCase):
                 active=True,
             )
 
-        with self.assertNumQueries(17):
+        with self.assertNumQueries(20):
             r = self.client.get(
                 reverse("proxito_readthedocs_docs_addons"),
                 {
@@ -743,7 +720,7 @@ class TestReadTheDocsConfigJson(TestCase):
                 active=True,
             )
 
-        with self.assertNumQueries(21):
+        with self.assertNumQueries(24):
             r = self.client.get(
                 reverse("proxito_readthedocs_docs_addons"),
                 {
@@ -769,7 +746,7 @@ class TestReadTheDocsConfigJson(TestCase):
                 language=language,
             )
 
-        with self.assertNumQueries(21):
+        with self.assertNumQueries(24):
             r = self.client.get(
                 reverse("proxito_readthedocs_docs_addons"),
                 {

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -23,7 +23,7 @@ from readthedocs.builds.models import Version
 from readthedocs.core.resolver import Resolver
 from readthedocs.core.unresolver import UnresolverError, unresolver
 from readthedocs.core.utils.extend import SettingsOverrideObject
-from readthedocs.projects.models import Project
+from readthedocs.projects.models import AddonsConfig, Project
 
 log = structlog.get_logger(__name__)  # noqa
 
@@ -280,15 +280,9 @@ class AddonsResponse:
             #     en (original), es, ru
             project_translations = itertools.chain([main_project], project_translations)
 
-        # Make one DB query here and then check on Python code
-        # TODO: make usage of ``Project.addons.<name>_enabled`` to decide if enabled
-        #
-        # NOTE: using ``feature_id__startswith="addons_"`` to make the query faster.
-        # It went down from 20ms to 1ms since it does not have to check the
-        # `Project.pub_date` against all the features.
-        project_features = project.features.filter(
-            feature_id__startswith="addons_"
-        ).values_list("feature_id", flat=True)
+        # Automatically create an AddonsConfig with the default values for
+        # projects that don't have one already
+        AddonsConfig.objects.get_or_create(project=project)
 
         data = {
             "api_version": "0",

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -23,7 +23,7 @@ from readthedocs.builds.models import Version
 from readthedocs.core.resolver import Resolver
 from readthedocs.core.unresolver import UnresolverError, unresolver
 from readthedocs.core.utils.extend import SettingsOverrideObject
-from readthedocs.projects.models import Feature, Project
+from readthedocs.projects.models import Project
 
 log = structlog.get_logger(__name__)  # noqa
 
@@ -320,8 +320,7 @@ class AddonsResponse:
             # serializer than the keys ``project``, ``version`` and ``build`` from the top level.
             "addons": {
                 "analytics": {
-                    "enabled": Feature.ADDONS_ANALYTICS_DISABLED
-                    not in project_features,
+                    "enabled": project.addons.analytics_enabled,
                     # TODO: consider adding this field into the ProjectSerializer itself.
                     # NOTE: it seems we are removing this feature,
                     # so we may not need the ``code`` attribute here
@@ -329,15 +328,13 @@ class AddonsResponse:
                     "code": project.analytics_code,
                 },
                 "external_version_warning": {
-                    "enabled": Feature.ADDONS_EXTERNAL_VERSION_WARNING_DISABLED
-                    not in project_features,
+                    "enabled": project.addons.external_version_warning_enabled,
                     # NOTE: I think we are moving away from these selectors
                     # since we are doing floating noticications now.
                     # "query_selector": "[role=main]",
                 },
                 "non_latest_version_warning": {
-                    "enabled": Feature.ADDONS_NON_LATEST_VERSION_WARNING_DISABLED
-                    not in project_features,
+                    "enabled": project.addons.stable_latest_version_warning_enabled,
                     # NOTE: I think we are moving away from these selectors
                     # since we are doing floating noticications now.
                     # "query_selector": "[role=main]",
@@ -346,7 +343,7 @@ class AddonsResponse:
                     ),
                 },
                 "flyout": {
-                    "enabled": Feature.ADDONS_FLYOUT_DISABLED not in project_features,
+                    "enabled": project.addons.flyout_enabled,
                     "translations": [
                         {
                             # TODO: name this field "display_name"
@@ -398,7 +395,7 @@ class AddonsResponse:
                     # },
                 },
                 "search": {
-                    "enabled": Feature.ADDONS_SEARCH_DISABLED not in project_features,
+                    "enabled": project.addons.search_enabled,
                     "project": project.slug,
                     "version": version.slug if version else None,
                     "api_endpoint": "/_/api/v3/search/",
@@ -416,7 +413,7 @@ class AddonsResponse:
                     else None,
                 },
                 "hotkeys": {
-                    "enabled": Feature.ADDONS_HOTKEYS_DISABLED not in project_features,
+                    "enabled": project.addons.hotkeys_enabled,
                     "doc_diff": {
                         "enabled": True,
                         "trigger": "KeyD",  # Could be something like "Ctrl + D"
@@ -437,8 +434,7 @@ class AddonsResponse:
             data["addons"].update(
                 {
                     "doc_diff": {
-                        "enabled": Feature.ADDONS_DOC_DIFF_DISABLED
-                        not in project_features,
+                        "enabled": project.addons.doc_diff_enabled,
                         # "http://test-builds-local.devthedocs.org/en/latest/index.html"
                         "base_url": resolver.resolve(
                             project=project,
@@ -478,8 +474,7 @@ class AddonsResponse:
             data["addons"].update(
                 {
                     "ethicalads": {
-                        "enabled": Feature.ADDONS_ETHICALADS_DISABLED
-                        not in project_features,
+                        "enabled": project.addons.ethicalads_enabled,
                         # NOTE: this endpoint is not authenticated, the user checks are done over an annonymous user for now
                         #
                         # NOTE: it requires ``settings.USE_PROMOS=True`` to return ``ad_free=false`` here


### PR DESCRIPTION
Add all the configuration options to the `AddonsConfigForm` so the user is able to enable/disable each of the addons independently.

This is the initial version of this work. We will keep adding more configuration options to each of the addons. That's why I decided to create one section per each. In the future, instead of just a regular `FieldSet` we can get more fancy and use tabs instead (creating a custom class or giving it a try to https://crispy-forms-gds.readthedocs.io/en/latest/components/tabs.html)

## Preview

![Screenshot 2024-01-15 at 16-04-18 test-builds - Addons - Read the Docs](https://github.com/readthedocs/readthedocs.org/assets/244656/7b631ee1-e66a-4444-88bb-f16159cbf9d1)


## ToDo

- [x] get a review on the copy for each of the sections
- [ ] migrate projects with `Feature` flags to disable specific addons

Closes https://github.com/readthedocs/ext-theme/issues/211