### PR TITLE
Build: use actual git identifier for READTHEDOCS_GIT_IDENTIFIER

### DIFF
--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -187,6 +187,7 @@ class VersionAdminSerializer(VersionSerializer):
             "build_data",
             "canonical_url",
             "machine",
+            "git_identifier",
         ]
 
 

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -354,6 +354,9 @@ class Version(TimeStampedModel):
             return self.identifier.removeprefix("origin/")
 
         if self.type == EXTERNAL:
+            # If this version is a EXTERNAL version, the identifier will
+            # contain the actual commit hash. which we can use to
+            # generate url for a given file name
             return self.identifier
 
         # For all other cases, verbose_name contains the actual name of the branch/tag.

--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -696,7 +696,7 @@ class BuildDirector:
             # TODO: we don't have access to the database from the builder.
             # We need to find a way to expose HTML_URL here as well.
             # "READTHEDOCS_GIT_HTML_URL": self.data.project.remote_repository.html_url,
-            "READTHEDOCS_GIT_IDENTIFIER": self.data.version.identifier,
+            "READTHEDOCS_GIT_IDENTIFIER": self.data.version.git_identifier,
             "READTHEDOCS_GIT_COMMIT_HASH": self.data.build["commit"],
             "READTHEDOCS_PRODUCTION_DOMAIN": settings.PRODUCTION_DOMAIN,
         }

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -372,7 +372,7 @@ class TestBuildTask(BuildEnvironmentBase):
                 self.project.checkout_path(self.version.slug), "_readthedocs/"
             ),
             "READTHEDOCS_GIT_CLONE_URL": self.project.repo,
-            "READTHEDOCS_GIT_IDENTIFIER": self.version.identifier,
+            "READTHEDOCS_GIT_IDENTIFIER": self.version.git_identifier,
             "READTHEDOCS_GIT_COMMIT_HASH": self.build.commit,
             "READTHEDOCS_PRODUCTION_DOMAIN": settings.PRODUCTION_DOMAIN,
         }

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -3292,6 +3292,7 @@ class APIVersionTests(TestCase):
             "privacy_level": "public",
             "downloads": {},
             "identifier": "2404a34eba4ee9c48cc8bc4055b99a48354f4950",
+            "git_identifier": "0.8",
             "slug": "0.8",
             "has_epub": False,
             "has_htmlzip": False,

--- a/readthedocs/rtd_tests/tests/test_project_forms.py
+++ b/readthedocs/rtd_tests/tests/test_project_forms.py
@@ -478,29 +478,6 @@ class TestProjectAdvancedFormDefaultBranch(TestCase):
             ],
         )
 
