### PR TITLE
Add an initial resync_versions API to v3

### DIFF
--- a/docs/user/api/v3.rst
+++ b/docs/user/api/v3.rst
@@ -465,7 +465,7 @@ Project update
 
        Privacy levels are only available in :doc:`Read the Docs for Business </commercial/index>`.
 
-    :statuscode 204: Task created successfully
+    :statuscode 204: Updated successfully
 
 
 Project versions sync
@@ -498,7 +498,7 @@ Project versions sync
             )
             print(response.json())
 
-    :statuscode 202: Updated successfully
+    :statuscode 202: Task created successfully
     :statuscode 400: Bad request, task not created
 
 Versions

--- a/docs/user/api/v3.rst
+++ b/docs/user/api/v3.rst
@@ -465,7 +465,43 @@ Project update
 
        Privacy levels are only available in :doc:`Read the Docs for Business </commercial/index>`.
 
-    :statuscode 204: Updated successfully
+    :statuscode 204: Task created successfully
+    :statuscode 400: Bad request, task not created
+
+
+Project versions sync
++++++++++++++++++++++
+
+.. http:post:: /api/v3/projects/(string:project_slug)/sync-versions/
+
+    Trigger a background task to sync the versions of the project.
+
+    **Example request**:
+
+    .. tabs::
+
+        .. code-tab:: bash
+
+            $ curl \
+              -X POST \
+              -H "Authorization: Token <token>" \
+              https://readthedocs.org/api/v3/projects/pip/sync-versions/
+
+        .. code-tab:: python
+
+            import requests
+            URL = 'https://readthedocs.org/api/v3/projects/pip/sync-versions/'
+            TOKEN = '<token>'
+            HEADERS = {'Authorization': f'token {TOKEN}'}
+            response = requests.post(
+                URL,
+                headers=HEADERS,
+            )
+            print(response.json())
+
+    :statuscode 202: Updated successfully
+
+
 
 
 Versions

--- a/docs/user/api/v3.rst
+++ b/docs/user/api/v3.rst
@@ -466,7 +466,6 @@ Project update
        Privacy levels are only available in :doc:`Read the Docs for Business </commercial/index>`.
 
     :statuscode 204: Task created successfully
-    :statuscode 400: Bad request, task not created
 
 
 Project versions sync
@@ -500,9 +499,7 @@ Project versions sync
             print(response.json())
 
     :statuscode 202: Updated successfully
-
-
-
+    :statuscode 400: Bad request, task not created
 
 Versions
 ~~~~~~~~

--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -499,6 +499,7 @@ class ProjectLinksSerializer(BaseLinksSerializer):
     superproject = serializers.SerializerMethodField()
     translations = serializers.SerializerMethodField()
     notifications = serializers.SerializerMethodField()
+    sync_versions = serializers.SerializerMethodField()
 
     def get__self(self, obj):
         path = reverse("projects-detail", kwargs={"project_slug": obj.slug})
@@ -552,6 +553,15 @@ class ProjectLinksSerializer(BaseLinksSerializer):
     def get_superproject(self, obj):
         path = reverse(
             "projects-superproject",
+            kwargs={
+                "project_slug": obj.slug,
+            },
+        )
+        return self._absolute_url(path)
+
+    def get_sync_versions(self, obj):
+        path = reverse(
+            "projects-sync-versions",
             kwargs={
                 "project_slug": obj.slug,
             },

--- a/readthedocs/api/v3/tests/responses/projects-detail.json
+++ b/readthedocs/api/v3/tests/responses/projects-detail.json
@@ -76,6 +76,7 @@
         "redirects": "https://readthedocs.org/api/v3/projects/project/redirects/",
         "subprojects": "https://readthedocs.org/api/v3/projects/project/subprojects/",
         "superproject": "https://readthedocs.org/api/v3/projects/project/superproject/",
+       "sync_versions": "https://readthedocs.org/api/v3/projects/project/sync_versions/",
         "translations": "https://readthedocs.org/api/v3/projects/project/translations/",
         "versions": "https://readthedocs.org/api/v3/projects/project/versions/"
     },

