### PR TITLE
Domains: check for urlparse errors

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -1089,7 +1089,7 @@ class DomainForm(forms.ModelForm):
         try:
             return urlparse(url)
         except ValueError:
-            raise forms.ValidationError(f"Invalid domain")
+            raise forms.ValidationError("Invalid domain")
 
     def clean_canonical(self):
         canonical = self.cleaned_data["canonical"]

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -994,11 +994,11 @@ class DomainForm(forms.ModelForm):
     def clean_domain(self):
         """Validates domain."""
         domain = self.cleaned_data["domain"].lower()
-        parsed = urlparse(domain)
+        parsed = self._safe_urlparse(domain)
 
         # Force the scheme to have a valid netloc.
         if not parsed.scheme:
-            parsed = urlparse(f"https://{domain}")
+            parsed = self._safe_urlparse(f"https://{domain}")
 
         if not parsed.netloc:
             raise forms.ValidationError(f"{domain} is not a valid domain.")
@@ -1083,6 +1083,13 @@ class DomainForm(forms.ModelForm):
             raise forms.ValidationError(
                 _("The domain is not valid."),
             )
+
+    def _safe_urlparse(self, url):
+        """Wrapper around urlparse to throw ValueError exceptions as ValidationError."""
+        try:
+            return urlparse(url)
+        except ValueError:
+            raise forms.ValidationError(f"Invalid domain")
 
     def clean_canonical(self):
         canonical = self.cleaned_data["canonical"]

--- a/readthedocs/rtd_tests/tests/test_domains.py
+++ b/readthedocs/rtd_tests/tests/test_domains.py
@@ -154,6 +154,7 @@ class FormTests(TestCase):
             "1.23.45.67",
             "127.0.0.1",
             "127.0.0.10",
+            "[1.2.3.4.com"
         ]
         for domain in domains:
             form = DomainForm(

--- a/readthedocs/rtd_tests/tests/test_domains.py
+++ b/readthedocs/rtd_tests/tests/test_domains.py
@@ -154,7 +154,7 @@ class FormTests(TestCase):
             "1.23.45.67",
             "127.0.0.1",
             "127.0.0.10",
-            "[1.2.3.4.com"
+            "[1.2.3.4.com",
         ]
         for domain in domains:
             form = DomainForm(


### PR DESCRIPTION
urlparse can throw ValueError when parsing a URL, we didn't experience this before because none of our tests were failing when calling urlparse, but there was a new release of python that now fails parsing some of our test cases https://github.com/python/cpython/issues/122792.