### PR TITLE
docs: update uv instructions

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -359,8 +359,8 @@ Take a look at the following example:
 Install dependencies with ``uv``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Projects managed with `uv <https://github.com/astral-sh/uv/>`__,
-can use the ``post_create_environment`` user-defined job to use ``uv`` for installing Python dependencies.
+Projects can use `uv <https://github.com/astral-sh/uv/>`__,
+to install Python dependencies, usually reducing the time taken to install compared to pip, possibly dramatically.
 Take a look at the following example:
 
 
@@ -373,19 +373,15 @@ Take a look at the following example:
      os: "ubuntu-22.04"
      tools:
        python: "3.10"
-     jobs:
-       post_create_environment:
-         # Install uv
-         - pip install uv
-       post_install:
-         # Install dependencies with 'docs' dependency group
-         # VIRTUAL_ENV needs to be set manually for now.
-         # See https://github.com/readthedocs/readthedocs.org/pull/11152/
-         - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH uv pip install .[docs]
+     commands:
+       - asdf plugin add uv
+       - asdf install uv latest
+       - asdf global uv latest
+       - uv venv
+       - uv pip install .[docs]
+       - .venv/bin/python -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
 
-   sphinx:
-     configuration: docs/conf.py
-
+You can use ``-r docs/requirements.txt``, etc. instead as needed. And mkdocs would use ``.venv/bin/python -m mkdocs build --site-dir $READTHEDOCS_OUTPUT/html``.
 
 Update Conda version
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -381,7 +381,7 @@ Take a look at the following example:
        - uv pip install .[docs]
        - .venv/bin/python -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
 
-You can use ``-r docs/requirements.txt``, etc. instead as needed. And mkdocs would use ``.venv/bin/python -m mkdocs build --site-dir $READTHEDOCS_OUTPUT/html``.
+You can use ``-r docs/requirements.txt``, etc. instead as needed. And mkdocs would use ``NO_COLOR=1 .venv/bin/mkdocs build --strict --site-dir $READTHEDOCS_OUTPUT/html``.
 
 Update Conda version
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -360,7 +360,7 @@ Install dependencies with ``uv``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Projects can use `uv <https://github.com/astral-sh/uv/>`__,
-to install Python dependencies, usually reducing the time taken to install compared to pip, possibly dramatically.
+to install Python dependencies, usually reducing the time taken to install compared to pip.
 Take a look at the following example:
 
 
@@ -381,7 +381,7 @@ Take a look at the following example:
        - uv pip install .[docs]
        - .venv/bin/python -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
 
-You can use ``-r docs/requirements.txt``, etc. instead as needed. And mkdocs would use ``NO_COLOR=1 .venv/bin/mkdocs build --strict --site-dir $READTHEDOCS_OUTPUT/html``.
+You can use ``-r docs/requirements.txt``, etc. instead as needed. MkDocs projects could use ``NO_COLOR=1 .venv/bin/mkdocs build --strict --site-dir $READTHEDOCS_OUTPUT/html`` instead.
 
 Update Conda version
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
See https://github.com/readthedocs/readthedocs.org/issues/11289. Hopefully this is what was requested.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11322.org.readthedocs.build/en/11322/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11322.org.readthedocs.build/en/11322/

<!-- readthedocs-preview dev end -->