### PR TITLE
Development: accept `PRUNE_PACKAGE_CACHE` argument in Dockerfile

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -69,6 +69,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 
 WORKDIR /tmp
 
+ARG PRUNE_PACKAGE_CACHE=0
 COPY requirements/docker.txt docker.txt
 RUN uv pip sync docker.txt
 


### PR DESCRIPTION
Use `ARG` in Dockerfile to invalidate the cache when this argument changes.

Requires https://github.com/readthedocs/common/pull/244