### PR TITLE
CSP: remove obsolete block-all-mixed-content directive

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -125,7 +125,6 @@ class CommunityBaseSettings(Settings):
 
     # Content Security Policy
     # https://django-csp.readthedocs.io/
-    CSP_BLOCK_ALL_MIXED_CONTENT = True
     CSP_DEFAULT_SRC = None  # This could be improved
     CSP_FRAME_ANCESTORS = ("'none'",)
     CSP_OBJECT_SRC = ("'none'",)


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/block-all-mixed-content

> This directive is marked as obsolete in the specification. This
> directive was previously used to prevent "optionally blockable" mixed
> content from being fetched insecurely and displayed. Content that isn't
> blocked is now always upgraded to a secure connection, so this directive
> is not needed.