### PR TITLE
Oauth: Fix GitLab access token URL

### DIFF
--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import structlog
 from allauth.socialaccount.models import SocialAccount
 from allauth.socialaccount.providers import registry
+from allauth.socialaccount.providers.oauth2.views import OAuth2Adapter
 from django.conf import settings
 from django.urls import reverse
 from django.utils import timezone
@@ -64,7 +65,7 @@ class Service:
         except SocialAccount.DoesNotExist:
             return []
 
-    def get_adapter(self):
+    def get_adapter(self) -> type[OAuth2Adapter]:
         return self.adapter
 
     @property
@@ -83,6 +84,8 @@ class Service:
     def get_access_token_url(self):
         # ``access_token_url`` is a property in some adapters,
         # so we need to instantiate it to get the actual value.
+        # pylint doesn't recognize that get_adapter returns a class.
+        # pylint: disable=not-callable
         adapter = self.get_adapter()(request=None)
         return adapter.access_token_url
 

--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -80,6 +80,12 @@ class Service:
             self.create_session()
         return self.session
 
+    def get_access_token_url(self):
+        # ``access_token_url`` is a property in some adapters,
+        # so we need to instantiate it to get the actual value.
+        adapter = self.get_adapter()(request=None)
+        return adapter.access_token_url
+
     def create_session(self):
         """
         Create OAuth session for user.
@@ -113,7 +119,7 @@ class Service:
                 "client_id": social_app.client_id,
                 "client_secret": social_app.secret,
             },
-            auto_refresh_url=self.get_adapter().access_token_url,
+            auto_refresh_url=self.get_access_token_url(),
             token_updater=self.token_updater(token),
         )
 

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -531,6 +531,10 @@ class GitHubOAuthTests(TestCase):
             "GitHub webhook Listing failed for project.",
         )
 
+    def test_get_access_token_url(self):
+        url = self.service.get_access_token_url()
+        self.assertEqual(url, "https://github.com/login/oauth/access_token")
+
 
 class BitbucketOAuthTests(TestCase):
     fixtures = ["eric", "test_data"]
@@ -946,6 +950,10 @@ class BitbucketOAuthTests(TestCase):
         mock_logger.exception.assert_called_with(
             "Bitbucket webhook Listing failed for project.",
         )
+
+    def test_get_access_token_url(self):
+        url = self.service.get_access_token_url()
+        self.assertEqual(url, "https://bitbucket.org/site/oauth2/access_token")
 
 
 class GitLabOAuthTests(TestCase):
@@ -1403,3 +1411,7 @@ class GitLabOAuthTests(TestCase):
         mock_logger.exception.assert_called_with(
             "GitLab webhook Listing failed for project.",
         )
+
+    def test_get_access_token_url(self):
+        url = self.service.get_access_token_url()
+        self.assertEqual(url, "https://gitlab.com/oauth/token")


### PR DESCRIPTION
The provider was changed to be a property now
https://github.com/pennersr/django-allauth/commit/5db1b482307ab13de3db34b7395c287c495bba13