### PR TITLE
Notification: fix `choices` rendering for `INVALID_CHOICE`

### DIFF
--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -114,9 +114,7 @@ class BuildConfigBase:
         except ConfigValidationError as error:
             # Expand the format values defined when the exception is risen
             # with extra ones we have here
-            format_values = (
-                error.format_values if hasattr(error, "format_values") else {}
-            )
+            format_values = getattr(error, "format_values", {})
             format_values.update(
                 {
                     "key": key,

--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -112,13 +112,22 @@ class BuildConfigBase:
         try:
             yield
         except ConfigValidationError as error:
-            raise ConfigError(
-                message_id=error.message_id,
-                format_values={
+            # Expand the format values defined when the exception is risen
+            # with extra ones we have here
+            format_values = (
+                error.format_values if hasattr(error, "format_values") else {}
+            )
+            format_values.update(
+                {
                     "key": key,
                     "value": error.format_values.get("value"),
                     "source_file": os.path.relpath(self.source_file, self.base_path),
-                },
+                }
+            )
+
+            raise ConfigError(
+                message_id=error.message_id,
+                format_values=format_values,
             ) from error
 
     def pop(self, name, container, default, raise_ex):

--- a/readthedocs/config/tests/test_config.py
+++ b/readthedocs/config/tests/test_config.py
@@ -424,6 +424,9 @@ class TestBuildConfigV2:
             build.validate()
         assert excinfo.value.message_id == ConfigValidationError.INVALID_CHOICE
         assert excinfo.value.format_values.get("key") == "build.tools.python"
+        assert excinfo.value.format_values.get("choices") == ", ".join(
+            settings.RTD_DOCKER_BUILD_SETTINGS["tools"]["python"].keys()
+        )
 
     def test_new_build_config(self):
         build = get_build_config(


### PR DESCRIPTION
While taking a look at #11189 I found that the rendering was broken. I found the `with` + `yield` pattern pretty complex (I have a note about this in the code) and it seems that complexity is confusing enough to make this hard to dealt with.

Anyways, I fixed the problem for now and I added a test case. We can come back to refactoring this in the future with more time.

This PR solves this problem where the choices are not shown in between brackets.

![Screenshot_2024-03-05_16-59-44](https://github.com/readthedocs/readthedocs.org/assets/244656/6e983527-d02d-4874-8751-d287004eeacf)
