### PR TITLE
Fix 404 pages?

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@ for more information read https://sphinx-multiproject.readthedocs.io/.
 
 import os
 import sys
+from urllib.parse import urlparse
 
 from multiproject.utils import get_project
 
@@ -195,6 +196,8 @@ notfound_context = {
 <p>Try using the search box or go to the homepage.</p>
 """,
 }
+notfound_urls_prefix = urlparse(os.environ.get("READTHEDOCS_CANONICAL_URL", "/")).path
+
 linkcheck_retries = 2
 linkcheck_timeout = 1
 linkcheck_workers = 10


### PR DESCRIPTION


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11958.org.readthedocs.build/en/11958/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11958.org.readthedocs.build/en/11958/

<!-- readthedocs-preview dev end -->