### PR TITLE
Set better success URL for version form views

### DIFF
--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -223,6 +223,17 @@ class ProjectVersionMixin(ProjectAdminMixin, PrivateViewMixin):
     lookup_field = "slug"
 
     def get_success_url(self):
+        if settings.RTD_EXT_THEME_ENABLED:
+            # Redirect to the main version listing view instead of the version
+            # admin listing. The version admin view, ``project_version_list``,
+            # is an old view without filtering and splits up active/inactive
+            # versions into two separate querysets.
+            #
+            # See: https://github.com/readthedocs/ext-theme/issues/288
+            return reverse(
+                "projects_detail",
+                kwargs={"project_slug": self.get_project().slug},
+            )
         return reverse(
             "project_version_list",
             kwargs={"project_slug": self.get_project().slug},


### PR DESCRIPTION
The normal view is an old view that splits up active/inactive versions
into two queries. It's mostly identical in function otherwise, so the
new dashboard doesn't reimplement this view. Instead, forms should have
a success URL of the normal project version listing.

See https://github.com/readthedocs/ext-theme/issues/288 for the
reasoning here.

- Refs https://github.com/readthedocs/ext-theme/issues/288