### PR TITLE
Settings: explicitly set password hashers

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -14,6 +14,8 @@ from corsheaders.defaults import default_headers
 from readthedocs.core.settings import Settings
 from readthedocs.builds import constants_docker
 
+from django.conf.global_settings import PASSWORD_HASHERS
+
 try:
     import readthedocsext.cdn  # noqa
 
@@ -363,6 +365,10 @@ class CommunityBaseSettings(Settings):
             "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
         },
     ]
+
+    # Explicitly set the password hashers to the default ones,
+    # so we can change them in our test settings.
+    PASSWORD_HASHERS = PASSWORD_HASHERS
 
     # Paths
     SITE_ROOT = os.path.dirname(

--- a/readthedocs/settings/test.py
+++ b/readthedocs/settings/test.py
@@ -37,11 +37,11 @@ class CommunityTestSettings(CommunityBaseSettings):
         }
     }
 
-    # Speed up tests by using a fast password hasher.
-    # https://docs.djangoproject.com/en/5.0/topics/testing/overview/#speeding-up-the-tests.
-    PASSWORD_HASHERS = [
-        "django.contrib.auth.hashers.MD5PasswordHasher",
-    ]
+    @property
+    def PASSWORD_HASHERS(self):
+        # Speed up tests by using a fast password hasher as the default.
+        # https://docs.djangoproject.com/en/5.0/topics/testing/overview/#speeding-up-the-tests.
+        return ["django.contrib.auth.hashers.MD5PasswordHasher"] + super().PASSWORD_HASHERS
 
     @property
     def DATABASES(self):  # noqa


### PR DESCRIPTION
We need to explicitly define the hashers,
so we can append an extra hasher we are using on .com.