--- a/readthedocs/api/v3/tests/responses/projects-detail.json
+++ b/readthedocs/api/v3/tests/responses/projects-detail.json
@@ -76,7 +76,7 @@
         "redirects": "https://readthedocs.org/api/v3/projects/project/redirects/",
         "subprojects": "https://readthedocs.org/api/v3/projects/project/subprojects/",
         "superproject": "https://readthedocs.org/api/v3/projects/project/superproject/",
-       "sync_versions": "https://readthedocs.org/api/v3/projects/project/sync_versions/",
+       "sync_versions": "https://readthedocs.org/api/v3/projects/project/sync-versions/",
         "translations": "https://readthedocs.org/api/v3/projects/project/translations/",
         "versions": "https://readthedocs.org/api/v3/projects/project/versions/"
     },

--- a/readthedocs/api/v3/tests/responses/projects-list.json
+++ b/readthedocs/api/v3/tests/responses/projects-list.json
@@ -52,6 +52,7 @@
                 "redirects": "https://readthedocs.org/api/v3/projects/project/redirects/",
                 "subprojects": "https://readthedocs.org/api/v3/projects/project/subprojects/",
                 "superproject": "https://readthedocs.org/api/v3/projects/project/superproject/",
+       "sync_versions": "https://readthedocs.org/api/v3/projects/project/sync_versions/",
                 "translations": "https://readthedocs.org/api/v3/projects/project/translations/"
             },
             "privacy_level": "public",

--- a/readthedocs/api/v3/tests/responses/projects-list.json
+++ b/readthedocs/api/v3/tests/responses/projects-list.json
@@ -52,7 +52,7 @@
                 "redirects": "https://readthedocs.org/api/v3/projects/project/redirects/",
                 "subprojects": "https://readthedocs.org/api/v3/projects/project/subprojects/",
                 "superproject": "https://readthedocs.org/api/v3/projects/project/superproject/",
-       "sync_versions": "https://readthedocs.org/api/v3/projects/project/sync_versions/",
+       "sync_versions": "https://readthedocs.org/api/v3/projects/project/sync-versions/",
                 "translations": "https://readthedocs.org/api/v3/projects/project/translations/"
             },
             "privacy_level": "public",

--- a/readthedocs/api/v3/tests/responses/projects-list_POST.json
+++ b/readthedocs/api/v3/tests/responses/projects-list_POST.json
@@ -7,6 +7,7 @@
         "redirects": "https://readthedocs.org/api/v3/projects/test-project/redirects/",
         "subprojects": "https://readthedocs.org/api/v3/projects/test-project/subprojects/",
         "superproject": "https://readthedocs.org/api/v3/projects/test-project/superproject/",
+       "sync_versions": "https://readthedocs.org/api/v3/projects/test-project/sync_versions/",
         "translations": "https://readthedocs.org/api/v3/projects/test-project/translations/",
         "versions": "https://readthedocs.org/api/v3/projects/test-project/versions/"
     },

--- a/readthedocs/api/v3/tests/responses/projects-list_POST.json
+++ b/readthedocs/api/v3/tests/responses/projects-list_POST.json
@@ -7,7 +7,7 @@
         "redirects": "https://readthedocs.org/api/v3/projects/test-project/redirects/",
         "subprojects": "https://readthedocs.org/api/v3/projects/test-project/subprojects/",
         "superproject": "https://readthedocs.org/api/v3/projects/test-project/superproject/",
-       "sync_versions": "https://readthedocs.org/api/v3/projects/test-project/sync_versions/",
+       "sync_versions": "https://readthedocs.org/api/v3/projects/test-project/sync-versions/",
         "translations": "https://readthedocs.org/api/v3/projects/test-project/translations/",
         "versions": "https://readthedocs.org/api/v3/projects/test-project/versions/"
     },

