### PR TITLE
Prefetch build and project on version list

### DIFF
--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -123,7 +123,11 @@ class ProjectDetailViewBase(
                 queryset=versions,
                 project=project,
             )
-            versions = self.get_filtered_queryset()
+            versions = (
+                self.get_filtered_queryset()
+                .prefetch_related("project")
+                .prefetch_subquery()
+            )
         context["versions"] = versions
 
         protocol = "http"


### PR DESCRIPTION
This optimizes the version listing view and removes redundant queries.

- Requires readthedocs/ext-theme#493
- Fixes readthedocs/ext-theme#463
- Fixes https://github.com/readthedocs/ext-theme/issues/60