### PR TITLE
add example list for showing basic asciidoc using Antora 

### DIFF
--- a/docs/user/examples.rst
+++ b/docs/user/examples.rst
@@ -32,7 +32,10 @@ Sphinx and MkDocs examples
      - Jupyter Book and Sphinx
      - `[Git] <https://github.com/readthedocs-examples/example-jupyter-book/>`__ `[Rendered] <https://example-jupyter-book.readthedocs.io/>`__
      - Jupyter Book with popular integrations configured
-
+   * - Basic AsciiDoc
+     - Antora
+     - `[Git] <https://github.com/man-chi/example-antora-basic/>`__ `[Rendered] <https://example-antora-basic.readthedocs.io/>`__
+     - Antora with asciidoctor-kroki extension configured for AsciiDoc and Diagram as Code.
 
 Real-life examples
 ------------------


### PR DESCRIPTION

I would like to contribute my example for AsciiDoc using Antora site generator and asciidoctor-kroki diagramming

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11091.org.readthedocs.build/en/11091/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11091.org.readthedocs.build/en/11091/

<!-- readthedocs-preview dev end -->