### PR TITLE
API V3: use a restricted serializer for when showing org info from a project

### DIFF
--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -1214,6 +1214,7 @@ class OrganizationSerializer(serializers.ModelSerializer):
 
 
 class RestrictedOrganizationSerializer(serializers.ModelSerializer):
+
     """
     Stripped version of the OrganizationSerializer to be used when listing projects.
 


### PR DESCRIPTION
If a project is public, we don't want to show
the organization information, but it can still be useful to see which organization the project belongs to.

Tests are in .com