### PR TITLE
Addons: rename fields on API response

### DIFF
--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -984,8 +984,8 @@ class TestReadTheDocsConfigJson(TestCase):
                     {
                         "filename": "new-file.html",
                         "urls": {
-                            "version_a": "https://project--123.dev.readthedocs.build/en/123/new-file.html",
-                            "version_b": "https://project.dev.readthedocs.io/en/latest/new-file.html",
+                            "current": "https://project--123.dev.readthedocs.build/en/123/new-file.html",
+                            "base": "https://project.dev.readthedocs.io/en/latest/new-file.html",
                         },
                     },
                 ],
@@ -993,8 +993,8 @@ class TestReadTheDocsConfigJson(TestCase):
                     {
                         "filename": "deleted.html",
                         "urls": {
-                            "version_a": "https://project--123.dev.readthedocs.build/en/123/deleted.html",
-                            "version_b": "https://project.dev.readthedocs.io/en/latest/deleted.html",
+                            "current": "https://project--123.dev.readthedocs.build/en/123/deleted.html",
+                            "base": "https://project.dev.readthedocs.io/en/latest/deleted.html",
                         },
                     },
                 ],
@@ -1002,8 +1002,8 @@ class TestReadTheDocsConfigJson(TestCase):
                     {
                         "filename": "tutorial/index.html",
                         "urls": {
-                            "version_a": "https://project--123.dev.readthedocs.build/en/123/tutorial/index.html",
-                            "version_b": "https://project.dev.readthedocs.io/en/latest/tutorial/index.html",
+                            "current": "https://project--123.dev.readthedocs.build/en/123/tutorial/index.html",
+                            "base": "https://project.dev.readthedocs.io/en/latest/tutorial/index.html",
                         },
                     },
                 ],

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -657,12 +657,12 @@ class AddonsResponseBase:
                     {
                         "filename": filename,
                         "urls": {
-                            "version_a": resolver.resolve_version(
+                            "current": resolver.resolve_version(
                                 project=project,
                                 filename=filename,
                                 version=version,
                             ),
-                            "version_b": resolver.resolve_version(
+                            "base": resolver.resolve_version(
                                 project=project,
                                 filename=filename,
                                 version=latest_version,
@@ -675,12 +675,12 @@ class AddonsResponseBase:
                     {
                         "filename": filename,
                         "urls": {
-                            "version_a": resolver.resolve_version(
+                            "current": resolver.resolve_version(
                                 project=project,
                                 filename=filename,
                                 version=version,
                             ),
-                            "version_b": resolver.resolve_version(
+                            "base": resolver.resolve_version(
                                 project=project,
                                 filename=filename,
                                 version=latest_version,
@@ -693,12 +693,12 @@ class AddonsResponseBase:
                     {
                         "filename": filename,
                         "urls": {
-                            "version_a": resolver.resolve_version(
+                            "current": resolver.resolve_version(
                                 project=project,
                                 filename=filename,
                                 version=version,
                             ),
-                            "version_b": resolver.resolve_version(
+                            "base": resolver.resolve_version(
                                 project=project,
                                 filename=filename,
                                 version=latest_version,


### PR DESCRIPTION
Instead of using `version_a` and `version_b`, we are using `current` and `base` for these field names. These names are standard GitHub/Git names, for example when creating pull requests and you have to select the "base branch".

* Refs: https://github.com/readthedocs/readthedocs.org/pull/11762#issuecomment-2471388313
* Refs: https://github.com/readthedocs/readthedocs.org/pull/11749#discussion_r1836357613