### PR TITLE
Celery: user `builder` instead of `instance` as argument

### DIFF
--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -430,7 +430,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         # once we don't need to rely on `self.data.project`.
         if self.data.project.has_feature(Feature.SCALE_IN_PROTECTION):
             set_builder_scale_in_protection.delay(
-                instance=socket.gethostname(),
+                builder=socket.gethostname(),
                 protected_from_scale_in=True,
             )
 
@@ -746,7 +746,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         # Disable scale-in protection on this instance
         if self.data.project.has_feature(Feature.SCALE_IN_PROTECTION):
             set_builder_scale_in_protection.delay(
-                instance=socket.gethostname(),
+                builder=socket.gethostname(),
                 protected_from_scale_in=False,
             )
 

--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -165,14 +165,14 @@ def send_external_build_status(version_type, build_pk, commit, status):
 
 
 @app.task(queue="web")
-def set_builder_scale_in_protection(instance, protected_from_scale_in):
+def set_builder_scale_in_protection(builder, protected_from_scale_in):
     """
-    Set scale-in protection on this builder ``instance``.
+    Set scale-in protection on this builder ``builder``.
 
-    This way, AWS will not scale-in this instance while it's building the documentation.
+    This way, AWS will not scale-in this builder while it's building the documentation.
     This is pretty useful for long running tasks.
     """
-    log.bind(instance=instance, protected_from_scale_in=protected_from_scale_in)
+    log.bind(builder=builder, protected_from_scale_in=protected_from_scale_in)
 
     if settings.DEBUG or settings.RTD_DOCKER_COMPOSE:
         log.info(
@@ -188,7 +188,7 @@ def set_builder_scale_in_protection(instance, protected_from_scale_in):
     )
 
     # web-extra-i-0c3e866c4e323928f
-    hostname_match = re.match(r"([a-z\-]+)-(i-[a-f0-9]+)", instance)
+    hostname_match = re.match(r"([a-z\-]+)-(i-[a-f0-9]+)", builder)
     if not hostname_match:
         log.warning(
             "Unable to set scale-in protection. Hostname name matching not found.",


### PR DESCRIPTION
It seems that `CeleryTaskWrapper` from New Relic passes their own `instance=` attribute and the Celery task attributes as well as `kwargs`. This results in passing `instance` attribute twice and it breaks:

https://read-the-docs.sentry.io/issues/5385629903/?project=148442&query=is%3Aunresolved+%21message%3A%22%21message%3A%22%21message%3A%22SystemExit%22+%21message%3A%22frame-ancestors%22&referrer=issue-stream&statsPeriod=14d&stream_index=0

This commit renames `instance` argument to `builder` to avoid this.