### PR TITLE
Add version slug filtering to APIv3

### DIFF
--- a/readthedocs/api/v3/tests/test_versions.py
+++ b/readthedocs/api/v3/tests/test_versions.py
@@ -31,8 +31,8 @@ class VersionsEndpointTests(APIEndpointMixin):
         self.assertEqual(response.status_code, 200)
         response = response.json()
         self.assertEqual(len(response["results"]), 2)
-        self.assertEqual(response["results"][0]["slug"], "v1.0")
-        self.assertEqual(response["results"][1]["slug"], "latest")
+        self.assertEqual(response["results"][0]["slug"], "latest")
+        self.assertEqual(response["results"][1]["slug"], "v1.0")
 
     def test_others_projects_versions_list(self):
         self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -340,6 +340,10 @@ class VersionsViewSet(
         version.post_save(was_active=was_active)
         return result
 
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        return queryset.order_by("slug")
+
 
 class BuildsViewSet(
     APIv3Settings,

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -340,10 +340,6 @@ class VersionsViewSet(
         version.post_save(was_active=was_active)
         return result
 
-    def get_queryset(self):
-        queryset = super().get_queryset()
-        return queryset.order_by("slug")
-
 
 class BuildsViewSet(
     APIv3Settings,

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -207,7 +207,7 @@ class Version(TimeStampedModel):
 
     class Meta:
         unique_together = [("project", "slug")]
-        ordering = ["-verbose_name"]
+        ordering = ["verbose_name"]
 
     def __str__(self):
         return gettext(


### PR DESCRIPTION
Hopefully this doesn't collide with anything else, but I did notice the
results seem backwards while working on the version form. You can
reproduce this with:

https://beta.readthedocs.org/api/v3/projects/test-builds/versions/

I see the `yaml-v2` branch first.

- Refs https://github.com/readthedocs/ext-theme/issues/287