### PR TITLE
Addons: return all active versions on single version project

### DIFF
--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -400,9 +400,8 @@ class TestReadTheDocsConfigJson(TestCase):
             },
         )
         assert r.status_code == 200
-
-        expected = []
-        assert r.json()["versions"]["active"] == expected
+        expected = ["latest"]
+        assert [v["slug"] for v in r.json()["versions"]["active"]] == expected
 
         expected = {
             "pdf": "https://project.dev.readthedocs.io/_/downloads/en/latest/pdf/",

--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -384,6 +384,18 @@ class TestReadTheDocsConfigJson(TestCase):
         self.version.has_htmlzip = True
         self.version.save()
 
+        # Add extra built and active versions to emulate a project that went
+        # from multiple versions to single version.
+        # These versions shouldn't be included in the `versions.active` field.
+        for i in range(5):
+            fixture.get(
+                Version,
+                privacy_level=PUBLIC,
+                active=True,
+                built=True,
+                project=self.project,
+            )
+
         self.project.versioning_scheme = SINGLE_VERSION_WITHOUT_TRANSLATIONS
         self.project.save()
 

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -348,8 +348,15 @@ class AddonsResponseBase:
             .order_by("-slug")
         )
         sorted_versions_active_built_not_hidden = versions_active_built_not_hidden
-
-        if project.supports_multiple_versions:
+        if not project.supports_multiple_versions:
+            # Return only one version when the project doesn't support multiple versions.
+            # That version is the only one the project serves.
+            sorted_versions_active_built_not_hidden = (
+                sorted_versions_active_built_not_hidden.filter(
+                    slug=project.get_default_version()
+                )
+            )
+        else:
             if (
                 project.addons.flyout_sorting
                 == ADDONS_FLYOUT_SORTING_SEMVER_READTHEDOCS_COMPATIBLE

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -342,14 +342,14 @@ class AddonsResponseBase:
         # projects that don't have one already
         AddonsConfig.objects.get_or_create(project=project)
 
-        if project.supports_multiple_versions:
-            versions_active_built_not_hidden = (
-                self._get_versions(request, project)
-                .select_related("project")
-                .order_by("-slug")
-            )
-            sorted_versions_active_built_not_hidden = versions_active_built_not_hidden
+        versions_active_built_not_hidden = (
+            self._get_versions(request, project)
+            .select_related("project")
+            .order_by("-slug")
+        )
+        sorted_versions_active_built_not_hidden = versions_active_built_not_hidden
 
+        if project.supports_multiple_versions:
             if (
                 project.addons.flyout_sorting
                 == ADDONS_FLYOUT_SORTING_SEMVER_READTHEDOCS_COMPATIBLE


### PR DESCRIPTION
We always return all the active versions no matter the versioning scheme of the project. That's how `versions.active` is expected to work.

However, it seems the conditional was below where these versions are calculated. I also updated the test case that checks for the active versions on single versions projects.

Closes https://github.com/readthedocs/sphinx_rtd_theme/issues/1613