--- a/readthedocs/api/v3/tests/responses/projects-subprojects-detail.json
+++ b/readthedocs/api/v3/tests/responses/projects-subprojects-detail.json
@@ -13,6 +13,7 @@
             "redirects": "https://readthedocs.org/api/v3/projects/subproject/redirects/",
             "subprojects": "https://readthedocs.org/api/v3/projects/subproject/subprojects/",
             "superproject": "https://readthedocs.org/api/v3/projects/subproject/superproject/",
+       "sync_versions": "https://readthedocs.org/api/v3/projects/subproject/sync_versions/",
             "translations": "https://readthedocs.org/api/v3/projects/subproject/translations/",
             "versions": "https://readthedocs.org/api/v3/projects/subproject/versions/"
         },

--- a/readthedocs/api/v3/tests/responses/projects-subprojects-detail.json
+++ b/readthedocs/api/v3/tests/responses/projects-subprojects-detail.json
@@ -13,7 +13,7 @@
             "redirects": "https://readthedocs.org/api/v3/projects/subproject/redirects/",
             "subprojects": "https://readthedocs.org/api/v3/projects/subproject/subprojects/",
             "superproject": "https://readthedocs.org/api/v3/projects/subproject/superproject/",
-       "sync_versions": "https://readthedocs.org/api/v3/projects/subproject/sync_versions/",
+       "sync_versions": "https://readthedocs.org/api/v3/projects/subproject/sync-versions/",
             "translations": "https://readthedocs.org/api/v3/projects/subproject/translations/",
             "versions": "https://readthedocs.org/api/v3/projects/subproject/versions/"
         },

--- a/readthedocs/api/v3/tests/responses/projects-subprojects-list.json
+++ b/readthedocs/api/v3/tests/responses/projects-subprojects-list.json
@@ -18,7 +18,7 @@
                     "redirects": "https://readthedocs.org/api/v3/projects/subproject/redirects/",
                     "subprojects": "https://readthedocs.org/api/v3/projects/subproject/subprojects/",
                     "superproject": "https://readthedocs.org/api/v3/projects/subproject/superproject/",
-       "sync_versions": "https://readthedocs.org/api/v3/projects/subproject/sync_versions/",
+       "sync_versions": "https://readthedocs.org/api/v3/projects/subproject/sync-versions/",
                     "translations": "https://readthedocs.org/api/v3/projects/subproject/translations/",
                     "versions": "https://readthedocs.org/api/v3/projects/subproject/versions/"
                 },

--- a/readthedocs/api/v3/tests/responses/projects-subprojects-list.json
+++ b/readthedocs/api/v3/tests/responses/projects-subprojects-list.json
@@ -18,6 +18,7 @@
                     "redirects": "https://readthedocs.org/api/v3/projects/subproject/redirects/",
                     "subprojects": "https://readthedocs.org/api/v3/projects/subproject/subprojects/",
                     "superproject": "https://readthedocs.org/api/v3/projects/subproject/superproject/",
+       "sync_versions": "https://readthedocs.org/api/v3/projects/subproject/sync_versions/",
                     "translations": "https://readthedocs.org/api/v3/projects/subproject/translations/",
                     "versions": "https://readthedocs.org/api/v3/projects/subproject/versions/"
                 },

--- a/readthedocs/api/v3/tests/responses/projects-subprojects-list_POST.json
+++ b/readthedocs/api/v3/tests/responses/projects-subprojects-list_POST.json
@@ -13,7 +13,7 @@
             "redirects": "https://readthedocs.org/api/v3/projects/new-project/redirects/",
             "subprojects": "https://readthedocs.org/api/v3/projects/new-project/subprojects/",
             "superproject": "https://readthedocs.org/api/v3/projects/new-project/superproject/",
-            "sync_versions": "https://readthedocs.org/api/v3/projects/new-project/sync_versions/",
+            "sync_versions": "https://readthedocs.org/api/v3/projects/new-project/sync-versions/",
             "translations": "https://readthedocs.org/api/v3/projects/new-project/translations/",
             "versions": "https://readthedocs.org/api/v3/projects/new-project/versions/"
         },

