### PR TITLE
Add invitation template filter

### DIFF
--- a/readthedocs/invitations/templatetags/invitations.py
+++ b/readthedocs/invitations/templatetags/invitations.py
@@ -1,0 +1,14 @@
+"""Invitation template filters."""
+
+from django import template
+
+from readthedocs.invitations.models import Invitation
+
+register = template.Library()
+
+
+@register.filter
+def can_revoke_invitation(user, object):
+    if isinstance(object, Invitation):
+        return object.can_revoke_invitation(user)
+    return False


### PR DESCRIPTION
Because Django. This is just a wrapper for working around the lack of support for calling methods with arguments in Django templates.

- Supersedes https://github.com/readthedocs/readthedocs-corporate/pull/1793
- Supersedes https://github.com/readthedocs/readthedocs.org/pull/11351
- Needed for https://github.com/readthedocs/ext-theme/issues/354