### PR TITLE
Fix slack notifications for stripe events

### DIFF
--- a/readthedocs/subscriptions/event_handlers.py
+++ b/readthedocs/subscriptions/event_handlers.py
@@ -6,7 +6,7 @@ https://docs.dj-stripe.dev/en/master/usage/webhooks/.
 import requests
 import structlog
 from django.conf import settings
-from django.contrib import humanize
+from django.contrib.humanize.templatetags import humanize
 from django.db.models import Sum
 from django.utils import timezone
 from djstripe import models as djstripe


### PR DESCRIPTION
We should write a test for this

ref https://read-the-docs.sentry.io/issues/5584105103/?project=161479&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=24h&stream_index=0