### PR TITLE
Allauth: define secrets in settings

### DIFF
--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -105,12 +105,13 @@ class Service:
                 }
             )
 
+        social_app = self.account.get_provider().app
         self.session = OAuth2Session(
-            client_id=token.app.client_id,
+            client_id=social_app.client_id,
             token=token_config,
             auto_refresh_kwargs={
-                "client_id": token.app.client_id,
-                "client_secret": token.app.secret,
+                "client_id": social_app.client_id,
+                "client_secret": social_app.secret,
             },
             auto_refresh_url=self.get_adapter().access_token_url,
             token_updater=self.token_updater(token),

--- a/readthedocs/rtd_tests/tests/test_oauth_sync.py
+++ b/readthedocs/rtd_tests/tests/test_oauth_sync.py
@@ -1,6 +1,6 @@
 import django_dynamic_fixture as fixture
 import requests_mock
-from allauth.socialaccount.models import SocialAccount, SocialApp, SocialToken
+from allauth.socialaccount.models import SocialAccount, SocialToken
 from allauth.socialaccount.providers.github.views import GitHubOAuth2Adapter
 from django.contrib.auth.models import User
 from django.test import TestCase
@@ -61,10 +61,6 @@ class GitHubOAuthSyncTests(TestCase):
 
     def setUp(self):
         self.user = fixture.get(User)
-        self.socialapp = fixture.get(
-            SocialApp,
-            provider=GitHubOAuth2Adapter.provider_id,
-        )
         self.socialaccount = fixture.get(
             SocialAccount,
             user=self.user,
@@ -72,7 +68,6 @@ class GitHubOAuthSyncTests(TestCase):
         )
         self.token = fixture.get(
             SocialToken,
-            app=self.socialapp,
             account=self.socialaccount,
         )
         self.service = GitHubService.for_user(self.user)[0]
@@ -293,7 +288,6 @@ class GitHubOAuthSyncTests(TestCase):
         )
         fixture.get(
             SocialToken,
-            app=self.socialapp,
             account=user_2_socialaccount,
         )
 

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -646,6 +646,13 @@ class CommunityBaseSettings(Settings):
 
     SOCIALACCOUNT_PROVIDERS = {
         'github': {
+            "APPS": [
+                {
+                    "client_id": "123",
+                    "secret": "456",
+                    "key": ""
+                },
+            ],
             "VERIFIED_EMAIL": True,
             'SCOPE': [
                 'user:email',
@@ -655,13 +662,29 @@ class CommunityBaseSettings(Settings):
             ],
         },
         'gitlab': {
+            "APPS": [
+                {
+                    "client_id": "123",
+                    "secret": "456",
+                    "key": ""
+                },
+            ],
             "VERIFIED_EMAIL": True,
             'SCOPE': [
                 'api',
                 'read_user',
             ],
         },
-        # Bitbucket scope/permissions are determined by the Oauth consumer setup on bitbucket.org
+        "bitbucket_oauth2": {
+            "APPS": [
+                {
+                    "client_id": "123",
+                    "secret": "456",
+                    "key": ""
+                },
+            ],
+            # Bitbucket scope/permissions are determined by the Oauth consumer setup on bitbucket.org.
+        },
     }
     ACCOUNT_FORMS = {
         'signup': 'readthedocs.forms.SignupFormWithNewsletter',


### PR DESCRIPTION
Allauth used to merge the settings from the file and the database, this is not the case anymore.

The actual values will be in the ops repos, this is only to fix tests, since if the settings don't have the `APPS` key, isn't considered as valid.