### PR TITLE
Move dashboard API filter fields to model queryset filter fields

### DIFF
--- a/readthedocs/core/filters.py
+++ b/readthedocs/core/filters.py
@@ -10,7 +10,7 @@ log = structlog.get_logger(__name__)
 class ModelFilterSet(FilterSet):
 
     """
-    Filterset that supports empty querysets
+    Filterset that supports empty querysets.
 
     By default, unbound filter forms result in none of the filters functioning.
     Instead, we want filters to always work, even when there is no filter data
@@ -26,7 +26,7 @@ class ModelFilterSet(FilterSet):
 class FilteredModelChoiceField(ModelChoiceField):
 
     """
-    Choice field for tuning model choices
+    Choice field for tuning model choices.
 
     The underlying ModelChoiceField assumes that the model's ``__repr__`` method
     will return the best choice label. In our modeling, ``__repr__`` is almost
@@ -44,12 +44,12 @@ class FilteredModelChoiceField(ModelChoiceField):
         self.has_search = has_search
         super().__init__(queryset, **kwargs)
 
-    def label_from_instance(self, value):
+    def label_from_instance(self, obj):
         if self.label_attribute is not None:
-            label = getattr(value, self.label_attribute, None)
+            label = getattr(obj, self.label_attribute, None)
             if label is not None:
                 return label
-        return super().label_from_instance(value)
+        return super().label_from_instance(obj)
 
 
 class FilteredModelChoiceFilter(ModelChoiceFilter):

--- a/readthedocs/organizations/views/private.py
+++ b/readthedocs/organizations/views/private.py
@@ -72,7 +72,6 @@ class ListOrganization(
     admin_only = False
 
     filterset_class = OrganizationListFilterSet
-    strict = True  # Return an empty queryset on filter validation errors
 
     def get_queryset(self):
         return Organization.objects.for_user(user=self.request.user)

--- a/readthedocs/projects/filters.py
+++ b/readthedocs/projects/filters.py
@@ -2,9 +2,11 @@
 
 import structlog
 from django.db.models import Count, F, Max
-from django.forms.widgets import HiddenInput
 from django.utils.translation import gettext_lazy as _
-from django_filters import CharFilter, ChoiceFilter, FilterSet, OrderingFilter
+from django_filters import ChoiceFilter, OrderingFilter
+
+from readthedocs.core.filters import FilteredModelChoiceFilter, ModelFilterSet
+from readthedocs.projects.models import Project
 
 log = structlog.get_logger(__name__)
 
@@ -49,6 +51,7 @@ class VersionSortOrderingFilter(OrderingFilter):
         # This is where we use the None value for this custom filter. This
         # doesn't work with a standard model filter. Note: ``value`` is always
         # an iterable, but can be empty.
+
         if not value:
             value = [self.SORT_BUILD_DATE]
 
@@ -135,7 +138,7 @@ class ProjectSortOrderingFilter(OrderingFilter):
         return qs.annotate(**annotations).order_by(*order_bys)
 
 
-class ProjectListFilterSet(FilterSet):
+class ProjectListFilterSet(ModelFilterSet):
 
     """
     Project list filter set for project list view.
@@ -144,14 +147,28 @@ class ProjectListFilterSet(FilterSet):
     provides search-as-you-type lookup filter as well.
     """
 
-    project = CharFilter(field_name="slug", widget=HiddenInput)
+    slug = FilteredModelChoiceFilter(
+        label=_("Project"),
+        empty_label=_("All projects"),
+        to_field_name="slug",
+        queryset_method="get_project_queryset",
+        method="get_project",
+        label_attribute="name",
+    )
+
     sort = ProjectSortOrderingFilter(
         field_name="sort",
         label=_("Sort by"),
     )
 
+    def get_project_queryset(self):
+        return Project.objects.for_user(user=self.request.user)
 
-class ProjectVersionListFilterSet(FilterSet):
+    def get_project(self, queryset, field_name, project):
+        return queryset.filter(slug=project.slug)
+
+
+class ProjectVersionListFilterSet(ModelFilterSet):
 
     """
     Filter and sorting for project version listing page.
@@ -175,7 +192,15 @@ class ProjectVersionListFilterSet(FilterSet):
     )
 
     # Attribute filter fields
-    version = CharFilter(field_name="slug", widget=HiddenInput)
+    slug = FilteredModelChoiceFilter(
+        label=_("Version"),
+        empty_label=_("All versions"),
+        to_field_name="slug",
+        queryset_method="get_version_queryset",
+        method="get_version",
+        label_attribute="verbose_name",
+    )
+
     privacy = ChoiceFilter(
         field_name="privacy_level",
         label=_("Privacy"),
@@ -197,6 +222,17 @@ class ProjectVersionListFilterSet(FilterSet):
         field_name="sort",
         label=_("Sort by"),
     )
+
+    def __init__(self, *args, project=None, **kwargs):
+        self.project = project
+        super().__init__(*args, **kwargs)
+
+    def get_version(self, queryset, field_name, version):
+        return queryset.filter(slug=version.slug)
+
+    def get_version_queryset(self):
+        # This query is passed in at instantiation
+        return self.queryset
 
     def get_visibility(self, queryset, *, value):
         if value == self.VISIBILITY_HIDDEN:

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -37,6 +37,7 @@ from readthedocs.builds.models import (
     Version,
     VersionAutomationRule,
 )
+from readthedocs.core.filters import FilterContextMixin
 from readthedocs.core.history import UpdateChangeReasonPostView
 from readthedocs.core.mixins import ListViewWithForm, PrivateViewMixin
 from readthedocs.core.notifications import MESSAGE_EMAIL_VALIDATION_PENDING
@@ -93,12 +94,14 @@ from readthedocs.subscriptions.products import get_feature
 log = structlog.get_logger(__name__)
 
 
-class ProjectDashboard(PrivateViewMixin, ListView):
+class ProjectDashboard(FilterContextMixin, PrivateViewMixin, ListView):
 
     """Project dashboard."""
 
     model = Project
     template_name = "projects/project_dashboard.html"
+
+    filterset_class = ProjectListFilterSet
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -106,11 +109,8 @@ class ProjectDashboard(PrivateViewMixin, ListView):
         context["type"] = "file"
 
         if settings.RTD_EXT_THEME_ENABLED:
-            filter = ProjectListFilterSet(
-                self.request.GET, queryset=self.get_queryset()
-            )
-            context["filter"] = filter
-            context["project_list"] = filter.qs
+            context["filter"] = self.get_filterset()
+            context["project_list"] = self.get_filtered_queryset()
             # Alternatively, dynamically override super()-derived `project_list` context_data
             # context[self.get_context_object_name(filter.qs)] = filter.qs
 


### PR DESCRIPTION
This moves a lot of dashboard JS/API logic into our standard FilterSet
instances:

- Project listing filter field
- Version listing filter field
- Build list version listing filter field

To accomplish this, a few helper classes were added for making the
fields easier to work with and display.

Template and JS were updated in

- https://github.com/readthedocs/ext-theme/pull/351