### PR TITLE
doc: Document `build.commands` working directory

### DIFF
--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -487,6 +487,11 @@ The ``$READTHEDOCS_OUTPUT/html`` directory will be uploaded and hosted by Read t
 
    ``build.os`` and ``build.tools`` are also required when using ``build.commands``.
 
+.. note::
+
+   All items in the ``build.commands`` array are executed in a clean shell environment, i.e. environment changes do not
+   persist and the working directory always start from the git repo.
+
 :Type: ``list``
 :Required: ``false``
 :Default: ``[]``


### PR DESCRIPTION
I just got bit by this trying to do
```yaml
build:
  commands:
    - cd docs
    - myst build --html
```

After the `cd docs`, the next command is reset to the main repo root

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11218.org.readthedocs.build/en/11218/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11218.org.readthedocs.build/en/11218/

<!-- readthedocs-preview dev end -->