### PR TITLE
Docs: remove beta framing from pull request

### DIFF
--- a/docs/user/guides/setup/git-repo-automatic.rst
+++ b/docs/user/guides/setup/git-repo-automatic.rst
@@ -138,8 +138,6 @@ which allow us to build your documentation on every change to your repository.
       Repository status (``repo:status``)
           Repository statuses allow Read the Docs to report the status
           (eg. passed, failed, pending) of pull requests to GitHub.
-          This is used for a feature currently in beta testing
-          that builds documentation on each pull request similar to a continuous integration service.
 
       .. note::
 


### PR DESCRIPTION


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11492.org.readthedocs.build/en/11492/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11492.org.readthedocs.build/en/11492/

<!-- readthedocs-preview dev end -->