### PR TITLE
Match User method in TeamMember

### DIFF
--- a/readthedocs/organizations/models.py
+++ b/readthedocs/organizations/models.py
@@ -410,7 +410,7 @@ class TeamMember(models.Model):
     @property
     def full_name(self):
         """
-        Alias property for `get_full_name`
+        Alias property for `get_full_name`.
 
         This is deprecated, use `get_full_name` as it matches the underlying
         :py:method:`User.get_full_name`.

--- a/readthedocs/organizations/models.py
+++ b/readthedocs/organizations/models.py
@@ -401,12 +401,21 @@ class TeamMember(models.Model):
 
         return "Unknown"
 
-    @property
-    def full_name(self):
+    def get_full_name(self):
         """Return member or invite full name."""
         if self.is_member:
             return self.member.get_full_name()
         return ""
+
+    @property
+    def full_name(self):
+        """
+        Alias property for `get_full_name`
+
+        This is deprecated, use `get_full_name` as it matches the underlying
+        :py:method:`User.get_full_name`.
+        """
+        return self.get_full_name()
 
     @property
     def email(self):


### PR DESCRIPTION
I'm not sure why this doesn't match, but it's confusing to work with in
some templates that sometimes list `TeamMember` and other times list
`User` instances. Instead, just match these methods so it's always the
same.

- Refs readthedocs/ext-theme#546