### PR TITLE
The `python.install` requires  the `path` key

### DIFF
--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -173,7 +173,7 @@ The path to the package, relative to the root of the project.
 
 :Key: ``path``
 :Type: ``path``
-:Required: ``false``
+:Required: ``true``
 
 The installation method.
 


### PR DESCRIPTION
The `path` key seems to be required per:
https://github.com/readthedocs/readthedocs.org/blob/cb50bbfe3bc1882d990db91a2bbb337df5f714b5/readthedocs/rtd_tests/fixtures/spec/v2/schema.json#L277-L278

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11300.org.readthedocs.build/en/11300/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11300.org.readthedocs.build/en/11300/

<!-- readthedocs-preview dev end -->