### PR TITLE
SAML: update Okta setup steps

### DIFF
--- a/docs/user/guides/set-up-single-sign-on-saml.rst
+++ b/docs/user/guides/set-up-single-sign-on-saml.rst
@@ -35,6 +35,7 @@ In order to enable SSO with Okta, you need to create a new SAML application in y
    * :guilabel:`Single Sign On URL`: ``https://readthedocs.com/accounts/saml/<organization-slug>/acs/`` (replace ``<organization-slug>`` with your organization slug)
    * :guilabel:`Audience URI (SP Entity ID)`: ``https://readthedocs.com/accounts/saml/<organization-slug>/metadata/`` (replace ``<organization-slug>`` with your organization slug)
    * :guilabel:`Name ID format`: ``EmailAddress``
+   * :guilabel:`Application username`: ``Email``
    * Leave the rest of the fields as default.
 
 6. Add the following "attribute statements" to be used when creating a new user:


### PR DESCRIPTION
By default Okta uses the username as the NameID,
which isn't always equal to the email address.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11569.org.readthedocs.build/en/11569/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11569.org.readthedocs.build/en/11569/

<!-- readthedocs-preview dev end -->