### PR TITLE
Docs: remove past sponsors and old blog post link

### DIFF
--- a/docs/user/sponsors.rst
+++ b/docs/user/sponsors.rst
@@ -41,13 +41,6 @@ Past sponsors
 .. _Chan Zuckerberg Initiative: https://chanzuckerberg.com/
 
 
-Sponsorship information
------------------------
-
-As part of increasing sustainability,
-Read the Docs is testing out promoting sponsors on documentation pages.
-We have more information about this in our `blog post <https://blog.readthedocs.com/ads-on-read-the-docs/>`_ about this effort.
-
 Sponsor us
 ~~~~~~~~~~
 


### PR DESCRIPTION
Leave this page only for sponsors.
We do have another page that explains adverstising in a better way.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11457.org.readthedocs.build/en/11457/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11457.org.readthedocs.build/en/11457/

<!-- readthedocs-preview dev end -->