### PR TITLE
Use clone_url for remote repository field

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -90,7 +90,7 @@ class ProjectForm(SimpleHistoryModelForm):
         if current_remote_repo and current_remote_repo not in queryset:
             options.append((current_remote_repo.pk, str(current_remote_repo)))
 
-        options.extend((repo.pk, str(repo)) for repo in queryset)
+        options.extend((repo.pk, repo.clone_url) for repo in queryset)
         return options
 
     def save(self, commit=True):


### PR DESCRIPTION
This is currently using `str()` which renders the website URL. This is fine for public repositories, but private repositories use the clone_url as the project repo_url and so these two fields don't match.

With this change, the field renders the clone_url, matching the `repo_url` field above:

![image](https://github.com/user-attachments/assets/13cbaf52-60dc-48b5-945b-2d2f44dcbb53)


- Fixes #11562