### PR TITLE
Docs: use the latest rc1 release of the theme

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -33,12 +33,6 @@ build:
           exit 183;
         fi
 
-    # Install our Sphinx Theme version that uses the Addons CustomEvent to generate the integrated flyout
-    # TODO: remove this custom installation once a new release has been done
-    post_install:
-      - pip uninstall --yes sphinx-rtd-theme
-      - pip install git+https://github.com/readthedocs/sphinx_rtd_theme.git@357e76dc42a89c1c387cafd8cb134378a57e4d6d#egg=sphinx-rtd-theme
-
 search:
   ranking:
     # Deprecated content

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -4,7 +4,7 @@ sphinx
 
 matplotlib  # opengraph social cards
 
-sphinx_rtd_theme==2.0.0rc2
+sphinx_rtd_theme==2.1.0rc1
 sphinx-tabs
 sphinx-intl
 sphinx-design

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -133,7 +133,7 @@ sphinx-notfound-page==1.0.2
     # via -r requirements/docs.in
 sphinx-prompt==1.8.0
     # via -r requirements/docs.in
-sphinx-rtd-theme==2.0.0rc2
+sphinx-rtd-theme==2.1.0rc1
     # via -r requirements/docs.in
 sphinx-tabs==3.4.5
     # via -r requirements/docs.in


### PR DESCRIPTION
We just released 2.1.0rc1 that uses the JavaScript `CustomEvent` to generate the flyout.