### PR TITLE
Builds: don't call `git clean` anymore

### DIFF
--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -798,7 +798,6 @@ class TestBuildTask(BuildEnvironmentBase):
                     record=False,
                 ),
                 mock.call("git", "checkout", "--force", "origin/a1b2c3"),
-                mock.call("git", "clean", "-d", "-f", "-f"),
                 mock.call(
                     "git",
                     "ls-remote",

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -427,8 +427,6 @@ class Backend(BaseVCS):
         # Checkout the correct identifier for this branch.
         code, out, err = self.checkout_revision(identifier)
 
-        # Clean any remains of previous checkouts
-        self.run("git", "clean", "-d", "-f", "-f")
         return code, out, err
 
     def update_submodules(self, config):


### PR DESCRIPTION
We used to call `git clean` because we used to re-use a previous cloned repository. However, we are always starting from a fresh environment now.