### PR TITLE
Specify that hidden versions in RTD are blocked from indexing

### DIFF
--- a/docs/user/reference/robots.rst
+++ b/docs/user/reference/robots.rst
@@ -11,7 +11,7 @@ It's useful for:
 Read the Docs automatically generates one for you with a configuration that works for most projects.
 By default, the automatically created ``robots.txt``:
 
-* Hides versions which are set to :ref:`versions:Version states` from being indexed.
+* Hides versions which are set to :ref:`Hidden <versions:Version states>` from being indexed.
 * Allows indexing of all other versions.
 
 .. warning::


### PR DESCRIPTION
This is to fix the "Version states" link text (below) in the docs. I think this is meant to say that hidden versions are not indexed?

![image](https://github.com/user-attachments/assets/ea8d3ee3-1dd3-4504-8c3e-3d6ba16e2f67)


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11644.org.readthedocs.build/en/11644/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11644.org.readthedocs.build/en/11644/

<!-- readthedocs-preview dev end -->