### PR TITLE
Docs: warm about password sharing links with the same password

### DIFF
--- a/docs/user/commercial/sharing.rst
+++ b/docs/user/commercial/sharing.rst
@@ -67,6 +67,13 @@ view your project.
    This is useful for when you have documentation you want users to bookmark.
    They can enter a URL directly and enter the password when prompted.
 
+.. warning::
+
+   Since multiple passwords can be created for a single project,
+   each password must be unique within that project.
+   If you generate multiple sharing links using the same password for a project,
+   only the first link will work.
+
 HTTP Authorization Header
 *************************
 


### PR DESCRIPTION


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11525.org.readthedocs.build/en/11525/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11525.org.readthedocs.build/en/11525/

<!-- readthedocs-preview dev end -->