### PR TITLE
Custom domain: don't allow external domain

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -818,8 +818,15 @@ class DomainForm(forms.ModelForm):
 
         domain_string = parsed.netloc
 
-        # Don't allow production or public domain to be set as custom domain
-        for invalid_domain in [settings.PRODUCTION_DOMAIN, settings.PUBLIC_DOMAIN]:
+        # Don't allow internal domains to be added, we have:
+        # - Dashboard domain
+        # - Public domain (from where documentation pages are served)
+        # - External version domain (from where PR previews are served)
+        for invalid_domain in [
+            settings.PRODUCTION_DOMAIN,
+            settings.PUBLIC_DOMAIN,
+            settings.RTD_EXTERNAL_VERSION_DOMAIN,
+        ]:
             if invalid_domain and domain_string.endswith(invalid_domain):
                 raise forms.ValidationError(
                     f'{invalid_domain} is not a valid domain.'

--- a/readthedocs/rtd_tests/tests/test_domains.py
+++ b/readthedocs/rtd_tests/tests/test_domains.py
@@ -101,7 +101,7 @@ class FormTests(TestCase):
             )
             self.assertFalse(form.is_valid())
             self.assertEqual(
-                form.errors["domain"][0], f"{domain} is not a valid domain."
+                form.errors["domain"][0], "readthedocs.build is not a valid domain."
             )
 
     def test_domain_with_path(self):

--- a/readthedocs/rtd_tests/tests/test_domains.py
+++ b/readthedocs/rtd_tests/tests/test_domains.py
@@ -92,6 +92,18 @@ class FormTests(TestCase):
             f"{settings.PUBLIC_DOMAIN} is not a valid domain.",
         )
 
+    @override_settings(RTD_EXTERNAL_VERSION_DOMAIN="readthedocs.build")
+    def test_external_domain_not_allowed(self):
+        for domain in ["readthedocs.build", "test.readthedocs.build"]:
+            form = DomainForm(
+                {"domain": domain},
+                project=self.project,
+            )
+            self.assertFalse(form.is_valid())
+            self.assertEqual(
+                form.errors["domain"][0], f"{domain} is not a valid domain."
+            )
+
     def test_domain_with_path(self):
         form = DomainForm(
             {"domain": "domain.com/foo/bar"},


### PR DESCRIPTION
We have a CNAME from our external domain to readthedocs.io, making these domains valid if they are added to a project.

This isn't a security issue, since our code won't resolve those domains because custom domains are checked last, and we have this protection in place:

https://github.com/readthedocs/readthedocs.org/blob/7daff3d6cc953898934cc80cba53403d6e0fa259/readthedocs/core/unresolver.py#L590-L594