### PR TITLE
Docs: update "Example projects" a little

### DIFF
--- a/docs/user/examples.rst
+++ b/docs/user/examples.rst
@@ -10,47 +10,54 @@ Sphinx
 
 Sphinx example with versioning and Python doc autogeneration.
 
-* Markup language: reStructuredText, Markdown or MyST
-* Rendered version: https://example-sphinx-basic.readthedocs.io/en/latest/>
-* Repository: https://github.com/readthedocs-examples/example-sphinx-basic/
+Markup language
+  reStructuredText, Markdown or MyST
+Rendered version
+  https://example-sphinx-basic.readthedocs.io/en/latest/>
+Repository
+  https://github.com/readthedocs-examples/example-sphinx-basic/
 
 MkDocs
 ------
 
 Basic example of using MkDocs.
 
-* Markup language: Markdown
-* Rendered version: https://example-mkdocs-basic.readthedocs.io/en/latest/
-* Repository: https://github.com/readthedocs-examples/example-mkdocs-basic/
+Markup language
+  Markdown
+Rendered version
+  https://example-mkdocs-basic.readthedocs.io/en/latest/
+Repository
+  https://github.com/readthedocs-examples/example-mkdocs-basic/
 
 Jupyter Book
 ------------
 
 Jupyter Book with popular integrations configured.
 
-* Markup language: MyST.
-* Rendered version: https://example-jupyter-book.readthedocs.io/
-* Repository: https://github.com/readthedocs-examples/example-jupyter-book/
+Markup language
+  MyST
+Rendered version
+  https://example-jupyter-book.readthedocs.io/
+Repository
+  https://github.com/readthedocs-examples/example-jupyter-book/
 
 Antora
 ------
 
 Antora with asciidoctor-kroki extension configured for AsciiDoc and Diagram as Code.
 
-* Markup language: AsciiDoc
-* Rendered version: https://example-antora-basic.readthedocs.io/
-* Repository: https://github.com/man-chi/example-antora-basic/
+Markup language
+  AsciiDoc
+Rendered version
+  https://example-antora-basic.readthedocs.io/
+Repository
+  https://github.com/man-chi/example-antora-basic/
 
 Real-life examples
 ------------------
 
-.. image:: _static/images/awesome-list.svg
-  :alt: Awesome List badge
-  :target: https://github.com/readthedocs-examples/awesome-read-the-docs
-
-We maintain an **Awesome List** where you can contribute new shiny examples of using Read the Docs.
+We maintain an Awesome List where you can contribute new shiny examples of using Read the Docs.
 Please refer to the instructions on how to submit new entries on `Awesome Read the Docs Projects <https://github.com/readthedocs-examples/awesome-read-the-docs>`__.
-
 
 Contributing an example project
 -------------------------------

--- a/docs/user/examples.rst
+++ b/docs/user/examples.rst
@@ -5,8 +5,17 @@ The following example projects show a rich variety of uses of Read the Docs.
 You can use them for inspiration, for learning and for recipes to start your own documentation projects.
 View the *rendered* version of each project and then head over to the Git repository to see how it's done and reuse the code.
 
+Real-life examples
+------------------
+
+We maintain an Awesome List where you can contribute new shiny examples of using Read the Docs.
+Please refer to the instructions on how to submit new entries on `Awesome Read the Docs Projects <https://github.com/readthedocs-examples/awesome-read-the-docs>`__.
+
+Minimal basic examples
+----------------------
+
 Sphinx
-------
+~~~~~~
 
 Sphinx example with versioning and Python doc autogeneration.
 
@@ -18,7 +27,7 @@ Repository
   https://github.com/readthedocs-examples/example-sphinx-basic/
 
 MkDocs
-------
+~~~~~~
 
 Basic example of using MkDocs.
 
@@ -30,7 +39,7 @@ Repository
   https://github.com/readthedocs-examples/example-mkdocs-basic/
 
 Jupyter Book
-------------
+~~~~~~~~~~~~
 
 Jupyter Book with popular integrations configured.
 
@@ -42,7 +51,7 @@ Repository
   https://github.com/readthedocs-examples/example-jupyter-book/
 
 Antora
-------
+~~~~~~
 
 Antora with asciidoctor-kroki extension configured for AsciiDoc and Diagram as Code.
 
@@ -52,12 +61,6 @@ Rendered version
   https://example-antora-basic.readthedocs.io/
 Repository
   https://github.com/man-chi/example-antora-basic/
