### PR TITLE
Add historial records for `djstripe.models.Subscription`

### DIFF
--- a/readthedocs/subscriptions/apps.py
+++ b/readthedocs/subscriptions/apps.py
@@ -1,7 +1,6 @@
 """Subscriptions app."""
 
 from django.apps import AppConfig
-from simple_history import register
 
 
 class SubscriptionsConfig(AppConfig):
@@ -17,7 +16,6 @@ class SubscriptionsConfig(AppConfig):
         import readthedocs.subscriptions.tasks  # noqa
 
         self._add_custom_manager()
-        self._add_subscription_historical_records()
 
     def _add_custom_manager(self):
         """
@@ -37,10 +35,3 @@ class SubscriptionsConfig(AppConfig):
 
         manager = StripeSubscriptionQueryset.as_manager()
         manager.contribute_to_class(Subscription, "readthedocs")
-
-    def _add_subscription_historical_records(self):
-        from djstripe.models import Subscription
-
-        from readthedocs.core.history import ExtraHistoricalRecords
-
-        register(Subscription, records_class=ExtraHistoricalRecords, app=__package__)

--- a/readthedocs/subscriptions/apps.py
+++ b/readthedocs/subscriptions/apps.py
@@ -1,6 +1,7 @@
 """Subscriptions app."""
 
 from django.apps import AppConfig
+from simple_history import register
 
 
 class SubscriptionsConfig(AppConfig):
@@ -16,6 +17,7 @@ class SubscriptionsConfig(AppConfig):
         import readthedocs.subscriptions.tasks  # noqa
 
         self._add_custom_manager()
+        self._add_subscription_historical_records()
 
     def _add_custom_manager(self):
         """
@@ -35,3 +37,10 @@ class SubscriptionsConfig(AppConfig):
 
         manager = StripeSubscriptionQueryset.as_manager()
         manager.contribute_to_class(Subscription, "readthedocs")
+
+    def _add_subscription_historical_records(self):
+        from djstripe.models import Subscription
+
+        from readthedocs.core.history import ExtraHistoricalRecords
+
+        register(Subscription, records_class=ExtraHistoricalRecords, app=__package__)

--- a/readthedocs/subscriptions/models.py
+++ b/readthedocs/subscriptions/models.py
@@ -1,2 +1,6 @@
-# This file is left empty on purpose.
-# It's required to be able to register ``HistoricalRecords`` on ``djstripe.models.Subscription``
+from djstripe.models import Subscription
+from simple_history import register
+
+from readthedocs.core.history import ExtraHistoricalRecords
+
+register(Subscription, records_class=ExtraHistoricalRecords, app=__package__)

--- a/readthedocs/subscriptions/models.py
+++ b/readthedocs/subscriptions/models.py
@@ -1,0 +1,2 @@
+# This file is left empty on purpose.
+# It's required to be able to register ``HistoricalRecords`` on ``djstripe.models.Subscription``


### PR DESCRIPTION
Some time ago we wanted this in
https://github.com/readthedocs/meta/issues/53#issuecomment-1234010087. It seems we wanted this to plot "historical number of subscriptions group by `start_date` and `status`".

This PR adds historial records to that model for now. If we are happy merging it, we can come back later and plot more questions related with historial data and project/organization fields.

Closes #53