### PR TITLE
Match login template with changes from .com

### DIFF
--- a/readthedocs/templates/account/login.html
+++ b/readthedocs/templates/account/login.html
@@ -11,29 +11,68 @@
 
 <h1>{% trans "Sign In" %}</h1>
 
-<p><small>{% blocktrans trimmed %}If you have not created an account yet, then please
-<a href="{{ signup_url }}">sign up</a> first.{% endblocktrans %}</small></p>
+{% if is_from_cas_login %}
+<p>
+  {% blocktrans %}
+    In order to view this documentation, you must log in first.
+  {% endblocktrans %}
+</p>
+{% endif %}
 
-<form class="login" method="POST" action="{% url "account_login" %}">
-  {% csrf_token %}
-  {{ form.as_p }}
-  {% if redirect_field_value %}
-  <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
-  {% endif %}
-  <button class="primaryAction" type="submit">{% trans "Sign In" %}</button>
+{% if allowed_providers %}
+  {# If allowed providers is given, don't show the username/password form #}
+  <div class="clearfix">
+    <ul class="socialaccount_providers">
+      {% include "socialaccount/snippets/provider_list.html" with process="login" next=request.GET.next verbiage="Sign in with" %}
+    </ul>
+  </div>
 
-  {% url 'account_reset_password' as password_reset_url %}
+  {% if project_password_url %}
+  <h3>{% trans 'Or' %}</h3>
   <p>
-    <small>{% blocktrans trimmed %}If you forgot your password, <a href="{{ password_reset_url }}">reset it.</a>{% endblocktrans %}</small>
+      {% blocktrans trimmed with project_password_url=project_password_url %}
+      Do you have a password to access this documentation?
+      <a href="{{ project_password_url }}">Access here</a>.
+      {% endblocktrans %}
   </p>
-</form>
+  {% endif %}
 
-<h3>{% trans 'Or' %}</h3>
+{% else %}
 
-<div class="clearfix">
-  <ul class="socialaccount_providers">
-    {% include "socialaccount/snippets/provider_list.html" with process="login" next=request.GET.next verbiage="Sign in with" %}
-  </ul>
-</div>
+  <p><small>{% blocktrans trimmed %}If you have not created an account yet, then please
+  <a href="{{ signup_url }}">sign up</a> first.{% endblocktrans %}</small></p>
+
+  <form class="login" method="POST" action="{% url "account_login" %}">
+    {% csrf_token %}
+    {{ form.as_p }}
+    {% if redirect_field_value %}
+    <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+    {% endif %}
+    <button class="primaryAction" type="submit">{% trans "Sign In" %}</button>
+
+    {% url 'account_reset_password' as password_reset_url %}
+    <p>
+      <small>{% blocktrans trimmed %}If you forgot your password, <a href="{{ password_reset_url }}">reset it.</a>{% endblocktrans %}</small>
+    </p>
+  </form>
+
+  {% if project_password_url %}
+  <h3>{% trans 'Or' %}</h3>
+  <p>
+      {% blocktrans trimmed with project_password_url=project_password_url %}
+      Do you have a password to access this documentation?
+      <a href="{{ project_password_url }}">Access here</a>.
+      {% endblocktrans %}
+  </p>
+  {% endif %}
+
+  <h3>{% trans 'Or' %}</h3>
+
+  <div class="clearfix">
+    <ul class="socialaccount_providers">
+      {% include "socialaccount/snippets/provider_list.html" with process="login" next=request.GET.next verbiage="Sign in with" %}
+    </ul>
+  </div>
+{% endif %}
 
 {% endblock content %}


### PR DESCRIPTION
This basically merges the CAS login (https://github.com/readthedocs/readthedocs-corporate/blob/main/readthedocsinc/corporate/templates/mama_cas/login.html) view with the allauth login view.

Is it okay to change the template on .org? Or maybe just override the template on .com? I'm changing the template here because we already do something similar with the signup template.

https://github.com/readthedocs/readthedocs.org/blob/9339163811d787fb01e71cdf49907a54b2e71767/readthedocs/templates/account/signup.html#L16-L32

Also, doesn't look like the `if allowed_providers` logic has been ported to ext-theme, for example https://readthedocs.com/accounts/signup/?organization=humitos-google vs https://beta.readthedocs.com/accounts/signup/?organization=humitos-google

ref https://github.com/readthedocs/readthedocs-corporate/pull/1726