### PR TITLE
Requirements: upgrade `psycopg` to v3

### DIFF
--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -286,8 +286,16 @@ prompt-toolkit==3.0.47
     #   -r requirements/pip.txt
     #   click-repl
     #   ipython
-psycopg2==2.9.9
+psycopg[binary,pool]==3.1.19
     # via -r requirements/pip.txt
+psycopg-binary==3.1.19
+    # via
+    #   -r requirements/pip.txt
+    #   psycopg
+psycopg-pool==3.2.2
+    # via
+    #   -r requirements/pip.txt
+    #   psycopg
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
@@ -404,6 +412,8 @@ typing-extensions==4.12.2
     #   asgiref
     #   elasticsearch-dsl
     #   ipython
+    #   psycopg
+    #   psycopg-pool
 tzdata==2024.1
     # via
     #   -r requirements/pip.txt

--- a/requirements/docker.in
+++ b/requirements/docker.in
@@ -2,9 +2,6 @@
 
 -r pip.txt
 
-# https://www.psycopg.org/docs/install.html#psycopg-vs-psycopg-binary
-psycopg2-binary
-
 # run tests
 tox
 

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -310,10 +310,16 @@ prompt-toolkit==3.0.47
     #   -r requirements/pip.txt
     #   click-repl
     #   ipython
-psycopg2==2.9.9
+psycopg[binary,pool]==3.1.19
     # via -r requirements/pip.txt
-psycopg2-binary==2.9.9
-    # via -r requirements/docker.in
+psycopg-binary==3.1.19
+    # via
+    #   -r requirements/pip.txt
+    #   psycopg
+psycopg-pool==3.2.2
+    # via
+    #   -r requirements/pip.txt
+    #   psycopg
 ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
@@ -438,6 +444,8 @@ typing-extensions==4.12.2
     #   asgiref
     #   elasticsearch-dsl
     #   ipython
+    #   psycopg
+    #   psycopg-pool
 tzdata==2024.1
     # via
     #   -r requirements/pip.txt

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -7,9 +7,8 @@ django-extensions
 django-polymorphic
 django-autoslug
 
-# NOTE: we cannot use ``psycopg`` (3.x), even if it's supported by Django 4.2
-# because New Relic agent is not sending the data of the database to their servers.
-psycopg2
+# https://www.psycopg.org/psycopg3/docs/basic/install.html
+psycopg[binary,pool]
 
 # 3.1.0 includes changes that require running `makemigrations`
 # https://django-simple-history.readthedocs.io/en/latest/#changes

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -206,8 +206,12 @@ platformdirs==4.2.2
     # via virtualenv
 prompt-toolkit==3.0.47
     # via click-repl
-psycopg2==2.9.9
+psycopg[binary,pool]==3.1.19
     # via -r requirements/pip.in
+psycopg-binary==3.1.19
+    # via psycopg
+psycopg-pool==3.2.2
+    # via psycopg
 pycparser==2.22
     # via cffi
 pygments==2.18.0
@@ -288,6 +292,8 @@ typing-extensions==4.12.2
     # via
     #   asgiref
     #   elasticsearch-dsl
+    #   psycopg
+    #   psycopg-pool
 tzdata==2024.1
     # via
     #   -r requirements/pip.in

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -292,8 +292,16 @@ prompt-toolkit==3.0.47
     # via
     #   -r requirements/pip.txt
     #   click-repl
-psycopg2==2.9.9
+psycopg[binary,pool]==3.1.19
     # via -r requirements/pip.txt
+psycopg-binary==3.1.19
+    # via
+    #   -r requirements/pip.txt
+    #   psycopg
+psycopg-pool==3.2.2
+    # via
+    #   -r requirements/pip.txt
+    #   psycopg
 pycparser==2.22
     # via
     #   -r requirements/pip.txt
@@ -434,6 +442,8 @@ typing-extensions==4.12.2
     #   -r requirements/pip.txt
     #   asgiref
     #   elasticsearch-dsl
+    #   psycopg
+    #   psycopg-pool
 tzdata==2024.1
     # via
     #   -r requirements/pip.txt


### PR DESCRIPTION
We attempt to upgrade this some time ago (in #10667) but we reverted it later since New Relic Python client wasn't compatible with it.

The newer version of New Relic that we are already using added compatibility and should log database transactions properly now.

Closes #10596