### PR TITLE
Docs: disable `sphinx-hoverxref` in our docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,6 @@ from multiproject.utils import get_project
 
 sys.path.append(os.path.abspath("_ext"))
 extensions = [
-    "hoverxref.extension",
     "multiproject",
     "myst_parser",
     # For testing, conditionally disable the custom 404 pages on dev docs
@@ -124,14 +123,6 @@ intersphinx_disabled_reftypes = ["*"]
 myst_enable_extensions = [
     "deflist",
 ]
-hoverxref_intersphinx = [
-    "sphinx",
-    "pip",
-    "nbsphinx",
-    "myst-nb",
-    "ipywidgets",
-    "jupytext",
-]
 htmlhelp_basename = "ReadTheDocsdoc"
 latex_documents = [
     (
@@ -179,25 +170,6 @@ html_context = {
     "github_version": "main",
     # Use to generate the Plausible "data-domain" attribute from the template
     "plausible_domain": f"{os.environ.get('READTHEDOCS_PROJECT')}.readthedocs.io",
-}
-
-hoverxref_auto_ref = True
-hoverxref_domains = ["py"]
-hoverxref_roles = [
-    "option",
-    # Documentation pages
-    # Not supported yet: https://github.com/readthedocs/sphinx-hoverxref/issues/18
-    "doc",
-    # Glossary terms
-    "term",
-]
-hoverxref_role_types = {
-    "mod": "modal",  # for Python Sphinx Domain
-    "doc": "modal",  # for whole docs
-    "class": "tooltip",  # for Python Sphinx Domain
-    "ref": "tooltip",  # for hoverxref_auto_ref config
-    "confval": "tooltip",  # for custom object
-    "term": "tooltip",  # for glossaries
 }
 
 # See dev/style_guide.rst for documentation

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -11,7 +11,6 @@ sphinx-design
 sphinx-multiproject
 
 # RTD deps :)
-sphinx-hoverxref
 sphinx-notfound-page
 
 # Docs

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -110,7 +110,6 @@ sphinx==8.1.3
     #   sphinx-autobuild
     #   sphinx-copybutton
     #   sphinx-design
-    #   sphinx-hoverxref
     #   sphinx-intl
     #   sphinx-notfound-page
     #   sphinx-prompt
@@ -125,8 +124,6 @@ sphinx-autobuild==2024.10.3
 sphinx-copybutton==0.5.2
     # via -r requirements/docs.in
 sphinx-design==0.6.1
-    # via -r requirements/docs.in
-sphinx-hoverxref==1.4.1
     # via -r requirements/docs.in
 sphinx-intl==2.2.0
     # via -r requirements/docs.in
@@ -149,9 +146,7 @@ sphinxcontrib-htmlhelp==2.1.0
 sphinxcontrib-httpdomain==1.8.1
     # via -r requirements/docs.in
 sphinxcontrib-jquery==4.1
-    # via
-    #   sphinx-hoverxref
-    #   sphinx-rtd-theme
+    # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-qthelp==2.0.0


### PR DESCRIPTION
We are going to start using the new addon link previews.