### PR TITLE
Docs: final date for addons and link to blog post

### DIFF
--- a/docs/user/addons.rst
+++ b/docs/user/addons.rst
@@ -40,7 +40,8 @@ All projects using ``mkdocs`` :ref:`mkdocs <config-file/v2:mkdocs>` or the ``bui
 
 .. note::
 
-    Read the Docs Addons will be enabled by default for all Read the Docs projects some time in the second half of 2024.
+    Read the Docs Addons will be enabled by default for all Read the Docs projects on October 7th.
+    Read the full announcement in our `blog post <https://about.readthedocs.com/blog/2024/07/addons-by-default/>`_.
 
 Configuring Read the Docs Addons
 --------------------------------


### PR DESCRIPTION
Mention the explicit date and link people to the blog post for more context.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11588.org.readthedocs.build/en/11588/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11588.org.readthedocs.build/en/11588/

<!-- readthedocs-preview dev end -->