--- a/readthedocs/api/v3/tests/responses/projects-subprojects-list_POST.json
+++ b/readthedocs/api/v3/tests/responses/projects-subprojects-list_POST.json
@@ -13,6 +13,7 @@
             "redirects": "https://readthedocs.org/api/v3/projects/new-project/redirects/",
             "subprojects": "https://readthedocs.org/api/v3/projects/new-project/subprojects/",
             "superproject": "https://readthedocs.org/api/v3/projects/new-project/superproject/",
+            "sync_versions": "https://readthedocs.org/api/v3/projects/new-project/sync_versions/",
             "translations": "https://readthedocs.org/api/v3/projects/new-project/translations/",
             "versions": "https://readthedocs.org/api/v3/projects/new-project/versions/"
         },

--- a/readthedocs/api/v3/tests/responses/projects-superproject.json
+++ b/readthedocs/api/v3/tests/responses/projects-superproject.json
@@ -15,7 +15,7 @@
         "redirects": "https://readthedocs.org/api/v3/projects/project/redirects/",
         "subprojects": "https://readthedocs.org/api/v3/projects/project/subprojects/",
         "superproject": "https://readthedocs.org/api/v3/projects/project/superproject/",
-       "sync_versions": "https://readthedocs.org/api/v3/projects/project/sync_versions/",
+       "sync_versions": "https://readthedocs.org/api/v3/projects/project/sync-versions/",
         "translations": "https://readthedocs.org/api/v3/projects/project/translations/",
         "versions": "https://readthedocs.org/api/v3/projects/project/versions/"
     },

--- a/readthedocs/api/v3/tests/responses/projects-superproject.json
+++ b/readthedocs/api/v3/tests/responses/projects-superproject.json
@@ -15,6 +15,7 @@
         "redirects": "https://readthedocs.org/api/v3/projects/project/redirects/",
         "subprojects": "https://readthedocs.org/api/v3/projects/project/subprojects/",
         "superproject": "https://readthedocs.org/api/v3/projects/project/superproject/",
+       "sync_versions": "https://readthedocs.org/api/v3/projects/project/sync_versions/",
         "translations": "https://readthedocs.org/api/v3/projects/project/translations/",
         "versions": "https://readthedocs.org/api/v3/projects/project/versions/"
     },

--- a/readthedocs/api/v3/tests/responses/projects-sync-versions.json
+++ b/readthedocs/api/v3/tests/responses/projects-sync-versions.json
@@ -1,0 +1,1 @@
+{"triggered": true}

--- a/readthedocs/api/v3/tests/responses/projects-versions-builds-list_POST.json
+++ b/readthedocs/api/v3/tests/responses/projects-versions-builds-list_POST.json
@@ -42,6 +42,7 @@
             "notifications": "https://readthedocs.org/api/v3/projects/project/notifications/",
             "subprojects": "https://readthedocs.org/api/v3/projects/project/subprojects/",
             "superproject": "https://readthedocs.org/api/v3/projects/project/superproject/",
+       "sync_versions": "https://readthedocs.org/api/v3/projects/project/sync_versions/",
             "translations": "https://readthedocs.org/api/v3/projects/project/translations/",
             "versions": "https://readthedocs.org/api/v3/projects/project/versions/"
         },

--- a/readthedocs/api/v3/tests/responses/projects-versions-builds-list_POST.json
+++ b/readthedocs/api/v3/tests/responses/projects-versions-builds-list_POST.json
@@ -42,7 +42,7 @@
             "notifications": "https://readthedocs.org/api/v3/projects/project/notifications/",
             "subprojects": "https://readthedocs.org/api/v3/projects/project/subprojects/",
             "superproject": "https://readthedocs.org/api/v3/projects/project/superproject/",
