### PR TITLE
Fix AddonsConfig admin base_version.

### DIFF
--- a/readthedocs/projects/admin.py
+++ b/readthedocs/projects/admin.py
@@ -471,7 +471,7 @@ class EnvironmentVariableAdmin(admin.ModelAdmin):
 @admin.register(AddonsConfig)
 class AddonsConfigAdmin(admin.ModelAdmin):
     model = AddonsConfig
-    raw_id_fields = ("project",)
+    raw_id_fields = ("project", "options_base_version")
     list_display = ("project", "enabled")
     search_fields = ("project__slug",)
     list_editable = ("enabled",)


### PR DESCRIPTION
This was causing the AddonsConfig admin to time out.