-    def test_commit_name_not_in_default_branch_choices(self):
-        form = UpdateProjectForm(instance=self.project)
-        # This version is created by the user
-        latest = self.project.versions.filter(slug=LATEST)
-        # This version is created by the user
-        stable = self.project.versions.filter(slug=STABLE)
-
-        # `commit_name` can not be used as the value for the choices
-        self.assertNotIn(
-            latest.first().commit_name,
-            [
-                identifier
-                for identifier, _ in form.fields["default_branch"].widget.choices
-            ],
-        )
-        self.assertNotIn(
-            stable.first().commit_name,
-            [
-                identifier
-                for identifier, _ in form.fields["default_branch"].widget.choices
-            ],
-        )
-
     def test_external_version_not_in_default_branch_choices(self):
         external_version = get(
             Version,

--- a/readthedocs/rtd_tests/tests/test_version.py
+++ b/readthedocs/rtd_tests/tests/test_version.py
@@ -94,15 +94,15 @@ class TestVersionModel(VersionMixin, TestCase):
         stable.save()
         assert "https://github.com/pypa/pip/tree/stable/" == stable.vcs_url
 
-    def test_commit_name_for_stable_version(self):
-        self.assertEqual(self.branch_version.commit_name, "stable")
+    def test_git_identifier_for_stable_version(self):
+        self.assertEqual(self.branch_version.git_identifier, "stable")
 
-    def test_commit_name_for_latest_version(self):
-        self.assertEqual(self.tag_version.commit_name, "master")
+    def test_git_identifier_for_latest_version(self):
+        self.assertEqual(self.tag_version.git_identifier, "master")
 
-    def test_commit_name_for_external_version(self):
+    def test_git_identifier_for_external_version(self):
         self.assertEqual(
-            self.external_version.commit_name, self.external_version.identifier
+            self.external_version.git_identifier, self.external_version.identifier
         )
 
     @override_settings(

--- a/readthedocs/rtd_tests/tests/test_version_commit_name.py
+++ b/readthedocs/rtd_tests/tests/test_version_commit_name.py
@@ -71,7 +71,7 @@ class VersionCommitNameTests(TestCase):
 
     def test_stable_version_tag_uses_original_stable(self):
         project = get(Project)
-        version = get(
+        stable = get(
             Version,
             project=project,
             identifier="3d92b728b7d7b842259ac2020c2fa389f13aff0d",
@@ -80,7 +80,7 @@ class VersionCommitNameTests(TestCase):
             type=TAG,
             machine=True,
         )
-        get(
+        original_stable = get(
             Version,
             project=project,
             identifier="3d92b728b7d7b842259ac2020c2fa389f13aff0d",
@@ -89,7 +89,8 @@ class VersionCommitNameTests(TestCase):
             type=TAG,
             machine=True,
         )
-        self.assertEqual(version.git_identifier, "v2.0")
+        self.assertEqual(stable.git_identifier, "v2.0")
+        self.assertEqual(original_stable.git_identifier, "v2.0")
 
     def test_manual_stable_version(self):
         project = get(Project)

--- a/readthedocs/rtd_tests/tests/test_version_commit_name.py
+++ b/readthedocs/rtd_tests/tests/test_version_commit_name.py
@@ -33,7 +33,7 @@ class VersionCommitNameTests(TestCase):
             verbose_name="release-2.5.x",
             type=BRANCH,
         )
-        self.assertEqual(version.commit_name, "release-2.5.x")
+        self.assertEqual(version.git_identifier, "release-2.5.x")
 
     def test_tag_name(self):
         version = new(
@@ -43,7 +43,7 @@ class VersionCommitNameTests(TestCase):
             verbose_name="release-2.5.0",
             type=TAG,
         )
-        self.assertEqual(version.commit_name, "release-2.5.0")
+        self.assertEqual(version.git_identifier, "release-2.5.0")
 
     def test_branch_with_name_stable(self):
         version = new(
@@ -53,7 +53,7 @@ class VersionCommitNameTests(TestCase):
             verbose_name="stable",
             type=BRANCH,
         )
-        self.assertEqual(version.commit_name, "stable")
+        self.assertEqual(version.git_identifier, "stable")
 
     def test_stable_version_tag(self):
         version = new(
@@ -65,9 +65,31 @@ class VersionCommitNameTests(TestCase):
             machine=True,
         )
         self.assertEqual(
-            version.commit_name,
+            version.git_identifier,
             "3d92b728b7d7b842259ac2020c2fa389f13aff0d",
         )
+
+    def test_stable_version_tag_uses_original_stable(self):
+        project = get(Project)
+        version = get(
+            Version,
+            project=project,
+            identifier="3d92b728b7d7b842259ac2020c2fa389f13aff0d",
+            slug=STABLE,
+            verbose_name=STABLE,
+            type=TAG,
+            machine=True,
+        )
+        get(
+            Version,
+            project=project,
+            identifier="3d92b728b7d7b842259ac2020c2fa389f13aff0d",
+            slug="v2.0",
+            verbose_name="v2.0",
+            type=TAG,
+            machine=True,
+        )
+        self.assertEqual(version.git_identifier, "v2.0")
 
     def test_manual_stable_version(self):
         project = get(Project)
@@ -80,7 +102,7 @@ class VersionCommitNameTests(TestCase):
             type=BRANCH,
             machine=False,
         )
-        self.assertEqual(version.commit_name, "stable")
+        self.assertEqual(version.git_identifier, "stable")
 
     def test_git_latest_branch(self):
         git_project = get(Project, repo_type=REPO_TYPE_GIT)
@@ -93,14 +115,14 @@ class VersionCommitNameTests(TestCase):
             type=BRANCH,
             machine=True,
         )
-        self.assertEqual(version.commit_name, "master")
+        self.assertEqual(version.git_identifier, "master")
 
     def test_manual_latest_version(self):
         project = get(Project)
         version = project.versions.get(slug=LATEST)
         version.machine = False
         version.save()
-        self.assertEqual(version.commit_name, "latest")
+        self.assertEqual(version.git_identifier, "latest")
 
     def test_external_version(self):
         identifier = "ec26de721c3235aad62de7213c562f8c821"
@@ -111,4 +133,4 @@ class VersionCommitNameTests(TestCase):
             verbose_name="11",
             type=EXTERNAL,
         )
-        self.assertEqual(version.commit_name, identifier)
+        self.assertEqual(version.git_identifier, identifier)


### PR DESCRIPTION
A commit can point to more than one branch/tag, so using git describe/name-rev or similar doesn't work reliably. Since we already have the tag/branch name for most of the versions (verbose_name), we can just use that, there are only three special cases:

- LATEST: this is an alias for the default branch
- STABLE: this is an alias for the stable version
- External versions: we don't save the name of the base branch, just the commit and PR number, so not sure what to return here, I'm returning the commit for now. Maybe we can update the docs to mention this.

`commit_name` was doing exactly that, except for stable, so I went ahead and renamed it and refactored it (we were no longer using it) to use it in our API, so builders have access to it.

Closes https://github.com/readthedocs/readthedocs.org/issues/11662