### PR TITLE
Build: update all `build.tools` and add latest versions

### DIFF
--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -330,9 +330,11 @@ You can use several interpreters and versions, from CPython, Miniconda, and Mamb
   - ``3.12``
   - ``latest`` (alias for the latest version available on Read the Docs)
   - ``miniconda3-4.7``
+  - ``miniconda3-3.12``
   - ``miniconda-latest`` (alias for the latest version available on Read the Docs)
   - ``mambaforge-4.10``
   - ``mambaforge-22.9``
+  - ``mambaforge-23.11``
   - ``mambaforge-latest`` (alias for the latest version available on Read the Docs)
 
 build.tools.nodejs
@@ -371,6 +373,7 @@ Rust version to use.
    - ``1.64``
    - ``1.70``
    - ``1.75``
+   - ``1.78``
    - ``latest`` (alias for the latest version available on Read the Docs)
 
 build.tools.golang
@@ -385,6 +388,7 @@ Go version to use.
    - ``1.19``
    - ``1.20``
    - ``1.21``
+   - ``1.22``
    - ``latest`` (alias for the latest version available on Read the Docs)
 
 build.apt_packages

--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -330,7 +330,7 @@ You can use several interpreters and versions, from CPython, Miniconda, and Mamb
   - ``3.12``
   - ``latest`` (alias for the latest version available on Read the Docs)
   - ``miniconda3-4.7``
-  - ``miniconda3-3.12``
+  - ``miniconda3-3.12-24.1``
   - ``miniconda-latest`` (alias for the latest version available on Read the Docs)
   - ``mambaforge-4.10``
   - ``mambaforge-22.9``

--- a/readthedocs/builds/constants_docker.py
+++ b/readthedocs/builds/constants_docker.py
@@ -38,7 +38,7 @@ RTD_DOCKER_BUILD_SETTINGS = {
             "3.11": "3.11.9",
             "3.12": "3.12.3",
             "miniconda3-4.7": "miniconda3-4.7.12",
-            "miniconda3-3.12": "miniconda3-3.12-24.1.2-0",
+            "miniconda3-3.12-24.1": "miniconda3-3.12-24.1.2-0",
             "mambaforge-4.10": "mambaforge-4.10.3-10",
             "mambaforge-22.9": "mambaforge-22.9.0-3",
             "mambaforge-23.11": "mambaforge-23.11.0-0",
@@ -78,7 +78,7 @@ _TOOLS = RTD_DOCKER_BUILD_SETTINGS["tools"]
 _OS["ubuntu-lts-latest"] = _OS["ubuntu-22.04"]
 _TOOLS["python"]["3"] = _TOOLS["python"]["3.12"]
 _TOOLS["python"]["latest"] = _TOOLS["python"]["3"]
-_TOOLS["python"]["miniconda-latest"] = _TOOLS["python"]["miniconda3-3.12"]
+_TOOLS["python"]["miniconda-latest"] = _TOOLS["python"]["miniconda3-3.12-24.1"]
 _TOOLS["python"]["mambaforge-latest"] = _TOOLS["python"]["mambaforge-23.11"]
 _TOOLS["nodejs"]["latest"] = _TOOLS["nodejs"]["20"]
 _TOOLS["ruby"]["latest"] = _TOOLS["ruby"]["3.3"]

--- a/readthedocs/builds/constants_docker.py
+++ b/readthedocs/builds/constants_docker.py
@@ -32,24 +32,26 @@ RTD_DOCKER_BUILD_SETTINGS = {
             "2.7": "2.7.18",
             "3.6": "3.6.15",
             "3.7": "3.7.17",
-            "3.8": "3.8.18",
-            "3.9": "3.9.18",
-            "3.10": "3.10.13",
-            "3.11": "3.11.6",
-            "3.12": "3.12.0",
+            "3.8": "3.8.19",
+            "3.9": "3.9.19",
+            "3.10": "3.10.14",
+            "3.11": "3.11.9",
+            "3.12": "3.12.3",
             "miniconda3-4.7": "miniconda3-4.7.12",
+            "miniconda3-3.12": "miniconda3-3.12-24.1.2-0",
             "mambaforge-4.10": "mambaforge-4.10.3-10",
             "mambaforge-22.9": "mambaforge-22.9.0-3",
+            "mambaforge-23.11": "mambaforge-23.11.0-0",
         },
         "nodejs": {
             "14": "14.20.1",
             "16": "16.18.1",
             "18": "18.16.1",
             "19": "19.0.1",
-            "20": "20.11.0",  # LTS
+            "20": "20.14.0",  # LTS
         },
         "ruby": {
-            "3.3": "3.3.0",
+            "3.3": "3.3.2",
         },
         "rust": {
             "1.55": "1.55.0",
@@ -57,13 +59,15 @@ RTD_DOCKER_BUILD_SETTINGS = {
             "1.64": "1.64.0",
             "1.70": "1.70.0",
             "1.75": "1.75.0",
+            "1.78": "1.78.0",
         },
         "golang": {
             "1.17": "1.17.13",
             "1.18": "1.18.10",
-            "1.19": "1.19.10",
-            "1.20": "1.20.5",
-            "1.21": "1.21.6",
+            "1.19": "1.19.13",
+            "1.20": "1.20.14",
+            "1.21": "1.21.11",
+            "1.22": "1.22.4",
         },
     },
 }
