### PR TITLE
Notifications: show them based on permissions

### DIFF
--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -422,7 +422,7 @@ class NotificationsForUserViewSet(
     filterset_class = NotificationFilter
 
     def get_queryset(self):
-        return Notification.objects.for_user(self.request.user)
+        return Notification.objects.for_user(self.request.user, resource="all")
 
 
 class NotificationsProjectViewSet(

--- a/readthedocs/builds/views.py
+++ b/readthedocs/builds/views.py
@@ -14,9 +14,7 @@ from django.utils.decorators import method_decorator
 from django.views.generic import DetailView, ListView
 from requests.utils import quote
 
-from readthedocs.builds.constants import (
-    BUILD_FINAL_STATES,
-)
+from readthedocs.builds.constants import BUILD_FINAL_STATES
 from readthedocs.builds.filters import BuildListFilter
 from readthedocs.builds.models import Build, Version
 from readthedocs.core.permissions import AdminPermission
@@ -214,4 +212,5 @@ class BuildDetail(BuildBase, DetailView):
         issue_url = scheme.format(**scheme_dict)
         issue_url = urlparse(issue_url).geturl()
         context["issue_url"] = issue_url
+        context["notifications"] = build.notifications.all()
         return context

--- a/readthedocs/core/context_processors.py
+++ b/readthedocs/core/context_processors.py
@@ -44,7 +44,10 @@ def user_notifications(request):
 
     user_notifications = Notification.objects.none()
     if request.user.is_authenticated:
-        user_notifications = Notification.objects.for_user(request.user)
+        user_notifications = Notification.objects.for_user(
+            request.user,
+            resource=request.user,
+        )
 
     return {
         "user_notifications": user_notifications,

--- a/readthedocs/notifications/querysets.py
+++ b/readthedocs/notifications/querysets.py
@@ -71,8 +71,8 @@ class NotificationQuerySet(models.QuerySet):
         Retrieve notifications related to resource for a particular user.
 
         Given a user, returns all the notifications for the specified ``resource``
-        considering permissions (e.g. does not return any notification if the user
-        doesn't have admin permissions on the ``Project``).
+        considering permissions (e.g. does not return any notification if the ``user``
+        doesn't have admin permissions on the ``resource``).
 
         If ``resource="all"``, it returns the following notifications:
 

--- a/readthedocs/notifications/querysets.py
+++ b/readthedocs/notifications/querysets.py
@@ -66,7 +66,7 @@ class NotificationQuerySet(models.QuerySet):
             modified=timezone.now(),
         )
 
-    def for_user(self, user, resource=None):
+    def for_user(self, user, resource):
         """
         Retrieve notifications related to resource for a particular user.
 

--- a/readthedocs/notifications/tests/test_querysets.py
+++ b/readthedocs/notifications/tests/test_querysets.py
@@ -145,7 +145,9 @@ class TestNotificationQuerySet:
             state=CANCELLED,
         )
 
-        assert [n.message_id for n in Notification.objects.for_user(user)] == [
+        assert [
+            n.message_id for n in Notification.objects.for_user(user, resource="all")
+        ] == [
             "user:notification:read",
             "user:notification:unread",
         ]

--- a/readthedocs/notifications/tests/test_signals.py
+++ b/readthedocs/notifications/tests/test_signals.py
@@ -65,9 +65,9 @@ class TestSignals(TestCase):
             verified=False,
         )
 
-        self.assertEqual(Notification.objects.for_user(user).count(), 1)
+        self.assertEqual(Notification.objects.for_user(user, resource="all").count(), 1)
 
-        notification = Notification.objects.for_user(user).first()
+        notification = Notification.objects.for_user(user, resource="all").first()
         self.assertEqual(notification.message_id, MESSAGE_EMAIL_VALIDATION_PENDING)
         self.assertEqual(notification.state, UNREAD)
 
@@ -77,7 +77,7 @@ class TestSignals(TestCase):
         notification.refresh_from_db()
 
         # 0 notifications to show to the user (none UNREAD)
-        self.assertEqual(Notification.objects.for_user(user).count(), 0)
+        self.assertEqual(Notification.objects.for_user(user, resource="all").count(), 0)
 
         # 1 notification exists attached to this user, tho
         self.assertEqual(

--- a/readthedocs/organizations/templates/organizations/organization_detail.html
+++ b/readthedocs/organizations/templates/organizations/organization_detail.html
@@ -9,9 +9,9 @@
 {% block organization-bar-details %}active{% endblock %}
 
 {% block content %}
-  {% if organization.notifications.exists %}
+  {% if notifications %}
     <ul class="notifications">
-    {% for notification in organization.notifications.all %}
+    {% for notification in notifications %}
       <li class="notification">
         {{ notification.get_message.get_rendered_body|safe }}
       </li>

--- a/readthedocs/organizations/views/public.py
+++ b/readthedocs/organizations/views/public.py
@@ -8,6 +8,7 @@ from django.views.generic.base import TemplateView
 from vanilla import DetailView, GenericView, ListView
 
 from readthedocs.core.filters import FilterContextMixin
+from readthedocs.notifications.models import Notification
 from readthedocs.organizations.filters import (
     OrganizationProjectListFilterSet,
     OrganizationTeamListFilterSet,
@@ -38,7 +39,7 @@ class DetailOrganization(FilterContextMixin, OrganizationView, DetailView):
 
     """Display information about an organization."""
 
-    template_name = 'organizations/organization_detail.html'
+    template_name = "organizations/organization_detail.html"
     admin_only = False
 
     filterset_class = OrganizationProjectListFilterSet
@@ -48,10 +49,7 @@ class DetailOrganization(FilterContextMixin, OrganizationView, DetailView):
         context = super().get_context_data(**kwargs)
         org = self.get_object()
         projects = (
-            Project.objects
-            .for_user(self.request.user)
-            .filter(organizations=org)
-            .all()
+            Project.objects.for_user(self.request.user).filter(organizations=org).all()
         )
         if settings.RTD_EXT_THEME_ENABLED:
             context["filter"] = self.get_filterset(
@@ -69,6 +67,10 @@ class DetailOrganization(FilterContextMixin, OrganizationView, DetailView):
             context["owners"] = org.owners.all()
 
         context["projects"] = projects
+        context["notifications"] = Notification.objects.for_user(
+            self.request.user,
+            resource=org,
+        )
         return context
 
 
@@ -95,15 +97,15 @@ class ListOrganizationMembers(FilterContextMixin, OrganizationMixin, ListView):
 
     def get_success_url(self):
         return reverse_lazy(
-            'organization_members',
+            "organization_members",
             args=[self.get_organization().slug],
         )
 
 
 # Team Views
 class ListOrganizationTeams(FilterContextMixin, OrganizationTeamView, ListView):
-    template_name = 'organizations/team_list.html'
-    context_object_name = 'teams'
+    template_name = "organizations/team_list.html"
+    context_object_name = "teams"
     admin_only = False
 
     filterset_class = OrganizationTeamListFilterSet
@@ -127,13 +129,13 @@ class ListOrganizationTeams(FilterContextMixin, OrganizationTeamView, ListView):
 
 
 class ListOrganizationTeamMembers(OrganizationTeamMemberView, ListView):
-    template_name = 'organizations/team_detail.html'
-    context_object_name = 'team_members'
+    template_name = "organizations/team_detail.html"
+    context_object_name = "team_members"
     admin_only = False
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['projects'] = self.get_team().projects.all()
+        context["projects"] = self.get_team().projects.all()
         return context
 
 

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -31,6 +31,7 @@ from readthedocs.core.mixins import CDNCacheControlMixin
 from readthedocs.core.permissions import AdminPermission
 from readthedocs.core.resolver import Resolver
 from readthedocs.core.utils.extend import SettingsOverrideObject
+from readthedocs.notifications.models import Notification
 from readthedocs.projects.filters import ProjectVersionListFilterSet
 from readthedocs.projects.models import Project
 from readthedocs.projects.templatetags.projects_tags import sort_version_aware
@@ -142,6 +143,10 @@ class ProjectDetailViewBase(
         context["is_project_admin"] = AdminPermission.is_admin(
             self.request.user,
             project,
+        )
+        context["notifications"] = Notification.objects.for_user(
+            self.request.user,
+            resource=project,
         )
 
         return context

--- a/readthedocs/templates/builds/build_detail.html
+++ b/readthedocs/templates/builds/build_detail.html
@@ -170,7 +170,7 @@ $(document).ready(function () {
 
       This temporal until we render these notifications from the front-end.
     {% endcomment %}
-    {% for notification in build.notifications.all %}
+    {% for notification in notifications %}
     {% if notification.get_message.type != "error" %}
     <p class="build-ideas">
       {{ notification.get_message.get_rendered_body|safe }}
@@ -216,7 +216,7 @@ $(document).ready(function () {
 
       This temporal until we render these notifications from the front-end.
     {% endcomment %}
-    {% for notification in build.notifications.all %}
+    {% for notification in notifications %}
     {% if notification.get_message.type == "error" %}
     <div class="build-error">
         <h3>{{ notification.get_message.type|title }}</h3>

--- a/readthedocs/templates/core/project_bar_base.html
+++ b/readthedocs/templates/core/project_bar_base.html
@@ -34,7 +34,7 @@
         This notification will be shown here using the same style we used before.
     {% endcomment %}
 
-    {% for notification in project.notifications.all %}
+    {% for notification in notifications %}
     <p class="build-failure">
       {{ notification.get_message.get_rendered_body|safe }}
     </p>


### PR DESCRIPTION
Expand `.for_user()` to accept `resource=` parameter and return only the notifications attached to that resource only if the user has permissions over it. Otherwise, return an empty queryset.

Closes #11082
Closes #11113
