### PR TITLE
Addons API: change `versions.active` to `.actives` since it's a list

### DIFF
--- a/readthedocs/proxito/tests/responses/v1.json
+++ b/readthedocs/proxito/tests/responses/v1.json
@@ -66,7 +66,7 @@
       },
       "verbose_name": "latest"
     },
-    "active": [
+    "actives": [
       {
         "active": true,
         "aliases": [],

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -367,7 +367,7 @@ class AddonsResponse:
                 if version
                 else None,
                 # These are "sorted active, built, not hidden versions"
-                "active": VersionSerializerNoLinks(
+                "actives": VersionSerializerNoLinks(
                     sorted_versions_active_built_not_hidden,
                     resolver=resolver,
                     many=True,


### PR DESCRIPTION
Make this breaking change before it's too late and we start exposing this to our users.