@@ -74,9 +78,9 @@ _TOOLS = RTD_DOCKER_BUILD_SETTINGS["tools"]
 _OS["ubuntu-lts-latest"] = _OS["ubuntu-22.04"]
 _TOOLS["python"]["3"] = _TOOLS["python"]["3.12"]
 _TOOLS["python"]["latest"] = _TOOLS["python"]["3"]
-_TOOLS["python"]["miniconda-latest"] = _TOOLS["python"]["miniconda3-4.7"]
-_TOOLS["python"]["mambaforge-latest"] = _TOOLS["python"]["mambaforge-22.9"]
+_TOOLS["python"]["miniconda-latest"] = _TOOLS["python"]["miniconda3-3.12"]
+_TOOLS["python"]["mambaforge-latest"] = _TOOLS["python"]["mambaforge-23.11"]
 _TOOLS["nodejs"]["latest"] = _TOOLS["nodejs"]["20"]
 _TOOLS["ruby"]["latest"] = _TOOLS["ruby"]["3.3"]
-_TOOLS["rust"]["latest"] = _TOOLS["rust"]["1.75"]
-_TOOLS["golang"]["latest"] = _TOOLS["golang"]["1.21"]
+_TOOLS["rust"]["latest"] = _TOOLS["rust"]["1.78"]
+_TOOLS["golang"]["latest"] = _TOOLS["golang"]["1.22"]

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -524,7 +524,7 @@ class TestBuildTask(BuildEnvironmentBase):
                     },
                     "tools": {
                         "python": {
-                            "full_version": "3.12.0",
+                            "full_version": "3.12.3",
                             "version": "3",
                         }
                     },

--- a/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
+++ b/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
@@ -153,9 +153,11 @@
                 "3.12",
                 "latest",
                 "miniconda3-4.7",
+                "miniconda3-3.12",
                 "miniconda-latest",
                 "mambaforge-4.10",
                 "mambaforge-22.9",
+                "mambaforge-23.11",
                 "mambaforge-latest"
               ]
             },
@@ -182,6 +184,7 @@
                 "1.64",
                 "1.70",
                 "1.75",
+                "1.78",
                 "latest"
               ]
             },
@@ -192,6 +195,7 @@
                 "1.19",
                 "1.20",
                 "1.21",
+                "1.22",
                 "latest"
               ]
             }

--- a/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
+++ b/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
@@ -153,7 +153,7 @@
                 "3.12",
                 "latest",
                 "miniconda3-4.7",
-                "miniconda3-3.12",
+                "miniconda3-3.12-24.1",
                 "miniconda-latest",
                 "mambaforge-4.10",
                 "mambaforge-22.9",


### PR DESCRIPTION
Matches https://github.com/readthedocs/readthedocs-docker-images/pull/205

Closes #11350

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11386.org.readthedocs.build/en/11386/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11386.org.readthedocs.build/en/11386/

<!-- readthedocs-preview dev end -->