### PR TITLE
Pin requests to a version compatible with docker

### DIFF
--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -332,7 +332,7 @@ redis==5.0.4
     #   django-cacheops
 regex==2024.5.15
     # via -r requirements/pip.txt
-requests==2.32.2
+requests==2.30.0
     # via
     #   -r requirements/pip.txt
     #   django-allauth

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -364,7 +364,7 @@ redis==5.0.4
     #   django-cacheops
 regex==2024.5.15
     # via -r requirements/pip.txt
-requests==2.32.2
+requests==2.30.0
     # via
     #   -r requirements/pip.txt
     #   django-allauth

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -92,7 +92,7 @@ pyyaml==6.0.1
     # via myst-parser
 readthedocs-sphinx-search==0.3.2
     # via -r requirements/docs.in
-requests==2.32.2
+requests==2.30.0
     # via sphinx
 six==1.16.0
     # via

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -38,7 +38,10 @@ jsonfield
 
 django-safemigrate
 
-requests
+# The latest version of requests isn't compatible with the
+# version of the docker-py library we're using.
+# See https://github.com/docker/docker-py/issues/3256.
+requests==2.30.0
 requests-toolbelt
 slumber
 pyyaml

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -238,7 +238,7 @@ redis==5.0.4
     #   django-cacheops
 regex==2024.5.15
     # via -r requirements/pip.in
-requests==2.32.2
+requests==2.30.0
     # via
     #   -r requirements/pip.in
     #   django-allauth

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -354,7 +354,7 @@ redis==5.0.4
     #   django-cacheops
 regex==2024.5.15
     # via -r requirements/pip.txt
-requests==2.32.2
+requests==2.30.0
     # via
     #   -r requirements/pip.txt
     #   django-allauth


### PR DESCRIPTION
Fixes https://github.com/readthedocs/readthedocs.org/issues/11363.

We should upgrade the docker library we are using, there is a fix in place in the latest version.