### PR TITLE
Update instructions for Jupyter notebook galleries

### DIFF
--- a/docs/user/guides/jupyter.rst
+++ b/docs/user/guides/jupyter.rst
@@ -237,21 +237,10 @@ Creating galleries of examples using notebooks
 
 `nbsphinx`_ has support for :doc:`creating thumbnail galleries from a list of Jupyter
 notebooks <nbsphinx:subdir/gallery>`.
-This functionality relies on `Sphinx-Gallery <https://sphinx-gallery.github.io/>`_
-and extends it to work with Jupyter notebooks rather than Python scripts.
+This functionality is inspired by, but doesn't depend on
+`Sphinx-Gallery <https://sphinx-gallery.github.io/>`_.
 
-To use it, you will need to install both nbsphinx and Sphinx-Gallery,
-and modify your ``conf.py`` as follows:
-
-.. code-block:: python
-   :caption: conf.py
-
-   extensions = [
-       "nbsphinx",
-       "sphinx_gallery.load_style",
-   ]
-
-After doing that, there are two ways to create the gallery:
+There are two ways to create the gallery:
 
 - From a reStructuredText source file, using the ``.. nbgallery::`` directive,
   :ref:`as showcased in the

--- a/docs/user/guides/jupyter.rst
+++ b/docs/user/guides/jupyter.rst
@@ -237,8 +237,6 @@ Creating galleries of examples using notebooks
 
 `nbsphinx`_ has support for :doc:`creating thumbnail galleries from a list of Jupyter
 notebooks <nbsphinx:subdir/gallery>`.
-This functionality is inspired by, but doesn't depend on
-`Sphinx-Gallery <https://sphinx-gallery.github.io/>`_.
 
 There are two ways to create the gallery:
 

--- a/docs/user/guides/jupyter.rst
+++ b/docs/user/guides/jupyter.rst
@@ -253,9 +253,7 @@ There are two ways to create the gallery:
 
    Panel to modify cell metadata in JupyterLab
 
-For example, this reST markup would create a thumbnail gallery
-with generic images as thumbnails,
-thanks to the Sphinx-Gallery default style:
+For example, this markup would create a thumbnail gallery:
 
 .. tabs::
 


### PR DESCRIPTION
Since a while, `nbsphinx` doesn't depend on Sphinx-Gallery anymore and uses its own CSS (which can still be overwritten/extended by site authors), see https://github.com/spatialaudio/nbsphinx/pull/706.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11545.org.readthedocs.build/en/11545/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11545.org.readthedocs.build/en/11545/

<!-- readthedocs-preview dev end -->