### PR TITLE
Fix Read the Docs config file name in notifications

### DIFF
--- a/readthedocs/config/notifications.py
+++ b/readthedocs/config/notifications.py
@@ -29,7 +29,7 @@ messages = [
         body=_(
             textwrap.dedent(
                 """
-            The required <code>readthedocs.yaml</code> configuration file was not found at repository's root.
+            The required <code>.readthedocs.yaml</code> configuration file was not found at repository's root.
             Learn how to use this file in our <a href="https://docs.readthedocs.io/en/stable/config-file/index.html">configuration file tutorial</a>.
             """
             ).strip(),


### PR DESCRIPTION
The correct filename is `.readthedocs.yaml` rather than `readthedocs.yaml`