### PR TITLE
Notifications: fix rendering

### DIFF
--- a/readthedocs/config/notifications.py
+++ b/readthedocs/config/notifications.py
@@ -265,7 +265,7 @@ messages = [
             Config validation error in <code>{{key}}</code>.
             Expected one of ({{choices}}), got type <code>{{value|to_class_name}}</code> (<code>{{value}}</code>).
             Double check the type of the value.
-            A string may be required (e.g. <code>"3.10"</code> insted of <code>3.10</code>)
+            A string may be required (e.g. <code>"3.10"</code> instead of <code>3.10</code>)
             """
             ).strip(),
         ),

--- a/readthedocs/notifications/models.py
+++ b/readthedocs/notifications/models.py
@@ -7,7 +7,6 @@ from django.db import models
 from django.utils.translation import gettext_noop as _
 from django_extensions.db.models import TimeStampedModel
 
-
 from .constants import CANCELLED, DISMISSED, READ, UNREAD, WARNING
 from .messages import Message, registry
 from .querysets import NotificationQuerySet
@@ -67,9 +66,12 @@ class Notification(TimeStampedModel):
 
     def get_message(self):
         # Pass the instance attached to this notification
-        format_values = {
-            "instance": self.attached_to,
-        }
+        format_values = self.format_values or {}
+        format_values.update(
+            {
+                "instance": self.attached_to,
+            }
+        )
 
         message = registry.get(self.message_id, format_values=format_values)
         if message is None:


### PR DESCRIPTION
In #11094 we introduce a bug in the rendering because we stopped initializing
the Message class with the `format_values` from the `Notification` object
itself. That's why all the notifications weren't rendering these values.