### PR TITLE
Project: force PR previews to match repo only if the repo is public

### DIFF
--- a/docs/user/guides/pull-requests.rst
+++ b/docs/user/guides/pull-requests.rst
@@ -26,7 +26,8 @@ Privacy levels
 
    Privacy levels are only supported on :doc:`/commercial/index`.
 
-If you didn’t import your project manually, the privacy level of pull request previews will match your repository,
+If you didn’t import your project manually and your repository is public,
+the privacy level of pull request previews will be set to *Public*,
 otherwise it will be set to *Private*.
 Public pull request previews are available to anyone with the link to the preview,
 while private previews are only available to users with access to the Read the Docs project.

--- a/docs/user/pull-requests.rst
+++ b/docs/user/pull-requests.rst
@@ -48,7 +48,8 @@ if you have environment variables with private information, make sure they aren'
 See :ref:`environment-variables:Environment variables and build process` for more information.
 
 On |com_brand| you can set pull request previews to be private or public,
-if you didn't import your project manually, the privacy level of pull request previews will match your repository.
+If you didn’t import your project manually and your repository is public,
+the privacy level of pull request previews will be set to *Public*.
 Public pull request previews are available to anyone with the link to the preview,
 while private previews are only available to users with access to the Read the Docs project.
 

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -384,16 +384,15 @@ class UpdateProjectForm(
 
     def setup_external_builds_option(self):
         """Disable the external builds option if the project doesn't meet the requirements."""
-        if settings.ALLOW_PRIVATE_REPOS and self.instance.remote_repository:
+        if (
+            settings.ALLOW_PRIVATE_REPOS
+            and self.instance.remote_repository
+            and not self.instance.remote_repository.private
+        ):
             self.fields["external_builds_privacy_level"].disabled = True
-            if self.instance.remote_repository.private:
-                help_text = _(
-                    "We have detected that this project is private, pull request previews are set to private."
-                )
-            else:
-                help_text = _(
-                    "We have detected that this project is public, pull request previews are set to public."
-                )
+            help_text = _(
+                "We have detected that this project is public, pull request previews are set to public."
+            )
             self.fields["external_builds_privacy_level"].help_text = help_text
 
         integrations = list(self.instance.integrations.all())

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -65,7 +65,6 @@ from .constants import (
     MEDIA_TYPES,
     MULTIPLE_VERSIONS_WITH_TRANSLATIONS,
     MULTIPLE_VERSIONS_WITHOUT_TRANSLATIONS,
-    PRIVATE,
     PUBLIC,
 )
 
@@ -583,9 +582,11 @@ class Project(models.Model):
                     _("Model must have slug")
                 )
 
-        if self.remote_repository:
-            privacy_level = PRIVATE if self.remote_repository.private else PUBLIC
-            self.external_builds_privacy_level = privacy_level
+        # If the project is linked to a remote repository,
+        # and the repository is public, we force the privacy level of
+        # pull requests previews to be public, see GHSA-pw32-ffxw-68rh.
+        if self.remote_repository and not self.remote_repository.private:
+            self.external_builds_privacy_level = PUBLIC
 
         super().save(*args, **kwargs)
 

--- a/readthedocs/projects/tests/test_views.py
+++ b/readthedocs/projects/tests/test_views.py
@@ -11,7 +11,6 @@ from readthedocs.organizations.models import Organization
 from readthedocs.projects.constants import (
     DOWNLOADABLE_MEDIA_TYPES,
     MEDIA_TYPE_HTMLZIP,
-    PRIVATE,
     PUBLIC,
 )
 from readthedocs.projects.models import Project

--- a/readthedocs/projects/tests/test_views.py
+++ b/readthedocs/projects/tests/test_views.py
@@ -111,7 +111,7 @@ class TestExternalBuildOption(TestCase):
         )
 
     @override_settings(ALLOW_PRIVATE_REPOS=True)
-    def test_privacy_level_pr_previews_match_remote_repository(self):
+    def test_privacy_level_pr_previews_match_remote_repository_if_public(self):
         remote_repository = get(RemoteRepository, private=False)
         self.project.remote_repository = remote_repository
         self.project.save()
@@ -128,9 +128,8 @@ class TestExternalBuildOption(TestCase):
 
         resp = self.client.get(self.url)
         field = resp.context["form"].fields["external_builds_privacy_level"]
-        self.assertTrue(field.disabled)
-        self.assertIn("We have detected that this project is private", field.help_text)
-        self.assertEqual(self.project.external_builds_privacy_level, PRIVATE)
+        self.assertFalse(field.disabled)
+        self.assertEqual(self.project.external_builds_privacy_level, PUBLIC)
 
 
 @override_settings(RTD_ALLOW_ORGANIZATIONS=True)


### PR DESCRIPTION
Closes https://github.com/readthedocs/readthedocs-corporate/issues/1749

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11184.org.readthedocs.build/en/11184/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11184.org.readthedocs.build/en/11184/

<!-- readthedocs-preview dev end -->