### PR TITLE
Project: build both default and latest version when saving the project form

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -80,7 +80,11 @@ class ProjectTriggerBuildMixin:
             if default_branch and default_branch.active:
                 trigger_build(project=project, version=default_branch)
             latest_version = project.get_latest_version()
-            if latest_version and latest_version != default_branch and latest_version.active:
+            if (
+                latest_version
+                and latest_version != default_branch
+                and latest_version.active
+            ):
                 trigger_build(project=project, version=latest_version)
         return project
 

--- a/readthedocs/rtd_tests/tests/test_project.py
+++ b/readthedocs/rtd_tests/tests/test_project.py
@@ -263,7 +263,7 @@ class TestProjectTranslations(ProjectMixin, TestCase):
         # Create translation of ``main_project``.
         get(Project, main_language_project=main_project)
 
-        url = reverse("project-translations", [main_project.id])
+        url = reverse("project-translations", args=[main_project.id])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 

--- a/readthedocs/rtd_tests/tests/test_project.py
+++ b/readthedocs/rtd_tests/tests/test_project.py
@@ -7,9 +7,9 @@ import pytest
 from django.contrib.auth.models import User
 from django.forms.models import model_to_dict
 from django.test import TestCase
+from django.urls import reverse
 from django.utils import timezone
 from django_dynamic_fixture import get
-from django.urls import reverse
 
 from readthedocs.builds.constants import (
     BUILD_STATE_CLONING,
@@ -36,55 +36,53 @@ from readthedocs.projects.tasks.utils import finish_inactive_builds
 
 
 class ProjectMixin:
-
-    fixtures = ['eric', 'test_data']
+    fixtures = ["eric", "test_data"]
 
     def setUp(self):
-        self.client.login(username='eric', password='test')
-        self.pip = Project.objects.get(slug='pip')
+        self.client.login(username="eric", password="test")
+        self.pip = Project.objects.get(slug="pip")
         # Create a External Version. ie: pull/merge request Version.
         self.external_version = get(
             Version,
-            identifier='pr-version',
-            verbose_name='99',
-            slug='99',
+            identifier="pr-version",
+            verbose_name="99",
+            slug="99",
             project=self.pip,
             active=True,
-            type=EXTERNAL
+            type=EXTERNAL,
         )
 
 
 class TestProject(ProjectMixin, TestCase):
-
     def test_subprojects(self):
-        r = self.client.get('/api/v2/project/6/subprojects/', {})
+        r = self.client.get("/api/v2/project/6/subprojects/", {})
         resp = json.loads(r.content)
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(resp['subprojects'][0]['id'], 23)
+        self.assertEqual(resp["subprojects"][0]["id"], 23)
 
-    @patch('readthedocs.projects.models.Project.find')
+    @patch("readthedocs.projects.models.Project.find")
     def test_conf_file_found(self, find_method):
         find_method.return_value = [
-            '/home/docs/rtfd/code/readthedocs.org/user_builds/pip/checkouts/latest/src/conf.py',
+            "/home/docs/rtfd/code/readthedocs.org/user_builds/pip/checkouts/latest/src/conf.py",
         ]
         self.assertEqual(
             self.pip.conf_file(),
-            '/home/docs/rtfd/code/readthedocs.org/user_builds/pip/checkouts/latest/src/conf.py',
+            "/home/docs/rtfd/code/readthedocs.org/user_builds/pip/checkouts/latest/src/conf.py",
         )
 
-    @patch('readthedocs.projects.models.Project.find')
+    @patch("readthedocs.projects.models.Project.find")
     def test_multiple_conf_file_one_doc_in_path(self, find_method):
         find_method.return_value = [
-            '/home/docs/rtfd/code/readthedocs.org/user_builds/pip/checkouts/latest/src/conf.py',
-            '/home/docs/rtfd/code/readthedocs.org/user_builds/pip/checkouts/latest/docs/conf.py',
+            "/home/docs/rtfd/code/readthedocs.org/user_builds/pip/checkouts/latest/src/conf.py",
+            "/home/docs/rtfd/code/readthedocs.org/user_builds/pip/checkouts/latest/docs/conf.py",
         ]
         self.assertEqual(
             self.pip.conf_file(),
-            '/home/docs/rtfd/code/readthedocs.org/user_builds/pip/checkouts/latest/docs/conf.py',
+            "/home/docs/rtfd/code/readthedocs.org/user_builds/pip/checkouts/latest/docs/conf.py",
         )
 
-    @patch('readthedocs.projects.models.Project.find')
-    @patch('readthedocs.projects.models.Project.full_find')
+    @patch("readthedocs.projects.models.Project.find")
+    @patch("readthedocs.projects.models.Project.full_find")
     def test_conf_file_not_found(self, find_method, full_find_method):
         find_method.return_value = []
         full_find_method.return_value = []
@@ -95,12 +93,12 @@ class TestProject(ProjectMixin, TestCase):
             ProjectConfigurationError.NOT_FOUND,
         )
 
