### PR TITLE
Uppercase G for Gold membership in subscription_detail.html

### DIFF
--- a/readthedocs/gold/templates/gold/subscription_detail.html
+++ b/readthedocs/gold/templates/gold/subscription_detail.html
@@ -72,7 +72,7 @@ Read the Docs Gold
     {% if golduser %}
     <h3>
         {% blocktrans trimmed %}
-        Your gold membership
+        Your Gold membership
         {% endblocktrans %}
     </h3>
 


### PR DESCRIPTION
Checking translation strings, I noticed this is the only occurrence of lowercase g for the Gold membership. This PR is to achieve consistency.