### PR TITLE
Ops: delete triggering a `time-test` build on `build-large` queue

### DIFF
--- a/readthedocs/metrics/tasks.py
+++ b/readthedocs/metrics/tasks.py
@@ -44,13 +44,4 @@ class CommunityMetrics5mTask(Metrics5mTaskBase):
             doc_url=None,
             webhook_url="{api_host}/api/v2/webhook/{project}/{webhook_id}/",
         ),
-        BuildLatencyMetric(
-            project="time-test",
-            queue_name="build-large",
-            version="latency-test-large",
-            doc="index",
-            section="Time",
-            doc_url=None,
-            webhook_url="{api_host}/api/v2/webhook/{project}/{webhook_id}/",
-        ),
     ]


### PR DESCRIPTION
We don't have 2 different queues anymore, so there is no need to trigger 2 `time-test` builds anymore.