### PR TITLE
Fix test on .com

### DIFF
--- a/readthedocs/rtd_tests/tests/test_project_forms.py
+++ b/readthedocs/rtd_tests/tests/test_project_forms.py
@@ -430,6 +430,7 @@ class TestProjectAdvancedFormDefaultBranch(TestCase):
         )
 
 
+@override_settings(RTD_ALLOW_ORGANIZATIONS=False)
 class TestProjectPrevalidationForms(TestCase):
     def setUp(self):
         # User with connection


### PR DESCRIPTION
On .com we default to have orgs enabled, but these tests are for when we don't use orgs