### PR TITLE
Docs: update connected accounts steps to use env vars

### DIFF
--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -257,10 +257,7 @@ For others, the webhook will simply fail to connect when there are new commits t
   For each of these, the callback URI is ``http://devthedocs.org/accounts/<provider>/login/callback/``
   where ``<provider>`` is one of ``github``, ``gitlab``, or ``bitbucket_oauth2``.
   When setup, you will be given a "Client ID" (also called an "Application ID" or just "Key") and a "Secret".
-* Take the "Client ID" and "Secret" for each service and enter it in your local Django admin at:
-  ``http://devthedocs.org/admin/socialaccount/socialapp/``.
-  Make sure to apply it to the "Site".
-
+* Take the "Client ID" and "Secret" for each service and set them as :ref:`environment variables <settings:Allauth secrets>`.
 
 Troubleshooting
 ---------------


### PR DESCRIPTION


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11777.org.readthedocs.build/en/11777/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11777.org.readthedocs.build/en/11777/

<!-- readthedocs-preview dev end -->