### PR TITLE
Proxito: remove `X-RTD-Hosting-Integrations` HTTP header

### DIFF
--- a/readthedocs/proxito/tests/test_headers.py
+++ b/readthedocs/proxito/tests/test_headers.py
@@ -199,18 +199,6 @@ class ProxitoHeaderTests(BaseDocServing):
         self.assertEqual(r[http_header], http_header_value)
         self.assertEqual(r[http_header_secure], http_header_value)
 
-    def test_hosting_integrations_header(self):
-        version = self.project.versions.get(slug=LATEST)
-        version.addons = True
-        version.save()
-
-        r = self.client.get(
-            "/en/latest/", secure=True, headers={"host": "project.dev.readthedocs.io"}
-        )
-        self.assertEqual(r.status_code, 200)
-        self.assertIsNotNone(r.get("X-RTD-Hosting-Integrations"))
-        self.assertEqual(r["X-RTD-Hosting-Integrations"], "true")
-
     def test_force_addons_header(self):
         fixture.get(AddonsConfig, project=self.project, enabled=True)
 


### PR DESCRIPTION
This header is useless now that we are fully migrated to Addons. I'm removing the only the test for now, since it's failing on all the PRs.

Related #11653