### PR TITLE
Docs: update build limits on community

### DIFF
--- a/docs/user/builds.rst
+++ b/docs/user/builds.rst
@@ -131,7 +131,7 @@ Our build limits are:
    .. tab:: |org_brand|
 
       * 15 minutes build time
-      * 3GB of memory
+      * 7GB of memory
       * 2 concurrent builds
 
       We can increase build limits on a per-project basis.


### PR DESCRIPTION
We are using only `build-default` now and it uses 7Gb now.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11475.org.readthedocs.build/en/11475/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11475.org.readthedocs.build/en/11475/

<!-- readthedocs-preview dev end -->