### PR TITLE
Set session cookie `SameSite` attribute to `Lax` for main site

### DIFF
--- a/docs/user/advertising/ad-blocking.rst
+++ b/docs/user/advertising/ad-blocking.rst
@@ -62,7 +62,7 @@ Thank you for supporting Read the Docs.
    `Supporters <https://readthedocs.org/sustainability/#donations>`_
    were provided an ad-free reading experience across all projects on Read the Docs while logged-in.
    However, the cross-site cookies needed to make that work are no longer supported by major browsers outside of Chrome,
-   and this feature will soon disappear entirely.
+   and this feature has been removed.
 
 
 Statistics and data

--- a/docs/user/api/cross-site-requests.rst
+++ b/docs/user/api/cross-site-requests.rst
@@ -22,15 +22,13 @@ We implement it such way that it strictly match the intention of the API endpoin
 Cookies
 -------
 
-On |org_brand|, our session cookies have the ``SameSite`` attribute set to ``None``,
-this means they can be sent in cross site requests.
-This is needed for our sustainability API only,
-to not show ads if the current user is a :ref:`Gold User <advertising/ad-blocking:Going ad-free>`.
+On |org_brand|, our session cookies have the ``SameSite`` attribute set to ``Lax``,
+This means that browsers will not include them in cross site requests.
 All resources in |org_brand| are public, you don't need to pass cookies to make use
 of our allowed APIs from other sites.
 
-On |com_brand|, our session cookies have the ``SameSite`` attribute set to ``Lax``.
-This means that browsers will not include them in cross site requests.
+On |com_brand|, our session cookies have the ``SameSite`` attribute set to ``Lax``,
+this means that browsers will not include them in cross site requests.
 If you need to have access to versions that the current user has permissions over,
 you can make use of our proxied APIs, they can be accessed from docs domains with the `/_/` prefix.
 For example, you can make use of our search API from `<your-docs-domain>/_/api/v2/search/`.

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -104,16 +104,7 @@ class CommunityBaseSettings(Settings):
     SESSION_COOKIE_HTTPONLY = True
     SESSION_COOKIE_AGE = 30 * 24 * 60 * 60  # 30 days
     SESSION_SAVE_EVERY_REQUEST = False
-
-    @property
-    def SESSION_COOKIE_SAMESITE(self):
-        """
-        Cookie used in cross-origin API requests from *.rtd.io to rtd.org/api/v2/sustainability/.
-        """
-        if self.USE_PROMOS:
-            return "None"
-        # This is django's default.
-        return "Lax"
+    SESSION_COOKIE_SAMESITE = "Lax"
 
     # CSRF
     CSRF_COOKIE_HTTPONLY = True
@@ -724,17 +715,12 @@ class CommunityBaseSettings(Settings):
     # CORS
     # Don't allow sending cookies in cross-domain requests, this is so we can
     # relax our CORS headers for more views, but at the same time not opening
-    # users to CSRF attacks. The sustainability API is the only view that requires
-    # cookies to be send cross-site, we override that for that view only.
+    # users to CSRF attacks.
     CORS_ALLOW_CREDENTIALS = False
 
     # Allow cross-site requests from any origin,
     # all information from our allowed endpoits is public.
-    #
-    # NOTE: We don't use `CORS_ALLOW_ALL_ORIGINS=True`,
-    # since that will set the `Access-Control-Allow-Origin` header to `*`,
-    # we won't be able to pass credentials fo the sustainability API with that value.
-    CORS_ALLOWED_ORIGIN_REGEXES = [re.compile(".+")]
+    CORS_ALLOW_ALL_ORIGINS = True
     CORS_ALLOW_HEADERS = list(default_headers) + [
         "x-hoverxref-version",
     ]


### PR DESCRIPTION
We are now injecting ads via addons,
which doesn't make use of the sustainability endpoint. That endpoint was used to check if the user was a Gold member, and not show ads to them.

The usage of the sustainability API was he only reason to set the `SameSite` attribute to `None`.

Using Lax is more secure, as browser will never send the cookie in a cross-site request.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11721.org.readthedocs.build/en/11721/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11721.org.readthedocs.build/en/11721/

<!-- readthedocs-preview dev end -->