### PR TITLE
Templates: pass `ADMIN_URL` into context

### DIFF
--- a/readthedocs/core/context_processors.py
+++ b/readthedocs/core/context_processors.py
@@ -26,6 +26,7 @@ def readthedocs_processor(request):
         "SUPPORT_EMAIL": settings.SUPPORT_EMAIL,
         "PUBLIC_API_URL": settings.PUBLIC_API_URL,
         "RTD_EXT_THEME_ENABLED": settings.RTD_EXT_THEME_ENABLED,
+        "ADMIN_URL": settings.ADMIN_URL,
     }
     return exports
 

--- a/readthedocs/rtd_tests/tests/test_notifications.py
+++ b/readthedocs/rtd_tests/tests/test_notifications.py
@@ -49,6 +49,7 @@ class NotificationTests(TestCase):
                 "foo": build,
                 "production_uri": "https://readthedocs.org",
                 # readthedocs_processor context
+                "ADMIN_URL": mock.ANY,
                 "DASHBOARD_ANALYTICS_CODE": mock.ANY,
                 "DO_NOT_TRACK_ENABLED": mock.ANY,
                 "GLOBAL_ANALYTICS_CODE": mock.ANY,

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -381,6 +381,7 @@ class CommunityBaseSettings(Settings):
     MEDIA_ROOT = os.path.join(SITE_ROOT, "media/")
     MEDIA_URL = "/media/"
     ADMIN_MEDIA_PREFIX = "/media/admin/"
+    ADMIN_URL = "/admin"
     STATICFILES_DIRS = [
         os.path.join(SITE_ROOT, "readthedocs", "static"),
         os.path.join(SITE_ROOT, "media"),


### PR DESCRIPTION
We use this setting in some Django Templates.
See https://github.com/readthedocs/ext-theme/pull/362