### PR TITLE
Build: update `asdf` and its plugins so we can build latest versions

### DIFF
--- a/scripts/compile_version_upload_s3.sh
+++ b/scripts/compile_version_upload_s3.sh
@@ -80,6 +80,12 @@ echo "Running all the commands in Docker container: $CONTAINER_ID"
 # echo -n 'asdf version: '
 # docker exec --user root $CONTAINER_ID asdf version
 
+# Update asdf to the latest stable release
+docker exec $CONTAINER_ID asdf update
+# Update all asdf plugins to the latest commit
+# (we require this to be able to compile newer versions)
+docker exec $CONTAINER_ID asdf plugin update --all
+
 # Install the tool version requested
 if [[ $TOOL == "python" ]]
 then


### PR DESCRIPTION
CircleCI is failing when building `build.tools` because Ruby 3.3.2 is not yet available in the `asdf` version we have in our Ubuntu Docker image. Updating the version of `asdf` and its plugins allows us to pre-compile these versions when running the CircleCI job.

This is required by #11386

Once this PR gets merged, we need to restart the CircleCI job.

https://app.circleci.com/pipelines/github/readthedocs/readthedocs-docker-images/294/workflows/3764492d-0fd4-44a3-bb0c-fccb696dc130/jobs/514