### PR TITLE
Fix site-wide new dashboard notification

### DIFF
--- a/readthedocs/builds/views.py
+++ b/readthedocs/builds/views.py
@@ -192,27 +192,9 @@ class BuildDetail(BuildBase, ProjectSpamMixin, DetailView):
 
         build = self.get_object()
 
-        # Temporary notification to point to the same page on the new dashboard
-        #
-        # To support readthedocs.com, we have to point to the login view. We
-        # can't point directly to the build view on the new dashboard as this
-        # will give the users a 404 because they aren't logged in.
-        #
-        # On community, we _don't want this_ as this requires the user to have
-        # a login to view the new dashboard.
-        url_domain = settings.PRODUCTION_DOMAIN
-        if url_domain.startswith("app."):
-            url_domain = url_domain[4:]
-        else:
-            url_domain = f"app.{url_domain}"
-        url_build = build.get_absolute_url()
-        # Point to the login view with the build as ?next. We are expecting
-        # users to have accounts to view this.
-        if settings.RTD_ALLOW_ORGANIZATIONS:
-            url_build = reverse("account_login") + f"?next={url_build}"
-        context["url_switch_dashboard"] = f"https://{url_domain}{url_build}"
-
-        context["notifications"] = build.notifications.all()
+        # We consume these notifications through the API in the new dashboard
+        if not settings.RTD_EXT_THEME_ENABLED:
+            context["notifications"] = build.notifications.all()
         if not build.notifications.filter(
             message_id=BuildAppError.GENERIC_WITH_BUILD_ID
         ).exists():

--- a/readthedocs/core/context_processors.py
+++ b/readthedocs/core/context_processors.py
@@ -13,9 +13,12 @@ def readthedocs_processor(request):
     If you need to add something that depends on the request,
     create a new context processor.
     """
+
     exports = {
         "PUBLIC_DOMAIN": settings.PUBLIC_DOMAIN,
         "PRODUCTION_DOMAIN": settings.PRODUCTION_DOMAIN,
+        # TODO this can be removed with RTD_EXT_THEME_ENABLED
+        "SWITCH_PRODUCTION_DOMAIN": settings.SWITCH_PRODUCTION_DOMAIN,
         "GLOBAL_ANALYTICS_CODE": settings.GLOBAL_ANALYTICS_CODE,
         "DASHBOARD_ANALYTICS_CODE": settings.DASHBOARD_ANALYTICS_CODE,
         "SITE_ROOT": settings.SITE_ROOT + "/",

--- a/readthedocs/core/notifications.py
+++ b/readthedocs/core/notifications.py
@@ -4,11 +4,11 @@ import textwrap
 
 from django.utils.translation import gettext_lazy as _
 
-from readthedocs.notifications.constants import INFO, WARNING
+from readthedocs.notifications.constants import TIP, WARNING
 from readthedocs.notifications.messages import Message, registry
 
 MESSAGE_EMAIL_VALIDATION_PENDING = "core:email:validation-pending"
-MESSAGE_BETA_DASHBOARD_AVAILABLE = "core:dashboard:beta-available"
+MESSAGE_NEW_DASHBOARD = "core:dashboard:new"
 messages = [
     Message(
         id=MESSAGE_EMAIL_VALIDATION_PENDING,
@@ -23,24 +23,38 @@ messages = [
         ),
         type=WARNING,
     ),
+    # This message looks quite odd because we need to show different content in
+    # the notification depending on which instance the user is on -- if the user
+    # is on our legacy dashboard, we don't want a notification "Welcome to our
+    # new dashboard!".
+    #
+    # Localization is avoided because the body has template logic inside and we
+    # don't want to push that to our translations sources.
     Message(
-        id=MESSAGE_BETA_DASHBOARD_AVAILABLE,
-        header=_("New beta dashboard"),
-        body=_(
-            textwrap.dedent(
-                """
-                {% if RTD_EXT_THEME_ENABLED %}
-                This dashboard is currently in beta,
-                you can <a href="https://{{ PRODUCTION_DOMAIN }}">return to the legacy dashboard</a> if you encounter any problems.
-                Feel free to <a href="https://{{ PRODUCTION_DOMAIN }}/support/">report any feedback</a> you may have.
-                {% else %}
-                Our new <strong>beta dashboard</strong> is now available for testing.
-                <a href="https://app.{{ PRODUCTION_DOMAIN }}/">Give it a try</a> and send us feedback.
-                {% endif %}
+        id=MESSAGE_NEW_DASHBOARD,
+        header=textwrap.dedent(
             """
-            ).strip(),
-        ),
-        type=INFO,
+            {% if RTD_EXT_THEME_ENABLED %}
+              Welcome to our new dashboard!
+            {% else %}
+              Our new dashboard is ready!
+            {% endif %}
+            """
+        ).strip(),
+        body=textwrap.dedent(
+            """
+            {% if RTD_EXT_THEME_ENABLED %}
+              We are beginning to direct users to our new dashboard as we work to retire our legacy dashboard.
+            {% else %}
+              You are currently using our legacy dashboard, which will be retired on <time datetime="2025-03-01">March 1st, 2025</time>.
+              You should <a href="//{{ SWITCH_PRODUCTION_DOMAIN }}{% url "account_login" %}">switch to our new dashboard</a> before then.
+            {% endif %}
+            For more information on this change and what to expect,
+            <a href="https://about.readthedocs.com/blog/2024/11/new-dashboard/">read our blog post</a>.
+            """
+        ).strip(),
+        type=TIP,
+        icon_classes="fad fa-sparkles",
     ),
 ]
 

