### PR TITLE
Add a doc for how to integrate search without other customization

### DIFF
--- a/docs/user/addons.rst
+++ b/docs/user/addons.rst
@@ -55,7 +55,7 @@ To configure your site to use :doc:`Read the Docs search </server-side-search/in
         :caption: javascript/readthedocs.js
 
         // TODO: Change me if needed
-        const selector = ".search-button__button";
+        const selector = "input[type='search']";
 
         document.addEventListener("DOMContentLoaded", function(event) {
             // Trigger Read the Docs' search addon instead of the default search

--- a/docs/user/addons.rst
+++ b/docs/user/addons.rst
@@ -43,6 +43,32 @@ Individual configuration options for each addon are available in :guilabel:`Sett
 #. In the left bar, go to :guilabel:`Addons`.
 #. Configure each Addon individually.
 
+Integrating with Addons
+-----------------------
+
+Integrate with Search as you type
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To configure your site to use :doc:`Read the Docs search </server-side-search/index>` instead of the default search, add the following block of JavaScript:
+
+    .. code-block:: js
+        :caption: javascript/readthedocs.js
+
+        // TODO: Change me if needed
+        selector = "input[type='search']";
+
+        document.addEventListener("DOMContentLoaded", function(event) {
+        // Trigger Read the Docs' search addon instead of the default search
+        document.querySelector(selector).addEventListener("focus", (e) => {
+                const event = new CustomEvent("readthedocs-search-show");
+                document.dispatchEvent(event);
+            });
+        });
+
+.. note::   Depending on the tool you are using,
+            you may need to change the selector to match the search input field.
+            You will also need to ensure that the JavaScript file is included in your documentation build.
+
 Addons data and customization
 -----------------------------
 

--- a/docs/user/addons.rst
+++ b/docs/user/addons.rst
@@ -49,17 +49,17 @@ Integrating with Addons
 Integrate with Search as you type
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To configure your site to use :doc:`Read the Docs search </server-side-search/index>` instead of the default search, add the following block of JavaScript:
+To configure your site to use :doc:`Read the Docs search </server-side-search/index>` instead of the default search, adapt the following block of JavaScript to your own site:
 
     .. code-block:: js
         :caption: javascript/readthedocs.js
 
         // TODO: Change me if needed
-        selector = "input[type='search']";
+        const selector = ".search-button__button";
 
         document.addEventListener("DOMContentLoaded", function(event) {
-        // Trigger Read the Docs' search addon instead of the default search
-        document.querySelector(selector).addEventListener("focus", (e) => {
+            // Trigger Read the Docs' search addon instead of the default search
+            document.querySelector(selector).addEventListener("click", (e) => {
                 const event = new CustomEvent("readthedocs-search-show");
                 document.dispatchEvent(event);
             });


### PR DESCRIPTION
We had a user asking about this,
so pulled it from the Mkdocs example to the high-level Addons docs.


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--11984.org.readthedocs.build/en/11984/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--11984.org.readthedocs.build/en/11984/

<!-- readthedocs-preview dev end -->