### PR TITLE
Login: add link to SAML login

### DIFF
--- a/readthedocs/templates/account/login.html
+++ b/readthedocs/templates/account/login.html
@@ -71,6 +71,15 @@
   <div class="clearfix">
     <ul class="socialaccount_providers">
       {% include "socialaccount/snippets/provider_list.html" with process="login" next=request.GET.next verbiage="Log in using" %}
+      {% if USE_ORGANIZATIONS %}
+      <li>
+        <form action="{% url "saml_resolve_login" %}{% if redirect_field_value %}?{{ redirect_field_name }}={{ redirect_field_value }}{% endif %}" method="get">
+          <button class="socialaccount-provider button" type="submit">
+              {% trans "Login usin single sign-on" %}
+          </button>
+        </form>
+      </li>
+      {% endif %}
     </ul>
   </div>
 {% endif %}

--- a/readthedocs/templates/account/login.html
+++ b/readthedocs/templates/account/login.html
@@ -75,7 +75,7 @@
       <li>
         <form action="{% url "saml_resolve_login" %}{% if redirect_field_value %}?{{ redirect_field_name }}={{ redirect_field_value }}{% endif %}" method="get">
           <button class="socialaccount-provider button" type="submit">
-              {% trans "Login usin single sign-on" %}
+              {% trans "Log in using single sign-on" %}
           </button>
         </form>
       </li>


### PR DESCRIPTION
We initially had this on the new dashboard only, but the new dashboard doesn't work for granting access to docs pages yet.

![Screenshot 2024-08-14 at 13-16-34 Log in - Read the Docs for Business](https://github.com/user-attachments/assets/a4651e55-dd3d-4254-8909-f0100865b5e8)
