### PR TITLE
Support: create a form to render it nicely in ext-theme

### DIFF
--- a/readthedocs/core/forms.py
+++ b/readthedocs/core/forms.py
@@ -209,6 +209,7 @@ class SupportForm(forms.Form):
             ("high", _("High")),
         ),
         help_text=_("Please rate the severity of this event."),
+        required=False,
     )
     subject = forms.CharField(widget=forms.HiddenInput)
 
@@ -217,17 +218,15 @@ class SupportForm(forms.Form):
 
         self.fields["name"].initial = user.get_full_name
         self.fields["email"].initial = user.email
-        self.fields["subject"].hidden = True
 
         if settings.ALLOW_PRIVATE_REPOS:
             self.fields["subject"].initial = "Commercial Support Request"
         else:
             self.fields["subject"].initial = "Community Support Request"
 
-            if not (user.gold.exists or user.goldonce.exists):
-                self.fields["security_level"].widget = forms.HiddenInput
-                self.fields["security_level"].disabled = True
-                self.fields["security_level"].required = False
-                self.fields["security_level"].help_text = _(
+            if not (user.gold.exists() or user.goldonce.exists()):
+                self.fields["severity_level"].disabled = True
+                self.fields["severity_level"].widget.attrs["readonly"] = True
+                self.fields["severity_level"].help_text = _(
                     "This option is only enabled for Gold users."
                 )

--- a/readthedocs/core/forms.py
+++ b/readthedocs/core/forms.py
@@ -198,8 +198,10 @@ class SupportForm(forms.Form):
         help_text=_("Is there a specific page this happened?"),
         required=False,
     )
-    # TODO: "field_file.html" is not available on SemanticUI
-    # attachment = forms.ImageField(label=_("Screenshot or additional file"), help_text=_("Anything else that would help us solve this issue?"))
+    attachment = forms.FileField(
+        label=_("Screenshot or additional file"),
+        help_text=_("Anything else that would help us solve this issue?"),
+    )
     severity_level = forms.ChoiceField(
         choices=(
             ("low", _("Low")),

--- a/readthedocs/core/views/__init__.py
+++ b/readthedocs/core/views/__init__.py
@@ -12,6 +12,7 @@ from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.views.generic import TemplateView, View
 
+from readthedocs.core.forms import SupportForm
 from readthedocs.core.mixins import CDNCacheControlMixin, PrivateViewMixin
 
 log = structlog.get_logger(__name__)
@@ -69,12 +70,17 @@ class HomepageView(TemplateView):
 
 
 class SupportView(PrivateViewMixin, TemplateView):
+    form_class = SupportForm
     template_name = "support/index.html"
 
     def get_context_data(self, **kwargs):
         """Pass along endpoint for support form."""
         context = super().get_context_data(**kwargs)
         context["SUPPORT_FORM_ENDPOINT"] = settings.SUPPORT_FORM_ENDPOINT
+
+        if settings.RTD_EXT_THEME_ENABLED:
+            context["form"] = self.form_class(self.request.user)
+
         return context
 
 

--- a/readthedocs/templates/support/index.html
+++ b/readthedocs/templates/support/index.html
@@ -59,20 +59,6 @@ and we will get back to you as soon as possible.
 </p>
 
 
-{% if form %}
-<form
-    class="ui form"
-    method="POST"
-    name="support-request"
-    action="{{ SUPPORT_FORM_ENDPOINT }}"
-    enctype="multipart/form-data"
-    accept-charset="utf-8"
->
-  {{ form|crispy }}
-
-  <input class="ui primary button" type="submit" value="Submit support request">
-
-{% else %}
 </form>
   method="POST"
   name="support-request"
@@ -142,7 +128,6 @@ and we will get back to you as soon as possible.
 
   </div>
 </form>
-{% endif %}
 {% endif %}
 
 </div>

--- a/readthedocs/templates/support/index.html
+++ b/readthedocs/templates/support/index.html
@@ -59,7 +59,7 @@ and we will get back to you as soon as possible.
 </p>
 
 
-</form>
+<form
   method="POST"
   name="support-request"
   action="{{ SUPPORT_FORM_ENDPOINT }}"

--- a/readthedocs/templates/support/index.html
+++ b/readthedocs/templates/support/index.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% load i18n %}
+{% load crispy_forms_tags %}
 
 
 {% block title %}Support{% endblock %}
@@ -57,7 +58,22 @@ Fill out the form below,
 and we will get back to you as soon as possible.
 </p>
 
+
+{% if form %}
 <form
+    class="ui form"
+    method="POST"
+    name="support-request"
+    action="{{ SUPPORT_FORM_ENDPOINT }}"
+    enctype="multipart/form-data"
+    accept-charset="utf-8"
+>
+  {{ form|crispy }}
+
+  <input class="ui primary button" type="submit" value="Submit support request">
+
+{% else %}
+</form>
   method="POST"
   name="support-request"
   action="{{ SUPPORT_FORM_ENDPOINT }}"
@@ -126,7 +142,7 @@ and we will get back to you as soon as possible.
 
   </div>
 </form>
-
+{% endif %}
 {% endif %}
 
 </div>

--- a/readthedocs/templates/support/index.html
+++ b/readthedocs/templates/support/index.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 
 {% load i18n %}
-{% load crispy_forms_tags %}
 
 
 {% block title %}Support{% endblock %}
@@ -57,7 +56,6 @@ and we will get back to you as soon as possible.
 Fill out the form below,
 and we will get back to you as soon as possible.
 </p>
-
 
 <form
   method="POST"
@@ -128,6 +126,7 @@ and we will get back to you as soon as possible.
 
   </div>
 </form>
+
 {% endif %}
 
 </div>


### PR DESCRIPTION
Use a Django form and crispy filter to render the form on the support page. Also moves the logic from the template to the form itself.


## Demo

![Screenshot_2024-03-06_12-17-20](https://github.com/readthedocs/readthedocs.org/assets/244656/2dfda4f0-5a0c-43f8-b40b-63d23d4ccc79)

Closes https://github.com/readthedocs/ext-theme/issues/296
