### PR TITLE
Docs: recover "Edit on GitHub" links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -173,6 +173,10 @@ html_context = {
     # TODO: remove once we support different rtd config
     # files per project.
     "conf_py_path": f"/docs/{docset}/",
+    "display_github": True,
+    "github_user": "readthedocs",
+    "github_repo": "readthedocs.org",
+    "github_version": "main",
     # Use to generate the Plausible "data-domain" attribute from the template
     "plausible_domain": f"{os.environ.get('READTHEDOCS_PROJECT')}.readthedocs.io",
 }


### PR DESCRIPTION

![Screenshot_2024-10-15_11-30-53](https://github.com/user-attachments/assets/53ee6aa6-1fe7-46b9-86cb-ea29c0119c26)

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11681.org.readthedocs.build/en/11681/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11681.org.readthedocs.build/en/11681/

<!-- readthedocs-preview dev end -->