### PR TITLE
Admin: remove "default settings"

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -4,13 +4,10 @@ from random import choice
 from re import fullmatch
 from urllib.parse import urlparse
 
-from crispy_forms.helper import FormHelper
-from crispy_forms.layout import HTML, Fieldset, Layout, Submit
 from django import forms
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.db.models import Q
-from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
@@ -202,7 +199,7 @@ class ProjectAdvancedForm(ProjectTriggerBuildMixin, ProjectForm):
 
     class Meta:
         model = Project
-        per_project_settings = (
+        fields = (
             "default_version",
             "default_branch",
             "privacy_level",
@@ -213,20 +210,6 @@ class ProjectAdvancedForm(ProjectTriggerBuildMixin, ProjectForm):
             "external_builds_enabled",
             "external_builds_privacy_level",
             "readthedocs_yaml_path",
-        )
-        # These that can be set per-version using a config file.
-        per_version_settings = (
-            "documentation_type",
-            "requirements_file",
-            "python_interpreter",
-            "install_project",
-            "conf_py_file",
-            "enable_pdf_build",
-            "enable_epub_build",
-        )
-        fields = (
-            *per_project_settings,
-            *per_version_settings,
         )
 
     def __init__(self, *args, **kwargs):
@@ -253,43 +236,15 @@ class ProjectAdvancedForm(ProjectTriggerBuildMixin, ProjectForm):
             )
             self.fields["versioning_scheme"].disabled = True
 
-        self.helper = FormHelper()
-        help_text = render_to_string(
-            'projects/project_advanced_settings_helptext.html'
-        )
-
-        per_project_settings = list(self.Meta.per_project_settings)
-
         # NOTE: we are deprecating this feature.
         # However, we will keep it available for projects that already using it.
         # Old projects not using it already or new projects won't be able to enable.
         if not self.instance.has_feature(Feature.ALLOW_VERSION_WARNING_BANNER):
             self.fields.pop("show_version_warning")
-            per_project_settings.remove("show_version_warning")
 
         if not settings.ALLOW_PRIVATE_REPOS:
             for field in ['privacy_level', 'external_builds_privacy_level']:
                 self.fields.pop(field)
-                per_project_settings.remove(field)
-
-        # TODO: remove the "Global settings" fieldset since we only have one
-        # fieldset not. Also, considering merging this "Advanced settings" with
-        # the regular "Settings" tab. Also also, take into account that we may
-        # want to add a new tab for "Read the Docs Addons" to configure each of
-        # them from there.
-        field_sets = [
-            Fieldset(
-                _("Global settings"),
-                *per_project_settings,
-            ),
-            Fieldset(
-                _("Default settings"),
-                HTML(help_text),
-                *self.Meta.per_version_settings,
-            ),
-        ]
-        self.helper.layout = Layout(*field_sets)
-        self.helper.add_input(Submit('save', _('Save')))
 
         default_choice = (None, '-' * 9)
         versions_choices = self.instance.versions(manager=INTERNAL).filter(
@@ -309,11 +264,6 @@ class ProjectAdvancedForm(ProjectTriggerBuildMixin, ProjectForm):
             )
         else:
             self.fields['default_version'].widget.attrs['readonly'] = True
-
-        # Disable "per_version_settings" because they are deprecated.
-        # This fieldset will be removed in the next few weeks, after giving users some time to perform the migration.
-        for field in self.Meta.per_version_settings:
-            self.fields[field].disabled = True
 
         self.setup_external_builds_option()
 

--- a/readthedocs/templates/projects/project_advanced.html
+++ b/readthedocs/templates/projects/project_advanced.html
@@ -15,8 +15,6 @@
 {% block project_edit_content %}
 <form method="post" action=".">{% csrf_token %}
   {{ form|crispy }}
-  <p>
-    <input style="display: inline;" type="submit" value="{% trans "Save" %}">
-  </p>
+  <input type="submit" value="{% trans "Save" %}">
 </form>
 {% endblock %}

--- a/readthedocs/templates/projects/project_advanced.html
+++ b/readthedocs/templates/projects/project_advanced.html
@@ -13,5 +13,10 @@
 {% block project_edit_content_header %}{% trans "Advanced Settings" %}{% endblock %}
 
 {% block project_edit_content %}
-  {% crispy form %}
+<form method="post" action=".">{% csrf_token %}
+  {{ form|crispy }}
+  <p>
+    <input style="display: inline;" type="submit" value="{% trans "Save" %}">
+  </p>
+</form>
 {% endblock %}

--- a/readthedocs/templates/projects/project_advanced_settings_helptext.html
+++ b/readthedocs/templates/projects/project_advanced_settings_helptext.html
@@ -1,9 +1,0 @@
-{% load i18n %}
-<p class="empty">
-  {% blocktrans trimmed with deprecation_link="https://blog.readthedocs.com/migrate-configuration-v2/" %}
-    Usage of the below settings is <strong>deprecated</strong> and support for these fields was removed on <strong>September 25th, 2023</strong>.
-    Their values are shown here in read-only to allow you to migrate to the YAML config file if you haven't already.
-    <br><br>
-    Read our blog post <a href="{{ deprecation_link }}" target="_blank">Migrate your project to .readthedocs.yaml configuration file v2</a> to learn how to perform the migration.
-  {% endblocktrans %}
-</p>


### PR DESCRIPTION
These settings have been disabled for 6 months already. They are useless now that we _require_ a `readthedocs.yaml` file.

Closes https://github.com/readthedocs/ext-theme/issues/159