### PR TITLE
Build: don't run default steps if no `sphinx` or `mkdocs`

### DIFF
--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -828,7 +828,14 @@ class BuildConfigV2(BuildConfigBase):
 
         if self.mkdocs:
             return "mkdocs"
-        return self.sphinx.builder
+
+        # NOTE: we need to use "source config" here because `_config` is
+        # auto-populated with Sphinx if no `sphinx` and no `mkdocs` keys are
+        # declared.
+        if self.source_config.get("sphinx"):
+            return self.sphinx.builder
+
+        return GENERIC
 
     @property
     def submodules(self):


### PR DESCRIPTION
This PR modifies the build to **not run default commands** when the user doesn't specify `sphinx` or `mkdocs` configs in the YAML file.

This allows to use the following YAML file to build with Docusaurus, for example:

```yaml
version: 2

build:
  os: ubuntu-24.04
  tools:
    nodejs: "22"
  jobs:
    install:
      - cd docs/ && npm install
    build:
      html:
        - cd docs/ && npm run build
    post_build:
      - mkdir --parents $READTHEDOCS_OUTPUT/html/
      - cp --recursive docs/build/* $READTHEDOCS_OUTPUT/html/
```

This is the structure I've been wanting to have to allow any type of doctool to work in our platform following the `build.jobs` pattern.

The code deployed in production doesn't allow this because it runs automatically `create_environment`, `install_core_dependencies` and `install_requirements` even if the project is not using Python --which is incorrect. It fails with the generic error: _"Unknown problem. There was a problem with Read the Docs while building your documentation"_

- https://app.readthedocs.org/projects/test-builds/builds/26425680/
- https://read-the-docs.sentry.io/issues/4458662274/

This PR detects if the user is defining `sphinx` or `mkdocs` and if it's not, it doesn't run those jobs and leave the user to handle the build workflow completely.

* Related https://github.com/readthedocs/readthedocs.org/issues/11216
* Related https://github.com/readthedocs/readthedocs.org/issues/11551