### PR TITLE
Addons: return 404 when the `project` does not exist in the DB

### DIFF
--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -19,6 +19,7 @@ from readthedocs.projects.constants import (
     SINGLE_VERSION_WITHOUT_TRANSLATIONS,
 )
 from readthedocs.projects.models import AddonsConfig, Domain, Project
+from readthedocs.proxito.views.hosting import ClientError
 
 
 @override_settings(
@@ -665,6 +666,25 @@ class TestReadTheDocsConfigJson(TestCase):
             r.json()["versions"]["active"][0]["urls"]["documentation"]
             == "https://docs.example.com/en/latest/"
         )
+
+    def test_non_existent_project(self):
+        r = self.client.get(
+            reverse("proxito_readthedocs_docs_addons"),
+            {
+                "api-version": "1.0.0",
+                "client-version": "0.6.0",
+                "project-slug": "non-existent-project",
+                "version-slug": "latest",
+            },
+            secure=True,
+            headers={
+                "host": "project.dev.readthedocs.io",
+            },
+        )
+        assert r.status_code == 404
+        assert r.json() == {
+            "error": ClientError.PROJECT_NOT_FOUND,
+        }
 
     def test_number_of_queries_project_version_slug(self):
         # The number of queries should not increase too much, even if we change

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -47,6 +47,7 @@ class ClientError(Exception):
         "The version specified in 'api-version' is currently not supported"
     )
     VERSION_INVALID = "The version specifified in 'api-version' is invalid"
+    PROJECT_NOT_FOUND = "There is no project with the 'project-slug' requested"
 
 
 class BaseReadTheDocsConfigJson(CDNCacheTagsMixin, APIView):
@@ -189,6 +190,11 @@ class BaseReadTheDocsConfigJson(CDNCacheTagsMixin, APIView):
             )
 
         project, version, build, filename = self._resolve_resources()
+        if not project:
+            return JsonResponse(
+                {"error": ClientError.PROJECT_NOT_FOUND},
+                status=404,
+            )
 
         data = AddonsResponse().get(
             addons_version,


### PR DESCRIPTION
Found via Sentry at
https://read-the-docs.sentry.io/issues/5206873079/events/66c67d38c3a74ac1a4048b8aad3f1f55/