### PR TITLE
Build: bugfix to show build notifications

### DIFF
--- a/readthedocs/builds/views.py
+++ b/readthedocs/builds/views.py
@@ -168,6 +168,7 @@ class BuildDetail(BuildBase, DetailView):
         context["project"] = self.project
 
         build = self.get_object()
+        context["notifications"] = build.notifications.all()
 
         if not build.notifications.filter(
             message_id=BuildAppError.GENERIC_WITH_BUILD_ID
@@ -212,5 +213,5 @@ class BuildDetail(BuildBase, DetailView):
         issue_url = scheme.format(**scheme_dict)
         issue_url = urlparse(issue_url).geturl()
         context["issue_url"] = issue_url
-        context["notifications"] = build.notifications.all()
+
         return context


### PR DESCRIPTION
The context was updated in the wrong place.

Notifications are back:

![Screenshot_2024-02-26_12-23-16](https://github.com/readthedocs/readthedocs.org/assets/244656/e0317cb8-2934-4e91-bc18-f1369f3de7ee)


Closes #11146
Closes #11143