### PR TITLE
File indexers: correctly get page content from PR previews

### DIFF
--- a/readthedocs/projects/tasks/search.py
+++ b/readthedocs/projects/tasks/search.py
@@ -165,7 +165,7 @@ def _get_indexers(*, version: Version, build: Build, search_index_name=None):
         indexers.append(search_indexer)
 
     # File tree diff is under a feature flag for now,
-    # and we only allow to compare PR previous against the latest version.
+    # and we only allow to compare PR previews against the latest version.
     has_feature = version.project.has_feature(
         Feature.GENERATE_MANIFEST_FOR_FILE_TREE_DIFF
     )

--- a/readthedocs/rtd_tests/tests/test_imported_file.py
+++ b/readthedocs/rtd_tests/tests/test_imported_file.py
@@ -366,19 +366,19 @@ class ImportedFileTests(TestCase):
             files=[
                 FileTreeDiffFile(
                     path="index.html",
-                    main_content_hash=mock.ANY,
+                    main_content_hash="f3336aabed1ae8057ffb0cca20d23d4c",
                 ),
                 FileTreeDiffFile(
                     path="404.html",
-                    main_content_hash=mock.ANY,
+                    main_content_hash="b855c3d54f84e075b70faa9958123377",
                 ),
                 FileTreeDiffFile(
                     path="test.html",
-                    main_content_hash=mock.ANY,
+                    main_content_hash="04e5dc4003413e36b8bec86bc5e28b07",
                 ),
                 FileTreeDiffFile(
                     path="api/index.html",
-                    main_content_hash=mock.ANY,
+                    main_content_hash="15958dc725d925c8524b1766cde73d66",
                 ),
             ],
         )
@@ -402,4 +402,4 @@ class ImportedFileTests(TestCase):
         with override_settings(DOCROOT=self.test_dir):
             self._copy_storage_dir(new_version)
         index_build(self.build.pk)
-        write_manifest.assert_called_once()
+        write_manifest.assert_called_once_with(new_version, manifest)

--- a/readthedocs/search/parsers.py
+++ b/readthedocs/search/parsers.py
@@ -67,6 +67,7 @@ class GenericParser:
                 type_="html",
                 version_slug=self.version.slug,
                 include_file=False,
+                version_type=self.version.type,
             )
             file_path = self.storage.join(storage_path, page)
             with self.storage.open(file_path, mode="r") as f:


### PR DESCRIPTION
We were missing passing the type of the version here, we didn't notice this before since we weren't reading the files (no search indexing for PR previews), but now we need to read the content for file tree diff.

We should probably have this parameter as required... I checked all other calls, and we are good.