### PR TITLE
Docs: fix external resources link on support page

### DIFF
--- a/docs/user/support.rst
+++ b/docs/user/support.rst
@@ -7,7 +7,7 @@ We're happy to assist with any questions or problems you have using either of ou
 .. note::
    Read the Docs does not offer support for questions or problems with documentation tools or content.
    If you have a question or problem using a particular documentation tool,
-   you should refer to `external resources <External resources>`_ for help instead.
+   you should refer to :ref:`external resources <support:External resources>` for help instead.
 
 Some examples of requests that we support are:
 


### PR DESCRIPTION


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11340.org.readthedocs.build/en/11340/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11340.org.readthedocs.build/en/11340/

<!-- readthedocs-preview dev end -->