### PR TITLE
Tests: use a faster password hasher

### DIFF
--- a/readthedocs/core/fixtures/eric.json
+++ b/readthedocs/core/fixtures/eric.json
@@ -12,7 +12,7 @@
             "last_login": "2010-08-14T01:51:05+00:00",
             "groups": [],
             "user_permissions": [],
-            "password": "pbkdf2_sha256$30000$Vs87OlKZEzCb$nUw1o5pGQw7ff/QhnleSpUOupBaT1DogZrVaoZyQRyc=",
+            "password": "md5$HLrlTqy6uMMO08qQZ75Z4K$65492930ade63899137c23db46cb2253",
             "email": "e@e.co",
             "date_joined": "2010-08-14T01:50:58+00:00"
         }
@@ -30,7 +30,7 @@
             "last_login": "2010-08-14T01:51:05+00:00",
             "groups": [],
             "user_permissions": [],
-            "password": "pbkdf2_sha256$30000$Vs87OlKZEzCb$nUw1o5pGQw7ff/QhnleSpUOupBaT1DogZrVaoZyQRyc=",
+            "password": "md5$HLrlTqy6uMMO08qQZ75Z4K$65492930ade63899137c23db46cb2253",
             "email": "e@etest.co",
             "date_joined": "2010-08-14T01:50:58+00:00"
         }
@@ -48,7 +48,7 @@
             "last_login": "2010-08-14T01:51:05+00:00",
             "groups": [],
             "user_permissions": [],
-            "password": "pbkdf2_sha256$30000$Vs87OlKZEzCb$nUw1o5pGQw7ff/QhnleSpUOupBaT1DogZrVaoZyQRyc=",
+            "password": "md5$HLrlTqy6uMMO08qQZ75Z4K$65492930ade63899137c23db46cb2253",
             "email": "e@e.co",
             "date_joined": "2010-08-14T01:50:58+00:00"
         }

--- a/readthedocs/settings/test.py
+++ b/readthedocs/settings/test.py
@@ -37,6 +37,12 @@ class CommunityTestSettings(CommunityBaseSettings):
         }
     }
 
+    # Speed up tests by using a fast password hasher.
+    # https://docs.djangoproject.com/en/5.0/topics/testing/overview/#speeding-up-the-tests.
+    PASSWORD_HASHERS = [
+        "django.contrib.auth.hashers.MD5PasswordHasher",
+    ]
+
     @property
     def DATABASES(self):  # noqa
         return {


### PR DESCRIPTION
Should save us some seconds at least.
https://docs.djangoproject.com/en/5.0/topics/testing/overview/#speeding-up-the-tests