### PR TITLE
Organization: disable organization on non-active subscription

### DIFF
--- a/readthedocs/subscriptions/event_handlers.py
+++ b/readthedocs/subscriptions/event_handlers.py
@@ -132,6 +132,13 @@ def subscription_updated_event(event):
         log.info("Re-enabling organization.", organization_slug=organization.slug)
         organization.disabled = False
 
+    if stripe_subscription.status != SubscriptionStatus.active:
+        log.info(
+            "Organization disabled due its subscription is not active anymore.",
+            organization_slug=organization.slug,
+        )
+        organization.disabled = True
+
     new_stripe_subscription = organization.get_stripe_subscription()
     if organization.stripe_subscription != new_stripe_subscription:
         old_subscription_id = (

--- a/readthedocs/subscriptions/event_handlers.py
+++ b/readthedocs/subscriptions/event_handlers.py
@@ -132,7 +132,10 @@ def subscription_updated_event(event):
         log.info("Re-enabling organization.", organization_slug=organization.slug)
         organization.disabled = False
 
-    if stripe_subscription.status != SubscriptionStatus.active:
+    if stripe_subscription.status not in (
+        SubscriptionStatus.active,
+        SubscriptionStatus.trialing,
+    ):
         log.info(
             "Organization disabled due its subscription is not active anymore.",
             organization_slug=organization.slug,

--- a/readthedocs/subscriptions/tasks.py
+++ b/readthedocs/subscriptions/tasks.py
@@ -60,22 +60,6 @@ def daily_email():
 
 
 @app.task(queue="web")
-def disable_organization_expired_trials():
-    """Daily task to disable organization with expired Trial Plans."""
-    queryset = Organization.objects.disable_soon(
-        days=30, exact=True
-    ).subscription_trial_plan_ended()
-
-    for organization in queryset:
-        log.info(
-            "Organization disabled due to trial ended.",
-            organization_slug=organization.slug,
-        )
-        organization.disabled = True
-        organization.save()
-
-
-@app.task(queue="web")
 def weekly_subscription_stats_email(recipients=None):
     """
     Weekly email to communicate stats about subscriptions.

--- a/readthedocs/subscriptions/tests/test_event_handlers.py
+++ b/readthedocs/subscriptions/tests/test_event_handlers.py
@@ -283,6 +283,7 @@ class TestStripeEventHandlers(TestCase):
             },
         )
         event_handlers.subscription_canceled(event)
+        event_handlers.subscription_updated_event(event)
         notification_send.assert_called_once()
 
     @mock.patch(
@@ -314,7 +315,11 @@ class TestStripeEventHandlers(TestCase):
             },
         )
         event_handlers.subscription_canceled(event)
+        event_handlers.subscription_updated_event(event)
         notification_send.assert_called_once()
+
+        self.organization.refresh_from_db()
+        self.assertTrue(self.organization.disabled)
 
     @mock.patch(
         "readthedocs.subscriptions.event_handlers.SubscriptionEndedNotification.send"
@@ -343,6 +348,7 @@ class TestStripeEventHandlers(TestCase):
             },
         )
         event_handlers.subscription_canceled(event)
+        event_handlers.subscription_updated_event(event)
         notification_send.assert_not_called()
 
     def test_register_events(self):


### PR DESCRIPTION
With this change, all organization that go to canceled, unpaid, past due or similar subscription status that are not `active`, will be immediately disabled. This means they won't be able to trigger builds anymore. However, we will still keep serving documentation for their projects.

Closes https://github.com/readthedocs/readthedocs-corporate/issues/1798