### PR TITLE
More concise uv example

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -26,7 +26,7 @@ The jobs where users can customize our default build process are:
    :header-rows: 1
    :widths: 25 75
 
-   * - Step
+   * - Stepf
      - Customizable jobs
    * - Checkout
      - ``post_checkout``
@@ -460,6 +460,9 @@ Take a look at the following example:
 
    version: 2
 
+   sphinx:
+      configuration: docs/conf.py
+
    build:
       os: ubuntu-24.04
       tools:
@@ -469,14 +472,8 @@ Take a look at the following example:
             - asdf plugin add uv
             - asdf install uv latest
             - asdf global uv latest
-            - uv venv
          install:
-            - uv pip install -r requirements.txt
-         build:
-            html:
-               - uv run sphinx-build -T -b html docs $READTHEDOCS_OUTPUT/html
-
-MkDocs projects could use ``NO_COLOR=1 uv run mkdocs build --strict --site-dir $READTHEDOCS_OUTPUT/html`` instead.
+            - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --frozen --extra docs
 
 Update Conda version
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -468,12 +468,14 @@ Take a look at the following example:
       tools:
          python: "3.13"
       jobs:
-         create_environment:
+         post_system_dependencies:
             - asdf plugin add uv
             - asdf install uv latest
             - asdf global uv latest
+         create_environment:
+            - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
          install:
-            - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --frozen --extra docs
+            - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --frozen --group docs
 
 Update Conda version
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -26,7 +26,7 @@ The jobs where users can customize our default build process are:
    :header-rows: 1
    :widths: 25 75
 
-   * - Stepf
+   * - Step
      - Customizable jobs
    * - Checkout
      - ``post_checkout``


### PR DESCRIPTION
This provides a more succinct uv example using `uv sync`. It also has the benefit of not requiring overriding of any `build` steps.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11946.org.readthedocs.build/en/11946/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11946.org.readthedocs.build/en/11946/

<!-- readthedocs-preview dev end -->