### PR TITLE
Settings: remove unused

### DIFF
--- a/docs/dev/settings.rst
+++ b/docs/dev/settings.rst
@@ -35,11 +35,6 @@ DEFAULT_PRIVACY_LEVEL
 
 What privacy projects default to having. Generally set to `public`. Also acts as a proxy setting for blocking certain historically insecure options, like serving generated artifacts directly from the media server.
 
-INDEX_ONLY_LATEST
------------------
-
-In search, only index the `latest` version of a Project.
-
 PUBLIC_DOMAIN
 -------------
 

--- a/readthedocs/search/tests/test_views.py
+++ b/readthedocs/search/tests/test_views.py
@@ -306,9 +306,6 @@ class TestPageSearch:
         reason="Versions are not showing correctly! Fixme while rewrite!"
     )
     def test_file_search_show_versions(self, client, all_projects, es_index, settings):
-        # override the settings to index all versions
-        settings.INDEX_ONLY_LATEST = False
-
         project = all_projects[0]
         # Create some versions of the project
         versions = [get(Version, project=project) for _ in range(3)]


### PR DESCRIPTION
Remove `INDEX_ONLY_LATEST` which has no effect.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11116.org.readthedocs.build/en/11116/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11116.org.readthedocs.build/en/11116/

<!-- readthedocs-preview dev end -->