### PR TITLE
Wrangler: NGINX and redirects

### DIFF
--- a/dockerfiles/nginx/proxito.conf.template
+++ b/dockerfiles/nginx/proxito.conf.template
@@ -132,7 +132,6 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Host $host;
         add_header X-Served Proxito-404-Fallback always;
     }
 


### PR DESCRIPTION
Since we added `wrangler` to the equation this `$host` variable doesn't point anymore to the `*.devthedocs.org` (documentation) domain anymore, and instead it points to just `nginx`.

This is causing a problem in the redirects because our code checks `X-Forwarded-Host` as the domain where the request is from.

```
proxito_1      | [info     ] Invalid domain.                [readthedocs.core.unresolver] domain=nginx host=nginx ip=10.10.0.100 request_id=e6dd83a5-66fb-4ead-9d0d-7f40a422c294 user_id=None
```

Note that `domain=nginx` and `host=nginx`.

By removing the override of this setting here, we are sending the real domain from where the request was made, in my case `mystmd.devthedocs.org`.

This commit fixes the usage of redirects on local development.