-       "sync_versions": "https://readthedocs.org/api/v3/projects/project/sync_versions/",
+       "sync_versions": "https://readthedocs.org/api/v3/projects/project/sync-versions/",
             "translations": "https://readthedocs.org/api/v3/projects/project/translations/",
             "versions": "https://readthedocs.org/api/v3/projects/project/versions/"
         },

--- a/readthedocs/api/v3/tests/responses/remoterepositories-list.json
+++ b/readthedocs/api/v3/tests/responses/remoterepositories-list.json
@@ -25,6 +25,7 @@
           "redirects": "https://readthedocs.org/api/v3/projects/project/redirects/",
           "subprojects": "https://readthedocs.org/api/v3/projects/project/subprojects/",
           "superproject": "https://readthedocs.org/api/v3/projects/project/superproject/",
+       "sync_versions": "https://readthedocs.org/api/v3/projects/project/sync_versions/",
           "translations": "https://readthedocs.org/api/v3/projects/project/translations/",
           "versions": "https://readthedocs.org/api/v3/projects/project/versions/"
         },

--- a/readthedocs/api/v3/tests/responses/remoterepositories-list.json
+++ b/readthedocs/api/v3/tests/responses/remoterepositories-list.json
@@ -25,7 +25,7 @@
           "redirects": "https://readthedocs.org/api/v3/projects/project/redirects/",
           "subprojects": "https://readthedocs.org/api/v3/projects/project/subprojects/",
           "superproject": "https://readthedocs.org/api/v3/projects/project/superproject/",
-       "sync_versions": "https://readthedocs.org/api/v3/projects/project/sync_versions/",
+       "sync_versions": "https://readthedocs.org/api/v3/projects/project/sync-versions/",
           "translations": "https://readthedocs.org/api/v3/projects/project/translations/",
           "versions": "https://readthedocs.org/api/v3/projects/project/versions/"
         },

--- a/readthedocs/api/v3/tests/test_projects.py
+++ b/readthedocs/api/v3/tests/test_projects.py
@@ -218,6 +218,11 @@ class ProjectsEndpointTests(APIEndpointMixin):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 401)
 
+        # Test with a user that is not the owner
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.others_token.key}")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
         self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
         response = self.client.post(url)
         self.assertEqual(response.status_code, 202)

--- a/readthedocs/api/v3/tests/test_projects.py
+++ b/readthedocs/api/v3/tests/test_projects.py
@@ -220,7 +220,7 @@ class ProjectsEndpointTests(APIEndpointMixin):
 
         self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 202)
 
         self.assertDictEqual(
             response.json(),

--- a/readthedocs/api/v3/tests/test_projects.py
+++ b/readthedocs/api/v3/tests/test_projects.py
@@ -203,6 +203,30 @@ class ProjectsEndpointTests(APIEndpointMixin):
             self._get_response_dict("projects-superproject"),
         )
 
+    def test_projects_sync_versions(self):
+        # Ensure a default version exists to sync
+        self.project.update_latest_version()
+
+        url = reverse(
+            "projects-sync-versions",
+            kwargs={
+                "project_slug": self.project.slug,
+            },
+        )
+
+        self.client.logout()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 401)
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 200)
+
+        self.assertDictEqual(
+            response.json(),
+            self._get_response_dict("projects-sync-versions"),
+        )
+
     def test_others_projects_builds_list(self):
         self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
         response = self.client.get(

--- a/readthedocs/api/v3/tests/test_projects.py
+++ b/readthedocs/api/v3/tests/test_projects.py
@@ -217,10 +217,12 @@ class ProjectsEndpointTests(APIEndpointMixin):
         self.client.logout()
         response = self.client.get(url)
         self.assertEqual(response.status_code, 401)
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 401)
 
         # Test with a user that is not the owner
         self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.others_token.key}")
-        response = self.client.get(url)
+        response = self.client.post(url)
         self.assertEqual(response.status_code, 403)
 
         self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")

