### PR TITLE
Addons: update `projects.translations` API response

### DIFF
--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -300,12 +300,35 @@ class TestReadTheDocsConfigJson(TestCase):
         )
         assert r.status_code == 200
 
+        # Hitting the English version of the docs, will return Japanese as translation
         assert len(r.json()["projects"]["translations"]) == 1
         assert r.json()["projects"]["translations"][0]["slug"] == "translation"
         assert r.json()["projects"]["translations"][0]["language"]["code"] == "ja"
         assert (
             r.json()["projects"]["translations"][0]["urls"]["documentation"]
             == "https://project.dev.readthedocs.io/ja/latest/"
+        )
+
+        # Hitting the Japanese version of the docs, will return English as translation
+        r = self.client.get(
+            reverse("proxito_readthedocs_docs_addons"),
+            {
+                "url": "https://project.dev.readthedocs.io/ja/latest/",
+                "client-version": "0.6.0",
+                "api-version": "1.0.0",
+            },
+            secure=True,
+            headers={
+                "host": "project.dev.readthedocs.io",
+            },
+        )
+        assert r.status_code == 200
+        assert len(r.json()["projects"]["translations"]) == 1
+        assert r.json()["projects"]["translations"][0]["slug"] == "project"
+        assert r.json()["projects"]["translations"][0]["language"]["code"] == "en"
+        assert (
+            r.json()["projects"]["translations"][0]["urls"]["documentation"]
+            == "https://project.dev.readthedocs.io/en/latest/"
         )
 
     def test_flyout_downloads(self):

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -348,7 +348,15 @@ class AddonsResponse:
                 )
 
         main_project = project.main_language_project or project
-        project_translations = main_project.translations.all().order_by("language")
+
+        # Exclude the current project since we don't want to return itself as a translation
+        project_translations = main_project.translations.all().exclude(
+            slug=project.slug
+        )
+        # Include main project as translation if the current project is one of the translations
+        if project != main_project:
+            project_translations |= Project.objects.filter(slug=main_project.slug)
+        project_translations = project_translations.order_by("language")
 
         data = {
             "api_version": "1",


### PR DESCRIPTION
Return "source language project" in `projects.translations` when accessing a translation of the "source language project".

Closes #11292