### PR TITLE
Build: bump Python tool 3.12 version to 3.12.5

### DIFF
--- a/readthedocs/builds/constants_docker.py
+++ b/readthedocs/builds/constants_docker.py
@@ -37,7 +37,7 @@ RTD_DOCKER_BUILD_SETTINGS = {
             "3.9": "3.9.19",
             "3.10": "3.10.14",
             "3.11": "3.11.9",
-            "3.12": "3.12.3",
+            "3.12": "3.12.5",
             "miniconda3-4.7": "miniconda3-4.7.12",
             "miniconda3-3.12-24.1": "miniconda3-3.12-24.1.2-0",
             "mambaforge-4.10": "mambaforge-4.10.3-10",

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -572,7 +572,7 @@ class TestBuildTask(BuildEnvironmentBase):
                     },
                     "tools": {
                         "python": {
-                            "full_version": "3.12.3",
+                            "full_version": "3.12.5",
                             "version": "3",
                         }
                     },


### PR DESCRIPTION
I figured the platform could bump to 3.12.5 since it's already a month old and seems reasonably stable.

I based this on https://github.com/readthedocs/readthedocs.org/pull/11386.