### PR TITLE
Django Debug Toolbar: disable slow panels

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -63,6 +63,15 @@ class CommunityBaseSettings(Settings):
 
         return {
             "SHOW_TOOLBAR_CALLBACK": _show_debug_toolbar,
+            "DISABLE_PANELS": [
+                # Default ones
+                "debug_toolbar.panels.profiling.ProfilingPanel",
+                "debug_toolbar.panels.redirects.RedirectsPanel",
+                # Custome ones
+                # We are disabling these because they take a lot of time to execute in the new dashboard
+                "debug_toolbar.panels.sql.SQLPanel",
+                "debug_toolbar.panels.templates.TemplatesPanel",
+            ]
         }
 
     @property

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -68,7 +68,9 @@ class CommunityBaseSettings(Settings):
                 "debug_toolbar.panels.profiling.ProfilingPanel",
                 "debug_toolbar.panels.redirects.RedirectsPanel",
                 # Custome ones
-                # We are disabling these because they take a lot of time to execute in the new dashboard
+                # We are disabling these because they take a lot of time to execute in the new dashboard.
+                # We make an intensive usage of the ``include`` template tag there.
+                # It's a "known issue/bug" and there is no solution as far as we can tell.
                 "debug_toolbar.panels.sql.SQLPanel",
                 "debug_toolbar.panels.templates.TemplatesPanel",
             ]


### PR DESCRIPTION
SQL and Templates panles are pretty slow to render. We are disabling them by default but still showing the panel in the toolbar, so they can be re-enabled if required from there.