### PR TITLE
Requirements: unpin `requests` and `docker`

### DIFF
--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -28,11 +28,11 @@ billiard==3.6.4.0
     # via
     #   -r requirements/pip.txt
     #   celery
-boto3==1.36.16
+boto3==1.36.17
     # via
     #   -r requirements/pip.txt
     #   django-storages
-botocore==1.36.16
+botocore==1.36.17
     # via
     #   -r requirements/pip.txt
     #   boto3
@@ -85,7 +85,7 @@ cron-descriptor==1.4.5
     # via
     #   -r requirements/pip.txt
     #   django-celery-beat
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   -r requirements/pip.txt
     #   fido2
@@ -190,7 +190,7 @@ djangorestframework-jsonp==1.0.2
     # via -r requirements/pip.txt
 dnspython==2.7.0
     # via -r requirements/pip.txt
-docker==6.1.2
+docker==7.1.0
     # via -r requirements/pip.txt
 docutils==0.21.2
     # via -r requirements/pip.txt
@@ -260,7 +260,7 @@ lexid==2021.1006
     # via
     #   -r requirements/pip.txt
     #   bumpver
-lxml==5.3.0
+lxml==5.3.1
     # via
     #   -r requirements/pip.txt
     #   pyquery
@@ -282,7 +282,6 @@ packaging==24.2
     # via
     #   -r requirements/pip.txt
     #   djangorestframework-api-key
-    #   docker
     #   dparse
     #   gunicorn
 parso==0.8.4
@@ -362,7 +361,7 @@ redis==5.2.1
     #   django-cacheops
 regex==2024.11.6
     # via -r requirements/pip.txt
-requests==2.30.0
+requests==2.32.3
     # via
     #   -r requirements/pip.txt
     #   django-allauth
@@ -471,16 +470,12 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.29.1
+virtualenv==20.29.2
     # via -r requirements/pip.txt
 wcwidth==0.2.13
     # via
     #   -r requirements/pip.txt
     #   prompt-toolkit
-websocket-client==1.8.0
-    # via
-    #   -r requirements/pip.txt
-    #   docker
 xmlsec==1.3.14
     # via
     #   -r requirements/pip.txt

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -30,11 +30,11 @@ billiard==3.6.4.0
     # via
     #   -r requirements/pip.txt
     #   celery
-boto3==1.36.16
+boto3==1.36.17
     # via
     #   -r requirements/pip.txt
     #   django-storages
-botocore==1.36.16
+botocore==1.36.17
     # via
     #   -r requirements/pip.txt
     #   boto3
@@ -91,7 +91,7 @@ cron-descriptor==1.4.5
     # via
     #   -r requirements/pip.txt
     #   django-celery-beat
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   -r requirements/pip.txt
     #   fido2
@@ -200,7 +200,7 @@ djangorestframework-jsonp==1.0.2
     # via -r requirements/pip.txt
 dnspython==2.7.0
     # via -r requirements/pip.txt
-docker==6.1.2
+docker==7.1.0
     # via -r requirements/pip.txt
 docutils==0.21.2
     # via -r requirements/pip.txt
@@ -275,7 +275,7 @@ lexid==2021.1006
     # via
     #   -r requirements/pip.txt
     #   bumpver
-lxml==5.3.0
+lxml==5.3.1
     # via
     #   -r requirements/pip.txt
     #   pyquery
@@ -299,7 +299,6 @@ packaging==24.2
     # via
     #   -r requirements/pip.txt
     #   djangorestframework-api-key
-    #   docker
     #   dparse
     #   gunicorn
     #   pyproject-api
@@ -392,7 +391,7 @@ redis==5.2.1
     #   django-cacheops
 regex==2024.11.6
     # via -r requirements/pip.txt
-requests==2.30.0
+requests==2.32.3
     # via
     #   -r requirements/pip.txt
     #   django-allauth
@@ -504,7 +503,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.29.1
+virtualenv==20.29.2
     # via
     #   -r requirements/pip.txt
     #   tox
@@ -512,10 +511,6 @@ wcwidth==0.2.13
     # via
     #   -r requirements/pip.txt
     #   prompt-toolkit
-websocket-client==1.8.0
-    # via
-    #   -r requirements/pip.txt
-    #   docker
 wmctrl==0.5
     # via pdbpp
 xmlsec==1.3.14

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -38,10 +38,7 @@ django-safemigrate
 # Impersonate users in the Django admin for support.
 django-impersonate
 
-# The latest version of requests isn't compatible with the
-# version of the docker-py library we're using.
-# See https://github.com/docker/docker-py/issues/3256.
-requests==2.30.0
+requests
 requests-toolbelt
 slumber
 pyyaml
