### PR TITLE
New dashboard: use `app.` instead of `beta.`

### DIFF
--- a/docs/user/versions.rst
+++ b/docs/user/versions.rst
@@ -148,7 +148,7 @@ a more stable version of the documentation available. Specifically:
 
 
 This feature is enabled by default on projects using the new beta addons.
-The beta addons can be enabled by using ``build.commands`` config key or via the new beta dashboard (https://beta.readthedocs.org) going to the admin section of your docs (:guilabel:`Admin` > :guilabel:`Settings`)
+The beta addons can be enabled by using ``build.commands`` config key or via the new beta dashboard (https://app.readthedocs.org) going to the admin section of your docs (:guilabel:`Settings` > :guilabel:`Addons (Beta)`)
 
 .. note::
 

--- a/readthedocs/core/notifications.py
+++ b/readthedocs/core/notifications.py
@@ -35,7 +35,7 @@ messages = [
                 Feel free to <a href="https://{{ PRODUCTION_DOMAIN }}/support/">report any feedback</a> you may have.
                 {% else %}
                 Our new <strong>beta dashboard</strong> is now available for testing.
-                <a href="https://beta.{{ PRODUCTION_DOMAIN }}/">Give it a try</a> and send us feedback.
+                <a href="https://app.{{ PRODUCTION_DOMAIN }}/">Give it a try</a> and send us feedback.
                 {% endif %}
             """
             ).strip(),


### PR DESCRIPTION


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11412.org.readthedocs.build/en/11412/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11412.org.readthedocs.build/en/11412/

<!-- readthedocs-preview dev end -->