### PR TITLE
APIv3: bring back `OrganizationsViewSet` that was removed

### DIFF
--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -1103,6 +1103,7 @@ class EnvironmentVariableSerializer(serializers.ModelSerializer):
 class OrganizationLinksSerializer(BaseLinksSerializer):
     _self = serializers.SerializerMethodField()
     projects = serializers.SerializerMethodField()
+    notifications = serializers.SerializerMethodField()
 
     def get__self(self, obj):
         path = reverse(
@@ -1118,6 +1119,15 @@ class OrganizationLinksSerializer(BaseLinksSerializer):
             "organizations-projects-list",
             kwargs={
                 "parent_lookup_organizations__slug": obj.slug,
+            },
+        )
+        return self._absolute_url(path)
+
+    def get_notifications(self, obj):
+        path = reverse(
+            "organizations-notifications-list",
+            kwargs={
+                "parent_lookup_organization__slug": obj.slug,
             },
         )
         return self._absolute_url(path)

--- a/readthedocs/api/v3/tests/test_organizations.py
+++ b/readthedocs/api/v3/tests/test_organizations.py
@@ -114,7 +114,7 @@ class OrganizationsEndpointTests(APIEndpointMixin):
 
         self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.others_token.key}")
         response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 403)
 
     def test_organizations_notifications_detail_patch(self):
         url = reverse(

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -58,7 +58,12 @@ from .mixins import (
     UpdateMixin,
     UserQuerySetMixin,
 )
-from .permissions import CommonPermissions, IsOrganizationAdminMember, IsProjectAdmin
+from .permissions import (
+    CommonPermissions,
+    IsOrganizationAdmin,
+    IsOrganizationAdminMember,
+    IsProjectAdmin,
+)
 from .renderers import AlphabeticalSortedJSONRenderer
 from .serializers import (
     BuildCreateSerializer,
@@ -671,6 +676,7 @@ class NotificationsOrganizationViewSet(
     serializer_class = NotificationSerializer
     queryset = Notification.objects.all()
     filterset_class = NotificationFilter
+    permission_classes = [IsAuthenticated & IsOrganizationAdmin]
 
     def get_queryset(self):
         content_type = ContentType.objects.get_for_model(Organization)


### PR DESCRIPTION
This view was used on "Read the Docs for Business". See https://docs.readthedocs.io/en/stable/api/v3.html#organizations

It was deleted in
https://github.com/readthedocs/readthedocs.org/pull/11009/files#diff-1b2fcccf6a94ac362220161670adaf288aaece7381f18909cdd1da5e044d134a

I put them back here and make them extendable, so we can overwrite one of them from "Read the Docs for Business".