### PR TITLE
Fix migration

### DIFF
--- a/readthedocs/projects/migrations/0113_disable_analytics_addons.py
+++ b/readthedocs/projects/migrations/0113_disable_analytics_addons.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("projects", "0111_add_multiple_versions_without_translations"),
+        ("projects", "0112_alter_project_help_text"),
     ]
 
     operations = [


### PR DESCRIPTION
https://github.com/readthedocs/readthedocs.org/pull/11056 was merged together with https://github.com/readthedocs/readthedocs.org/commit/1cf47ce39764ea2d342d1e00c4c2e545dc7040df.

Both have a migration over the projects table,
I'm reaming the migration from #11056, since the other one is already applied in production.