### PR TITLE
Pin pip for pip-tools for now

### DIFF
--- a/.github/workflows/pip-tools.yaml
+++ b/.github/workflows/pip-tools.yaml
@@ -35,7 +35,8 @@ jobs:
         run: sudo apt-get install libpq-dev
 
       - name: Install piptools and invoke
-        run: python -m pip install --upgrade pip-tools invoke
+        # Pinning pip==24.2 due to https://github.com/jazzband/pip-tools/issues/2131
+        run: python -m pip install --upgrade pip-tools invoke pip==24.2
 
       - name: Update dependencies from requirements/*.txt
         run: invoke requirements.update


### PR DESCRIPTION
It started adding absolute paths, instead of relatives.

Related https://github.com/jazzband/pip-tools/issues/2131
Related https://github.com/readthedocs/readthedocs.org/pull/11754