### PR TITLE
Addons: expose `readthedocs.resolver.filename` in the API response

### DIFF
--- a/readthedocs/proxito/tests/responses/v1.json
+++ b/readthedocs/proxito/tests/responses/v1.json
@@ -118,6 +118,9 @@
   "readthedocs": {
     "analytics": {
       "code": null
+    },
+    "resolver": {
+      "filename": "/index.html"
     }
   },
   "addons": {

--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -667,6 +667,7 @@ class TestReadTheDocsConfigJson(TestCase):
         expected_response = self._get_response_dict("v1")
         # Remove `addons.doc_diff` from the response because it's not present when `url=` is not sent
         expected_response["addons"].pop("doc_diff")
+        expected_response["readthedocs"]["resolver"]["filename"] = None
 
         assert self._normalize_datetime_fields(r.json()) == expected_response
 

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -7,6 +7,8 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404
+from django.utils.encoding import iri_to_uri
+from django.utils.html import escape
 from rest_framework import permissions
 from rest_framework.renderers import JSONRenderer
 from rest_framework.views import APIView
@@ -451,6 +453,9 @@ class AddonsResponseBase:
             "readthedocs": {
                 "analytics": {
                     "code": settings.GLOBAL_ANALYTICS_CODE,
+                },
+                "resolver": {
+                    "filename": escape(iri_to_uri(filename)),
                 },
             },
             # TODO: the ``features`` is not polished and we expect to change drastically.

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -7,8 +7,6 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404
-from django.utils.encoding import iri_to_uri
-from django.utils.html import escape
 from rest_framework import permissions
 from rest_framework.renderers import JSONRenderer
 from rest_framework.views import APIView
@@ -455,7 +453,7 @@ class AddonsResponseBase:
                     "code": settings.GLOBAL_ANALYTICS_CODE,
                 },
                 "resolver": {
-                    "filename": escape(iri_to_uri(filename)),
+                    "filename": filename,
                 },
             },
             # TODO: the ``features`` is not polished and we expect to change drastically.


### PR DESCRIPTION
This is required to be able to dynamically update the URLs from the versions in the flyout when the page is changed using `history` object (without reloading / SPA) as Docusaurus does.

In that scenario we cannot use the HTML META tag because it was injected with the old value by CF Worker. Note that the CF Worker is not run after the initial request on SPA.

The addons frontend will use this attribute to update those URLs accordingly when the URL changes.

Required by:
* https://github.com/readthedocs/addons/pull/504