### PR TITLE
Docs: remove dead example

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,7 +97,6 @@ intersphinx_mapping = {
     "jupytext": ("https://jupytext.readthedocs.io/en/stable/", None),
     "ipyleaflet": ("https://ipyleaflet.readthedocs.io/en/latest/", None),
     "poliastro": ("https://docs.poliastro.space/en/stable/", None),
-    "qiskit": ("https://qiskit.org/documentation/", None),
     "myst-parser": ("https://myst-parser.readthedocs.io/en/stable/", None),
     "writethedocs": ("https://www.writethedocs.org/", None),
     "jupyterbook": ("https://jupyterbook.org/en/stable/", None),

--- a/docs/user/guides/jupyter.rst
+++ b/docs/user/guides/jupyter.rst
@@ -309,9 +309,6 @@ To see some examples of notebook galleries in the wild:
   In addition, `poliastro uses unpaired MyST
   Notebooks <https://github.com/poliastro/poliastro/tree/0.15.x/docs/source/examples>`_
   to reduce repository size and improve integration with git.
-- `Qiskit <https://qiskit.org/>`_ is a framework for quantum computing
-  that leverages ``nbgallery`` :doc:`for its tutorials <qiskit:tutorials>`
-  and uses a highly customized style to match the branding of the website.
 
 Background
 ----------


### PR DESCRIPTION
Builds are failing due to a warning of a broken link.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11047.org.readthedocs.build/en/11047/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11047.org.readthedocs.build/en/11047/

<!-- readthedocs-preview dev end -->