### PR TITLE
Don't require sphinx/mkdocs keys when using build.commands

### DIFF
--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -753,12 +753,16 @@ class BuildConfigV2(BuildConfigBase):
         """
         Check for deprecated usages and raise an exception if found.
 
+        - If the user is using build.commands, we don't need the sphinx or mkdocs keys.
         - If the sphinx key is used, a path to the configuration file is required.
         - If the mkdocs key is used, a path to the configuration file is required.
         - If none of the sphinx or mkdocs keys are used,
           and the user isn't overriding the new build jobs,
           the sphinx key is explicitly required.
         """
+        if self.is_using_build_commands:
+            return
+
         has_sphinx_key = "sphinx" in self.source_config
         has_mkdocs_key = "mkdocs" in self.source_config
         if has_sphinx_key and not self.sphinx.configuration:

--- a/readthedocs/config/tests/test_config.py
+++ b/readthedocs/config/tests/test_config.py
@@ -1864,6 +1864,18 @@ class TestBuildConfigV2:
         data_copy["build"]["jobs"]["build"] = {"html": ["echo 'Hello World'"]}
         get_build_config(data_copy, validate=True, deprecate_implicit_keys=True)
 
+    def test_sphinx_and_mkdocs_arent_required_when_using_build_commands(self):
+        data = {
+            "build": {
+                "os": "ubuntu-22.04",
+                "tools": {
+                    "python": "3",
+                },
+                "commands": ["echo 'Hello World'"],
+            },
+        }
+        get_build_config(data, validate=True, deprecate_implicit_keys=True)
+
     def test_as_dict_new_build_config(self, tmpdir):
         build = get_build_config(
             {


### PR DESCRIPTION
Closes https://github.com/readthedocs/readthedocs.org/issues/11912