### PR TITLE
Replace non-existant `python.install.package` with `python.install.path`

### DIFF
--- a/docs/user/config-file/index.rst
+++ b/docs/user/config-file/index.rst
@@ -128,7 +128,7 @@ you should define the Python version in ``build.tools.python``.
 The ``python`` key contains a list of sub-keys,
 specifying the requirements to install.
 
-- Use ``python.install.package`` to install the project itself as a Python package using pip
+- Use ``python.install.path`` to install the project itself as a Python package using pip
 - Use ``python.install.requirements`` to install packages from a requirements file
 - Use ``build.jobs`` to install packages using Poetry or PDM
 


### PR DESCRIPTION
This confused me initially because I was looking in https://docs.readthedocs.io/en/stable/config-file/v2.html#packages for `python.install.package`, which simply doesn't exist.

Instead, this should probably be `python.install.path` which _is_ a required key (https://github.com/readthedocs/readthedocs.org/pull/11300), and defaults to `pip`.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11301.org.readthedocs.build/en/11301/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11301.org.readthedocs.build/en/11301/

<!-- readthedocs-preview dev end -->