### PR TITLE
Support RTD_USE_PROMOS for setting USE_PROMOS in dev

### DIFF
--- a/docs/dev/settings.rst
+++ b/docs/dev/settings.rst
@@ -168,3 +168,10 @@ The following secrets are required to use ``djstripe`` and our Stripe integratio
 .. envvar:: RTD_STRIPE_SECRET
 .. envvar:: RTD_STRIPE_PUBLISHABLE
 .. envvar:: RTD_DJSTRIPE_WEBHOOK_SECRET
+
+Ethical Ads secrets
+~~~~~~~~~~~~~~~~~~~
+
+The following secrets are required to use ``ethicalads`` in dev:
+
+.. envvar:: RTD_USE_PROMOS

--- a/docs/dev/settings.rst
+++ b/docs/dev/settings.rst
@@ -170,7 +170,7 @@ The following secrets are required to use ``djstripe`` and our Stripe integratio
 .. envvar:: RTD_DJSTRIPE_WEBHOOK_SECRET
 
 Ethical Ads variables
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 The following variables are required to use ``ethicalads`` in dev:
 

--- a/docs/dev/settings.rst
+++ b/docs/dev/settings.rst
@@ -169,9 +169,9 @@ The following secrets are required to use ``djstripe`` and our Stripe integratio
 .. envvar:: RTD_STRIPE_PUBLISHABLE
 .. envvar:: RTD_DJSTRIPE_WEBHOOK_SECRET
 
-Ethical Ads secrets
+Ethical Ads variables
 ~~~~~~~~~~~~~~~~~~~
 
-The following secrets are required to use ``ethicalads`` in dev:
+The following variables are required to use ``ethicalads`` in dev:
 
 .. envvar:: RTD_USE_PROMOS

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -47,7 +47,7 @@ class DockerBaseSettings(CommunityBaseSettings):
         HOSTIP = ips[0][:-1] + "1"
 
     # Turn this on to test ads
-    USE_PROMOS = False
+    USE_PROMOS = os.environ.get("RTD_USE_PROMOS") is not None
     ADSERVER_API_BASE = f"http://{HOSTIP}:5000"
     # Create a Token for an admin User and set it here.
     ADSERVER_API_KEY = None


### PR DESCRIPTION


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11790.org.readthedocs.build/en/11790/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11790.org.readthedocs.build/en/11790/

<!-- readthedocs-preview dev end -->