### PR TITLE
Fix analytics links

### DIFF
--- a/docs/user/addons.rst
+++ b/docs/user/addons.rst
@@ -3,9 +3,6 @@ Read the Docs Addons
 
 **Read the Docs Addons** is a group of features for documentation readers and maintainers that you can add to any documentation set hosted on Read the Docs:
 
-:doc:`Traffic analytics </analytics>`
-    explore pageviews for your docs
-
 :doc:`DocDiff </pull-requests>`
     highlight changed output from pull requests
 

--- a/docs/user/commercial/index.rst
+++ b/docs/user/commercial/index.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Business hosting
 ================
 

--- a/docs/user/commercial/index.rst
+++ b/docs/user/commercial/index.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 Business hosting
 ================
 

--- a/docs/user/commercial/sharing.rst
+++ b/docs/user/commercial/sharing.rst
@@ -118,7 +118,7 @@ Authenticated redirect
 If you want to share documentation with a group of users,
 you need to authenticate those users against your own system first.
 The simplest way to do this is to create an authenticated redirect on your site,
-which then redirects to the Read the Docs :ref:`Secret link`.
+which then redirects to the Read the Docs :ref:`commercial/sharing:secret link`.
 
 This should require very little customization,
 and will ensure that only authenticated users can access the documentation.
@@ -134,7 +134,7 @@ and then proxies the request to Read the Docs.
 This is more complex to set up,
 but will allow users to access the documentation directly from a bookmark,
 
-This approach would use a :ref:`HTTP Authorization Header` to authenticate users,
+This approach would use a :ref:`commercial/sharing:HTTP Authorization Header` to authenticate users,
 and would be configured in your proxy server.
 
 Proxy example

--- a/docs/user/guides/content/index.rst
+++ b/docs/user/guides/content/index.rst
@@ -5,7 +5,7 @@ How-to guides: content, themes and SEO
     This article explains how documentation can be optimized to appear in search results,
     ultimately increasing traffic to your docs.
 
-⏩️ :doc:`Using traffic analytics </analytics>`
+⏩️ :doc:`Using traffic analytics </traffic-analytics>`
     In this guide, you can learn to use Read the Docs' built-in traffic analytics for your documentation project.
 
 ⏩️ :doc:`Managing translations for Sphinx projects </guides/manage-translations-sphinx>`
@@ -57,7 +57,7 @@ How-to guides: content, themes and SEO
    :hidden:
 
    Search engine optimization (SEO) for documentation projects </guides/technical-docs-seo-guide>
-   Using traffic analytics </analytics>
+   Using traffic analytics </traffic-analytics>
    Using search analytics </search-analytics>
    Enabling offline formats </guides/enable-offline-formats>
    Embedding content from your documentation </guides/embedding-content>

--- a/docs/user/guides/technical-docs-seo-guide.rst
+++ b/docs/user/guides/technical-docs-seo-guide.rst
@@ -320,7 +320,7 @@ Analytics tools
 ~~~~~~~~~~~~~~~
 
 A tool like Google Analytics,
-along with our :doc:`integrated Read the Docs analytics </analytics>`,
+along with our :doc:`integrated Read the Docs analytics </traffic-analytics>`,
 can give you feedback about the search terms people use to find your docs,
 your most popular pages, and lots of other useful data.
 

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -87,7 +87,7 @@ Read the Docs: documentation simplified
    /commercial/single-sign-on
    /commercial/sharing
    /commercial/subscriptions
-   /commercial/privacy-levels
+   /commercial/privacy-level
 
 .. toctree::
    :maxdepth: 2

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -83,6 +83,7 @@ Read the Docs: documentation simplified
    :hidden:
    :caption: Business features
 
+   /commercial/index
    /commercial/organizations
    /commercial/single-sign-on
    /commercial/sharing
@@ -222,14 +223,14 @@ Business features
 
 Features for organizations and businesses:
 
-:doc:`/commercial/index`
-  Learn more about our commercial features.
-
 :doc:`/commercial/organizations`
   Learn how to manage your organization on Read the Docs.
 
 :doc:`/commercial/single-sign-on`
   Learn how to use single sign-on with Read the Docs.
+
+:doc:`/commercial/sharing`
+  Learn how to share your documentation with others.
 
 How-to guides
 -------------

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -239,9 +239,6 @@ Step-by-step guides for common tasks:
 :doc:`/guides/pull-requests`
   Setup pull request builds and enjoy previews of each commit.
 
-:doc:`/analytics`
-  Learn more about how users are interacting with your documentation.
-
 :doc:`/guides/cross-referencing-with-sphinx`
   Learn how to use cross-references in a Sphinx project.
 

--- a/docs/user/tutorial/index.rst
+++ b/docs/user/tutorial/index.rst
@@ -527,7 +527,7 @@ Understanding traffic analytics
 
 The Traffic Analytics view gives you a simple overview of how your readers browse your documentation. It respects visitor privacy by not storing identifying information about your them.
 
-The :doc:`/analytics` view shows the top viewed documentation pages of the past 30 days,
+This page shows the most viewed documentation pages of the past 30 days,
 plus a visualization of the daily views during that period.
 
 To see the Traffic Analytics view, go back the :term:`project page` again,


### PR DESCRIPTION
Not sure how these didn't break the build..


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11661.org.readthedocs.build/en/11661/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11661.org.readthedocs.build/en/11661/

<!-- readthedocs-preview dev end -->