### PR TITLE
Fix version visibility filter method

### DIFF
--- a/readthedocs/projects/filters.py
+++ b/readthedocs/projects/filters.py
@@ -234,7 +234,7 @@ class ProjectVersionListFilterSet(ModelFilterSet):
         # This query is passed in at instantiation
         return self.queryset
 
-    def get_visibility(self, queryset, *, value):
+    def get_visibility(self, queryset, field_name, value):
         if value == self.VISIBILITY_HIDDEN:
             return queryset.filter(hidden=True)
         if value == self.VISIBILITY_VISIBLE:


### PR DESCRIPTION
The arguments aren't passed in by keyword ever, so this argument
signature was incorrect.

- Fixes #11231