### PR TITLE
Docs: use "Visual diff" for marketing "Doc Diff"

### DIFF
--- a/docs/user/addons.rst
+++ b/docs/user/addons.rst
@@ -5,7 +5,7 @@ Read the Docs Addons
 They are used in the rendered documentation,
 and can be accessed via hotkeys or on screen UI elements.
 
-:doc:`DocDiff </doc-diff>`
+:doc:`Visual diff </visual-diff>`
     Highlight changed output from pull requests
 
 :doc:`Link previews </link-previews>`

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -59,7 +59,7 @@ Read the Docs: documentation simplified
    :caption: Reading documentation
 
    /downloadable-documentation
-   /doc-diff
+   /visual-diff
    /link-previews
    /guides/embedding-content
    /server-side-search/index

--- a/docs/user/pull-requests.rst
+++ b/docs/user/pull-requests.rst
@@ -28,10 +28,10 @@ Pull request notifications
     A pull request notifications is shown at the top of preview pages,
     which let readers know they aren't viewing an active version of the project.
 
-:doc:`DocDiff </doc-diff>`
-    DocDiff shows proposed changes by visually highlighting the differences between the current pull request and the latest version of the project's documentation.
+:doc:`Visual diff </visual-diff>`
+    Visual diff shows proposed changes by visually highlighting the differences between the current pull request and the latest version of the project's documentation.
 
-    Press ``d`` to toggle between DocDiff and normal pull request preview.
+    Press ``d`` to toggle between Visual diff and normal pull request preview.
 
 .. seealso::
 

--- a/docs/user/visual-diff.rst
+++ b/docs/user/visual-diff.rst
@@ -1,27 +1,27 @@
-DocDiff
-=======
+Visual diff
+===========
 
-DocDiff allows you to see a visual :term:`diff` on a documentation page,
+Visual diff allows you to see a visual :term:`diff` on a documentation page,
 showing what has changed between the ``latest`` version and the active :doc:`pull request </pull-requests>`.
 
-DocDiff allows you to quickly review changes visually,
+Visual diff allows you to quickly review changes visually,
 and focus your review on what has changed in the current page.
 
 .. figure:: /img/addons-docdiff.gif
    :width: 80%
 
-   Example of DocDiff
+   Example of Visual diff
 
-Enabling DocDiff
-----------------
+Enabling Visual diff
+--------------------
 
-DocDiff is only enabled on pull request builds,
+Visual diff is only enabled on pull request builds,
 and can be toggled on and off with the ``d`` hotkey.
 
-Troubleshooting DocDiff
------------------------
+Troubleshooting Visual diff
+---------------------------
 
-DocDiff only works if there are changes on the page,
+Visual diff only works if there are changes on the page,
 so ensure you are on a page that has changed in the current pull request.
 
 There are also some known issues that currently don't display properly:


### PR DESCRIPTION
Related https://github.com/readthedocs/readthedocs.org/pull/11838

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11860.org.readthedocs.build/en/11860/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11860.org.readthedocs.build/en/11860/

<!-- readthedocs-preview dev end -->