### PR TITLE
Remove EthicalAd URLs

### DIFF
--- a/readthedocs/api/v2/urls.py
+++ b/readthedocs/api/v2/urls.py
@@ -1,6 +1,5 @@
 """Define routes between URL paths and views/endpoints."""
 
-from django.conf import settings
 from django.urls import include, path, re_path
 from rest_framework import routers
 
@@ -110,11 +109,3 @@ urlpatterns += integration_urls
 urlpatterns += [
     path("webhook/stripe/", StripeEventView.as_view(), name="api_webhook_stripe"),
 ]
-
-if "readthedocsext.donate" in settings.INSTALLED_APPS:
-    # pylint: disable=import-error
-    from readthedocsext.donate.restapi.urls import urlpatterns as sustainability_urls
-
-    urlpatterns += [
-        path("sustainability/", include(sustainability_urls)),
-    ]


### PR DESCRIPTION
We are not serving EthicalAds from Read the Docs anymore. We are hitting the EthicalAds server directly using Addons.

Matches https://github.com/readthedocs/readthedocs-ext/pull/563