### PR TITLE
chore: Update guidelines links

### DIFF
--- a/docs/dev/design.rst
+++ b/docs/dev/design.rst
@@ -47,6 +47,6 @@ making changes that render older browsers utterly unusable (or provide a sane fa
 Brand guidelines
 ----------------
 
-Find our branding guidelines in our guidelines documentation: https://read-the-docs-guidelines.readthedocs-hosted.com.
+Find our branding guidelines in our guidelines documentation: https://brand-guidelines.readthedocs.org.
 
 .. _Read the Docs GitHub project: https://github.com/readthedocs/readthedocs.org/pulls

--- a/docs/user/terms-of-service.rst
+++ b/docs/user/terms-of-service.rst
@@ -310,7 +310,7 @@ Read the Docs trademarks and logos
 If you'd like to use Read the Docs's trademarks,
 you must follow all of our `trademark guidelines`_.
 
-.. _trademark guidelines: https://read-the-docs-guidelines.readthedocs-hosted.com/
+.. _trademark guidelines: https://brand-guidelines.readthedocs.org/
 
 
 API terms

--- a/docs/user/user-defined-redirects.rst
+++ b/docs/user/user-defined-redirects.rst
@@ -29,7 +29,7 @@ Built-in redirects
 
 This section explains the redirects that are automatically active for all projects and how they are useful.
 Built-in redirects are especially useful for creating and sharing incoming links,
-which is discussed indepth in :doc:`/guides/best-practice/links`.
+which is discussed in depth in :doc:`/guides/best-practice/links`.
 
 .. _page_redirects:
 

--- a/readthedocs/templates/base.html
+++ b/readthedocs/templates/base.html
@@ -231,7 +231,7 @@
               <a href="https://readthedocs.com">{% trans 'Read the Docs for Business' %}</a>
             </li>
             <li>
-              <a href="https://read-the-docs-guidelines.readthedocs-hosted.com/">{% trans 'Branding & Media Kit' %}</a>
+              <a href="https://brand-guidelines.readthedocs.org/">{% trans 'Branding & Media Kit' %}</a>
             </li>
             <li>
               <a href="https://docs.readthedocs.io/page/privacy-policy.html">{% trans 'Privacy Policy' %}</a>


### PR DESCRIPTION
Updates the links to current brand-guidelines.readthedocs.org, fixes a typo along the way.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11261.org.readthedocs.build/en/11261/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11261.org.readthedocs.build/en/11261/

<!-- readthedocs-preview dev end -->