### PR TITLE
Link website from docs sidebar

### DIFF
--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -111,6 +111,7 @@ Read the Docs: documentation simplified
    /changelog
    /about/index
    Developer Documentation <https://dev.readthedocs.io>
+   Read the Docs website <https://about.readthedocs.com>
 
 .. meta::
    :description lang=en: Automate building, versioning, and hosting of your technical documentation continuously on Read the Docs.


### PR DESCRIPTION
Refs https://github.com/readthedocs/website/issues/286

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11426.org.readthedocs.build/en/11426/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11426.org.readthedocs.build/en/11426/

<!-- readthedocs-preview dev end -->