### PR TITLE
Addons: remove "beta" framing around addons

### DIFF
--- a/docs/user/addons.rst
+++ b/docs/user/addons.rst
@@ -35,7 +35,7 @@ All projects using ``mkdocs`` :ref:`mkdocs <config-file/v2:mkdocs>` or the ``bui
     * `Business <https://app.readthedocs.com>`_
 
 #. Click on a project name.
-#. Go to :guilabel:`Settings`, then in the left bar, go to :guilabel:`Addons (Beta)`.
+#. Go to :guilabel:`Settings`, then in the left bar, go to :guilabel:`Addons`.
 #. Check :guilabel:`Enable Addons`, and then configure each Addon individually.
 
 .. note::
@@ -53,5 +53,5 @@ Individual configuration options for each addon are available in :guilabel:`Sett
     * `Business <https://app.readthedocs.com>`_
 
 #. Click on a project name.
-#. Go to :guilabel:`Settings`, then in the left bar, go to :guilabel:`Addons (Beta)`.
+#. Go to :guilabel:`Settings`, then in the left bar, go to :guilabel:`Addons`.
 #. Configure each Addon individually.

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -418,7 +418,7 @@ Override the build process
 
    We are using :ref:`our new addons integration <rtd-blog:addons-flyout-menu-beta>`
    on projects using ``build.commands``.
-   This will become the default soon,
+   `This will become the default soon <https://about.readthedocs.com/blog/2024/07/addons-by-default/>`_,
    but has some slight differences from our previous flyout.
 
 If your project requires full control of the build process,

--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -460,7 +460,7 @@ The ``$READTHEDOCS_OUTPUT/html`` directory will be uploaded and hosted by Read t
 
    We are using :ref:`our new addons integration <rtd-blog:addons-flyout-menu-beta>`
    on projects using ``build.commands``.
-   This will become the default soon,
+   `This will become the default soon <https://about.readthedocs.com/blog/2024/07/addons-by-default/>`_,
    but has some slight differences from our previous flyout.
 
 .. code-block:: yaml

--- a/docs/user/flyout-menu.rst
+++ b/docs/user/flyout-menu.rst
@@ -27,7 +27,7 @@ offline formats, and a search bar.
 Customizing the flyout menu
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In your dashboard, you can configure flyout menu options in :guilabel:`Settings`, under :guilabel:`Addons (Beta)`.
+In your dashboard, you can configure flyout menu options in :guilabel:`Settings`, under :guilabel:`Addons`.
 
 Sort your versions :guilabel:`Alphabetically`, by :guilabel:`SemVer`, by :guilabel:`Python Packaging`,
 by :guilabel:`CalVer`, or define your own pattern.

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -625,7 +625,7 @@ class ProjectPullRequestForm(forms.ModelForm, ProjectPRBuildsMixin):
 
 class AddonsConfigForm(forms.ModelForm):
 
-    """Form to opt-in into new beta addons."""
+    """Form to opt-in into new addons."""
 
     project = forms.CharField(widget=forms.HiddenInput(), required=False)
 

--- a/readthedocs/projects/urls/private.py
+++ b/readthedocs/projects/urls/private.py
@@ -249,7 +249,7 @@ domain_urls = [
 
 urlpatterns += domain_urls
 
-# We are allowing users to enable the new beta addons only from the new dashboard
+# We are allowing users to enable the new addons only from the new dashboard
 if settings.RTD_EXT_THEME_ENABLED:
     addons_urls = [
         re_path(


### PR DESCRIPTION
It's now pretty stable and it will become the default soon: https://about.readthedocs.com/blog/2024/07/addons-by-default/

Closes #11453

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11493.org.readthedocs.build/en/11493/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11493.org.readthedocs.build/en/11493/

<!-- readthedocs-preview dev end -->