### PR TITLE
Addons: `build.current` API response fix

### DIFF
--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -114,7 +114,10 @@ class BaseReadTheDocsConfigJson(CDNCacheTagsMixin, APIView):
             project = Project.objects.filter(slug=project_slug).first()
             version = Version.objects.filter(slug=version_slug, project=project).first()
             if version:
-                build = version.builds.first()
+                build = version.builds.filter(
+                    success=True,
+                    state=BUILD_STATE_FINISHED,
+                ).first()
 
         return project, version, build, filename
 


### PR DESCRIPTION
When _not sending `url=` parameter_, we were returning the lastest build by date, but we need to filter it by `state=finished` and `success=True` in the same way as we are doing when sending the `url=` parameter.

I found this while working on https://github.com/readthedocs/addons/issues/88