### PR TITLE
Docs: remove CSS variables override for font-size

### DIFF
--- a/docs/user/intro/mdbook.rst
+++ b/docs/user/intro/mdbook.rst
@@ -33,26 +33,6 @@ Getting started
 
 .. _Getting started with mdBook: https://rust-lang.github.io/mdBook/guide/creating.html
 
-Configuring mdBook and Read the Docs Addons
--------------------------------------------
-
-Adjust the flyout menu font size
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Add a ``readthedocs.css`` to your build with the `additional-css <https://rust-lang.github.io/mdBook/format/configuration/renderers.html#html-renderer-options>`_ flag,
-so that the font in the :ref:`flyout-menu:Addons flyout menu` matches the theme better.
-
-.. code-block:: css
-    :caption: readthedocs.css:
-
-    :root {
-        /* Increase the font size of the flyout menu */
-        --readthedocs-flyout-font-size: 1.3rem;
-
-        /* Increase the font size of the notifications */
-        --readthedocs-notification-font-size: 1.3rem;
-
-    }
 
 Example repository and demo
 ---------------------------

--- a/docs/user/intro/mkdocs.rst
+++ b/docs/user/intro/mkdocs.rst
@@ -158,27 +158,6 @@ To integrate the :ref:`flyout-menu:Addons flyout menu` version menu into your si
         extra_javascript:
             - javascript/readthedocs.js
 
-Adjust the flyout menu font size
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Add a ``readthedocs.css`` to your build,
-so that the font in the :ref:`flyout-menu:Addons flyout menu` matches the theme better.
-
-.. code-block:: css
-    :caption: readthedocs.css:
-
-    :root {
-        /* Reduce Read the Docs' flyout font a little bit */
-        --readthedocs-flyout-font-size: 0.7rem;
-
-        /* Reduce Read the Docs' notification font a little bit */
-        --readthedocs-notification-font-size: 0.8rem;
-
-        /* This customization is not yet perfect because we can't change the `line-height` yet. */
-        /* See https://github.com/readthedocs/addons/issues/197 */
-        --readthedocs-search-font-size: 0.7rem;
-    }
-
 Example repository and demo
 ---------------------------
 


### PR DESCRIPTION
We don't need to tell the users to perform extra steps on these documentation tools because addons is going to do this by default now: https://github.com/readthedocs/addons/pull/473

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11897.org.readthedocs.build/en/11897/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11897.org.readthedocs.build/en/11897/

<!-- readthedocs-preview dev end -->