### PR TITLE
Build: do not use custom builder when `DISABLE_SPHINX_MANIPULATION`

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -360,6 +360,15 @@ class LocalMediaBuilder(BaseSphinx):
     sphinx_builder = "readthedocssinglehtmllocalmedia"
     relative_output_dir = "htmlzip"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # The builder `readthedocssinglehtmllocalmedia` is defined by our
+        # `readthedocs-sphinx-ext` extension that we are not installing
+        # anymore; so we want to use the default Sphinx `singlehtml` builder
+        if self.project.has_feature(Feature.DISABLE_SPHINX_MANIPULATION):
+            self.sphinx_builder = "singlehtml"
+
     def _post_build(self):
         """Internal post build to create the ZIP file from the HTML output."""
         target_file = os.path.join(


### PR DESCRIPTION
We are installing `readthedocssinglehtmllocalmedia` Sphinx builder via our `readthedocs-sphinx-ext` extension.

I checked that code and this builder doesn't do anything super special. It only adds a CSS file that it's related with the flyout, which it's not useful anymore:
https://github.com/readthedocs/readthedocs-sphinx-ext/blob/13edf78bab374f51e314e4994c319fadbab806f2/readthedocs_ext/readthedocs.py#L81-L83

This commit runs `singlehtml` Sphinx builder (the default from Sphinx) when the `DISABLE_SPHINX_MANIPULATION` feature flag is enabled. I tested this locally using `all-formats` branch from `test-builds` and I got the same results (except from the flyout, which is not injected anymore since there is no context injected in the new behavior)