### PR TITLE
EmbedAPI: main content based on documentation tool

### DIFF
--- a/docs/user/api/v3.rst
+++ b/docs/user/api/v3.rst
@@ -2001,10 +2001,11 @@ Embed
     :query string url: full URL of the document (with optional fragment) to fetch content from.
     :query string doctool: *optional* documentation tool key name used to generate the target documentation (currently, only ``sphinx`` is accepted)
     :query string doctoolversion: *optional* documentation tool version used to generate the target documentation (e.g. ``4.2.0``).
+    :query string maincontent: *optional* CSS selector for the main content of the page (e.g. ``div#main``).
 
     .. note::
 
-       Passing ``?doctool=`` and ``?doctoolversion=`` may improve the response,
+       Passing ``?doctool=``, ``?doctoolversion=`` and ``?maincontent=`` may improve the response
        since the endpoint will know more about the exact structure of the HTML and can make better decisions.
 
 Additional APIs

--- a/docs/user/guides/embedding-content.rst
+++ b/docs/user/guides/embedding-content.rst
@@ -63,6 +63,7 @@ from our own docs and will populate the content of it into the ``#help-container
       'url': 'https://docs.readthedocs.io/en/latest/automation-rules.html%23creating-an-automation-rule',
       // 'doctool': 'sphinx',
       // 'doctoolversion': '4.2.0',
+      // 'maincontent': 'div#main',
     };
     var url = 'https://readthedocs.org/api/v3/embed/?' + $.param(params);
     $.get(url, function(data) {

--- a/readthedocs/embed/v3/views.py
+++ b/readthedocs/embed/v3/views.py
@@ -50,7 +50,7 @@ class EmbedAPIBase(EmbedAPIMixin, CDNCacheTagsMixin, APIView):
     * url (with fragment) (required)
     * doctool
     * doctoolversion
-    * selector
+    * maincontent
 
     ### Example
 
@@ -306,7 +306,7 @@ class EmbedAPIBase(EmbedAPIMixin, CDNCacheTagsMixin, APIView):
         url = request.GET.get("url")
         doctool = request.GET.get("doctool")
         doctoolversion = request.GET.get("doctoolversion")
-        selector = request.GET.get("selector")
+        selector = request.GET.get("maincontent")
 
         if not url:
             return Response(

--- a/readthedocs/embed/v3/views.py
+++ b/readthedocs/embed/v3/views.py
@@ -389,12 +389,17 @@ class EmbedAPIBase(EmbedAPIMixin, CDNCacheTagsMixin, APIView):
             )
 
         if not content_requested:
-            log.warning("Identifier not found.", url=url, fragment=fragment)
+            log.warning(
+                "Identifier not found.",
+                url=url,
+                fragment=fragment,
+                maincontent=selector,
+            )
             return Response(
                 {
                     "error": (
                         "Can't find content for section: "
-                        f"url={url} fragment={fragment}"
+                        f"url={url} fragment={fragment} maincontent={selector}"
                     )
                 },
                 status=status.HTTP_404_NOT_FOUND,


### PR DESCRIPTION
We need different CSS selectors to find the main content node depending on the documentation tool used.

This PR adds the `?selector=` attribute to the EmbedAPI to accept a specific selector for the main content of the page. This attribute will be sent by the Addons frontend code using the heuristic code we wrote there.

If this specific selector is not sent, we fallback to the default selector's value.

### Using the _default selector_

![Screenshot_2024-11-28_16-04-58](https://github.com/user-attachments/assets/992d2f83-97c8-4860-9950-edcb4e7e2fb2)

### Using the specific selector for this documentation tool


![Screenshot_2024-11-28_16-05-48](https://github.com/user-attachments/assets/db88e3db-d6a1-4943-b0b3-61c1ef1c78fa)