-
-Real-life examples
-------------------
-
-We maintain an Awesome List where you can contribute new shiny examples of using Read the Docs.
-Please refer to the instructions on how to submit new entries on `Awesome Read the Docs Projects <https://github.com/readthedocs-examples/awesome-read-the-docs>`__.
 
 Contributing an example project
 -------------------------------

--- a/docs/user/examples.rst
+++ b/docs/user/examples.rst
@@ -1,41 +1,45 @@
 Example projects
 ================
 
-* Need inspiration?
-* Want to bootstrap a new documentation project?
-* Want to showcase your own solution?
-
 The following example projects show a rich variety of uses of Read the Docs.
 You can use them for inspiration, for learning and for recipes to start your own documentation projects.
-View the *rendered* version of each project and then head over to the Git source to see how it's done and reuse the code.
+View the *rendered* version of each project and then head over to the Git repository to see how it's done and reuse the code.
 
-Sphinx and MkDocs examples
---------------------------
+Sphinx
+------
 
-.. list-table::
-   :header-rows: 1
-   :widths: 20 20 40 20
+Sphinx example with versioning and Python doc autogeneration.
 
-   * - Topic
-     - Framework
-     - Links
-     - Description
-   * - Basic Sphinx
-     - Sphinx
-     - `[Git] <https://github.com/readthedocs-examples/example-sphinx-basic/>`__ `[Rendered] <https://example-sphinx-basic.readthedocs.io/en/latest/>`__
-     - Sphinx example with versioning and Python doc autogeneration
-   * - Basic MkDocs
-     - MkDocs
-     - `[Git] <https://github.com/readthedocs-examples/example-mkdocs-basic/>`__ `[Rendered] <https://example-mkdocs-basic.readthedocs.io/en/latest/>`__
-     - Basic example of using MkDocs
-   * - Jupyter Book
-     - Jupyter Book and Sphinx
-     - `[Git] <https://github.com/readthedocs-examples/example-jupyter-book/>`__ `[Rendered] <https://example-jupyter-book.readthedocs.io/>`__
-     - Jupyter Book with popular integrations configured
-   * - Basic AsciiDoc
-     - Antora
-     - `[Git] <https://github.com/man-chi/example-antora-basic/>`__ `[Rendered] <https://example-antora-basic.readthedocs.io/>`__
-     - Antora with asciidoctor-kroki extension configured for AsciiDoc and Diagram as Code.
+* Markup language: reStructuredText, Markdown or MyST
+* Rendered version: https://example-sphinx-basic.readthedocs.io/en/latest/>
+* Repository: https://github.com/readthedocs-examples/example-sphinx-basic/
+
+MkDocs
+------
+
+Basic example of using MkDocs.
+
+* Markup language: Markdown
+* Rendered version: https://example-mkdocs-basic.readthedocs.io/en/latest/
+* Repository: https://github.com/readthedocs-examples/example-mkdocs-basic/
+
+Jupyter Book
+------------
+
+Jupyter Book with popular integrations configured.
+
+* Markup language: MyST.
+* Rendered version: https://example-jupyter-book.readthedocs.io/
+* Repository: https://github.com/readthedocs-examples/example-jupyter-book/
+
+Antora
+------
+
+Antora with asciidoctor-kroki extension configured for AsciiDoc and Diagram as Code.
+
+* Markup language: AsciiDoc
+* Rendered version: https://example-antora-basic.readthedocs.io/
+* Repository: https://github.com/man-chi/example-antora-basic/
 
 Real-life examples
 ------------------
@@ -58,7 +62,7 @@ We **require** that an example project:
 * is **hosted and maintained by you** in its own Git repository, ``example-<topic>``.
 * contains a README.
 * uses a ``.readthedocs.yaml`` configuration.
-* is added to the above list by **opening a PR** targeting `examples.rst <https://github.com/readthedocs/readthedocs.org/blob/main/docs/user/examples.rst>`_.
+* is added to the above list by **opening a PR** targeting `examples.rst <https://github.com/readthedocs/readthedocs.org/blob/main/docs/user/examples.rst>`_ file from our documentation.
 
 
 We **recommend** that your project:


### PR DESCRIPTION
Convert the table into sections and bullet list. It's a lot more readable and easy to follow. I also added "Markup language" which is important.

This page still needs some work, but baby steps.

📖 https://docs--11404.org.readthedocs.build/en/11404/examples.html

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11404.org.readthedocs.build/en/11404/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11404.org.readthedocs.build/en/11404/

<!-- readthedocs-preview dev end -->