### PR TITLE
Allauth: Include Bitbucket in the list of social accounts

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -685,6 +685,16 @@ class CommunityBaseSettings(Settings):
             ],
             # Bitbucket scope/permissions are determined by the Oauth consumer setup on bitbucket.org.
         },
+        # Deprecated, we use `bitbucket_oauth2` for all new connections.
+        "bitbucket": {
+            "APPS": [
+                {
+                    "client_id": "123",
+                    "secret": "456",
+                    "key": ""
+                },
+            ],
+        },
     }
     ACCOUNT_FORMS = {
         'signup': 'readthedocs.forms.SignupFormWithNewsletter',


### PR DESCRIPTION
It's deprecated, but we still have like 1050 tokens/users, we need to decide what to do with them later.