### PR TITLE
Notifications: allow usernames with dots

### DIFF
--- a/readthedocs/api/v3/tests/test_users.py
+++ b/readthedocs/api/v3/tests/test_users.py
@@ -53,6 +53,21 @@ class UsersEndpointTests(APIEndpointMixin):
             self._get_response_dict("users-notifications-list"),
         )
 
+    def test_users_notifications_list_with_email_like_username(self):
+        """Test for #11260."""
+        self.me.username = "test@example.com"
+        self.me.save()
+        url = reverse(
+            "users-notifications-list",
+            kwargs={
+                "parent_lookup_user__username": self.me.username,
+            },
+        )
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
     def test_users_notifications_list_other_user(self):
         url = reverse(
             "users-notifications-list",

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -589,6 +589,10 @@ class UsersViewSet(
     serializer_class = UserSerializer
     queryset = User.objects.none()
     permission_classes = (IsAuthenticated,)
+    # We are using the username as the lookup field,
+    # by default, DRF does not allow dots and `/`,
+    # but we allow usernames to have dots.
+    lookup_value_regex = "[^/]+"
 
 
 class NotificationsUserViewSet(


### PR DESCRIPTION
Closes https://github.com/readthedocs/readthedocs.org/issues/11260. Tests are missing.

This is required for testing https://github.com/readthedocs/readthedocs-corporate/pull/1770.