### PR TITLE
API v3: always return projects when listing remote repositories

### DIFF
--- a/docs/user/api/v3.rst
+++ b/docs/user/api/v3.rst
@@ -1860,12 +1860,12 @@ Remote repository listing
 
         .. code-tab:: bash
 
-            $ curl -H "Authorization: Token <token>" https://readthedocs.org/api/v3/remote/repositories/?expand=projects,remote_organization
+            $ curl -H "Authorization: Token <token>" https://readthedocs.org/api/v3/remote/repositories/?expand=remote_organization
 
         .. code-tab:: python
 
             import requests
-            URL = 'https://readthedocs.org/api/v3/remote/repositories/?expand=projects,remote_organization'
+            URL = 'https://readthedocs.org/api/v3/remote/repositories/?expand=remote_organization'
             TOKEN = '<token>'
             HEADERS = {'Authorization': f'token {TOKEN}'}
             response = requests.get(URL, headers=HEADERS)
@@ -1877,7 +1877,7 @@ Remote repository listing
 
         {
             "count": 20,
-            "next": "api/v3/remote/repositories/?expand=projects,remote_organization&limit=10&offset=10",
+            "next": "api/v3/remote/repositories/?expand=remote_organization&limit=10&offset=10",
             "previous": null,
             "results": [
                 {
@@ -1891,7 +1891,7 @@ Remote repository listing
                         "url": "https://github.com/organization",
                         "vcs_provider": "github"
                     },
-                    "project": [{
+                    "projects": [{
                         "id": 12345,
                         "name": "project",
                         "slug": "project",
@@ -1962,7 +1962,7 @@ Remote repository listing
     :query string vcs_provider: return remote repositories for specific vcs provider (``github``, ``gitlab`` or ``bitbucket``)
     :query string organization: return remote repositories for specific remote organization (using remote organization ``slug``)
     :query string expand: Add additional fields in the response.
-                          Allowed values are ``projects`` and ``remote_organization``.
+                          Allowed values are: ``remote_organization``.
                           Multiple fields can be passed separated by commas.
 
     :requestheader Authorization: token to authenticate.

--- a/readthedocs/api/v3/tests/test_remoterepositories.py
+++ b/readthedocs/api/v3/tests/test_remoterepositories.py
@@ -1,7 +1,6 @@
-from django.urls import reverse
-
-from allauth.socialaccount.models import SocialAccount
 import django_dynamic_fixture as fixture
+from allauth.socialaccount.models import SocialAccount
+from django.urls import reverse
 
 from readthedocs.oauth.constants import GITHUB
 from readthedocs.oauth.models import (
@@ -11,6 +10,7 @@ from readthedocs.oauth.models import (
     RemoteRepositoryRelation,
 )
 from readthedocs.projects.constants import REPO_TYPE_GIT
+
 from .mixins import APIEndpointMixin
 
 
@@ -65,7 +65,7 @@ class RemoteRepositoryEndpointTests(APIEndpointMixin):
 
     def test_remote_repository_list(self):
         url = reverse("remoterepositories-list")
-        data = {"expand": ("projects," "remote_organization")}
+        data = {"expand": ["remote_organization"]}
 
         self.client.logout()
         response = self.client.get(url, data)
@@ -84,7 +84,7 @@ class RemoteRepositoryEndpointTests(APIEndpointMixin):
         self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
         response = self.client.get(
             reverse("remoterepositories-list"),
-            {"expand": ("projects," "remote_organization"), "name": "proj"},
+            {"expand": ["remote_organization"], "name": "proj"},
         )
         self.assertEqual(response.status_code, 200)
 
@@ -100,7 +100,7 @@ class RemoteRepositoryEndpointTests(APIEndpointMixin):
         self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
         response = self.client.get(
             reverse("remoterepositories-list"),
-            {"expand": ("projects," "remote_organization"), "full_name": "proj"},
+            {"expand": ["remote_organization"], "full_name": "proj"},
         )
         self.assertEqual(response.status_code, 200)
 

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -600,7 +600,7 @@ class RemoteRepositoryViewSet(
     serializer_class = RemoteRepositorySerializer
     filterset_class = RemoteRepositoryFilter
     permission_classes = (IsAuthenticated,)
-    permit_list_expands = ["remote_organization", "projects"]
+    permit_list_expands = ["remote_organization"]
 
     def get_queryset(self):
         queryset = (
@@ -620,9 +620,6 @@ class RemoteRepositoryViewSet(
 
         if is_expanded(self.request, "remote_organization"):
             queryset = queryset.select_related("organization")
-
-        if is_expanded(self.request, "projects"):
-            queryset = queryset.prefetch_related("projects__users")
 
         return queryset.order_by("organization__name", "full_name").distinct()
 


### PR DESCRIPTION
This allows us to filter by the permissions the current user has on the projects.

Closes https://github.com/readthedocs/readthedocs-corporate/issues/1876

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11731.org.readthedocs.build/en/11731/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11731.org.readthedocs.build/en/11731/

<!-- readthedocs-preview dev end -->