--- a/readthedocs/core/notifications.py
+++ b/readthedocs/core/notifications.py
@@ -46,11 +46,11 @@ messages = [
             {% if RTD_EXT_THEME_ENABLED %}
               We are beginning to direct users to our new dashboard as we work to retire our legacy dashboard.
             {% else %}
-              You are currently using our legacy dashboard, which will be retired on <time datetime="2025-03-01">March 1st, 2025</time>.
+              You are currently using our legacy dashboard, which will be retired on <time datetime="2025-03-11">March 11th, 2025</time>.
               You should <a href="//{{ SWITCH_PRODUCTION_DOMAIN }}{% url "account_login" %}">switch to our new dashboard</a> before then.
             {% endif %}
             For more information on this change and what to expect,
-            <a href="https://about.readthedocs.com/blog/2024/11/new-dashboard/">read our blog post</a>.
+            <a href="https://about.readthedocs.com/blog/2024/11/rollout-of-our-new-dashboard/">read our blog post</a>.
             """
         ).strip(),
         type=TIP,

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -123,7 +123,16 @@ class ProjectDashboard(FilterContextMixin, PrivateViewMixin, ListView):
             template_name = None
             projects = AdminPermission.projects(user=self.request.user, admin=True)
             n_projects = projects.count()
-            if n_projects == 0 or (
+
+            # TODO remove this with RTD_EXT_THEME_ENABLED
+            # This is going to try hard to show the new dashboard announcement.
+            # We can't yet back down to another announcement as we don't have
+            # the ability to evaluate local storage. Until we add the ability to
+            # dynamically change the announcement, this is going to be the only
+            # announcement shown.
+            if True:
+                template_name = "new-dashboard.html"
+            elif n_projects == 0 or (
                 n_projects < 3 and (timezone.now() - projects.first().pub_date).days < 7
             ):
                 template_name = "example-projects.html"

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -130,7 +130,7 @@ class ProjectDashboard(FilterContextMixin, PrivateViewMixin, ListView):
             # the ability to evaluate local storage. Until we add the ability to
             # dynamically change the announcement, this is going to be the only
             # announcement shown.
-            if True:
+            if True:  # pylint: disable=using-constant-test
                 template_name = "new-dashboard.html"
             elif n_projects == 0 or (
                 n_projects < 3 and (timezone.now() - projects.first().pub_date).days < 7

--- a/readthedocs/rtd_tests/tests/test_notifications.py
+++ b/readthedocs/rtd_tests/tests/test_notifications.py
@@ -54,6 +54,7 @@ class NotificationTests(TestCase):
                 "DO_NOT_TRACK_ENABLED": mock.ANY,
                 "GLOBAL_ANALYTICS_CODE": mock.ANY,
                 "PRODUCTION_DOMAIN": "readthedocs.org",
+                "SWITCH_PRODUCTION_DOMAIN": "app.readthedocs.org",
                 "PUBLIC_DOMAIN": mock.ANY,
                 "PUBLIC_API_URL": mock.ANY,
                 "RTD_EXT_THEME_ENABLED": mock.ANY,

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -86,6 +86,12 @@ class CommunityBaseSettings(Settings):
     RTD_INTERSPHINX_URL = "https://{}".format(PRODUCTION_DOMAIN)
     RTD_EXTERNAL_VERSION_DOMAIN = "external-builds.readthedocs.io"
 
+    @property
+    def SWITCH_PRODUCTION_DOMAIN(self):
+        if self.RTD_EXT_THEME_ENABLED:
+            return self.PRODUCTION_DOMAIN.removeprefix("app.")
+        return f"app.{self.PRODUCTION_DOMAIN}"
+
     # Doc Builder Backends
     MKDOCS_BACKEND = "readthedocs.doc_builder.backends.mkdocs"
     SPHINX_BACKEND = "readthedocs.doc_builder.backends.sphinx"


### PR DESCRIPTION
Notification on new dashboard:

![image](https://github.com/user-attachments/assets/1cc4c608-94c3-4a2f-bab1-6e4622fe6c72)

Notification on old dashboard:

![image](https://github.com/user-attachments/assets/3dbe24a1-9597-418c-82b7-c7962f2c969b)

----

- Fixes #11209
- Requires https://github.com/readthedocs/ext-theme/pull/524
- Refs https://github.com/readthedocs/website/pull/335