### PR TITLE
Don't reflect user input in raw response

### DIFF
--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -622,6 +622,7 @@ class ProjectUsersDelete(ProjectUsersMixin, GenericView):
             username=username,
         )
         if self._is_last_user():
+            # NOTE: don't include user input in the message, since it's a security risk.
             return HttpResponseBadRequest(_("User is the last owner, can't be removed"))
 
         project = self.get_project()

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -622,9 +622,7 @@ class ProjectUsersDelete(ProjectUsersMixin, GenericView):
             username=username,
         )
         if self._is_last_user():
-            return HttpResponseBadRequest(
-                _(f"{username} is the last owner, can't be removed")
-            )
+            return HttpResponseBadRequest(_("User is the last owner, can't be removed"))
 
         project = self.get_project()
         project.users.remove(user)


### PR DESCRIPTION
**THIS VULNERABILITY CAN'T BE EXPLOITED**

- We only allow values that are a from an existing username (usernames are alphanumeric)
- The user needs to have been added to the project
- The action is from a post request, the button that triggers that action is marked as disabled when the user is the last owner.