### PR TITLE
Docs: move warning from embed API to the top

### DIFF
--- a/docs/user/api/v3.rst
+++ b/docs/user/api/v3.rst
@@ -1894,6 +1894,11 @@ Embed
     Retrieve HTML-formatted content from documentation page or section.
     Read :doc:`/guides/embedding-content` to know more about how to use this endpoint.
 
+    .. warning::
+
+       The content will be returned as is, without any sanitization or escaping.
+       You should not include content from arbitrary projects, or projects you do not trust.
+
     **Example request**:
 
     .. prompt:: bash $
@@ -1924,11 +1929,6 @@ Embed
 
        Passing ``?doctool=`` and ``?doctoolversion=`` may improve the response,
        since the endpoint will know more about the exact structure of the HTML and can make better decisions.
-
-    .. warning::
-
-       The content will be returned as is, without any sanitization or escaping.
-       You should not include content from arbitrary projects, or projects you do not trust.
 
 Additional APIs
 ---------------


### PR DESCRIPTION


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11053.org.readthedocs.build/en/11053/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11053.org.readthedocs.build/en/11053/

<!-- readthedocs-preview dev end -->