### PR TITLE
Clarify support for an optional `v`-prefix in branch and tag names

### DIFF
--- a/docs/user/automation-rules.rst
+++ b/docs/user/automation-rules.rst
@@ -46,7 +46,8 @@ Predefined matches
 Automation rules support two predefined version matches:
 
 - **Any version**: All new versions will match the rule.
-- **SemVer versions**: All new versions that follow `semantic versioning <https://semver.org/>`__ will match the rule.
+- **SemVer versions**: All new versions that follow `semantic versioning <https://semver.org/>`__
+  (with or without a `v` prefix) will match the rule.
 
 Custom matches
 ~~~~~~~~~~~~~~

--- a/docs/user/versions.rst
+++ b/docs/user/versions.rst
@@ -19,7 +19,8 @@ During initial setup, Read the Docs also creates a ``latest`` version
 that points to the default branch defined in your Git repository (usually ``main``).
 This version should always exist and is the default version for your project.
 
-If your project has any tags or branches with a name following `semantic versioning <https://semver.org/>`_,
+If your project has any tags or branches with a name following
+`semantic versioning <https://semver.org/>`_ (with or without a ``v`` prefix),
 we also create a ``stable`` version tracking your most recent release.
 If you want a custom ``stable`` version,
 create either a tag or branch in your project with that name.
@@ -135,6 +136,7 @@ all of which can be reconfigured if necessary:
 
   Semantic versioning allows "normal" version numbers like ``1.4.2``, as
   well as pre-releases like this: ``2.0a1``. The ``stable`` version of your documentation never includes a pre-release.
+  An optional ``v`` prefix like ``v1.4.2`` or ``v2.0a1`` is also allowed.
 
 - Branches are assumed to be **long-lived branches**,
   This is most useful for **release branches**, which are maintained over time for a specific release.

--- a/readthedocs/builds/constants.py
+++ b/readthedocs/builds/constants.py
@@ -130,6 +130,8 @@ SEMVER_VERSIONS = "semver-versions"
 
 # Pattern referred from
 # https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+# without naming the capturing groups and with the addition of
+# allowing an optional "v" prefix.
 SEMVER_VERSIONS_REGEX = r"^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"  # noqa
 
 


### PR DESCRIPTION
Hey all, thanks for such a cool project ❤️

We at [Wagtail](https://github.com/wagtail/wagtail) use RTD for our docs, and we use `v`-prefixed names for our git tags. RTD seems to pick it up nicely, but I couldn't find any mention of the prefix in the docs. I wanted to make sure that this is the default RTD behaviour rather than something that we set up at some point and forgot about.

In https://docs.readthedocs.io/en/stable/versions.html it says that RTD follows SemVer and PEP 440 for its default versioning workflows. However, [SemVer.org](https://semver.org/#is-v123-a-semantic-version) says the following:

> **Is “v1.2.3” a semantic version?**
> No, “v1.2.3” is not a semantic version. However, prefixing a semantic version with a “v” is a common way (in English) to indicate it is a version number. Abbreviating “version” as “v” is often seen with version control. Example: `git tag v1.2.3 -m "Release version 1.2.3"`, in which case “v1.2.3” is a tag name and the semantic version is “1.2.3”.

I suppose that kind of implies RTD's behaviour. However, the first sentence of "No, “v1.2.3” is not a semantic version" and the reinforcement in the last part "the semantic version is “1.2.3”" combined with RTD's docs only saying "we follow semantic versioning" made me doubt whether the `v` prefix is supported by default or not.

It looks like this is something RTD has supported since the very beginning (at least since 556f67667c7f7dd92175a1746abe524407ef0f7f when automation rules were added). Then the regex is changed in #6402 to use the one suggested by SemVer.org, with the addition of the `v`-prefix support. This was explicitly acknowledged in https://github.com/readthedocs/readthedocs.org/issues/6395#issuecomment-555694223, but never documented.

I thought I'd add this info to help others who might stumble upon the same confusion as I did 🙂 

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11712.org.readthedocs.build/en/11712/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11712.org.readthedocs.build/en/11712/

<!-- readthedocs-preview dev end -->