### PR TITLE
Dev: Default RTD_DJANGO_DEBUG to False if not set

### DIFF
--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -8,7 +8,7 @@ class DockerBaseSettings(CommunityBaseSettings):
 
     """Settings for local development with Docker"""
 
-    DEBUG = bool(os.environ.get("RTD_DJANGO_DEBUG", True))
+    DEBUG = bool(os.environ.get("RTD_DJANGO_DEBUG", False))
 
     DOCKER_ENABLE = True
     RTD_DOCKER_COMPOSE = True


### PR DESCRIPTION
As suggested in https://github.com/readthedocs/common/pull/202#issuecomment-1963923938:

With the docker compose settings file, it is currently necessary to explicitly set RTD_DJANGO_DEBUG to a false-y value to clear the DEBUG flag.

Change the default value to False to make the setting more intuitive.

The docker invoke script in common passes RTD_DJANGO_DEBUG=t by default so the effective default behavior is unchanged.