### PR TITLE
Addons: disable the field instead of remove it

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -696,7 +696,7 @@ class AddonsConfigForm(forms.ModelForm):
 
         # Keep the ability to disable addons completely on Read the Docs for Business
         if not settings.RTD_ALLOW_ORGANIZATIONS and addons_enabled_by_default:
-            self.fields.pop("enabled")
+            self.fields["enabled"].disabled = True
 
     def clean(self):
         if (


### PR DESCRIPTION
Templates make usage of this field. If we remove it they break. Disabling it keeps the features and the template working as expected. We can come back later if we want to do something else here, but I'm making it to not break for now.

![Screenshot_2024-09-30_15-52-15](https://github.com/user-attachments/assets/68eced3c-90ac-4cf5-b38a-daf6c54d12cf)
