### PR TITLE
Proxito: define dummy dashboard URLs for addons serializers

### DIFF
--- a/readthedocs/config/notifications.py
+++ b/readthedocs/config/notifications.py
@@ -29,7 +29,7 @@ messages = [
         body=_(
             textwrap.dedent(
                 """
-            The required <code>readthedocs.yaml</code> configuration file was not found at repository's root.
+            The required <code>.readthedocs.yaml</code> configuration file was not found at repository's root.
             Learn how to use this file in our <a href="https://docs.readthedocs.io/en/stable/config-file/index.html">configuration file tutorial</a>.
             """
             ).strip(),

--- a/readthedocs/core/views/__init__.py
+++ b/readthedocs/core/views/__init__.py
@@ -89,7 +89,7 @@ class TeapotView(TemplateView):
 
     def get(self, request, *args, **kwargs):
         context = self.get_context_data(**kwargs)
-        return self.render_to_response(context, status=403)
+        return self.render_to_response(context, status=418)
 
 
 def server_error_500(request, template_name="500.html"):

--- a/readthedocs/core/views/__init__.py
+++ b/readthedocs/core/views/__init__.py
@@ -84,6 +84,14 @@ class SupportView(PrivateViewMixin, TemplateView):
         return context
 
 
+class TeapotView(TemplateView):
+    template_name = "core/teapot.html"
+
+    def get(self, request, *args, **kwargs):
+        context = self.get_context_data(**kwargs)
+        return self.render_to_response(context, status=403)
+
+
 def server_error_500(request, template_name="500.html"):
     """A simple 500 handler so we get media."""
     r = render(request, template_name)

--- a/readthedocs/proxito/tests/responses/v0.json
+++ b/readthedocs/proxito/tests/responses/v0.json
@@ -30,6 +30,12 @@
       "subproject_of": null,
       "tags": ["project", "tag", "test"],
       "translation_of": null,
+      "urls": {
+        "builds": "https://readthedocs.org/project/builds/",
+        "documentation": "https://project.dev.readthedocs.io/en/latest/",
+        "home": "https://readthedocs.org/project/",
+        "versions": "https://readthedocs.org/project/versions/"
+      },
       "users": [
         {
           "username": "testuser"
@@ -49,6 +55,13 @@
       "ref": null,
       "slug": "latest",
       "type": "tag",
+      "urls": {
+        "dashboard": {
+          "edit": "https://readthedocs.org/project/version/latest/edit/"
+        },
+        "documentation": "https://project.dev.readthedocs.io/en/latest/",
+        "vcs": "https://github.com/readthedocs/project/tree/master/"
+      },
       "verbose_name": "latest"
     }
   },
@@ -66,6 +79,11 @@
         "name": "Finished"
       },
       "success": true,
+      "urls": {
+        "build": "https://readthedocs.org/project/builds/1/",
+        "project": "https://readthedocs.org/project/",
+        "version": "https://readthedocs.org/project/version/latest/edit/"
+      },
       "version": "latest"
     }
   },

--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -701,7 +701,7 @@ class TestReadTheDocsConfigJson(TestCase):
                 active=True,
             )
 