@@ -135,9 +132,7 @@ django-formtools
 # django.template.exceptions.TemplateDoesNotExist: bootstrap/field.html
 django-crispy-forms<2
 
-# Force to upgrade to a version with a fix for socket timeouts
-# https://docker-py.readthedocs.io/en/stable/change-log.html#bugfixes
-docker==6.1.2
+docker
 
 django-annoying
 djangorestframework-jsonp

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -17,9 +17,9 @@ async-timeout==5.0.1
     # via redis
 billiard==3.6.4.0
     # via celery
-boto3==1.36.16
+boto3==1.36.17
     # via django-storages
-botocore==1.36.16
+botocore==1.36.17
     # via
     #   boto3
     #   s3transfer
@@ -54,7 +54,7 @@ colorama==0.4.6
     # via bumpver
 cron-descriptor==1.4.5
     # via django-celery-beat
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   fido2
     #   pyjwt
@@ -150,7 +150,7 @@ djangorestframework-jsonp==1.0.2
     # via -r requirements/pip.in
 dnspython==2.7.0
     # via -r requirements/pip.in
-docker==6.1.2
+docker==7.1.0
     # via -r requirements/pip.in
 docutils==0.21.2
     # via -r requirements/pip.in
@@ -196,7 +196,7 @@ kombu==5.4.2
     # via celery
 lexid==2021.1006
     # via bumpver
-lxml==5.3.0
+lxml==5.3.1
     # via
     #   pyquery
     #   python3-saml
@@ -211,7 +211,6 @@ packaging==24.2
     # via
     #   -r requirements/pip.in
     #   djangorestframework-api-key
-    #   docker
     #   dparse
     #   gunicorn
 platformdirs==4.3.6
@@ -260,7 +259,7 @@ redis==5.2.1
     #   django-cacheops
 regex==2024.11.6
     # via -r requirements/pip.in
-requests==2.30.0
+requests==2.32.3
     # via
     #   -r requirements/pip.in
     #   django-allauth
@@ -339,12 +338,10 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.29.1
+virtualenv==20.29.2
     # via -r requirements/pip.in
 wcwidth==0.2.13
     # via prompt-toolkit
-websocket-client==1.8.0
-    # via docker
 xmlsec==1.3.14
     # via python3-saml
 

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -30,11 +30,11 @@ billiard==3.6.4.0
     # via
     #   -r requirements/pip.txt
     #   celery
-boto3==1.36.16
+boto3==1.36.17
     # via
     #   -r requirements/pip.txt
     #   django-storages
-botocore==1.36.16
+botocore==1.36.17
     # via
     #   -r requirements/pip.txt
     #   boto3
@@ -88,7 +88,7 @@ cron-descriptor==1.4.5
     # via
     #   -r requirements/pip.txt
     #   django-celery-beat
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   -r requirements/pip.txt
     #   fido2
@@ -197,7 +197,7 @@ djangorestframework-jsonp==1.0.2
     # via -r requirements/pip.txt
 dnspython==2.7.0
     # via -r requirements/pip.txt
-docker==6.1.2
+docker==7.1.0
     # via -r requirements/pip.txt
 docutils==0.21.2
     # via
@@ -269,7 +269,7 @@ lexid==2021.1006
     # via
     #   -r requirements/pip.txt
     #   bumpver
-lxml==5.3.0
+lxml==5.3.1
     # via
     #   -r requirements/pip.txt
     #   pyquery
@@ -289,7 +289,6 @@ packaging==24.2
     # via
     #   -r requirements/pip.txt
     #   djangorestframework-api-key
-    #   docker
     #   dparse
     #   gunicorn
     #   pytest
@@ -380,7 +379,7 @@ redis==5.2.1
     #   django-cacheops
 regex==2024.11.6
     # via -r requirements/pip.txt
-requests==2.30.0
+requests==2.32.3
     # via
     #   -r requirements/pip.txt
     #   django-allauth
@@ -500,16 +499,12 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.29.1
+virtualenv==20.29.2
     # via -r requirements/pip.txt
 wcwidth==0.2.13
     # via
     #   -r requirements/pip.txt
     #   prompt-toolkit
-websocket-client==1.8.0
-    # via
-    #   -r requirements/pip.txt
-    #   docker
 xmlsec==1.3.14
     # via
     #   -r requirements/pip.txt


### PR DESCRIPTION
They were pinned due to a bug, but it was fixed already.

closes https://github.com/readthedocs/readthedocs.org/issues/11367