### PR TITLE
Docs: fix markdoc example

### DIFF
--- a/docs/user/intro/markdoc.rst
+++ b/docs/user/intro/markdoc.rst
@@ -21,7 +21,7 @@ Minimal configuration is required to build an existing Markdoc project on Read t
         install:
           # Install dependencies
           - cd docs/ && npm install
-        build
+        build:
           # Build the site
           - cd docs/ && npm run build
           # Copy generated files into Read the Docs directory


### PR DESCRIPTION


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11932.org.readthedocs.build/en/11932/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11932.org.readthedocs.build/en/11932/

<!-- readthedocs-preview dev end -->