### PR TITLE
Use initial value for default dashboard template name

### DIFF
--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -116,6 +116,7 @@ class ProjectDashboard(PrivateViewMixin, ListView):
 
             projects = AdminPermission.projects(user=self.request.user, admin=True)
             n_projects = projects.count()
+            template_name = "security-logs.html"
             if n_projects < 3 and (timezone.now() - projects.first().pub_date).days < 7:
                 template_name = "example-projects.html"
             elif (
@@ -128,8 +129,6 @@ class ProjectDashboard(PrivateViewMixin, ListView):
                 and not projects.filter(addons__analytics_enabled=True).exists()
             ):
                 template_name = "traffic-analytics.html"
-            else:
-                context["promotion"] = "security-logs.html"
 
             context["promotion"] = f"projects/partials/dashboard/{template_name}"
 


### PR DESCRIPTION
Solve bug https://read-the-docs.sentry.io/issues/5244784623/?project=148442&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=1h&stream_index=3&utc=true

```
  File "django/views/generic/list.py", line 174, in get
    context = self.get_context_data()
  File "readthedocs/projects/views/private.py", line 134, in get_context_data
    context["promotion"] = f"projects/partials/dashboard/{template_name}"
  UnboundLocalError: local variable 'template_name' referenced before assignment
```