### PR TITLE
Enable subproject filters for projects with subprojects

### DIFF
--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -736,7 +736,7 @@ class TestReadTheDocsConfigJson(TestCase):
                 active=True,
             )
 
-        with self.assertNumQueries(22):
+        with self.assertNumQueries(24):
             r = self.client.get(
                 reverse("proxito_readthedocs_docs_addons"),
                 {
@@ -765,7 +765,7 @@ class TestReadTheDocsConfigJson(TestCase):
                 active=True,
             )
 
-        with self.assertNumQueries(24):
+        with self.assertNumQueries(26):
             r = self.client.get(
                 reverse("proxito_readthedocs_docs_addons"),
                 {
@@ -801,7 +801,7 @@ class TestReadTheDocsConfigJson(TestCase):
                 active=True,
             )
 
-        with self.assertNumQueries(31):
+        with self.assertNumQueries(35):
             r = self.client.get(
                 reverse("proxito_readthedocs_docs_addons"),
                 {
@@ -827,7 +827,7 @@ class TestReadTheDocsConfigJson(TestCase):
                 language=language,
             )
 
-        with self.assertNumQueries(60):
+        with self.assertNumQueries(62):
             r = self.client.get(
                 reverse("proxito_readthedocs_docs_addons"),
                 {

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -489,14 +489,11 @@ class AddonsResponseBase:
                         # to the user's query.
                         # It uses "Search query sintax":
                         # https://docs.readthedocs.io/en/stable/server-side-search/syntax.html
-                        [
-                            "Include subprojects",
-                            f"subprojects:{project.slug}/{version.slug}",
-                        ],
-                    ]
-                    # Show the subprojects filter on the parent project and subproject
-                    if project.subprojects.exists() or project.superprojects.exists()
-                    else [],
+                        # [
+                        #     "Include subprojects",
+                        #     f"subprojects:{project.slug}/{version.slug}",
+                        # ],
+                    ],
                     "default_filter": f"project:{project.slug}/{version.slug}"
                     if version
                     else None,
@@ -514,6 +511,23 @@ class AddonsResponseBase:
                 },
             },
         }
+
+        # Show the subprojects filter on the parent project and subproject
+        if project.subprojects.exists():
+            data["addons"]["search"]["filters"].append(
+                [
+                    "Include subprojects",
+                    f"subprojects:{project.slug}/{version.slug}",
+                ]
+            )
+        if project.superprojects.exists():
+            superproject = project.superprojects.first()
+            data["addons"]["search"]["filters"].append(
+                [
+                    "Include subprojects",
+                    f"subprojects:{superproject.slug}/{version.slug}",
+                ]
+            )
 
         # DocDiff depends on `url=` GET attribute.
         # This attribute allows us to know the exact filename where the request was made.

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -489,12 +489,12 @@ class AddonsResponseBase:
                         # to the user's query.
                         # It uses "Search query sintax":
                         # https://docs.readthedocs.io/en/stable/server-side-search/syntax.html
-                        # [
-                        #     "Include subprojects",
-                        #     f"subprojects:{project.slug}/{version.slug}",
-                        # ],
+                        [
+                            "Include subprojects",
+                            f"subprojects:{project.slug}/{version.slug}",
+                        ],
                     ]
-                    if version
+                    if project.subprojects.exists()
                     else [],
                     "default_filter": f"project:{project.slug}/{version.slug}"
                     if version

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -494,7 +494,8 @@ class AddonsResponseBase:
                             f"subprojects:{project.slug}/{version.slug}",
                         ],
                     ]
-                    if project.subprojects.exists()
+                    # Show the subprojects filter on the parent project and subproject
+                    if project.subprojects.exists() or project.superprojects.exists()
                     else [],
                     "default_filter": f"project:{project.slug}/{version.slug}"
                     if version

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -513,6 +513,8 @@ class AddonsResponseBase:
         }
 
         # Show the subprojects filter on the parent project and subproject
+        # TODO: Remove these queries and try to find a way to get this data
+        # from the resolver, which has already done these queries.
         if project.subprojects.exists():
             data["addons"]["search"]["filters"].append(
                 [
@@ -521,7 +523,7 @@ class AddonsResponseBase:
                 ]
             )
         if project.superprojects.exists():
-            superproject = project.superprojects.first()
+            superproject = project.superprojects.first().parent
             data["addons"]["search"]["filters"].append(
                 [
                     "Include subprojects",

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -515,6 +515,8 @@ class AddonsResponseBase:
         # Show the subprojects filter on the parent project and subproject
         # TODO: Remove these queries and try to find a way to get this data
         # from the resolver, which has already done these queries.
+        # TODO: Replace this fixed filters with the work proposed in
+        # https://github.com/readthedocs/addons/issues/22
         if project.subprojects.exists():
             data["addons"]["search"]["filters"].append(
                 [

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -513,25 +513,26 @@ class AddonsResponseBase:
         }
 
         # Show the subprojects filter on the parent project and subproject
-        # TODO: Remove these queries and try to find a way to get this data
-        # from the resolver, which has already done these queries.
-        # TODO: Replace this fixed filters with the work proposed in
-        # https://github.com/readthedocs/addons/issues/22
-        if project.subprojects.exists():
-            data["addons"]["search"]["filters"].append(
-                [
-                    "Include subprojects",
-                    f"subprojects:{project.slug}/{version.slug}",
-                ]
-            )
-        if project.superprojects.exists():
-            superproject = project.superprojects.first().parent
-            data["addons"]["search"]["filters"].append(
-                [
-                    "Include subprojects",
-                    f"subprojects:{superproject.slug}/{version.slug}",
-                ]
-            )
+        if version:
+            # TODO: Remove these queries and try to find a way to get this data
+            # from the resolver, which has already done these queries.
+            # TODO: Replace this fixed filters with the work proposed in
+            # https://github.com/readthedocs/addons/issues/22
+            if project.subprojects.exists():
+                data["addons"]["search"]["filters"].append(
+                    [
+                        "Include subprojects",
+                        f"subprojects:{project.slug}/{version.slug}",
+                    ]
+                )
+            if project.superprojects.exists():
+                superproject = project.superprojects.first().parent
+                data["addons"]["search"]["filters"].append(
+                    [
+                        "Include subprojects",
+                        f"subprojects:{superproject.slug}/{version.slug}",
+                    ]
+                )
 
         # DocDiff depends on `url=` GET attribute.
         # This attribute allows us to know the exact filename where the request was made.


### PR DESCRIPTION
This at least shows the UI element if it makes sense to show.
Currently there's no way without knowing the query syntax to get subprojects,
which has caused confusion for a few of our users and broke existing behavior.

Refs https://github.com/readthedocs/readthedocs.org/pull/11638
