### PR TITLE
API v3: remove last_build expandable field

### DIFF
--- a/docs/user/api/v3.rst
+++ b/docs/user/api/v3.rst
@@ -287,8 +287,8 @@ Project details
         }
 
     :query string expand: Add additional fields in the response.
-                          Allowed values are ``active_versions``, ``active_versions.last_build`` and
-                          ``active_versions.last_build.config``. Multiple fields can be passed separated by commas.
+                          Allowed values are: ``active_versions``.
+                          Multiple fields can be passed separated by commas.
 
     .. note::
 
@@ -588,7 +588,6 @@ Version detail
             "aliases": ["VERSION"],
             "hidden": false,
             "type": "tag",
-            "last_build": "{BUILD}",
             "privacy_level": "public",
             "downloads": {
                 "pdf": "https://pip.readthedocs.io/_/downloads/pdf/pip/stable/",
@@ -612,10 +611,6 @@ Version detail
     :>json string ref: the version slug where the ``stable`` version points to.
                        ``null`` when it's not the stable version.
     :>json boolean built: the version has at least one successful build.
-
-    :query string expand: Add additional fields in the response.
-                          Allowed values are ``last_build`` and ``last_build.config``.
-                          Multiple fields can be passed separated by commas.
 
 Version update
 ++++++++++++++

--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -751,7 +751,6 @@ class ProjectSerializer(FlexFieldsModelSerializer):
     programming_language = ProgrammingLanguageSerializer()
     repository = RepositorySerializer(source="*")
     urls = ProjectURLsSerializer(source="*")
-    # These should check for permissions!
     subproject_of = serializers.SerializerMethodField()
     translation_of = serializers.SerializerMethodField()
     default_branch = serializers.CharField(source="get_default_branch")

--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -357,8 +357,6 @@ class VersionSerializer(FlexFieldsModelSerializer):
             "privacy_level",
         ]
 
-        expandable_fields = {"last_build": (BuildSerializer,)}
-
     def __init__(self, *args, resolver=None, version_serializer=None, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -753,6 +751,7 @@ class ProjectSerializer(FlexFieldsModelSerializer):
     programming_language = ProgrammingLanguageSerializer()
     repository = RepositorySerializer(source="*")
     urls = ProjectURLsSerializer(source="*")
+    # These should check for permissions!
     subproject_of = serializers.SerializerMethodField()
     translation_of = serializers.SerializerMethodField()
     default_branch = serializers.CharField(source="get_default_branch")

--- a/readthedocs/api/v3/tests/responses/projects-detail.json
+++ b/readthedocs/api/v3/tests/responses/projects-detail.json
@@ -12,35 +12,6 @@
             },
             "id": 2,
             "identifier": "a1b2c3",
-            "last_build": {
-                "commit": "a1b2c3",
-                "config": {
-                    "property": "test value"
-                },
-                "created": "2019-04-29T10:00:00Z",
-                "duration": 60,
-                "error": "",
-                "finished": "2019-04-29T10:01:00Z",
-                "id": 1,
-                "_links": {
-                    "_self": "https://readthedocs.org/api/v3/projects/project/builds/1/",
-                    "notifications": "https://readthedocs.org/api/v3/projects/project/builds/1/notifications/",
-                    "project": "https://readthedocs.org/api/v3/projects/project/",
-                    "version": "https://readthedocs.org/api/v3/projects/project/versions/v1.0/"
-                },
-                "urls": {
-                    "build": "https://readthedocs.org/projects/project/builds/1/",
-                    "project": "https://readthedocs.org/projects/project/",
-                    "version": "https://readthedocs.org/dashboard/project/version/v1.0/edit/"
-                },
-                "project": "project",
-                "state": {
-                    "code": "finished",
-                    "name": "Finished"
-                },
-                "success": true,
-                "version": "v1.0"
-            },
             "_links": {
                 "_self": "https://readthedocs.org/api/v3/projects/project/versions/v1.0/",
                 "builds": "https://readthedocs.org/api/v3/projects/project/versions/v1.0/builds/",

--- a/readthedocs/api/v3/tests/test_projects.py
+++ b/readthedocs/api/v3/tests/test_projects.py
@@ -284,7 +284,6 @@ class ProjectsEndpointTests(APIEndpointMixin):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
 
-    # NOTE: this test is slow
     def test_projects_sync_versions(self):
         # Ensure a default version exists to sync
         self.project.update_latest_version()

--- a/readthedocs/api/v3/tests/test_projects.py
+++ b/readthedocs/api/v3/tests/test_projects.py
@@ -108,12 +108,7 @@ class ProjectsEndpointTests(APIEndpointMixin):
             },
         )
         data = {
-            "expand": (
-                "active_versions,"
-                "active_versions.last_build,"
-                "active_versions.last_build.config,"
-                "permissions"
-            ),
+            "expand": ("active_versions," "permissions"),
         }
         expected_response = self._get_response_dict("projects-detail")
         expected_response["permissions"]["admin"] = False
@@ -138,12 +133,7 @@ class ProjectsEndpointTests(APIEndpointMixin):
             },
         )
         data = {
-            "expand": (
-                "active_versions,"
-                "active_versions.last_build,"
-                "active_versions.last_build.config,"
-                "permissions"
-            ),
+            "expand": ("active_versions," "permissions"),
         }
         expected_response = self._get_response_dict("projects-detail")
 
@@ -170,12 +160,7 @@ class ProjectsEndpointTests(APIEndpointMixin):
             },
         )
         data = {
-            "expand": (
-                "active_versions,"
-                "active_versions.last_build,"
-                "active_versions.last_build.config,"
-                "permissions"
-            ),
+            "expand": ("active_versions," "permissions"),
         }
         expected_response = self._get_response_dict("projects-detail")
         expected_response["permissions"]["admin"] = False
@@ -203,12 +188,7 @@ class ProjectsEndpointTests(APIEndpointMixin):
             },
         )
         query_params = {
-            "expand": (
-                "active_versions,"
-                "active_versions.last_build,"
-                "active_versions.last_build.config,"
-                "permissions"
-            ),
+            "expand": ("active_versions," "permissions"),
         }
 
         self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
@@ -304,6 +284,7 @@ class ProjectsEndpointTests(APIEndpointMixin):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
 
+    # NOTE: this test is slow
     def test_projects_sync_versions(self):
         # Ensure a default version exists to sync
         self.project.update_latest_version()

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -133,8 +133,6 @@ class ProjectsViewSetBase(
     filterset_class = ProjectFilter
     permit_list_expands = [
         "active_versions",
-        "active_versions.last_build",
-        "active_versions.last_build.config",
         "organization",
         "permissions",
         "teams",
@@ -356,10 +354,6 @@ class VersionsViewSet(
 
     filterset_class = VersionFilter
     permission_classes = [ReadOnlyPermission | (IsAuthenticated & IsProjectAdmin)]
-    permit_list_expands = [
-        "last_build",
-        "last_build.config",
-    ]
 
     def get_serializer_class(self):
         """


### PR DESCRIPTION
There is no data for this field in CF, so nobody is using it.

Closes https://github.com/readthedocs/readthedocs-corporate/issues/1874

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11730.org.readthedocs.build/en/11730/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11730.org.readthedocs.build/en/11730/

<!-- readthedocs-preview dev end -->