### PR TITLE
Fully roll out stickybox

### DIFF
--- a/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
+++ b/readthedocs/core/static-src/core/js/doc-embed/sponsorship.js
@@ -70,12 +70,10 @@ function create_ad_placement() {
                 selector = $('<div />').insertAfter('footer hr');
                 class_name = 'ethical-rtd';
 
-                // Use the stickybox placement 25% of the time during rollout
-                // But only when the ad would be in the footer
-                if (Math.random() <= 0.25) {
-                    style_name = 'stickybox';
-                    ad_type = 'image';
-                }
+                // Use the stickybox placement 100% of the time,
+                // now that we're happy with its performance.
+                style_name = 'stickybox';
+                ad_type = 'image';
             } else if (rtd.is_alabaster_like_theme()) {
                 selector = 'div.bodywrapper .body';
                 class_name = 'ethical-alabaster';


### PR DESCRIPTION
This enables the stickybox placements (floating bottom right) on RTD theme docs, and never uses the footer placement.