### PR TITLE
Docs: use addons search

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,6 @@ extensions = [
     "notfound.extension",
     "sphinx_copybutton",
     "sphinx_design",
-    "sphinx_search.extension",
     "sphinx_tabs.tabs",
     "sphinx-prompt",
     "sphinx.ext.autodoc",


### PR DESCRIPTION
Do not install `readthedocs-sphinx-search` extension and hook the "Search docs" input from the top right to the `readthedocs-search-show` event to trigger the addons search modal 🎉 


![Peek 2024-04-24 13-52](https://github.com/readthedocs/readthedocs.org/assets/244656/3d263c46-402f-4c2e-890b-1cd4806d2391)



<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11303.org.readthedocs.build/en/11303/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11303.org.readthedocs.build/en/11303/

<!-- readthedocs-preview dev end -->