### PR TITLE
Revert "Notifications: show "Maxium concurrency limit reached" as `WARNING`"

### DIFF
--- a/readthedocs/notifications/messages.py
+++ b/readthedocs/notifications/messages.py
@@ -135,7 +135,7 @@ BUILD_MESSAGES = [
             """
             ).strip(),
         ),
-        type=WARNING,
+        type=ERROR,
     ),
     Message(
         id=BuildCancelled.CANCELLED_BY_USER,


### PR DESCRIPTION
I think I merged this too quick. The dashboard is not prepared to show other type of notifications yet and these notifications are not displayed properly. We should come back to this and implement it on the new-dashboard directly once we are ready.

Reverts readthedocs/readthedocs.org#11196