### PR TITLE
Embed API: fix regex patterns for allowed external domains

### DIFF
--- a/readthedocs/embed/v3/tests/test_basics.py
+++ b/readthedocs/embed/v3/tests/test_basics.py
@@ -10,7 +10,7 @@ class TestEmbedAPIv3Basics:
     @pytest.fixture(autouse=True)
     def setup_method(self, settings):
         settings.PUBLIC_DOMAIN = "readthedocs.io"
-        settings.RTD_EMBED_API_EXTERNAL_DOMAINS = ["docs.project.com"]
+        settings.RTD_EMBED_API_EXTERNAL_DOMAINS = [r"^docs\.project\.com$"]
 
         self.api_url = reverse("embed_api_v3")
 

--- a/readthedocs/embed/v3/tests/test_external_pages.py
+++ b/readthedocs/embed/v3/tests/test_external_pages.py
@@ -14,7 +14,7 @@ class TestEmbedAPIv3ExternalPages:
     @pytest.fixture(autouse=True)
     def setup_method(self, settings):
         settings.PUBLIC_DOMAIN = "readthedocs.io"
-        settings.RTD_EMBED_API_EXTERNAL_DOMAINS = ["docs.project.com"]
+        settings.RTD_EMBED_API_EXTERNAL_DOMAINS = [r"^docs\.project\.com$"]
 
         self.api_url = reverse("embed_api_v3")
 

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -932,10 +932,10 @@ class CommunityBaseSettings(Settings):
     MAILERLITE_API_KEY = None
 
     RTD_EMBED_API_EXTERNAL_DOMAINS = [
-        r'docs\.python\.org',
-        r'docs\.scipy\.org',
-        r'docs\.sympy\.org',
-        r'numpy\.org',
+        r'^docs\.python\.org$',
+        r'^docs\.scipy\.org$',
+        r'^docs\.sympy\.org$',
+        r'^numpy\.org$',
     ]
     RTD_EMBED_API_PAGE_CACHE_TIMEOUT = 5 * 10
     RTD_EMBED_API_DEFAULT_REQUEST_TIMEOUT = 1

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -83,10 +83,10 @@ class DockerBaseSettings(CommunityBaseSettings):
         domains = super().RTD_EMBED_API_EXTERNAL_DOMAINS
         domains.extend(
             [
-                r".*\.readthedocs\.io",
-                r".*\.org\.readthedocs\.build",
-                r".*\.readthedocs-hosted\.com",
-                r".*\.com\.readthedocs\.build",
+                r"^.*\.readthedocs\.io$",
+                r"^.*\.org\.readthedocs\.build$",
+                r"^.*\.readthedocs-hosted\.com$",
+                r"^.*\.com\.readthedocs\.build$",
             ]
         )
         return domains


### PR DESCRIPTION
The patterns were not ending with `$`,
so any domain that started with the allowed domain would be allowed (docs.python.org.example.com).

This isn't a security issue, since including content from a domain that isn't allowed is not differently than including content from a domain that is hosted on RTD (users shouldn't allow including content from projects they don't trust).
This is mostly to prevent abuse.