### PR TITLE
Metrics: don't rely on Embed APIv2

### DIFF
--- a/readthedocs/metrics/tasks.py
+++ b/readthedocs/metrics/tasks.py
@@ -39,9 +39,7 @@ class CommunityMetrics5mTask(Metrics5mTaskBase):
             project="time-test",
             queue_name="build-default",
             version="latency-test",
-            doc="index",
-            section="Time",
-            doc_url=None,
+            doc_url="https://time-test.readthedocs.io/en/latency-test/",
             webhook_url="{api_host}/api/v2/webhook/{project}/{webhook_id}/",
         ),
     ]


### PR DESCRIPTION
Today we enabled Addons by default. That removes the `readthedocs-sphinx-ext` that generates `.json` files which are used by Embed APIv2.

Now, we are hitting the URL directly.