### PR TITLE
Don't set a project-language on RTD links.

### DIFF
--- a/.github/workflows/pr-preview-links.yaml
+++ b/.github/workflows/pr-preview-links.yaml
@@ -16,6 +16,7 @@ jobs:
       - uses: readthedocs/actions/preview@v1
         with:
           project-slug: "docs"
+          project-language: ""
           message-template: |
             ---
             :books: Documentation previews :books:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,7 +5,7 @@ To build each project, the ``PROJECT`` environment variable is used.
 
 .. code:: console
 
-   $ make html  # build default project
+   $ make html  # build default project (user)
    $ PROJECT=dev make html  # build the dev project
 
 for more information read https://sphinx-multiproject.readthedocs.io/.


### PR DESCRIPTION
This is a hack to support version-only URLs
