### PR TITLE
Add support for successful build prefetch

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -575,6 +575,7 @@ class Project(models.Model):
 
     # Property used for storing the latest build for a project when prefetching
     LATEST_BUILD_CACHE = "_latest_build"
+    LATEST_SUCCESSFUL_BUILD_CACHE = "_latest_successful_build"
 
     class Meta:
         ordering = ("slug",)
@@ -920,6 +921,13 @@ class Project(models.Model):
 
     @property
     def has_good_build(self):
+        # Check if there is `_latest_successful_build` attribute in the Queryset.
+        # Used for database optimization.
+        if hasattr(self, self.LATEST_SUCCESSFUL_BUILD_CACHE):
+            if build_successful := getattr(self, self.LATEST_SUCCESSFUL_BUILD_CACHE):
+                return build_successful[0]
+            return None
+
         # Check if there is `_good_build` annotation in the Queryset.
         # Used for Database optimization.
         if hasattr(self, "_good_build"):


### PR DESCRIPTION
We use both latest build and latest successful build in the project
listing template.

- Refs https://github.com/readthedocs/ext-theme/issues/463
- Fixes https://github.com/readthedocs/ext-theme/issues/61