### PR TITLE
Fix Poetry instructions

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -348,7 +348,8 @@ Take a look at the following example:
        post_install:
          # Install dependencies with 'docs' dependency group
          # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
-         # VIRTUAL_ENV needs to be set manually for now, see #11150
+         # VIRTUAL_ENV needs to be set manually for now.
+         # See https://github.com/readthedocs/readthedocs.org/pull/11152/
          - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
 
    sphinx:

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -345,12 +345,11 @@ Take a look at the following example:
          # Install poetry
          # https://python-poetry.org/docs/#installing-manually
          - pip install poetry
-         # Tell poetry to not use a virtual environment
-         - poetry config virtualenvs.create false
        post_install:
          # Install dependencies with 'docs' dependency group
          # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
-         - poetry install --with docs
+         # VIRTUAL_ENV needs to be set manually for now, see #11150
+         - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
 
    sphinx:
      configuration: docs/conf.py


### PR DESCRIPTION
Fixes #11150

I believe we will make the (Python) world a better place by setting `VIRTUAL_ENV`, but this change should be evaluated before breaking other people's build for moving too hastily, so I'm making a first fix.

2 questions:
- I added a reference to the ticket, because I'm hopeful the `VIRTUAL_ENV` fix will happen. Is it right?
- Should we add a warning/notice that these instructions changed in Feb 2024, so that people experiencing the issue know they need to update it?

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11152.org.readthedocs.build/en/11152/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11152.org.readthedocs.build/en/11152/

<!-- readthedocs-preview dev end -->