### PR TITLE
Fix small docs display issue on tutorial

### DIFF
--- a/docs/user/tutorial/index.rst
+++ b/docs/user/tutorial/index.rst
@@ -318,7 +318,7 @@ and you will see several warnings:
    No module named 'lumache'
 
 To spot these warnings more easily and help you to address them,
- add the ``sphinx.fail_on_warning`` option to your Read the Docs configuration file.
+add the ``sphinx.fail_on_warning`` option to your Read the Docs configuration file.
 
 To fail on warnings to your Read the Docs project, edit the ``.readthedocs.yaml`` file in your project, add the three lines of ``sphinx`` configuration below, and commit the file:
 


### PR DESCRIPTION
The additional whitespace invoked a definition list on this paragraph.

![image](https://github.com/readthedocs/readthedocs.org/assets/1140183/da3b99ed-673a-4533-aaa6-2df1a7ce0c8b)


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11347.org.readthedocs.build/en/11347/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11347.org.readthedocs.build/en/11347/

<!-- readthedocs-preview dev end -->