### PR TITLE
Allauth: add 429 handler

### DIFF
--- a/readthedocs/urls.py
+++ b/readthedocs/urls.py
@@ -17,6 +17,9 @@ handler400 = ErrorView.as_view(status_code=400)
 handler403 = ErrorView.as_view(status_code=403)
 handler404 = ErrorView.as_view(status_code=404)
 handler500 = ErrorView.as_view(status_code=500)
+# Rate limit handler for allauth views,
+# this isn't a Django built-in handler.
+handler429 = ErrorView.as_view(status_code=429)
 
 basic_urls = [
     path("", HomepageView.as_view(), name="homepage"),

--- a/readthedocs/urls.py
+++ b/readthedocs/urls.py
@@ -19,6 +19,7 @@ handler404 = ErrorView.as_view(status_code=404)
 handler500 = ErrorView.as_view(status_code=500)
 # Rate limit handler for allauth views,
 # this isn't a Django built-in handler.
+# https://docs.allauth.org/en/latest/account/rate_limits.html.
 handler429 = ErrorView.as_view(status_code=429)
 
 basic_urls = [


### PR DESCRIPTION
Allauth expects a handler429 view in urls.py,
or a 429.html template in the root of the templates directory. We don't want to create symlinks, so a custom handler429 view is added.

Ref https://read-the-docs.sentry.io/issues/5835964680/?project=161479&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=19