### PR TITLE
Build: mark build as CANCELLED when command exits with 183

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -31,7 +31,7 @@ from .constants import (
     DOCKER_VERSION,
     RTD_SKIP_BUILD_EXIT_CODE,
 )
-from .exceptions import BuildAppError, BuildUserError
+from .exceptions import BuildAppError, BuildCancelled, BuildUserError
 
 log = structlog.get_logger(__name__)
 
@@ -527,7 +527,7 @@ class BaseBuildEnvironment:
                     version_slug=self.version.slug if self.version else "",
                 )
             elif build_cmd.exit_code == RTD_SKIP_BUILD_EXIT_CODE:
-                raise BuildUserError(BuildUserError.SKIPPED_EXIT_CODE_183)
+                raise BuildCancelled(BuildCancelled.SKIPPED_EXIT_CODE_183)
             else:
                 # TODO: for now, this still outputs a generic error message
                 # that is the same across all commands. We could improve this

--- a/readthedocs/doc_builder/exceptions.py
+++ b/readthedocs/doc_builder/exceptions.py
@@ -31,7 +31,6 @@ class BuildAppError(BuildBaseException):
 
 class BuildUserError(BuildBaseException):
     GENERIC = "build:user:generic"
-    SKIPPED_EXIT_CODE_183 = "build:user:exit-code-183"
 
     BUILD_COMMANDS_WITHOUT_OUTPUT = "build:user:output:no-html"
     BUILD_OUTPUT_IS_NOT_A_DIRECTORY = "build:user:output:is-no-a-directory"
@@ -59,6 +58,7 @@ class BuildMaxConcurrencyError(BuildUserError):
 
 class BuildCancelled(BuildUserError):
     CANCELLED_BY_USER = "build:user:cancelled"
+    SKIPPED_EXIT_CODE_183 = "build:user:exit-code-183"
 
 
 class MkDocsYAMLParseError(BuildUserError):

--- a/readthedocs/notifications/messages.py
+++ b/readthedocs/notifications/messages.py
@@ -150,7 +150,7 @@ BUILD_MESSAGES = [
         type=ERROR,
     ),
     Message(
-        id=BuildUserError.SKIPPED_EXIT_CODE_183,
+        id=BuildCancelled.SKIPPED_EXIT_CODE_183,
         header=_("Build skipped."),
         body=_(
             textwrap.dedent(

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -300,7 +300,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
     # Do not send notifications on failure builds for these exceptions.
     exceptions_without_notifications = (
         BuildCancelled.CANCELLED_BY_USER,
-        BuildUserError.SKIPPED_EXIT_CODE_183,
+        BuildCancelled.SKIPPED_EXIT_CODE_183,
         BuildAppError.BUILDS_DISABLED,
         BuildMaxConcurrencyError.LIMIT_REACHED,
     )
@@ -541,7 +541,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
                 version_type = self.data.version.type
 
             status = BUILD_STATUS_FAILURE
-            if message_id == BuildUserError.SKIPPED_EXIT_CODE_183:
+            if message_id == BuildCancelled.SKIPPED_EXIT_CODE_183:
                 # The build was skipped by returning the magic exit code,
                 # marked as CANCELLED, but communicated to GitHub as successful.
                 # This is because the PR has to be available for merging when the build

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -49,7 +49,7 @@ from readthedocs.builds.constants import (
     LATEST,
 )
 from readthedocs.builds.models import APIVersion, Build, BuildCommandResult, Version
-from readthedocs.doc_builder.exceptions import BuildMaxConcurrencyError, BuildUserError
+from readthedocs.doc_builder.exceptions import BuildCancelled, BuildMaxConcurrencyError
 from readthedocs.integrations.models import GenericAPIWebhook, Integration
 from readthedocs.notifications.constants import READ, UNREAD
 from readthedocs.notifications.models import Notification
@@ -113,7 +113,7 @@ class APIBuildTests(TestCase):
 
         Notification.objects.add(
             attached_to=build,
-            message_id=BuildUserError.SKIPPED_EXIT_CODE_183,
+            message_id=BuildCancelled.SKIPPED_EXIT_CODE_183,
         )
 
         self.assertEqual(build.commands.count(), 1)


### PR DESCRIPTION

![Screenshot_2024-03-25_13-33-43](https://github.com/readthedocs/readthedocs.org/assets/244656/426ac174-6909-45cc-b15a-956af578835e)


Closes #11232