### PR TITLE
Addons: prepare Proxito and dashboard to enable them by default

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -1,16 +1,19 @@
 """Project forms."""
 
+import datetime
 import json
 from random import choice
 from re import fullmatch
 from urllib.parse import urlparse
 
+import pytz
 from allauth.socialaccount.models import SocialAccount
 from django import forms
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.db.models import Q
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from readthedocs.builds.constants import INTERNAL
@@ -662,13 +665,22 @@ class AddonsConfigForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         self.project = kwargs.pop("project", None)
+
+        tzinfo = pytz.timezone("America/Los_Angeles")
+        addons_enabled_by_default = timezone.now() > datetime.datetime(
+            2024, 10, 7, 0, 0, 0, tzinfo=tzinfo
+        )
+
         addons, created = AddonsConfig.objects.get_or_create(project=self.project)
         if created:
-            addons.enabled = False
+            addons.enabled = addons_enabled_by_default
             addons.save()
 
         kwargs["instance"] = addons
         super().__init__(*args, **kwargs)
+
+        if addons_enabled_by_default:
+            self.fields.pop("enabled")
 
     def clean(self):
         if (


### PR DESCRIPTION
Prepare Proxito's code and dashboard to enable addons by default starting on October 7th, as planned:
https://about.readthedocs.com/blog/2024/07/addons-by-default/

- Removes the "Enabled" checkbox from the dashboard. All the addons will be enabled by default. Users will be able to disable each of them one by one, tho
- Always inject the HTTP header that tells Cloudflare to inject our JavaScript [^1]

Note this code is temporary and can be deployed _before_ reaching that particular date. The idea is to remove this code once this behavior becomes the default.

Related https://github.com/readthedocs/readthedocs.org/issues/11474

[^1]: we will eventually remove this header and _always_ inject our files.