### PR TITLE
Some fixes for notifications

### DIFF
--- a/readthedocs/doc_builder/exceptions.py
+++ b/readthedocs/doc_builder/exceptions.py
@@ -11,20 +11,18 @@ All these exception should only define the "message id" under one of these categ
 Then the header/body texts should be defined in ``readthedocs/notifications/messages.py``.
 """
 
+from django.utils.translation import gettext_lazy as _
+
+from readthedocs.notifications.exceptions import NotificationBaseException
 
 
-class BuildBaseException(Exception):
+class BuildBaseException(NotificationBaseException):
 
-    default_message = "Build user exception"
-
-    def __init__(self, message_id, format_values=None, **kwargs):
-        self.message_id = message_id
-        self.format_values = format_values
-        super().__init__(self.default_message, **kwargs)
+    default_message = _("Build user exception")
 
 
 class BuildAppError(BuildBaseException):
-    default_message = "Build app exception"
+    default_message = _("Build application exception")
 
     GENERIC_WITH_BUILD_ID = "build:app:generic-with-build-id"
     BUILDS_DISABLED = "build:app:project-builds-disabled"

--- a/readthedocs/notifications/exceptions.py
+++ b/readthedocs/notifications/exceptions.py
@@ -1,0 +1,18 @@
+from django.utils.translation import gettext_lazy as _
+
+
+class NotificationBaseException(Exception):
+
+    """
+    The base exception class for notification and messages.
+
+    This provides the additional ``message_id`` and ``format_values`` attributes
+    that are used for message display and registry lookup.
+    """
+
+    default_message = _("Undefined error")
+
+    def __init__(self, message_id, format_values=None, **kwargs):
+        self.message_id = message_id
+        self.format_values = format_values
+        super().__init__(self.default_message, **kwargs)

--- a/readthedocs/notifications/messages.py
+++ b/readthedocs/notifications/messages.py
@@ -516,7 +516,7 @@ class MessagesRegistry:
                 raise ValueError("A message with the same 'id' is already registered.")
             self.messages[message.id] = message
 
-    def get(self, message_id, format_values={}):
+    def get(self, message_id, format_values=None):
         # Copy to avoid setting format values on the static instance of the
         # message inside the registry, set on a per-request instance instead.
         message = copy.copy(self.messages.get(message_id))

--- a/readthedocs/projects/exceptions.py
+++ b/readthedocs/projects/exceptions.py
@@ -2,6 +2,7 @@
 
 
 from readthedocs.doc_builder.exceptions import BuildAppError, BuildUserError
+from readthedocs.notifications.exceptions import NotificationBaseException
 
 
 class ProjectConfigurationError(BuildUserError):
@@ -32,3 +33,20 @@ class SyncRepositoryLocked(BuildAppError):
     """Error risen when there is another sync_repository_task already running."""
 
     REPOSITORY_LOCKED = "project:repository:locked"
+
+
+class ProjectAutomaticCreationDisallowed(NotificationBaseException):
+
+    """Used for raising messages in the project automatic create form view"""
+
+    NO_CONNECTED_ACCOUNT = "project:create:automatic:no-connected-account"
+    SSO_ENABLED = "project:create:automatic:sso-enabled"
+    INADEQUATE_PERMISSIONS = "project:create:automatic:inadequate-permissions"
+
+
+class ProjectManualCreationDisallowed(NotificationBaseException):
+
+    """Used for raising messages in the project manual create form view"""
+
+    SSO_ENABLED = "project:create:manual:sso-enabled"
+    INADEQUATE_PERMISSIONS = "project:create:manual:inadequate-permissions"

--- a/readthedocs/projects/notifications.py
+++ b/readthedocs/projects/notifications.py
@@ -6,7 +6,9 @@ from django.utils.translation import gettext_noop as _
 from readthedocs.notifications.constants import ERROR, INFO, WARNING
 from readthedocs.notifications.messages import Message, registry
 from readthedocs.projects.exceptions import (
+    ProjectAutomaticCreationDisallowed,
     ProjectConfigurationError,
+    ProjectManualCreationDisallowed,
     RepositoryError,
     SyncRepositoryLocked,
     UserFileNotFound,
@@ -140,6 +142,49 @@ messages = [
                 """
                 We can't perform the versions/branches synchronize at the moment.
                 There is another sync already running.
+                """
+            ).strip(),
+        ),
+        type=WARNING,
+    ),
+    # The following messages are added to the registry but are only used
+    # directly by the project creation view template. These could be split out
+    # directly for use by import, instead of reusing message id lookup.
+    Message(
+        id=ProjectAutomaticCreationDisallowed.NO_CONNECTED_ACCOUNT,
+        header=_("No connected services found"),
+        body=_(
+            textwrap.dedent(
+                # Translators: "connected service" refers to the user setting page for "Connected Services"
+                """
+                You must first <a href="{{ url }}">add a connected service to your account</a>
+                to enable automatic configuration of repositories.
+                """
+            ).strip(),
+        ),
+        type=WARNING,
+    ),
+    Message(
+        id=ProjectAutomaticCreationDisallowed.SSO_ENABLED,
+        header=_("Organization single sign-on enabled"),
+        body=_(
+            textwrap.dedent(
+                """
+                Only organization owners may create new projects when single
+                sign-on is enabled.
+                """
+            ).strip(),
+        ),
+        type=WARNING,
+    ),
+    Message(
+        id=ProjectManualCreationDisallowed.SSO_ENABLED,
+        header=_("Organization single sign-on enabled"),
+        body=_(
+            textwrap.dedent(
+                """
+                Projects cannot be manually configured when single sign-on is
+                enabled.
                 """
             ).strip(),
         ),


### PR DESCRIPTION
This includes a few fixes and small restructuring to the notification/message classes.

- Centralize message lookup and format string population on the registry model instead of the Notification model. This change will make more sense with my next PR
- Use `copy()` when setting the format values, as to ensure thread safety, these shouldn't be set on the static instance class in the registry.
- Add a base class for notifications, for messages/notifications that fall outside doc building.