### PR TITLE
fix highlighting of "fail_on_warning: true" in tutorial

### DIFF
--- a/docs/user/tutorial/index.rst
+++ b/docs/user/tutorial/index.rst
@@ -390,7 +390,7 @@ click on the |:pencil2:| icon, and add these contents:
 
 .. code-block:: yaml
    :caption: .readthedocs.yaml
-   :emphasize-lines: 12-13
+   :emphasize-lines: 14
 
    version: 2
 


### PR DESCRIPTION


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11144.org.readthedocs.build/en/11144/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11144.org.readthedocs.build/en/11144/

<!-- readthedocs-preview dev end -->