--- a/readthedocs/api/v3/urls.py
+++ b/readthedocs/api/v3/urls.py
@@ -24,7 +24,7 @@ router = DefaultRouterWithNesting()
 # allows /api/v3/projects/
 # allows /api/v3/projects/pip/
 # allows /api/v3/projects/pip/superproject/
-# allows /api/v3/projects/pip/sync_versions/
+# allows /api/v3/projects/pip/sync-versions/
 projects = router.register(
     r"projects",
     ProjectsViewSet,

--- a/readthedocs/api/v3/urls.py
+++ b/readthedocs/api/v3/urls.py
@@ -24,6 +24,7 @@ router = DefaultRouterWithNesting()
 # allows /api/v3/projects/
 # allows /api/v3/projects/pip/
 # allows /api/v3/projects/pip/superproject/
+# allows /api/v3/projects/pip/sync_versions/
 projects = router.register(
     r"projects",
     ProjectsViewSet,

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -28,6 +28,7 @@ from readthedocs.api.v2.permissions import ReadOnlyPermission
 from readthedocs.builds.models import Build, Version
 from readthedocs.core.utils import trigger_build
 from readthedocs.core.utils.extend import SettingsOverrideObject
+from readthedocs.core.views.hooks import trigger_sync_versions
 from readthedocs.notifications.models import Notification
 from readthedocs.oauth.models import (
     RemoteOrganization,
@@ -217,6 +218,25 @@ class ProjectsViewSetBase(
             return Response(data)
         except Exception:
             return Response(status=status.HTTP_404_NOT_FOUND)
+
+    @action(detail=True, methods=["post"])
+    def sync_versions(self, request, project_slug):
+        """
+        Kick off a task to sync versions for a project.
+
+        This will be used in a button in the frontend,
+        but also can be used to trigger a sync from the API.
+        """
+        project = self.get_object()
+        triggered = trigger_sync_versions(project)
+        data = {}
+        if triggered:
+            data.update({"triggered": True})
+            code = status.HTTP_202_ACCEPTED
+        else:
+            data.update({"triggered": False})
+            code = status.HTTP_400_BAD_REQUEST
+        return Response(data=data, status=code)
 
 
 class ProjectsViewSet(SettingsOverrideObject):

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -227,6 +227,8 @@ class ProjectsViewSetBase(
         """
         Kick off a task to sync versions for a project.
 
+        POST to this endpoint to trigger a task that syncs versions for the project.
+
         This will be used in a button in the frontend,
         but also can be used to trigger a sync from the API.
         """

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -222,7 +222,7 @@ class ProjectsViewSetBase(
         except Exception:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
-    @action(detail=True, methods=["post"])
+    @action(detail=True, methods=["post"], url_path="sync-versions/")
     def sync_versions(self, request, project_slug):
         """
         Kick off a task to sync versions for a project.

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -162,6 +162,9 @@ class ProjectsViewSetBase(
         if self.action in ("update", "partial_update"):
             return ProjectUpdateSerializer
 
+        # Default serializer so that sync_versions works with the BrowseableAPI
+        return ProjectSerializer
+
     def get_queryset(self):
         # Allow hitting ``/api/v3/projects/`` to list their own projects
         if self.basename == "projects" and self.action == "list":

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -222,7 +222,7 @@ class ProjectsViewSetBase(
         except Exception:
             return Response(status=status.HTTP_404_NOT_FOUND)
 
-    @action(detail=True, methods=["post"], url_path="sync-versions/")
+    @action(detail=True, methods=["post"], url_path="sync-versions")
     def sync_versions(self, request, project_slug):
         """
         Kick off a task to sync versions for a project.


### PR DESCRIPTION
This will be used in the frontend,
but also available as an API.

Mostly curious if this is a good approach,
and I can get some tests together for it.

Looks like:
```
-> curl -X POST http://devthedocs.com/api/v3/projects/read-the-docs/sync_versions/ -H "Authorization: Token $TOKEN" 
{"triggered":true}
```
Refs https://github.com/readthedocs/readthedocs.org/issues/6090
