### PR TITLE
Add build detail view beta notification

### DIFF
--- a/readthedocs/builds/views.py
+++ b/readthedocs/builds/views.py
@@ -169,7 +169,7 @@ class BuildDetail(BuildBase, DetailView):
 
         build = self.get_object()
 
-        # Temporary notification to point to the new dashboard.
+        # Temporary notification to point to the same page on the new dashboard
         #
         # To support readthedocs.com, we have to point to the login view. We
         # can't point directly to the build view on the new dashboard as this
@@ -177,15 +177,17 @@ class BuildDetail(BuildBase, DetailView):
         #
         # On community, we _don't want this_ as this requires the user to have
         # a login to view the new dashboard.
-        if not settings.RTD_EXT_THEME_ENABLED:
-            url_build = build.get_absolute_url()
-            # Point to the login view with the build as ?next. We are expecting
-            # users to have accounts to view this.
-            if settings.RTD_ALLOW_ORGANIZATIONS:
-                url_build = reverse("account_login") + f"?next={url_build}"
-            context[
-                "url_beta"
-            ] = f"https://beta.{settings.PRODUCTION_DOMAIN}{url_build}"
+        url_domain = settings.PRODUCTION_DOMAIN
+        if url_domain.startswith("beta."):
+            url_domain = url_domain[5:]
+        else:
+            url_domain = f"beta.{url_domain}"
+        url_build = build.get_absolute_url()
+        # Point to the login view with the build as ?next. We are expecting
+        # users to have accounts to view this.
+        if settings.RTD_ALLOW_ORGANIZATIONS:
+            url_build = reverse("account_login") + f"?next={url_build}"
+        context["url_switch_dashboard"] = f"https://{url_domain}{url_build}"
 
         context["notifications"] = build.notifications.all()
         if not build.notifications.filter(

--- a/readthedocs/templates/builds/build_detail.html
+++ b/readthedocs/templates/builds/build_detail.html
@@ -28,6 +28,22 @@ $(document).ready(function () {
 {% endblock %}
 
 {% block content %}
+  {% comment %}
+    Temporary notification to point to the beta dashboard, url_beta comes from the view
+  {% endcomment %}
+  {% block build_detail_beta %}
+    {% if url_beta %}
+      <div class="notifications">
+        <p class="notification notification-20">
+          {% blocktrans trimmed with url=url_beta %}
+            Our new beta dashboard is now available for testing!
+            <a href="{{ url }}">Try viewing this this build on the new dashboard</a>.
+          {% endblocktrans %}
+        </p>
+      </div>
+    {% endif %}
+  {% endblock build_detail_beta %}
+
   <div class="build build-detail" id="build-detail">
 
     {% if build.state != "finished" and build.state != "cancelled" and request.user|is_admin:project %}

--- a/readthedocs/templates/builds/build_detail.html
+++ b/readthedocs/templates/builds/build_detail.html
@@ -28,14 +28,14 @@ $(document).ready(function () {
 {% endblock %}
 
 {% block content %}
-  {% comment %}
-    Temporary notification to point to the beta dashboard, url_beta comes from the view
-  {% endcomment %}
   {% block build_detail_beta %}
-    {% if url_beta %}
+    {% comment %}
+      Temporary notification to point to the beta dashboard, url_beta comes from the view
+    {% endcomment %}
+    {% if url_switch_dashboard %}
       <div class="notifications">
         <p class="notification notification-20">
-          {% blocktrans trimmed with url=url_beta %}
+          {% blocktrans trimmed with url=url_switch_dashboard %}
             Our new beta dashboard is now available for testing!
             <a href="{{ url }}">Try viewing this build on the new dashboard</a>.
           {% endblocktrans %}

--- a/readthedocs/templates/builds/build_detail.html
+++ b/readthedocs/templates/builds/build_detail.html
@@ -37,7 +37,7 @@ $(document).ready(function () {
         <p class="notification notification-20">
           {% blocktrans trimmed with url=url_beta %}
             Our new beta dashboard is now available for testing!
-            <a href="{{ url }}">Try viewing this this build on the new dashboard</a>.
+            <a href="{{ url }}">Try viewing this build on the new dashboard</a>.
           {% endblocktrans %}
         </p>
       </div>


### PR DESCRIPTION
This adds a notification to the corresponding beta build detail view,
and works for both community and commercial. There are two separate
patterns here as a link to the beta dashboard will 404 if the user is not logged in there yet. That is, linking to `beta.readthedocs.com/projects/foo/` will 404 instead of ask the user to sign in first.

The two URLs generated for me are:

- https://beta.devthedocs.org/projects/test-builds/builds/229/
- https://beta.devthedocs.com/accounts/login/?next=/projects/test-test-builds/builds/10/

![image](https://github.com/readthedocs/readthedocs.org/assets/1140183/f8157dba-3faa-459e-8c2b-ca3ddcc711a1)
![image](https://github.com/readthedocs/readthedocs.org/assets/1140183/fa2d6b02-3eda-43df-8bc8-be0d48734aab)

- Refs https://github.com/readthedocs/ext-theme/issues/284
- Refs https://github.com/readthedocs/readthedocs-corporate/issues/1760