### PR TITLE
Migrations: re-order them for deploy

### DIFF
--- a/readthedocs/projects/migrations/0134_addons_customscript.py
+++ b/readthedocs/projects/migrations/0134_addons_customscript.py
@@ -8,7 +8,7 @@ class Migration(migrations.Migration):
     safe = Safe.before_deploy
 
     dependencies = [
-        ('projects', '0134_addons_load_when_embedded_notnull'),
+        ('projects', '0133_addons_load_when_embedded'),
     ]
 
     operations = [

--- a/readthedocs/projects/migrations/0135_addons_load_when_embedded_notnull.py
+++ b/readthedocs/projects/migrations/0135_addons_load_when_embedded_notnull.py
@@ -8,7 +8,7 @@ class Migration(migrations.Migration):
     safe = Safe.after_deploy
 
     dependencies = [
-        ('projects', '0133_addons_load_when_embedded'),
+        ('projects', '0134_addons_customscript'),
     ]
 
     operations = [

--- a/readthedocs/projects/migrations/0136_addons_customscript_notnull.py
+++ b/readthedocs/projects/migrations/0136_addons_customscript_notnull.py
@@ -8,7 +8,7 @@ class Migration(migrations.Migration):
     safe = Safe.after_deploy
 
     dependencies = [
-        ('projects', '0135_addons_customscript'),
+        ('projects', '0135_addons_load_when_embedded_notnull'),
     ]
 
     operations = [


### PR DESCRIPTION
Run all the `before_deploy` migrations first. Then run all the `after_deploy` migrations.

We hit an issue while doing the deploy because of this.