### PR TITLE
Fix a typo in "invited" in email notification subjects

### DIFF
--- a/readthedocs/invitations/backends.py
+++ b/readthedocs/invitations/backends.py
@@ -67,7 +67,7 @@ class Backend:
         )
         send_email(
             recipient=email,
-            subject=f"{from_name} has invite you to join the {object_description}",
+            subject=f"{from_name} has invited you to join the {object_description}",
             template="invitations/email/invitation.txt",
             template_html="invitations/email/invitation.html",
             context={


### PR DESCRIPTION
The mistake has been introduced in #9440.