-        with self.assertNumQueries(20):
+        with self.assertNumQueries(23):
             r = self.client.get(
                 reverse("proxito_readthedocs_docs_addons"),
                 {
@@ -730,7 +730,7 @@ class TestReadTheDocsConfigJson(TestCase):
                 active=True,
             )
 
-        with self.assertNumQueries(20):
+        with self.assertNumQueries(22):
             r = self.client.get(
                 reverse("proxito_readthedocs_docs_addons"),
                 {
@@ -766,7 +766,7 @@ class TestReadTheDocsConfigJson(TestCase):
                 active=True,
             )
 
-        with self.assertNumQueries(24):
+        with self.assertNumQueries(28):
             r = self.client.get(
                 reverse("proxito_readthedocs_docs_addons"),
                 {
@@ -792,7 +792,7 @@ class TestReadTheDocsConfigJson(TestCase):
                 language=language,
             )
 
-        with self.assertNumQueries(24):
+        with self.assertNumQueries(26):
             r = self.client.get(
                 reverse("proxito_readthedocs_docs_addons"),
                 {

--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -701,7 +701,7 @@ class TestReadTheDocsConfigJson(TestCase):
                 active=True,
             )
 
-        with self.assertNumQueries(23):
+        with self.assertNumQueries(21):
             r = self.client.get(
                 reverse("proxito_readthedocs_docs_addons"),
                 {

--- a/readthedocs/proxito/urls.py
+++ b/readthedocs/proxito/urls.py
@@ -36,10 +36,9 @@ pip.rtd.io/_/api/*
 from django.conf import settings
 from django.urls import include, path, re_path
 from django.views import defaults
-from django.views.generic import TemplateView
 
 from readthedocs.constants import pattern_opts
-from readthedocs.core.views import HealthCheckView
+from readthedocs.core.views import HealthCheckView, TeapotView
 from readthedocs.projects.views.public import ProjectDownloadMedia
 from readthedocs.proxito.views.hosting import ReadTheDocsConfigJson
 from readthedocs.proxito.views.serve import (
@@ -162,19 +161,19 @@ dummy_dashboard_urls = [
     # /dashboard/<project_slug>/
     re_path(
         r"^(?P<project_slug>{project_slug})/$".format(**pattern_opts),
-        TemplateView.as_view(template_name="proxied_view.html"),
+        TeapotView.as_view(),
         name="projects_detail",
     ),
     # /dashboard/<project_slug>/builds/
     re_path(
         (r"^(?P<project_slug>{project_slug})/builds/$".format(**pattern_opts)),
-        TemplateView.as_view(template_name="proxied_view.html"),
+        TeapotView.as_view(),
         name="builds_project_list",
     ),
     # /dashboard/<project_slug>/versions/
     re_path(
         r"^(?P<project_slug>{project_slug})/versions/$".format(**pattern_opts),
-        TemplateView.as_view(template_name="proxied_view.html"),
+        TeapotView.as_view(),
         name="project_version_list",
     ),
     # /dashboard/<project_slug>/builds/<build_id>/
@@ -184,13 +183,13 @@ dummy_dashboard_urls = [
                 **pattern_opts
             )
         ),
-        TemplateView.as_view(template_name="proxied_view.html"),
+        TeapotView.as_view(),
         name="builds_detail",
     ),
     # /dashboard/<project_slug>/version/<version_slug>/
     re_path(
         r"^(?P<project_slug>[-\w]+)/version/(?P<version_slug>[^/]+)/edit/$",
-        TemplateView.as_view(template_name="proxied_view.html"),
+        TeapotView.as_view(),
         name="project_version_detail",
     ),
 ]

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -124,12 +124,20 @@ class BaseReadTheDocsConfigJson(CDNCacheTagsMixin, APIView):
 
         else:
             project = Project.objects.filter(slug=project_slug).first()
-            version = Version.objects.filter(slug=version_slug, project=project).first()
+            version = (
+                Version.objects.filter(slug=version_slug, project=project)
+                .select_related("project")
+                .first()
+            )
             if version:
-                build = version.builds.filter(
-                    success=True,
-                    state=BUILD_STATE_FINISHED,
-                ).first()
+                build = (
+                    version.builds.filter(
+                        success=True,
+                        state=BUILD_STATE_FINISHED,
+                    )
+                    .select_related("project", "version")
+                    .first()
+                )
 
         return project, version, build, filename
 

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -195,10 +195,7 @@ class NoLinksMixin:
 
     """Mixin to remove conflicting fields from serializers."""
 
-    FIELDS_TO_REMOVE = (
-        "_links",
-        "urls",
-    )
+    FIELDS_TO_REMOVE = ("_links",)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -213,8 +210,8 @@ class NoLinksMixin:
 
 # NOTE: the following serializers are required only to remove some fields we
 # can't expose yet in this API endpoint because it's running under El Proxito
-# which cannot resolve some dashboard URLs because they are not defined on El
-# Proxito.
+# which cannot resolve URLs pointing to the APIv3 because they are not defined
+# on El Proxito.
 #
 # See https://github.com/readthedocs/readthedocs-ops/issues/1323
 class ProjectSerializerNoLinks(NoLinksMixin, ProjectSerializer):

--- a/readthedocs/templates/core/teapot.html
+++ b/readthedocs/templates/core/teapot.html
@@ -1,0 +1,11 @@
+{% extends "errors/base.html" %}
+{% load core_tags %}
+{% load i18n %}
+
+{% block title %}
+  {% trans "418. I'm a teapot" %}
+{% endblock %}
+
+{% block content %}
+<h1>{% trans "418. I'm a teapot" %}</h1>
+{% endblock %}


### PR DESCRIPTION
This PR defines dummy dashboard URLs in El Proxito to allow calling `reverse()` for APIv3 serializers used under `/_/addons/` and return `*.urls` fields for resources.

Closes https://github.com/readthedocs/readthedocs-ops/issues/1323