### PR TITLE
Version sync: restore verbose_name for stable version

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -29,6 +29,7 @@ from readthedocs.builds.constants import (
     LATEST,
     LATEST_VERBOSE_NAME,
     STABLE,
+    STABLE_VERBOSE_NAME,
 )
 from readthedocs.core.history import ExtraHistoricalRecords
 from readthedocs.core.resolver import Resolver
@@ -1200,6 +1201,7 @@ class Project(models.Model):
                 version_updated = (
                     new_stable.identifier != current_stable.identifier
                     or new_stable.type != current_stable.type
+                    or current_stable.verbose_name != STABLE_VERBOSE_NAME
                 )
                 if version_updated:
                     log.info(
@@ -1209,6 +1211,7 @@ class Project(models.Model):
                         version_type=new_stable.type,
                     )
                     current_stable.identifier = new_stable.identifier
+                    current_stable.verbose_name = STABLE_VERBOSE_NAME
                     current_stable.type = new_stable.type
                     current_stable.save()
                     return new_stable


### PR DESCRIPTION
Closes https://github.com/readthedocs/readthedocs.org/issues/11939

This also discovered another problem, we are using the verbose name to check for latest/stable, but we should use the slug

https://github.com/readthedocs/readthedocs.org/blob/10d9ef95736b3106b4c5c551df57dda8ed1000e2/readthedocs/vcs_support/backends/git.py#L135-L145

Will try to fix that in another PR, as we need to pass the slug down...