### PR TITLE
Build: do not install our extension when building with Conda

### DIFF
--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -356,7 +356,9 @@ class Conda(PythonEnvironment):
         if self.config.doctype == "mkdocs":
             pip_requirements.append("mkdocs")
         else:
-            pip_requirements.append("readthedocs-sphinx-ext")
+            if not self.project.has_feature(Feature.DISABLE_SPHINX_MANIPULATION):
+                pip_requirements.append("readthedocs-sphinx-ext")
+
             conda_requirements.extend(["sphinx"])
 
         return pip_requirements, conda_requirements


### PR DESCRIPTION
I missed this in https://github.com/readthedocs/readthedocs.org/pull/11441