### PR TITLE
Docs: Handle long commit messages in [skip ci] example

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -183,7 +183,7 @@ This other example shows how to cancel a build if the commit message contains ``
        post_checkout:
          # Use `git log` to check if the latest commit contains "skip ci",
          # in that case exit the command with 183 to cancel the build
-         - (git --no-pager log --pretty="tformat:%s -- %b" -1 | grep -viq "skip ci") || exit 183
+         - (git --no-pager log --pretty="tformat:%s -- %b" -1 | paste -s -d " " | grep -viq "skip ci") || exit 183
 
 
 Generate documentation from annotated sources with Doxygen


### PR DESCRIPTION
`git log` will wrap longer commit messages onto multiple lines, in which case a commit with `[skip ci]` will not cause a build to skip.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11601.org.readthedocs.build/en/11601/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11601.org.readthedocs.build/en/11601/

<!-- readthedocs-preview dev end -->