### PR TITLE
Tasks: delete closed PRs every 30 minutes

### DIFF
--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -251,7 +251,7 @@ def delete_closed_external_versions(limit=200, days=30 * 3):
     queryset = Version.external.filter(
         state=EXTERNAL_VERSION_STATE_CLOSED,
         modified__lte=days_ago,
-    )[:limit]
+    ).order_by("modified")[:limit]
     for version in queryset:
         try:
             last_build = version.last_build

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -549,7 +549,7 @@ class CommunityBaseSettings(Settings):
             "task": "readthedocs.builds.tasks.delete_closed_external_versions",
             # Increase the frequency because we have 255k closed versions and they keep growing.
             # It's better to increase this frequency than the `limit=` of the task.
-            "schedule": crontab(minute=0, hour="*/3"),
+            "schedule": crontab(minute="*/30", hour="*"),
             "options": {"queue": "web"},
         },
         "every-day-resync-remote-repositories": {

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -545,7 +545,7 @@ class CommunityBaseSettings(Settings):
                 "delete": True,
             },
         },
-        "every-three-hours-delete-inactive-external-versions": {
+        "every-30m-delete-inactive-external-versions": {
             "task": "readthedocs.builds.tasks.delete_closed_external_versions",
             # Increase the frequency because we have 255k closed versions and they keep growing.
             # It's better to increase this frequency than the `limit=` of the task.


### PR DESCRIPTION
We have 35K external versions pending deletion...

And we are now deleting old versions first, previously this was using the default sorting (verbose name).