### PR TITLE
Addons: always return the `addons.doc_diff` key

### DIFF
--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -628,7 +628,9 @@ class TestReadTheDocsConfigJson(TestCase):
         assert r.status_code == 200
         expected_response = self._get_response_dict("v0")
         # Remove `addons.doc_diff` from the response because it's not present when `url=` is not sent
-        expected_response["addons"].pop("doc_diff")
+        expected_response["addons"]["doc_diff"] = {
+            "enabled": False,
+        }
 
         assert self._normalize_datetime_fields(r.json()) == expected_response
 

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -324,6 +324,9 @@ class AddonsResponse:
                     # https://github.com/readthedocs/readthedocs.org/issues/9530
                     "code": project.analytics_code,
                 },
+                "doc_diff": {
+                    "enabled": False,
+                },
                 "external_version_warning": {
                     "enabled": project.addons.external_version_warning_enabled,
                     # NOTE: I think we are moving away from these selectors


### PR DESCRIPTION
By default, this addons is disabled unless the `url=` GET attribute is sent. In that case, the `addons.doc_diff` is updated with the corresponding data.

Before this PR we were only returning `addons.doc_diff` key when sending the `url=` producing a validation error since it wasn't present.

Closes https://github.com/readthedocs/addons/issues/252