### PR TITLE
Simplify instructions for installing dependencies with uv

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -377,7 +377,7 @@ Take a look at the following example:
        - asdf plugin add uv
        - asdf install uv latest
        - asdf global uv latest
-       - uv sync --extra docs
+       - uv sync --extra docs --frozen
        - uv run -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
 
 MkDocs projects could use ``NO_COLOR=1 uv run mkdocs build --strict --site-dir $READTHEDOCS_OUTPUT/html`` instead.

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -377,11 +377,10 @@ Take a look at the following example:
        - asdf plugin add uv
        - asdf install uv latest
        - asdf global uv latest
-       - uv venv
-       - uv pip install .[docs]
-       - .venv/bin/python -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
+       - uv sync --extra docs
+       - uv run -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
 
-You can use ``-r docs/requirements.txt``, etc. instead as needed. MkDocs projects could use ``NO_COLOR=1 .venv/bin/mkdocs build --strict --site-dir $READTHEDOCS_OUTPUT/html`` instead.
+MkDocs projects could use ``NO_COLOR=1 uv run mkdocs build --strict --site-dir $READTHEDOCS_OUTPUT/html`` instead.
 
 Update Conda version
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Since the instructions were added in https://github.com/readthedocs/readthedocs.org/pull/11322, uv gained a new capability to run `uv sync` and `uv run` enabling some simplifications

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11655.org.readthedocs.build/en/11655/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11655.org.readthedocs.build/en/11655/

<!-- readthedocs-preview dev end -->