### PR TITLE
Increase default docker limits

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -636,8 +636,8 @@ class CommunityBaseSettings(Settings):
         """
         # Our normal default
         limits = {
-            "memory": "1g",
-            "time": 600,
+            "memory": "2g",
+            "time": 900,
         }
 
         # Only run on our servers


### PR DESCRIPTION
I keep hitting memory limits locally.
I wonder if we should just use the "Determine limits dynamically" in dev.
I'm not sure why that isn't better than hard limits?
