### PR TITLE
Docs: use EthicalAd implementation from addons

### DIFF
--- a/docs/_templates/ethicalads.html
+++ b/docs/_templates/ethicalads.html
@@ -1,3 +1,0 @@
-<div id="rtd-stickybox-container">
-  <div class="raised" data-ea-publisher="readthedocs" data-ea-type="image" data-ea-style="stickybox"></div>
-</div>

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -7,9 +7,3 @@
   <script defer data-domain="{{ plausible_domain }}" src="https://plausible.io/js/script.js"></script>
   {% endif %}
 {% endblock extrahead %}
-
-{% block document %}
-  {{ super() }}
-
-  {% include "ethicalads.html" %}
-{% endblock document %}


### PR DESCRIPTION
Instead of injecting the EthicalAd in a customized way, we will injecting it by using the addons approach.

This will be a starting test before enabling this in all the projects that are using addons.

Requires:
* https://github.com/readthedocs/addons/pull/295

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11318.org.readthedocs.build/en/11318/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11318.org.readthedocs.build/en/11318/

<!-- readthedocs-preview dev end -->