### PR TITLE
Conditionally disabled custom 404 pages on dev docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,8 @@ extensions = [
     "hoverxref.extension",
     "multiproject",
     "myst_parser",
-    "notfound.extension",
+    # For testing, conditionally disable the custom 404 pages on dev docs
+    # "notfound.extension",
     "sphinx_copybutton",
     "sphinx_design",
     "sphinx_tabs.tabs",
@@ -54,6 +55,10 @@ multiproject_projects = {
 }
 
 docset = get_project(multiproject_projects)
+
+# Disable custom 404 on dev docs
+if docset == "user":
+    extensions.append("notfound.extension")
 
 ogp_site_name = "Read the Docs Documentation"
 ogp_use_first_image = True  # https://github.com/readthedocs/blog/pull/118


### PR DESCRIPTION
This is for testing error pages more in production and can be reverted later.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11596.org.readthedocs.build/en/11596/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11596.org.readthedocs.build/en/11596/

<!-- readthedocs-preview dev end -->