### PR TITLE
Notification: make "pending configuration" dismissable

### DIFF
--- a/readthedocs/domains/tasks.py
+++ b/readthedocs/domains/tasks.py
@@ -39,6 +39,7 @@ def email_pending_custom_domains(number_of_emails=3):
         Notification.objects.add(
             message_id=MESSAGE_DOMAIN_VALIDATION_PENDING,
             attached_to=domain.project,
+            dismissable=True,
             format_values={
                 "domain": domain.domain,
                 "domain_url": reverse(


### PR DESCRIPTION
Allow users to dismiss this notification:

![Screenshot_2024-10-14_11-21-28](https://github.com/user-attachments/assets/39cb7a85-b176-4368-8c05-e81b1a6c17a1)
