### PR TITLE
Add django-impersonate when admin is enabled

### DIFF
--- a/readthedocs/core/admin.py
+++ b/readthedocs/core/admin.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
+from impersonate.admin import UserAdminImpersonateMixin
 from rest_framework.authtoken.admin import TokenAdmin
 
 from readthedocs.core.history import ExtraSimpleHistoryAdmin
@@ -64,7 +65,7 @@ class UserProjectFilter(admin.SimpleListFilter):
             return queryset.filter(projects__builds__date__gt=recent_date)
 
 
-class UserAdminExtra(ExtraSimpleHistoryAdmin, UserAdmin):
+class UserAdminExtra(ExtraSimpleHistoryAdmin, UserAdminImpersonateMixin, UserAdmin):
 
     """Admin configuration for User."""
 
@@ -79,6 +80,9 @@ class UserAdminExtra(ExtraSimpleHistoryAdmin, UserAdmin):
     list_filter = (UserProjectFilter,) + UserAdmin.list_filter
     actions = ["ban_user", "sync_remote_repositories_action"]
     inlines = [UserProjectInline]
+
+    # Open a new tab when impersonating a user.
+    open_new_window = True
 
     @admin.display(
         description="Banned",

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -297,6 +297,8 @@ class CommunityBaseSettings(Settings):
             "allauth.socialaccount.providers.gitlab",
             "allauth.socialaccount.providers.bitbucket_oauth2",
             "allauth.mfa",
+            # Others
+            "impersonate",
             "cacheops",
         ]
         if ext:
@@ -829,6 +831,12 @@ class CommunityBaseSettings(Settings):
     ABSOLUTE_URL_OVERRIDES = {"auth.user": lambda o: "/profiles/{}/".format(o.username)}
 
     INTERNAL_IPS = ("127.0.0.1",)
+
+    # django-impersonate.
+    IMPERSONATE = {
+        # By default, only staff users can impersonate.
+        'REQUIRE_SUPERUSER': True,
+    }
 
     # Taggit
     # https://django-taggit.readthedocs.io

--- a/readthedocs/urls.py
+++ b/readthedocs/urls.py
@@ -7,6 +7,7 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path, re_path
 from django.views.generic.base import RedirectView, TemplateView
+from impersonate.views import impersonate, stop_impersonate
 
 from readthedocs.core.views import ErrorView, HomepageView, SupportView, do_not_track
 from readthedocs.search.views import GlobalSearchView
@@ -105,6 +106,22 @@ admin_urls = [
     re_path(r"^admin/", admin.site.urls),
 ]
 
+impersonate_urls = [
+    # We don't use ``include('impersonate.urls')`` here because we don't want to
+    # define ``/search`` and ``/list`` URLs
+    path(
+        "impersonate/stop/",
+        stop_impersonate,
+        name="impersonate-stop",
+    ),
+    path(
+        "impersonate/<path:uid>/",
+        impersonate,
+        name="impersonate-start",
+    ),
+]
+
+
 dnt_urls = [
     re_path(r"^\.well-known/dnt/$", do_not_track),
     # https://github.com/EFForg/dnt-guide#12-how-to-assert-dnt-compliance
@@ -158,6 +175,7 @@ if settings.READ_THE_DOCS_EXTENSIONS:
 
 if settings.ALLOW_ADMIN:
     groups.append(admin_urls)
+    groups.append(impersonate_urls)
 
 if settings.SHOW_DEBUG_TOOLBAR:
     import debug_toolbar

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -155,6 +155,8 @@ django-formtools==2.5.1
     # via -r requirements/pip.txt
 django-gravatar2==1.4.5
     # via -r requirements/pip.txt
+django-impersonate==1.9.4
+    # via -r requirements/pip.txt
 django-ipware==5.0.2
     # via
     #   -r requirements/pip.txt

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -165,6 +165,8 @@ django-formtools==2.5.1
     # via -r requirements/pip.txt
 django-gravatar2==1.4.5
     # via -r requirements/pip.txt
+django-impersonate==1.9.4
+    # via -r requirements/pip.txt
 django-ipware==5.0.2
     # via
     #   -r requirements/pip.txt

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -35,6 +35,9 @@ jsonfield
 
 django-safemigrate
 
+# Impersonate users in the Django admin for support.
+django-impersonate
+
 # The latest version of requests isn't compatible with the
 # version of the docker-py library we're using.
 # See https://github.com/docker/docker-py/issues/3256.

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -117,6 +117,8 @@ django-formtools==2.5.1
     # via -r requirements/pip.in
 django-gravatar2==1.4.5
     # via -r requirements/pip.in
+django-impersonate==1.9.4
+    # via -r requirements/pip.in
 django-ipware==5.0.2
     # via
     #   -r requirements/pip.in

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -162,6 +162,8 @@ django-formtools==2.5.1
     # via -r requirements/pip.txt
 django-gravatar2==1.4.5
     # via -r requirements/pip.txt
+django-impersonate==1.9.4
+    # via -r requirements/pip.txt
 django-ipware==5.0.2
     # via
     #   -r requirements/pip.txt


### PR DESCRIPTION
This used to live in .com, but I also find it useful to debug things in .org, specially now with the new dashboard. We used to check if the IMPERSONATE setting was defined in order to add the URLs, but since we are always using this when the admin is enabled, I'm just checking for that, that will allow us to have less code on .com/ops.