### PR TITLE
Docs: PO only allowed on annual Pro/Enterprise plans

### DIFF
--- a/docs/user/commercial/subscriptions.rst
+++ b/docs/user/commercial/subscriptions.rst
@@ -42,8 +42,8 @@ Billing information
 
 We provide both monthly and annual subscriptions for all plans.
 Annual plans are given a 2 month discount compared to monthly billing.
-We only support credit card billing for our Basic and Advanced plans.
-For our Pro and Enterprise users, we support invoice-based and PO billing.
+We support credit card billing for our Basic, Advanced and Pro plans.
+Pro and Enterprise plans can use invoice-based and PO billing for annual subscriptions.
 
 .. tip::
     We recommend paying by credit card for all users,

--- a/docs/user/commercial/subscriptions.rst
+++ b/docs/user/commercial/subscriptions.rst
@@ -42,7 +42,7 @@ Billing information
 
 We provide both monthly and annual subscriptions for all plans.
 Annual plans are given a 2 month discount compared to monthly billing.
-We support credit card billing for our Basic, Advanced and Pro plans.
+We support credit card billing for all plans.
 Pro and Enterprise plans can use invoice-based and PO billing for annual subscriptions.
 
 .. tip::


### PR DESCRIPTION
Small refactor of our docs explaining PO support.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11335.org.readthedocs.build/en/11335/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11335.org.readthedocs.build/en/11335/

<!-- readthedocs-preview dev end -->