### PR TITLE
Add project: improve way to get the `basics` form

### DIFF
--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -357,7 +357,15 @@ class ImportWizardView(ProjectImportMixin, PrivateViewMixin, SessionWizardView):
         other side effects for now, by signalling a save without commit. Then,
         finish by added the members to the project and saving.
         """
-        basics_form = form_list[0]
+
+        # We need to find the "basics" for here by iterating the list of bounded instance forms
+        # because community and business have different steps -- it's not always the first one.
+        basics_form = None
+        for form in form_list:
+            if isinstance(form, self.form_list.get("basics")):
+                basics_form = form
+                break
+
         # Save the basics form to create the project instance, then alter
         # attributes directly from other forms
         project = basics_form.save()


### PR DESCRIPTION
We are adding an extra step in Read the Docs for Business to allow users to select the Organization and Team as the first step.

Because of that, the _first_ step is not always the `basics` form and now we need to find it first.

Required by https://github.com/readthedocs/readthedocs-corporate/pull/1851
Closes #11111 