### PR TITLE
Build: add support for Ubuntu 24.04 LTS

### DIFF
--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -274,7 +274,7 @@ Image names refer to the operating system Read the Docs uses to build them.
    Arbitrary Docker images are not supported.
 
 :Type: ``string``
-:Options: ``ubuntu-20.04``, ``ubuntu-22.04``, ``ubuntu-lts-latest``
+:Options: ``ubuntu-20.04``, ``ubuntu-22.04``, ``ubuntu-24.04``, ``ubuntu-lts-latest``
 :Required: ``true``
 
 .. note::

--- a/readthedocs/builds/constants_docker.py
+++ b/readthedocs/builds/constants_docker.py
@@ -25,6 +25,7 @@ RTD_DOCKER_BUILD_SETTINGS = {
     "os": {
         "ubuntu-20.04": f"{DOCKER_DEFAULT_IMAGE}:ubuntu-20.04",
         "ubuntu-22.04": f"{DOCKER_DEFAULT_IMAGE}:ubuntu-22.04",
+        "ubuntu-24.04": f"{DOCKER_DEFAULT_IMAGE}:ubuntu-24.04",
     },
     # Mapping of build.tools options to specific versions.
     "tools": {
@@ -75,7 +76,7 @@ RTD_DOCKER_BUILD_SETTINGS = {
 # Set latest aliases for OS and tools.
 _OS = RTD_DOCKER_BUILD_SETTINGS["os"]
 _TOOLS = RTD_DOCKER_BUILD_SETTINGS["tools"]
-_OS["ubuntu-lts-latest"] = _OS["ubuntu-22.04"]
+_OS["ubuntu-lts-latest"] = _OS["ubuntu-24.04"]
 _TOOLS["python"]["3"] = _TOOLS["python"]["3.12"]
 _TOOLS["python"]["latest"] = _TOOLS["python"]["3"]
 _TOOLS["python"]["miniconda-latest"] = _TOOLS["python"]["miniconda3-3.12-24.1"]

--- a/readthedocs/builds/constants_docker.py
+++ b/readthedocs/builds/constants_docker.py
@@ -76,7 +76,11 @@ RTD_DOCKER_BUILD_SETTINGS = {
 # Set latest aliases for OS and tools.
 _OS = RTD_DOCKER_BUILD_SETTINGS["os"]
 _TOOLS = RTD_DOCKER_BUILD_SETTINGS["tools"]
-_OS["ubuntu-lts-latest"] = _OS["ubuntu-24.04"]
+
+# TODO: point ``ubuntu-lts-latest`` to Ubuntu 24.04 LTS once we have tested it
+# in production after some weeks
+_OS["ubuntu-lts-latest"] = _OS["ubuntu-22.04"]
+
 _TOOLS["python"]["3"] = _TOOLS["python"]["3.12"]
 _TOOLS["python"]["latest"] = _TOOLS["python"]["3"]
 _TOOLS["python"]["miniconda-latest"] = _TOOLS["python"]["miniconda3-3.12-24.1"]

--- a/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
+++ b/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
@@ -61,6 +61,7 @@
           "enum": [
             "ubuntu-20.04",
             "ubuntu-22.04",
+            "ubuntu-24.04",
             "ubuntu-lts-latest"
           ]
         },

--- a/scripts/compile_version_upload_s3.sh
+++ b/scripts/compile_version_upload_s3.sh
@@ -60,7 +60,7 @@ set -x # Echo commands
 
 # Define variables
 SLEEP=900 # Container timeout
-OS="${OS:-ubuntu-22.04}" # Docker image name
+OS="${OS:-ubuntu-24.04}" # Docker image name
 
 TOOL=$1
 VERSION=$2
@@ -68,7 +68,7 @@ VERSION=$2
 # https://stackoverflow.com/questions/59895/how-can-i-get-the-source-directory-of-a-bash-script-from-within-the-script-itsel
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-# Spin up a container with the Ubuntu 20.04 LTS image
+# Spin up a container with the Ubuntu LTS image
 CONTAINER_ID=$(docker run --user docs --rm --detach --volume ${SCRIPT_DIR}/python-build.diff:/tmp/python-build.diff readthedocs/build:$OS sleep $SLEEP)
 echo "Running all the commands in Docker container: $CONTAINER_ID"
 


### PR DESCRIPTION
Closes #11072
Requires:
* https://github.com/readthedocs/readthedocs-docker-images/pull/207
* https://github.com/readthedocs/readthedocs-ops/pull/1494

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11421.org.readthedocs.build/en/11421/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11421.org.readthedocs.build/en/11421/

<!-- readthedocs-preview dev end -->