### PR TITLE
feat: Build be triggered on labeled

### DIFF
--- a/readthedocs/api/v2/views/integrations.py
+++ b/readthedocs/api/v2/views/integrations.py
@@ -40,6 +40,7 @@ GITHUB_PULL_REQUEST_OPENED = "opened"
 GITHUB_PULL_REQUEST_CLOSED = "closed"
 GITHUB_PULL_REQUEST_REOPENED = "reopened"
 GITHUB_PULL_REQUEST_SYNC = "synchronize"
+GITHUB_PULL_REQUEST_LABELED = "labeled"
 GITHUB_CREATE = "create"
 GITHUB_DELETE = "delete"
 GITLAB_MERGE_REQUEST = "merge_request"
@@ -480,6 +481,7 @@ class GitHubWebhookView(WebhookMixin, APIView):
                 GITHUB_PULL_REQUEST_OPENED,
                 GITHUB_PULL_REQUEST_REOPENED,
                 GITHUB_PULL_REQUEST_SYNC,
+                GITHUB_PULL_REQUEST_LABELED,
             ]:
                 # Trigger a build when PR is opened/reopened/sync
                 return self.get_external_version_response(self.project)


### PR DESCRIPTION
![image](https://github.com/readthedocs/readthedocs.org/assets/31057849/29b307e3-06bf-45f7-b9dc-00318cf9f304)
readthedocs/actions/preview provides an example of adding preview to the text when the docs label is attached as shown above.
I am using the method above, and in post_checkout to reduce pointless builds,
I also use code like this:
https://github.com/lablup/backend.ai/blob/main/scripts/check-docs-label.sh
However, since rtd's build is triggered only when the payload of the pull_request is opened, reopened, or sync, it will not work properly if the docs label is not added at the same time as the pr is opened and added afterwards.

(It would be even better if it were possible to add a function like the above script as an official function)