### PR TITLE
APIv3: add `state__in` filter for Notifications

### DIFF
--- a/readthedocs/api/v3/filters.py
+++ b/readthedocs/api/v3/filters.py
@@ -62,9 +62,9 @@ class BuildFilter(filters.FilterSet):
 class NotificationFilter(filters.FilterSet):
     class Meta:
         model = Notification
-        fields = [
-            "state",
-        ]
+        fields = {
+            "state": ["in", "exact"],
+        }
 
 
 class RemoteRepositoryFilter(filters.FilterSet):


### PR DESCRIPTION
This is required by the new dashboard to filter notifications by `state__in=read,unread`.

Documentation:
https://django-filter.readthedocs.io/en/stable/guide/usage.html#generating-filters-with-meta-fields

Closes #11214