### PR TITLE
Make terminology and paths consistent for onboarding announcements

### DIFF
--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -143,7 +143,9 @@ class ProjectDashboard(FilterContextMixin, PrivateViewMixin, ListView):
                 template_name = "security-logs.html"
 
             if template_name:
-                context["promotion"] = f"projects/partials/dashboard/{template_name}"
+                context[
+                    "announcement"
+                ] = f"projects/partials/announcements/{template_name}"
 
         return context
 


### PR DESCRIPTION
We referred to these as `promotions` here, but as "announcements" in the
templates. I think "announcements" fits better, and we already describe
in documentation advertising as "promotions".

- Refs readthedocs/ext-theme#409