### PR TITLE
Build: don't trigger build if the project is spam

### DIFF
--- a/readthedocs/projects/querysets.py
+++ b/readthedocs/projects/querysets.py
@@ -89,7 +89,7 @@ class ProjectQuerySetBase(NoReprQuerySet, models.QuerySet):
         organization = project.organizations.first()
 
         if "readthedocsext.spamfighting" in settings.INSTALLED_APPS:
-            from readthedocsext.spamfighting.utils import spam_score
+            from readthedocsext.spamfighting.utils import spam_score  # noqa
 
             if spam_score(project) > settings.RTD_SPAM_THRESHOLD_DONT_SERVE_DOCS:
                 spam_project = True

--- a/readthedocs/projects/querysets.py
+++ b/readthedocs/projects/querysets.py
@@ -1,4 +1,5 @@
 """Project model QuerySet classes."""
+from django.conf import settings
 from django.db import models
 from django.db.models import Count, OuterRef, Prefetch, Q, Subquery
 
@@ -74,6 +75,7 @@ class ProjectQuerySetBase(NoReprQuerySet, models.QuerySet):
 
         * the Project shouldn't be marked as skipped.
         * any of the project's owners shouldn't be banned.
+        * the project shouldn't have a high spam score.
         * the organization associated to the project should not be disabled.
 
         :param project: project to be checked
@@ -82,9 +84,22 @@ class ProjectQuerySetBase(NoReprQuerySet, models.QuerySet):
         :returns: whether or not the project is active
         :rtype: bool
         """
+        spam_project = False
         any_owner_banned = any(u.profile.banned for u in project.users.all())
         organization = project.organizations.first()
-        if project.skip or any_owner_banned or (organization and organization.disabled):
+
+        if "readthedocsext.spamfighting" in settings.INSTALLED_APPS:
+            from readthedocsext.spamfighting.utils import spam_score
+
+            if spam_score(project) > settings.RTD_SPAM_THRESHOLD_DONT_SERVE_DOCS:
+                spam_project = True
+
+        if (
+            project.skip
+            or any_owner_banned
+            or (organization and organization.disabled)
+            or spam_project
+        ):
             return False
 
         return True


### PR DESCRIPTION
Use the DONT_SERVE_DOCS threshold to decide whether or not the build for this project should be triggered/skipped. This should avoid project already marked as spam to re-trigger builds and try to be re-classified as non-spam.