### PR TITLE
Drop unnecessary CSP directives for gold view

### DIFF
--- a/readthedocs/gold/views.py
+++ b/readthedocs/gold/views.py
@@ -39,18 +39,6 @@ class GoldSubscription(
     form_class = GoldSubscriptionForm
     template_name = "gold/subscription_detail.html"
 
-    def dispatch(self, request, *args, **kwargs):
-        response = super().dispatch(request, *args, **kwargs)
-        # Allow inline scripts for the gold view.
-        # We are using inline javascript to initialize Stripe Checkout.
-        # Allowing inline scripts defeats the purpose of using CSP,
-        # but we are limiting it to this view.
-        # TODO: use the `@csp_update` decorator once we are running
-        # ext-theme by default.
-        if settings.RTD_EXT_THEME_ENABLED:
-            response._csp_update = {"script-src": "'unsafe-inline'"}
-        return response
-
     def get(self, *args, **kwargs):
         subscribed = self.request.GET.get("subscribed", None)
         if subscribed == "true":


### PR DESCRIPTION
This does not seem needed, as there is no inline script src in
`subscription_detail.html`. It seems like maybe we wrote this for
`subscription_form.html`, which was old.

This conditional was breaking the view for me locally, as we don't have
any CSP directives for `script-src` locally, we only have these in
production. Because of this, there are no other `script-src` exceptions.

- Refs https://github.com/readthedocs/ext-theme/issues/407