### PR TITLE
Unbreak strings to proper extraction for translation

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -409,8 +409,7 @@ class UpdateProjectForm(
         url = reverse("projects_integrations", args=[self.instance.slug])
         if not has_supported_integration:
             msg = _(
-                "To build from pull requests you need a "
-                f'GitHub or GitLab <a href="{url}">integration</a>.'
+                f'To build from pull requests you need a GitHub or GitLab <a href="{url}">integration</a>.'
             )
         if has_supported_integration and not can_build_external_versions:
             # If there is only one integration, link directly to it.
@@ -420,9 +419,7 @@ class UpdateProjectForm(
                     args=[self.instance.slug, integrations[0].pk],
                 )
             msg = _(
-                "To build from pull requests your repository's webhook "
-                "needs to send pull request events. "
-                f'Try to <a href="{url}">resync your integration</a>.'
+                f'To build from pull requests your repository\'s webhook needs to send pull request events. Try to <a href="{url}">resync your integration</a>.'
             )
 
         if msg:


### PR DESCRIPTION
The messages are broken into normal strings and f-strings. While this might be successfully concatenated in the original language, this doesn't work when extracting messages for translation: Currently only the normal string is being considered, and f-string part is being ignored.

E.g., see how they are currently shown in pt_BR translation file (msgid is the source string extracted from source file):

https://github.com/readthedocs/readthedocs.org/blob/88d7c6e2bf4cc472e9cb349a7f4340160a55e4d6/readthedocs/locale/pt_BR/LC_MESSAGES/django.po#L2409-L2417