### PR TITLE
Build: remove "beta" from `build.commands`

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -416,8 +416,10 @@ Override the build process
 
 .. note::
 
-   We are currently testing :ref:`the new addons integrations we are building <rtd-blog:addons-flyout-menu-beta>`
-   on projects using ``build.commands`` configuration key.
+   We are using :ref:`our new addons integration <rtd-blog:addons-flyout-menu-beta>`
+   on projects using ``build.commands``.
+   This will become the default soon,
+   but has some slight differences from our previous flyout. 
 
 If your project requires full control of the build process,
 and :ref:`extending the build process <build-customization:extend the build process>` is not enough,

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -419,7 +419,7 @@ Override the build process
    We are using :ref:`our new addons integration <rtd-blog:addons-flyout-menu-beta>`
    on projects using ``build.commands``.
    This will become the default soon,
-   but has some slight differences from our previous flyout. 
+   but has some slight differences from our previous flyout.
 
 If your project requires full control of the build process,
 and :ref:`extending the build process <build-customization:extend the build process>` is not enough,

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -414,9 +414,8 @@ Take a look at the following example:
 Override the build process
 --------------------------
 
-.. warning::
+.. note::
 
-   This feature is in *beta* and could change without warning.
    We are currently testing :ref:`the new addons integrations we are building <rtd-blog:addons-flyout-menu-beta>`
    on projects using ``build.commands`` configuration key.
 

--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -470,8 +470,10 @@ The ``$READTHEDOCS_OUTPUT/html`` directory will be uploaded and hosted by Read t
 
 .. note::
 
-   We are currently testing :ref:`the new addons integrations we are building <rtd-blog:addons-flyout-menu-beta>`
-   on projects using ``build.commands`` configuration key.
+   We are using :ref:`our new addons integration <rtd-blog:addons-flyout-menu-beta>`
+   on projects using ``build.commands``.
+   This will become the default soon,
+   but has some slight differences from our previous flyout. 
 
 .. code-block:: yaml
 

--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -473,7 +473,7 @@ The ``$READTHEDOCS_OUTPUT/html`` directory will be uploaded and hosted by Read t
    We are using :ref:`our new addons integration <rtd-blog:addons-flyout-menu-beta>`
    on projects using ``build.commands``.
    This will become the default soon,
-   but has some slight differences from our previous flyout. 
+   but has some slight differences from our previous flyout.
 
 .. code-block:: yaml
 

--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -468,12 +468,10 @@ When ``build.commands`` is used, none of the :term:`pre-defined build jobs` will
 This allows you to run custom commands and control the build process completely.
 The ``$READTHEDOCS_OUTPUT/html`` directory will be uploaded and hosted by Read the Docs.
 
-.. warning::
+.. note::
 
-   This feature is in a *beta phase* and could suffer incompatible changes or even removed completely in the near feature.
-   We are currently testing `the new addons integrations we are building <rtd-blog:addons-flyout-menu-beta>`_
+   We are currently testing :ref:`the new addons integrations we are building <rtd-blog:addons-flyout-menu-beta>`
    on projects using ``build.commands`` configuration key.
-   Use it under your own responsibility.
 
 .. code-block:: yaml
 

--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -418,10 +418,6 @@ class BuildDirector:
     def run_build_commands(self):
         """Runs each build command in the build environment."""
 
-        self.attach_notification(
-            message_id=BuildUserError.BUILD_COMMANDS_IN_BETA,
-        )
-
         reshim_commands = (
             {"pip", "install"},
             {"conda", "create"},


### PR DESCRIPTION
Closes #11405

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11411.org.readthedocs.build/en/11411/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11411.org.readthedocs.build/en/11411/

<!-- readthedocs-preview dev end -->