### PR TITLE
Do not automatically create pip-tools pull requests on forks of this repo

### DIFF
--- a/.github/workflows/pip-tools.yaml
+++ b/.github/workflows/pip-tools.yaml
@@ -22,7 +22,6 @@ jobs:
 
     name: Update dependencies
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'readthedocs' # do not run this job on forks
     steps:
       - uses: actions/checkout@v4
       - name: Update submodules
@@ -35,12 +34,13 @@ jobs:
         run: sudo apt-get install libpq-dev
 
       - name: Install piptools and invoke
-        run: python -m pip install -U pip-tools invoke
+        run: python -m pip install --upgrade pip-tools invoke
 
       - name: Update dependencies from requirements/*.txt
         run: invoke requirements.update
 
       - name: Create Pull Request
+        if: github.repository_owner == 'readthedocs' # do not run this step on forks
         uses: peter-evans/create-pull-request@v6
         with:
           add-paths: |

--- a/.github/workflows/pip-tools.yaml
+++ b/.github/workflows/pip-tools.yaml
@@ -22,6 +22,7 @@ jobs:
 
     name: Update dependencies
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'readthedocs' # do not run this job on forks
     steps:
       - uses: actions/checkout@v4
       - name: Update submodules
@@ -40,7 +41,6 @@ jobs:
         run: invoke requirements.update
 
       - name: Create Pull Request
-        if: github.repository_owner == 'readthedocs' # do not run this step on forks
         uses: peter-evans/create-pull-request@v6
         with:
           add-paths: |

--- a/.github/workflows/pip-tools.yaml
+++ b/.github/workflows/pip-tools.yaml
@@ -1,5 +1,5 @@
 # Action to run pip-compile weekly and create a Pull Request with the changes.
-# Althought GitHub says that pip-compile is supported by dependabot, we couldn't make it work together.
+# Although GitHub says that pip-compile is supported by dependabot, we couldn't make it work together.
 # That's why this action exists.
 # If we ever find the proper configuration for dependabot+pip-compile,
 # we can delete this action.
@@ -22,6 +22,7 @@ jobs:
 
     name: Update dependencies
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'readthedocs' # do not run this job on forks
     steps:
       - uses: actions/checkout@v4
       - name: Update submodules


### PR DESCRIPTION
Currently, this GitHub Action creates new pull requests on the forks of all contributors.  Let's make sure that the job only creates pull requests
```yaml
if: github.repository_owner == 'readthedocs'
```
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context