### PR TITLE
Link to new dashboard Addons page in old dashboard settings.

### DIFF
--- a/readthedocs/templates/projects/project_edit_base.html
+++ b/readthedocs/templates/projects/project_edit_base.html
@@ -16,7 +16,7 @@
       <ul>
         <li class="{% block project-edit-active %}{% endblock %}"><a href="{% url "projects_edit" project.slug %}">{% trans "Settings" %} </a></li>
         <!-- Add a link to the Addons page so users can find it -->
-        <li><a href="//app.{{ PRODUCTION_DOMAIN }}{% url "projects_addons" project.slug %}">{% trans "Edit Versions" %}</a></li>
+        <li><a href="//app.{{ PRODUCTION_DOMAIN }}/dashboard/{{ project.slug }}/addons/edit/">{% trans " Addons" %}</a></li>
         <!-- Add a link to the dashboard versions page so users can find it -->
         <li><a href="{% url "project_version_list" project.slug %}">{% trans "Edit Versions" %}</a></li>
         <li class="{% block project-domains-active %}{% endblock %}"><a href="{% url "projects_domains" project.slug %}">{% trans "Domains" %}</a></li>

--- a/readthedocs/templates/projects/project_edit_base.html
+++ b/readthedocs/templates/projects/project_edit_base.html
@@ -15,7 +15,7 @@
     <div class="navigable">
       <ul>
         <li class="{% block project-edit-active %}{% endblock %}"><a href="{% url "projects_edit" project.slug %}">{% trans "Settings" %} </a></li>
-        <!-- Add a link to the Addons page so users can find it -->
+        <!-- Link the Addons on the new dashboard. Can't reverse the URL. -->
         <li><a href="//app.{{ PRODUCTION_DOMAIN }}/dashboard/{{ project.slug }}/addons/edit/">{% trans " Addons" %}</a></li>
         <!-- Add a link to the dashboard versions page so users can find it -->
         <li><a href="{% url "project_version_list" project.slug %}">{% trans "Edit Versions" %}</a></li>

--- a/readthedocs/templates/projects/project_edit_base.html
+++ b/readthedocs/templates/projects/project_edit_base.html
@@ -15,6 +15,8 @@
     <div class="navigable">
       <ul>
         <li class="{% block project-edit-active %}{% endblock %}"><a href="{% url "projects_edit" project.slug %}">{% trans "Settings" %} </a></li>
+        <!-- Add a link to the Addons page so users can find it -->
+        <li><a href="//app.{{ PRODUCTION_DOMAIN }}{% url "projects_addons" project.slug %}">{% trans "Edit Versions" %}</a></li>
         <!-- Add a link to the dashboard versions page so users can find it -->
         <li><a href="{% url "project_version_list" project.slug %}">{% trans "Edit Versions" %}</a></li>
         <li class="{% block project-domains-active %}{% endblock %}"><a href="{% url "projects_domains" project.slug %}">{% trans "Domains" %}</a></li>


### PR DESCRIPTION
This is just using the same pattern as for versions,
but linking to another dashboard.
Could use an external icon here,
but didn't want to get too deep :)