-    @patch('readthedocs.projects.models.Project.find')
+    @patch("readthedocs.projects.models.Project.find")
     def test_multiple_conf_files(self, find_method):
         find_method.return_value = [
-            '/home/docs/rtfd/code/readthedocs.org/user_builds/pip/checkouts/multi-conf.py/src/conf.py',
-            '/home/docs/rtfd/code/readthedocs.org/user_builds/pip/checkouts/multi-conf.py/src/sub/conf.py',
-            '/home/docs/rtfd/code/readthedocs.org/user_builds/pip/checkouts/multi-conf.py/src/sub/src/conf.py',
+            "/home/docs/rtfd/code/readthedocs.org/user_builds/pip/checkouts/multi-conf.py/src/conf.py",
+            "/home/docs/rtfd/code/readthedocs.org/user_builds/pip/checkouts/multi-conf.py/src/sub/conf.py",
+            "/home/docs/rtfd/code/readthedocs.org/user_builds/pip/checkouts/multi-conf.py/src/sub/src/conf.py",
         ]
         with self.assertRaises(ProjectConfigurationError) as e:
             self.pip.conf_file()
@@ -118,15 +116,15 @@ class TestProject(ProjectMixin, TestCase):
             )
         self.assertEqual(
             self.pip.get_storage_path(MEDIA_TYPE_PDF, LATEST),
-            'pdf/pip/latest/pip.pdf',
+            "pdf/pip/latest/pip.pdf",
         )
         self.assertEqual(
             self.pip.get_storage_path(MEDIA_TYPE_EPUB, LATEST),
-            'epub/pip/latest/pip.epub',
+            "epub/pip/latest/pip.epub",
         )
         self.assertEqual(
             self.pip.get_storage_path(MEDIA_TYPE_HTMLZIP, LATEST),
-            'htmlzip/pip/latest/pip.zip',
+            "htmlzip/pip/latest/pip.zip",
         )
 
     def test_get_storage_path_invalid_inputs(self):
