### PR TITLE
Revert "Allauth: don't completely override the `send_email` method (#11526)

### DIFF
--- a/readthedocs/core/adapters.py
+++ b/readthedocs/core/adapters.py
@@ -1,10 +1,13 @@
 """Allauth overrides."""
 
+import json
+
 import structlog
 from allauth.account.adapter import DefaultAccountAdapter
+from django.template.loader import render_to_string
 from django.utils.encoding import force_str
 
-from readthedocs.core.utils import send_email_from_object
+from readthedocs.core.utils import send_email
 from readthedocs.invitations.models import Invitation
 
 log = structlog.get_logger(__name__)
@@ -17,25 +20,36 @@ class AccountAdapter(DefaultAccountAdapter):
     def format_email_subject(self, subject):
         return force_str(subject)
 
-    def render_mail(self, template_prefix, email, context, headers=None):
-        """
-        Wrapper around render_mail to send emails using a task.
+    def send_mail(self, template_prefix, email, context):
+        subject = render_to_string(
+            "{}_subject.txt".format(template_prefix),
+            context,
+        )
+        subject = " ".join(subject.splitlines()).strip()
+        subject = self.format_email_subject(subject)
 
-        ``send_email`` makes use of the email object returned by this method,
-        and calls ``send`` on it. We override this method to return a dummy
-        object that has a ``send`` method, which in turn calls our task to send
-        the email.
-        """
-        email = super().render_mail(template_prefix, email, context, headers=headers)
+        # Allauth sends some additional data in the context, remove it if the
+        # pieces can't be json encoded
+        removed_keys = []
+        for key in list(context.keys()):
+            try:
+                _ = json.dumps(context[key])  # noqa for F841
+            except (ValueError, TypeError):
+                removed_keys.append(key)
+                del context[key]
+        if removed_keys:
+            log.debug(
+                "Removed context we were unable to serialize.",
+                removed_keys=removed_keys,
+            )
 
-        class DummyEmail:
-            def __init__(self, email):
-                self.email = email
-
-            def send(self):
-                send_email_from_object(self.email)
-
-        return DummyEmail(email)
+        send_email(
+            recipient=email,
+            subject=subject,
+            template="{}_message.txt".format(template_prefix),
+            template_html="{}_message.html".format(template_prefix),
+            context=context,
+        )
 
     def save_user(self, request, user, form, commit=True):
         """Override default account signup to redeem invitations at sign-up."""

--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -5,7 +5,6 @@ import signal
 
 import structlog
 from django.conf import settings
-from django.core.mail import EmailMessage, EmailMultiAlternatives
 from django.template.loader import render_to_string
 from django.utils.functional import keep_lazy
 from django.utils.safestring import SafeText, mark_safe
@@ -273,25 +272,6 @@ def cancel_build(build):
         terminate=terminate,
     )
     app.control.revoke(build.task_id, signal=signal.SIGINT, terminate=terminate)
-
-
-def send_email_from_object(email: EmailMultiAlternatives | EmailMessage):
-    """Given an email object, send it using our send_email_task task."""
-    from readthedocs.core.tasks import send_email_task
-
-    html_content = None
-    if isinstance(email, EmailMultiAlternatives):
-        for content, mimetype in email.alternatives:
-            if mimetype == "text/html":
-                html_content = content
-                break
-    send_email_task.delay(
-        recipient=email.to,
-        subject=email.subject,
-        content=email.body,
-        content_html=html_content,
-        from_email=email.from_email,
-    )
 
 
 def send_email(


### PR DESCRIPTION
This is a workaround for now because production is failing to send emails.

This reverts commit f0aaff22d447b01c9a440954a3b2a9f5ca0836cd.