### PR TITLE
Languages code are now normalized

### DIFF
--- a/docs/user/reference/environment-variables.rst
+++ b/docs/user/reference/environment-variables.rst
@@ -16,13 +16,14 @@ All :doc:`build processes </builds>` have the following environment variables au
 .. envvar:: READTHEDOCS_LANGUAGE
 
     The locale name, or the identifier for the locale, for the project being built.
-    This value comes from the project's configured language.
+    This value comes from the project's configured language,
+    normalized to be lowercase and use a dash as a separator instead of an underscore
 
     :Example: ``en``
     :Example: ``it``
-    :Example: ``de_AT``
+    :Example: ``de-at``
     :Example: ``es``
-    :Example: ``pt_BR``
+    :Example: ``pt-br``
 
 .. envvar:: READTHEDOCS_VERSION
 

--- a/docs/user/reference/environment-variables.rst
+++ b/docs/user/reference/environment-variables.rst
@@ -17,7 +17,7 @@ All :doc:`build processes </builds>` have the following environment variables au
 
     The locale name, or the identifier for the locale, for the project being built.
     This value comes from the project's configured language,
-    normalized to be lowercase and use a dash as a separator instead of an underscore
+    normalized to be lowercase and use a dash as a separator instead of an underscore.
 
     :Example: ``en``
     :Example: ``it``

--- a/docs/user/reference/environment-variables.rst
+++ b/docs/user/reference/environment-variables.rst
@@ -16,8 +16,8 @@ All :doc:`build processes </builds>` have the following environment variables au
 .. envvar:: READTHEDOCS_LANGUAGE
 
     The locale name, or the identifier for the locale, for the project being built.
-    This value comes from the project's configured language,
-    normalized to be lowercase and use a dash as a separator instead of an underscore.
+    This value comes from the project's configured language code,
+    which is in lowercase and use a dash as a separator.
 
     :Example: ``en``
     :Example: ``it``


### PR DESCRIPTION
As of October 2023. see https://blog.readthedocs.com/language-codes-are-now-normalized/

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11315.org.readthedocs.build/en/11315/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11315.org.readthedocs.build/en/11315/

<!-- readthedocs-preview dev end -->