### PR TITLE
Analytics: don't record page views for PR previews

### DIFF
--- a/readthedocs/analytics/models.py
+++ b/readthedocs/analytics/models.py
@@ -25,25 +25,25 @@ class PageViewManager(models.Manager):
 
     """Manager for PageView model."""
 
-    def register_page_view(self, project, version, path, full_path, status):
+    def register_page_view(self, project, version, filename, path, status):
         """Track page view with the given parameters."""
         # TODO: remove after the migration of duplicate records has been completed.
         if project.has_feature(Feature.DISABLE_PAGEVIEWS):
             return
 
         # Normalize paths to avoid duplicates.
+        filename = "/" + filename.lstrip("/")
         path = "/" + path.lstrip("/")
-        full_path = "/" + full_path.lstrip("/")
 
         page_view, created = self.get_or_create(
             project=project,
             version=version,
-            path=path,
+            path=filename,
             date=timezone.now().date(),
             status=status,
             defaults={
                 "view_count": 1,
-                "full_path": full_path,
+                "full_path": path,
             },
         )
         if not created:

--- a/readthedocs/analytics/proxied_api.py
+++ b/readthedocs/analytics/proxied_api.py
@@ -75,7 +75,8 @@ class BaseAnalyticsView(CDNCacheControlMixin, APIView):
         """Increase the page view count for the given project."""
         if is_suspicious_request(self.request):
             log.info(
-                "Suspicious request, not recording 404.",
+                "Suspicious request, not recording pageview.",
+                url=absolute_uri,
             )
             return
 

--- a/readthedocs/analytics/proxied_api.py
+++ b/readthedocs/analytics/proxied_api.py
@@ -80,6 +80,7 @@ class BaseAnalyticsView(CDNCacheControlMixin, APIView):
             )
             return
 
+        # Don't allow tracking page views from external domains.
         if self.request.unresolved_domain.is_from_external_domain:
             return
 
@@ -90,6 +91,7 @@ class BaseAnalyticsView(CDNCacheControlMixin, APIView):
             # isn't pointing to a valid RTD project.
             return
 
+        # Don't track external versions.
         if version.is_external or not unresolved.filename:
             return
 

--- a/readthedocs/core/utils/requests.py
+++ b/readthedocs/core/utils/requests.py
@@ -1,0 +1,24 @@
+import structlog
+
+log = structlog.get_logger(__name__)  # noqa
+
+
+def is_suspicious_request(request) -> bool:
+    """
+    Returns True if the request is suspicious.
+
+    This function is used to detect bots and spammers,
+    we use Cloudflare to detect them.
+    """
+    # This header is set from Cloudflare,
+    # it goes from 0 to 100, 0 being low risk,
+    # and values above 10 are bots/spammers.
+    # https://developers.cloudflare.com/ruleset-engine/rules-language/fields/#dynamic-fields.
+    threat_score = int(request.headers.get("X-Cloudflare-Threat-Score", 0))
+    if threat_score > 10:
+        log.info(
+            "Suspicious threat score",
+            threat_score=threat_score,
+        )
+        return True
+    return False


### PR DESCRIPTION
PR previews are ephemeral, they shouldn't be counted as page views.

Other changes are:

- Changed some variables to use the new naming from https://github.com/readthedocs/readthedocs.org/blob/main/readthedocs/proxito/README.rst#url-parts
- Don't record page views from suspicious requests, previously we were doing this check for 404s only.