### PR TITLE
Add vitepress doc page

### DIFF
--- a/docs/user/intro/doctools.rst
+++ b/docs/user/intro/doctools.rst
@@ -65,6 +65,16 @@ Below is a list of popular documentation tools that you can use to write your do
         Written in
              :bdg-info:`rust`
 
+    .. grid-item-card::  VitePress
+        :link: vitepress.html
+
+        VitePress is a static site generator with a focus on performance and simplicity.
+
+        Supported formats
+             :bdg-success:`md`
+        Written in
+             :bdg-info:`javascript`
+
 .. toctree::
    :hidden:
 
@@ -73,3 +83,4 @@ Below is a list of popular documentation tools that you can use to write your do
    /intro/docusaurus
    /intro/markdoc
    /intro/mdbook
+   /intro/vitepress

--- a/docs/user/intro/vitepress.rst
+++ b/docs/user/intro/vitepress.rst
@@ -31,8 +31,10 @@ Minimal configuration is required to build an existing VitePress project on Read
 .. _VitePress: https://vitepress.dev/
 
 .. button-link:: https://dbtoolsbundle.readthedocs.io/en/stable/
+   :color: secondary
 
-    DbToolsBundle uses VitePress and Read the Docs
+
+   🔗 DbToolsBundle uses VitePress and Read the Docs
 
 Getting started
 ---------------

--- a/docs/user/intro/vitepress.rst
+++ b/docs/user/intro/vitepress.rst
@@ -44,6 +44,28 @@ Getting started
 
 .. _Getting started with VitePress: https://vitepress.vuejs.org/guide/getting-started.html
 
+Using the proper basepath
+-------------------------
+
+To ensure that your VitePress site works correctly on Read the Docs,
+you need to set the ``base`` option in your VitePress configuration to the correct base path:
+
+.. code-block:: js
+   :caption: .vitepress/config.js
+
+    import { defineConfig } from 'vitepress'
+
+    // https://vitepress.dev/reference/site-config
+    export default defineConfig({
+        // Use Canonical URL, but only the path and with no trailing /
+        // End result is like: `/en/latest`
+        base: process.env.READTHEDOCS_CANONICAL_URL
+        ? new URL(process.env.READTHEDOCS_CANONICAL_URL).pathname.replace(/\/$/, "")
+        : "",
+
+    title: "My Awesome Project",
+    description: "A VitePress Site",
+    })
 
 Example repository and demo
 ---------------------------

--- a/docs/user/intro/vitepress.rst
+++ b/docs/user/intro/vitepress.rst
@@ -14,26 +14,22 @@ Minimal configuration is required to build an existing VitePress project on Read
     version: 2
 
     build:
-    os: ubuntu-lts-latest
-    tools:
-        nodejs: "latest"
-    jobs:
-        install:
-        - npm install vitepress
-        build:
-        # The site was created by running `vitepress init`
-        # and following the official guide
-        # https://vitepress.dev/guide/getting-started
-        - vitepress build docs
-        - mkdir -p $READTHEDOCS_OUTPUT/
-        - mv docs/.vitepress/dist $READTHEDOCS_OUTPUT/html
+        os: ubuntu-lts-latest
+        tools:
+            nodejs: "latest"
+        jobs:
+            install:
+                - npm install vitepress
+            build:
+                html:
+                    # The site was created by running `vitepress init`
+                    # and following the official guide
+                    # https://vitepress.dev/guide/getting-started
+                    - vitepress build docs
+                    - mkdir -p $READTHEDOCS_OUTPUT/
+                    - mv docs/.vitepress/dist $READTHEDOCS_OUTPUT/html
 
 .. _VitePress: https://vitepress.dev/
-
-.. button-link:: https://dbtoolsbundle.readthedocs.io/en/stable/
-   :color: secondary
-
-   🔗 DbToolsBundle uses VitePress and Read the Docs
 
 Getting started
 ---------------
@@ -43,8 +39,8 @@ Getting started
 
 .. _Getting started with VitePress: https://vitepress.vuejs.org/guide/getting-started.html
 
-Using the proper basepath
--------------------------
+Using the proper base path
+--------------------------
 
 To ensure that your VitePress site works correctly on Read the Docs,
 you need to set the ``base`` option in your VitePress configuration to the correct base path:
@@ -68,6 +64,9 @@ you need to set the ``base`` option in your VitePress configuration to the corre
 
 Example repository and demo
 ---------------------------
+
+Production example from DbToolsBundle
+    https://dbtoolsbundle.readthedocs.io/en/stable/
 
 Example repository
     https://github.com/readthedocs/test-builds/tree/vitepress

--- a/docs/user/intro/vitepress.rst
+++ b/docs/user/intro/vitepress.rst
@@ -33,7 +33,6 @@ Minimal configuration is required to build an existing VitePress project on Read
 .. button-link:: https://dbtoolsbundle.readthedocs.io/en/stable/
    :color: secondary
 
-
    🔗 DbToolsBundle uses VitePress and Read the Docs
 
 Getting started
@@ -81,4 +80,4 @@ Further reading
 
 * `VitePress documentation`_
 
-.. _VitePress documentation: https://vitepress.vuejs.org/
+.. _VitePress documentation: https://vitepress.dev/

--- a/docs/user/intro/vitepress.rst
+++ b/docs/user/intro/vitepress.rst
@@ -1,0 +1,60 @@
+VitePress
+=========
+
+.. meta::
+   :description lang=en: Learn how to host VitePress documentation on Read the Docs.
+
+`VitePress`_ is a static site generator with a focus on performance and simplicity.
+
+Minimal configuration is required to build an existing VitePress project on Read the Docs.
+
+.. code-block:: yaml
+   :caption: .readthedocs.yaml
+
+    version: 2
+
+    build:
+    os: ubuntu-lts-latest
+    tools:
+        nodejs: "latest"
+    jobs:
+        install:
+        - npm install vitepress
+        build:
+        # The site was created by running `vitepress init`
+        # and following the official guide
+        # https://vitepress.dev/guide/getting-started
+        - vitepress build docs
+        - mkdir -p $READTHEDOCS_OUTPUT/
+        - mv docs/.vitepress/dist $READTHEDOCS_OUTPUT/html
+
+.. _VitePress: https://vitepress.dev/
+
+.. button-link:: https://dbtoolsbundle.readthedocs.io/en/stable/
+
+    DbToolsBundle uses VitePress and Read the Docs
+
+Getting started
+---------------
+
+- If you have an existing VitePress project you want to host on Read the Docs, check out our :doc:`/intro/add-project` guide.
+- If you're new to VitePress, check out the official `Getting started with VitePress`_ guide.
+
+.. _Getting started with VitePress: https://vitepress.vuejs.org/guide/getting-started.html
+
+
+Example repository and demo
+---------------------------
+
+Example repository
+    https://github.com/readthedocs/test-builds/tree/vitepress
+
+Demo
+    https://test-builds.readthedocs.io/en/vitepress/
+
+Further reading
+---------------
+
+* `VitePress documentation`_
+
+.. _VitePress documentation: https://vitepress.vuejs.org/


### PR DESCRIPTION
I fixed the test-builds repo to work properly,
and this also links out to a user example repo, but I want to improve that probably with a logo.

Refs Refs https://github.com/readthedocs/addons/pull/503

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11944.org.readthedocs.build/en/11944/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11944.org.readthedocs.build/en/11944/

<!-- readthedocs-preview dev end -->