### PR TITLE
Environment variables: document special case for PR preview builds

### DIFF
--- a/docs/user/reference/environment-variables.rst
+++ b/docs/user/reference/environment-variables.rst
@@ -119,7 +119,7 @@ All :doc:`build processes </builds>` have the following environment variables au
 
     .. note::
 
-       When building pull requests, this variable contains the commit hash of the pull request branch,
+       When building pull requests, this variable contains the numeric ID of the pull request,
        as we don't have access to the branch name.
 
 .. envvar:: READTHEDOCS_GIT_COMMIT_HASH

--- a/docs/user/reference/environment-variables.rst
+++ b/docs/user/reference/environment-variables.rst
@@ -117,6 +117,11 @@ All :doc:`build processes </builds>` have the following environment variables au
     :Example: ``feature/signup``
     :Example: ``update-readme``
 
+    .. note::
+
+       When building PRs, this variable contains the commit hash of the PR branch,
+       as we don't have access to the branch name.
+
 .. envvar:: READTHEDOCS_GIT_COMMIT_HASH
 
     Git commit hash identifier checked out from the repository URL.

--- a/docs/user/reference/environment-variables.rst
+++ b/docs/user/reference/environment-variables.rst
@@ -119,7 +119,7 @@ All :doc:`build processes </builds>` have the following environment variables au
 
     .. note::
 
-       When building PRs, this variable contains the commit hash of the PR branch,
+       When building pull requests, this variable contains the commit hash of the pull request branch,
        as we don't have access to the branch name.
 
 .. envvar:: READTHEDOCS_GIT_COMMIT_HASH

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -338,7 +338,7 @@ class Version(TimeStampedModel):
 
         - If the version is latest (machine created), we resolve to the default branch of the project.
         - If the version is stable (machine created), we resolve to the branch that the stable version points to.
-        - If the version is external, we return the identifier, since we don't have access to the name of the branch.
+        - If the version is external, we return the PR identifier, since we don't have access to the name of the branch.
         """
         # Latest is special as it doesn't contain the actual name in verbose_name.
         if self.slug == LATEST and self.machine:
@@ -352,12 +352,6 @@ class Version(TimeStampedModel):
             if original_stable:
                 return original_stable.verbose_name.removeprefix("origin/")
             return self.identifier.removeprefix("origin/")
-
-        if self.type == EXTERNAL:
-            # If this version is a EXTERNAL version, the identifier will
-            # contain the actual commit hash. which we can use to
-            # generate url for a given file name
-            return self.identifier
 
         # For all other cases, verbose_name contains the actual name of the branch/tag.
         return self.verbose_name

--- a/readthedocs/rtd_tests/tests/test_version.py
+++ b/readthedocs/rtd_tests/tests/test_version.py
@@ -102,7 +102,7 @@ class TestVersionModel(VersionMixin, TestCase):
 
     def test_git_identifier_for_external_version(self):
         self.assertEqual(
-            self.external_version.git_identifier, self.external_version.identifier
+            self.external_version.git_identifier, self.external_version.verbose_name
         )
 
     @override_settings(

--- a/readthedocs/rtd_tests/tests/test_version_commit_name.py
+++ b/readthedocs/rtd_tests/tests/test_version_commit_name.py
@@ -134,4 +134,4 @@ class VersionCommitNameTests(TestCase):
             verbose_name="11",
             type=EXTERNAL,
         )
-        self.assertEqual(version.git_identifier, identifier)
+        self.assertEqual(version.git_identifier, "11")


### PR DESCRIPTION
Ref https://github.com/readthedocs/readthedocs.org/pull/11875

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11893.org.readthedocs.build/en/11893/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11893.org.readthedocs.build/en/11893/

<!-- readthedocs-preview dev end -->