@@ -147,22 +145,27 @@ class TestProject(ProjectMixin, TestCase):
     def test_get_storage_path_for_external_versions(self):
         self.assertEqual(
             self.pip.get_storage_path(
-                'pdf', self.external_version.slug,
-                version_type=self.external_version.type
+                "pdf",
+                self.external_version.slug,
+                version_type=self.external_version.type,
             ),
-            'external/pdf/pip/99/pip.pdf',
+            "external/pdf/pip/99/pip.pdf",
         )
         self.assertEqual(
-            self.pip.get_storage_path('epub', self.external_version.slug,
-                version_type=self.external_version.type
+            self.pip.get_storage_path(
+                "epub",
+                self.external_version.slug,
+                version_type=self.external_version.type,
             ),
-            'external/epub/pip/99/pip.epub',
+            "external/epub/pip/99/pip.epub",
         )
         self.assertEqual(
-            self.pip.get_storage_path('htmlzip', self.external_version.slug,
-                version_type=self.external_version.type
+            self.pip.get_storage_path(
+                "htmlzip",
+                self.external_version.slug,
+                version_type=self.external_version.type,
             ),
-            'external/htmlzip/pip/99/pip.zip',
+            "external/htmlzip/pip/99/pip.zip",
         )
 
     def test_ordered_active_versions_excludes_external_versions(self):
@@ -182,22 +185,22 @@ class TestProject(ProjectMixin, TestCase):
 
     def test_update_stable_version_machine_false(self):
         # Initial stable version from fixture
-        self.assertEqual(self.pip.update_stable_version().slug, '0.8.1')
+        self.assertEqual(self.pip.update_stable_version().slug, "0.8.1")
 
         # None, when there is no stable to promote
         self.assertEqual(self.pip.update_stable_version(), None)
 
         get(
             Version,
-            identifier='9.0',
-            verbose_name='9.0',
-            slug='9.0',
+            identifier="9.0",
+            verbose_name="9.0",
+            slug="9.0",
             type=TAG,
             project=self.pip,
             active=True,
         )
         # New stable now is the newly created version
-        self.assertEqual(self.pip.update_stable_version().slug, '9.0')
+        self.assertEqual(self.pip.update_stable_version().slug, "9.0")
 
         # Make stable version machine=False
         stable = self.pip.get_stable_version()
@@ -206,16 +209,16 @@ class TestProject(ProjectMixin, TestCase):
 
         get(
             Version,
-            identifier='10.0',
-            verbose_name='10.0',
-            slug='10.0',
+            identifier="10.0",
+            verbose_name="10.0",
+            slug="10.0",
             type=TAG,
             project=self.pip,
             active=True,
         )
         # None, since the stable version is marked as machine=False and Read
         # the Docs does not have control over it
-        with patch('readthedocs.projects.models.determine_stable_version') as m:
+        with patch("readthedocs.projects.models.determine_stable_version") as m:
             self.assertEqual(self.pip.update_stable_version(), None)
             m.assert_not_called()
 
@@ -232,44 +235,41 @@ class TestProject(ProjectMixin, TestCase):
         self.assertEqual(self.pip.get_latest_build(), None)
 
     def test_git_provider_name_github(self):
-        self.pip.repo = 'https://github.com/pypa/pip'
+        self.pip.repo = "https://github.com/pypa/pip"
         self.pip.save()
         self.assertEqual(self.pip.git_provider_name, GITHUB_BRAND)
 
     def test_git_service_class_github(self):
-        self.pip.repo = 'https://github.com/pypa/pip'
+        self.pip.repo = "https://github.com/pypa/pip"
         self.pip.save()
         self.assertEqual(self.pip.git_service_class(), GitHubService)
 
     def test_git_provider_name_gitlab(self):
-        self.pip.repo = 'https://gitlab.com/pypa/pip'
+        self.pip.repo = "https://gitlab.com/pypa/pip"
         self.pip.save()
         self.assertEqual(self.pip.git_provider_name, GITLAB_BRAND)
 
     def test_git_service_class_gitlab(self):
-        self.pip.repo = 'https://gitlab.com/pypa/pip'
+        self.pip.repo = "https://gitlab.com/pypa/pip"
         self.pip.save()
         self.assertEqual(self.pip.git_service_class(), GitLabService)
 
 
-@mock.patch('readthedocs.projects.forms.trigger_build', mock.MagicMock())
+@mock.patch("readthedocs.projects.forms.trigger_build", mock.MagicMock())
 class TestProjectTranslations(ProjectMixin, TestCase):
-
     def test_translations(self):
         main_project = get(Project)
 
         # Create translation of ``main_project``.
         get(Project, main_language_project=main_project)
 
-        url = reverse('project-translations', [main_project.id])
+        url = reverse("project-translations", [main_project.id])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
-        translation_ids_from_api = [
-            t['id'] for t in response.data['translations']
-        ]
+        translation_ids_from_api = [t["id"] for t in response.data["translations"]]
         translation_ids_from_orm = [
-            t[0] for t in main_project.translations.values_list('id')
+            t[0] for t in main_project.translations.values_list("id")
         ]
 
         self.assertEqual(
@@ -300,20 +300,24 @@ class TestProjectTranslations(ProjectMixin, TestCase):
         )
 
     def test_user_can_add_own_project_as_translation(self):
-        user_a = User.objects.get(username='eric')
+        user_a = User.objects.get(username="eric")
         project_a = get(
-            Project, users=[user_a],
-            language='en', main_language_project=None,
+            Project,
+            users=[user_a],
+            language="en",
+            main_language_project=None,
         )
         project_b = get(
-            Project, users=[user_a],
-            language='es', main_language_project=None,
+            Project,
+            users=[user_a],
+            language="es",
+            main_language_project=None,
         )
 
-        self.client.login(username=user_a.username, password='test')
+        self.client.login(username=user_a.username, password="test")
         self.client.post(
-            reverse('projects_translations', args=[project_a.slug]),
-            data={'project': project_b.slug},
+            reverse("projects_translations", args=[project_a.slug]),
+            data={"project": project_b.slug},
         )
 
         self.assertEqual(project_a.translations.first(), project_b)
@@ -322,49 +326,57 @@ class TestProjectTranslations(ProjectMixin, TestCase):
 
     def test_user_can_add_project_as_translation_if_is_owner(self):
         # Two users, two projects with different language
-        user_a = User.objects.get(username='eric')
+        user_a = User.objects.get(username="eric")
         project_a = get(
-            Project, users=[user_a],
-            language='es', main_language_project=None,
+            Project,
+            users=[user_a],
+            language="es",
+            main_language_project=None,
         )
 
-        user_b = User.objects.get(username='tester')
+        user_b = User.objects.get(username="tester")
         # User A and B are owners of project B
         project_b = get(
-            Project, users=[user_b, user_a],
-            language='en', main_language_project=None,
+            Project,
+            users=[user_b, user_a],
+            language="en",
+            main_language_project=None,
         )
 
-        self.client.login(username=user_a.username, password='test')
+        self.client.login(username=user_a.username, password="test")
         self.client.post(
-            reverse('projects_translations', args=[project_a.slug]),
-            data={'project': project_b.slug},
+            reverse("projects_translations", args=[project_a.slug]),
+            data={"project": project_b.slug},
         )
 
         self.assertEqual(project_a.translations.first(), project_b)
 
     def test_user_can_not_add_other_user_project_as_translation(self):
         # Two users, two projects with different language
-        user_a = User.objects.get(username='eric')
+        user_a = User.objects.get(username="eric")
         project_a = get(
-            Project, users=[user_a],
-            language='es', main_language_project=None,
+            Project,
+            users=[user_a],
+            language="es",
+            main_language_project=None,
         )
 
-        user_b = User.objects.get(username='tester')
+        user_b = User.objects.get(username="tester")
         project_b = get(
-            Project, users=[user_b],
-            language='en', main_language_project=None,
+            Project,
+            users=[user_b],
+            language="en",
+            main_language_project=None,
         )
 
         # User A try to add project B as translation of project A
-        self.client.login(username=user_a.username, password='test')
+        self.client.login(username=user_a.username, password="test")
         resp = self.client.post(
-            reverse('projects_translations', args=[project_a.slug]),
-            data={'project': project_b.slug},
+            reverse("projects_translations", args=[project_a.slug]),
+            data={"project": project_b.slug},
         )
 
-        self.assertContains(resp, 'Select a valid choice')
+        self.assertContains(resp, "Select a valid choice")
         self.assertEqual(project_a.translations.count(), 0)
         project_b.refresh_from_db()
         self.assertIsNone(project_b.main_language_project)
@@ -372,32 +384,36 @@ class TestProjectTranslations(ProjectMixin, TestCase):
     def test_previous_users_can_list_and_delete_translations_not_owner(self):
         """Test to make sure that previous users can list and delete projects
         where they aren't owners."""
-        user_a = User.objects.get(username='eric')
+        user_a = User.objects.get(username="eric")
         project_a = get(
-            Project, users=[user_a],
-            language='es', main_language_project=None,
+            Project,
+            users=[user_a],
+            language="es",
+            main_language_project=None,
         )
 
-        user_b = User.objects.get(username='tester')
+        user_b = User.objects.get(username="tester")
         project_b = get(
-            Project, users=[user_b],
-            language='en', main_language_project=None,
+            Project,
+            users=[user_b],
+            language="en",
+            main_language_project=None,
         )
 
         project_a.translations.add(project_b)
         project_a.save()
 
-        self.client.login(username=user_a.username, password='test')
+        self.client.login(username=user_a.username, password="test")
 
         # Project B is listed under user A translations
         resp = self.client.get(
-            reverse('projects_translations', args=[project_a.slug]),
+            reverse("projects_translations", args=[project_a.slug]),
         )
         self.assertContains(resp, project_b.slug)
 
         resp = self.client.post(
             reverse(
-                'projects_translations_delete',
+                "projects_translations_delete",
                 args=[project_a.slug, project_b.slug],
             ),
             follow=True,
@@ -406,37 +422,45 @@ class TestProjectTranslations(ProjectMixin, TestCase):
         self.assertNotIn(project_b, project_a.translations.all())
 
     def test_user_cant_delete_other_user_translations(self):
-        user_a = User.objects.get(username='eric')
+        user_a = User.objects.get(username="eric")
         project_a = get(
-            Project, users=[user_a],
-            language='es', main_language_project=None,
+            Project,
+            users=[user_a],
+            language="es",
+            main_language_project=None,
         )
         project_b = get(
-            Project, users=[user_a],
-            language='en', main_language_project=None,
+            Project,
+            users=[user_a],
+            language="en",
+            main_language_project=None,
         )
 
         project_a.translations.add(project_b)
         project_a.save()
 
-        user_b = User.objects.get(username='tester')
+        user_b = User.objects.get(username="tester")
         project_c = get(
-            Project, users=[user_b],
-            language='es', main_language_project=None,
+            Project,
+            users=[user_b],
+            language="es",
+            main_language_project=None,
         )
         project_d = get(
-            Project, users=[user_b, user_a],
-            language='en', main_language_project=None,
+            Project,
+            users=[user_b, user_a],
+            language="en",
+            main_language_project=None,
         )
         project_d.translations.add(project_c)
         project_d.save()
 
         # User B tries to delete translation from user A
-        self.client.login(username=user_b.username, password='test')
+        self.client.login(username=user_b.username, password="test")
         self.assertIn(project_b, project_a.translations.all())
         resp = self.client.post(
             reverse(
-                'projects_translations_delete',
+                "projects_translations_delete",
                 args=[project_a.slug, project_b.slug],
             ),
             follow=True,
@@ -446,11 +470,11 @@ class TestProjectTranslations(ProjectMixin, TestCase):
 
         # User B tries to delete translation from user A
         # with a different parent
-        self.client.login(username=user_b.username, password='test')
+        self.client.login(username=user_b.username, password="test")
         self.assertIn(project_b, project_a.translations.all())
         resp = self.client.post(
             reverse(
-                'projects_translations_delete',
+                "projects_translations_delete",
                 args=[project_d.slug, project_b.slug],
             ),
             follow=True,
@@ -460,11 +484,11 @@ class TestProjectTranslations(ProjectMixin, TestCase):
 
         # User A tries to delete translation from user A
         # with a different parent
-        self.client.login(username=user_a.username, password='test')
+        self.client.login(username=user_a.username, password="test")
         self.assertIn(project_b, project_a.translations.all())
         resp = self.client.post(
             reverse(
-                'projects_translations_delete',
+                "projects_translations_delete",
                 args=[project_b.slug, project_b.slug],
             ),
             follow=True,
@@ -473,11 +497,13 @@ class TestProjectTranslations(ProjectMixin, TestCase):
         self.assertIn(project_b, project_a.translations.all())
 
     def test_user_cant_change_lang_to_translation_lang(self):
-        user_a = User.objects.get(username='eric')
-        project_a = Project.objects.get(slug='read-the-docs')
+        user_a = User.objects.get(username="eric")
+        project_a = Project.objects.get(slug="read-the-docs")
         project_b = get(
-            Project, users=[user_a],
-            language='es', main_language_project=None,
+            Project,
+            users=[user_a],
+            language="es",
+            main_language_project=None,
         )
 
         project_a.translations.add(project_b)
@@ -485,19 +511,19 @@ class TestProjectTranslations(ProjectMixin, TestCase):
 
         # User tries to change the language
         # to the same of the translation
-        self.client.login(username=user_a.username, password='test')
+        self.client.login(username=user_a.username, password="test")
         self.assertIn(project_b, project_a.translations.all())
-        self.assertEqual(project_a.language, 'en')
-        self.assertEqual(project_b.language, 'es')
+        self.assertEqual(project_a.language, "en")
+        self.assertEqual(project_b.language, "es")
         data = model_to_dict(project_a)
 
         # Remove None values from data
         data = {k: v for k, v in data.items() if v is not None}
 
-        data['language'] = 'es'
+        data["language"] = "es"
         resp = self.client.post(
             reverse(
-                'projects_edit',
+                "projects_edit",
                 args=[project_a.slug],
             ),
             data=data,
@@ -506,53 +532,55 @@ class TestProjectTranslations(ProjectMixin, TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertContains(
             resp,
-            'There is already a &quot;es&quot; translation '
-            'for the read-the-docs project',
+            "There is already a &quot;es&quot; translation "
+            "for the read-the-docs project",
         )
 
     def test_user_can_change_project_with_same_lang(self):
-        user_a = User.objects.get(username='eric')
-        project_a = Project.objects.get(slug='read-the-docs')
+        user_a = User.objects.get(username="eric")
+        project_a = Project.objects.get(slug="read-the-docs")
         project_b = get(
-            Project, users=[user_a],
-            language='es', main_language_project=None,
+            Project,
+            users=[user_a],
+            language="es",
+            main_language_project=None,
         )
 
         project_a.translations.add(project_b)
         project_a.save()
 
         # User save the project with no modifications
-        self.client.login(username=user_a.username, password='test')
+        self.client.login(username=user_a.username, password="test")
         self.assertIn(project_b, project_a.translations.all())
-        self.assertEqual(project_a.language, 'en')
-        self.assertEqual(project_b.language, 'es')
+        self.assertEqual(project_a.language, "en")
+        self.assertEqual(project_b.language, "es")
         data = model_to_dict(project_a)
 
         # Remove None values from data
         data = {k: v for k, v in data.items() if v is not None}
 
         # Same language
-        data['language'] = 'en'
+        data["language"] = "en"
         resp = self.client.post(
             reverse(
-                'projects_edit',
+                "projects_edit",
                 args=[project_a.slug],
             ),
             data=data,
             follow=True,
         )
         self.assertEqual(resp.status_code, 200)
-        self.assertNotContains(resp, 'There is already a')
+        self.assertNotContains(resp, "There is already a")
 
 
 class TestFinishInactiveBuildsTask(TestCase):
-    fixtures = ['eric', 'test_data']
+    fixtures = ["eric", "test_data"]
 
     def setUp(self):
-        self.client.login(username='eric', password='test')
-        self.pip = Project.objects.get(slug='pip')
+        self.client.login(username="eric", password="test")
+        self.pip = Project.objects.get(slug="pip")
 
-        self.taggit = Project.objects.get(slug='taggit')
+        self.taggit = Project.objects.get(slug="taggit")
         self.taggit.container_time_limit = 7200  # 2 hours
         self.taggit.save()
 
@@ -569,9 +597,7 @@ class TestFinishInactiveBuildsTask(TestCase):
             version=self.pip.get_stable_version(),
             state=BUILD_STATE_TRIGGERED,
         )
-        self.build_2.date = (
-            timezone.now() - datetime.timedelta(hours=1)
-        )
+        self.build_2.date = timezone.now() - datetime.timedelta(hours=1)
         self.build_2.save()
 
         # Build started an hour ago with custom time (2 hours)
@@ -580,29 +606,27 @@ class TestFinishInactiveBuildsTask(TestCase):
             version=self.taggit.get_stable_version(),
             state=BUILD_STATE_TRIGGERED,
         )
-        self.build_3.date = (
-            timezone.now() - datetime.timedelta(hours=1)
-        )
+        self.build_3.date = timezone.now() - datetime.timedelta(hours=1)
         self.build_3.save()
 
-    @pytest.mark.xfail(reason='Fails while we work out Docker time limits', strict=True)
+    @pytest.mark.xfail(reason="Fails while we work out Docker time limits", strict=True)
     def test_finish_inactive_builds_task(self):
         finish_inactive_builds()
 
         # Legitimate build (just started) not finished
         self.build_1.refresh_from_db()
         self.assertTrue(self.build_1.success)
-        self.assertEqual(self.build_1.error, '')
+        self.assertEqual(self.build_1.error, "")
         self.assertEqual(self.build_1.state, BUILD_STATE_CLONING)
 
         # Build with default time finished
         self.build_2.refresh_from_db()
         self.assertFalse(self.build_2.success)
-        self.assertNotEqual(self.build_2.error, '')
+        self.assertNotEqual(self.build_2.error, "")
         self.assertEqual(self.build_2.state, BUILD_STATE_FINISHED)
 
         # Build with custom time not finished
         self.build_3.refresh_from_db()
         self.assertTrue(self.build_3.success)
-        self.assertEqual(self.build_3.error, '')
+        self.assertEqual(self.build_3.error, "")
         self.assertEqual(self.build_3.state, BUILD_STATE_TRIGGERED)

--- a/readthedocs/rtd_tests/tests/test_project.py
+++ b/readthedocs/rtd_tests/tests/test_project.py
@@ -9,7 +9,7 @@ from django.forms.models import model_to_dict
 from django.test import TestCase
 from django.utils import timezone
 from django_dynamic_fixture import get
-from rest_framework.reverse import reverse
+from django.urls import reverse
 
 from readthedocs.builds.constants import (
     BUILD_STATE_CLONING,

--- a/readthedocs/rtd_tests/tests/test_project_forms.py
+++ b/readthedocs/rtd_tests/tests/test_project_forms.py
@@ -313,7 +313,7 @@ class TestProjectAdvancedForm(TestCase):
     @mock.patch("readthedocs.projects.forms.trigger_build")
     def test_trigger_build_on_save(self, trigger_build):
         latest_version = self.project.get_latest_version()
-        default_branch = get(Version, project=self.project, slug='main', active=True)
+        default_branch = get(Version, project=self.project, slug="main", active=True)
 
         self.project.default_branch = default_branch.slug
         self.project.save()
@@ -329,7 +329,7 @@ class TestProjectAdvancedForm(TestCase):
         form = UpdateProjectForm(data, instance=self.project)
         self.assertTrue(form.is_valid())
         form.save()
-        
+
         self.assertEqual(trigger_build.call_count, 2)
         trigger_build.assert_has_calls(
             [
@@ -353,6 +353,7 @@ class TestProjectAdvancedForm(TestCase):
             project=self.project,
             version=default_branch,
         )
+
 
 class TestProjectAdvancedFormDefaultBranch(TestCase):
     def setUp(self):

--- a/readthedocs/rtd_tests/tests/test_project_forms.py
+++ b/readthedocs/rtd_tests/tests/test_project_forms.py
@@ -284,7 +284,7 @@ class TestProjectAdvancedForm(TestCase):
         self.assertTrue(form.is_valid())
         self.assertEqual(self.project.privacy_level, PRIVATE)
 
-    @mock.patch("readthedocs.core.utils.trigger_build")
+    @mock.patch("readthedocs.projects.forms.trigger_build")
     @override_settings(ALLOW_PRIVATE_REPOS=False)
     def test_custom_readthedocs_yaml(self, trigger_build):
         custom_readthedocs_yaml_path = "folder/.readthedocs.yaml"


### PR DESCRIPTION
We were triggering a build for the default version, but what we actually wanted to do is to trigger a build for the default branch, and latest. Default version is the one that / redirects to, but actual version may have been changed is LATEST or the default branch. Since the default version is usually LATEST, we never noticed the problem.

Closes https://github.com/readthedocs/readthedocs.org/issues/9685