### PR TITLE
Update security policy

### DIFF
--- a/docs/user/security.rst
+++ b/docs/user/security.rst
@@ -55,6 +55,7 @@ Bug bounties
 
 While we sincerely appreciate and encourage reports of suspected security problems,
 please note that the Read the Docs is an open source project, and **does not run any bug bounty programs**.
+But we will gladly give credit to you and/or your organization for responsibly reporting security issues.
 
 Security issue archive
 ----------------------

--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -279,15 +279,11 @@ class TestReadTheDocsConfigJson(TestCase):
         )
 
     def test_flyout_translations(self):
-        translation_ja = fixture.get(
+        fixture.get(
             Project,
             slug="translation",
             main_language_project=self.project,
             language="ja",
-        )
-        translation_ja.versions.update(
-            built=True,
-            active=True,
         )
 
         r = self.client.get(

--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -279,11 +279,15 @@ class TestReadTheDocsConfigJson(TestCase):
         )
 
     def test_flyout_translations(self):
-        fixture.get(
+        translation_ja = fixture.get(
             Project,
             slug="translation",
             main_language_project=self.project,
             language="ja",
+        )
+        translation_ja.versions.update(
+            built=True,
+            active=True,
         )
 
         r = self.client.get(


### PR DESCRIPTION
I like this paragraph from the wagtail project https://docs.wagtail.org/en/latest/contributing/security.html#bug-bounties :)

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11374.org.readthedocs.build/en/11374/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11374.org.readthedocs.build/en/11374/

<!-- readthedocs-preview dev end -->