### PR TITLE
Always run sync_versions on the default queue

### DIFF
--- a/readthedocs/core/views/hooks.py
+++ b/readthedocs/core/views/hooks.py
@@ -102,10 +102,11 @@ def trigger_sync_versions(project):
             log.info("Skipping sync versions for project.", project_slug=project.slug)
             return None
 
-        options = {}
-        if project.build_queue:
-            # respect the queue for this project
-            options["queue"] = project.build_queue
+        # Don't use the build queue for sync_versions, since it shouldn't have any specific server requirements
+        # options = {}
+        # if project.build_queue:
+        #     # respect the queue for this project
+        #     options["queue"] = project.build_queue
 
         _, build_api_key = BuildAPIKey.objects.create_key(project=project)
 
@@ -117,7 +118,6 @@ def trigger_sync_versions(project):
         sync_repository_task.apply_async(
             args=[version.pk],
             kwargs={"build_api_key": build_api_key},
-            **options,
         )
         return version.slug
     except Exception:

--- a/readthedocs/core/views/hooks.py
+++ b/readthedocs/core/views/hooks.py
@@ -102,12 +102,6 @@ def trigger_sync_versions(project):
             log.info("Skipping sync versions for project.", project_slug=project.slug)
             return None
 
-        # Don't use the build queue for sync_versions, since it shouldn't have any specific server requirements
-        # options = {}
-        # if project.build_queue:
-        #     # respect the queue for this project
-        #     options["queue"] = project.build_queue
-
         _, build_api_key = BuildAPIKey.objects.create_key(project=project)
 
         log.debug(

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -1806,6 +1806,9 @@ class IntegrationsTests(TestCase):
     def test_sync_repository_custom_project_queue(
         self, sync_repository_task, trigger_build
     ):
+        """
+        Check that the custom queue isn't used for sync_repository_task.
+        """
         client = APIClient()
         self.project.build_queue = "specific-build-queue"
         self.project.save()
@@ -1836,7 +1839,7 @@ class IntegrationsTests(TestCase):
             kwargs={
                 "build_api_key": mock.ANY,
             },
-            queue="specific-build-queue",
+            # No queue
         )
 
     def test_github_webhook_for_branches(self, trigger_build):


### PR DESCRIPTION
This is so we can better support custom queues,
but not block sync versions on them.
