### PR TITLE
Service: kwargs only when sending build statuses

### DIFF
--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -416,9 +416,9 @@ def send_build_status(build_pk, commit, status):
 
     for service in service_class.for_project(build.project):
         success = service.send_build_status(
-            build,
-            commit,
-            status,
+            build=build,
+            commit=commit,
+            status=status,
         )
         if success:
             log.debug("Build status report sent correctly.")

--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -86,7 +86,7 @@ class Service:
         """
         raise NotImplementedError
 
-    def send_build_status(self, build, commit, status):
+    def send_build_status(self, *, build, commit, status):
         """
         Create commit status for project.
 

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -406,7 +406,7 @@ class GitHubService(UserService):
 
         return (False, resp)
 
-    def send_build_status(self, build, commit, status):
+    def send_build_status(self, *, build, commit, status):
         """
         Create GitHub commit status for project.
 

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -495,7 +495,7 @@ class GitLabService(UserService):
 
         return (False, resp)
 
-    def send_build_status(self, build, commit, status):
+    def send_build_status(self, *, build, commit, status):
         """
         Create GitLab commit status for project.
 

--- a/readthedocs/rtd_tests/tests/test_celery.py
+++ b/readthedocs/rtd_tests/tests/test_celery.py
@@ -103,9 +103,9 @@ class TestCeleryBuilding(TestCase):
         )
 
         send_build_status.assert_called_once_with(
-            external_build,
-            external_build.commit,
-            BUILD_STATUS_SUCCESS,
+            build=external_build,
+            commit=external_build.commit,
+            status=BUILD_STATUS_SUCCESS,
         )
         self.assertEqual(Notification.objects.count(), 0)
 
@@ -123,9 +123,9 @@ class TestCeleryBuilding(TestCase):
         )
 
         send_build_status.assert_called_once_with(
-            external_build,
-            external_build.commit,
-            BUILD_STATUS_SUCCESS,
+            build=external_build,
+            commit=external_build.commit,
+            status=BUILD_STATUS_SUCCESS,
         )
         self.assertEqual(Notification.objects.count(), 0)
 
@@ -176,9 +176,9 @@ class TestCeleryBuilding(TestCase):
         )
 
         send_build_status.assert_called_once_with(
-            external_build,
-            external_build.commit,
-            BUILD_STATUS_SUCCESS,
+            build=external_build,
+            commit=external_build.commit,
+            status=BUILD_STATUS_SUCCESS,
         )
         self.assertEqual(Notification.objects.count(), 0)
 
@@ -196,9 +196,9 @@ class TestCeleryBuilding(TestCase):
         )
 
         send_build_status.assert_called_once_with(
-            external_build,
-            external_build.commit,
-            BUILD_STATUS_SUCCESS,
+            build=external_build,
+            commit=external_build.commit,
+            status=BUILD_STATUS_SUCCESS,
         )
         self.assertEqual(Notification.objects.count(), 0)
 

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -305,7 +305,9 @@ class GitHubOAuthTests(TestCase):
     def test_send_build_status_successful(self, session, mock_logger):
         session.post.return_value.status_code = 201
         success = self.service.send_build_status(
-            self.external_build, self.external_build.commit, BUILD_STATUS_SUCCESS
+            build=self.external_build,
+            commit=self.external_build.commit,
+            status=BUILD_STATUS_SUCCESS,
         )
 
         self.assertTrue(success)
@@ -319,7 +321,9 @@ class GitHubOAuthTests(TestCase):
     def test_send_build_status_404_error(self, session, mock_logger):
         session.post.return_value.status_code = 404
         success = self.service.send_build_status(
-            self.external_build, self.external_build.commit, BUILD_STATUS_SUCCESS
+            build=self.external_build,
+            commit=self.external_build.commit,
+            status=BUILD_STATUS_SUCCESS,
         )
 
         self.assertFalse(success)
@@ -333,7 +337,9 @@ class GitHubOAuthTests(TestCase):
     def test_send_build_status_value_error(self, session, mock_logger):
         session.post.side_effect = ValueError
         success = self.service.send_build_status(
-            self.external_build, self.external_build.commit, BUILD_STATUS_SUCCESS
+            build=self.external_build,
+            commit=self.external_build.commit,
+            status=BUILD_STATUS_SUCCESS,
         )
 
         self.assertFalse(success)
@@ -1163,7 +1169,9 @@ class GitLabOAuthTests(TestCase):
         repo_id().return_value = "9999"
 
         success = self.service.send_build_status(
-            self.external_build, self.external_build.commit, BUILD_STATUS_SUCCESS
+            build=self.external_build,
+            commit=self.external_build.commit,
+            status=BUILD_STATUS_SUCCESS,
         )
 
         self.assertTrue(success)
@@ -1180,7 +1188,9 @@ class GitLabOAuthTests(TestCase):
         repo_id.return_value = "9999"
 
         success = self.service.send_build_status(
-            self.external_build, self.external_build.commit, BUILD_STATUS_SUCCESS
+            build=self.external_build,
+            commit=self.external_build.commit,
+            status=BUILD_STATUS_SUCCESS,
         )
 
         self.assertFalse(success)
@@ -1197,7 +1207,9 @@ class GitLabOAuthTests(TestCase):
         repo_id().return_value = "9999"
 
         success = self.service.send_build_status(
-            self.external_build, self.external_build.commit, BUILD_STATUS_SUCCESS
+            build=self.external_build,
+            commit=self.external_build.commit,
+            status=BUILD_STATUS_SUCCESS,
         )
 
         self.assertFalse(success)


### PR DESCRIPTION
A small refactor extracted from https://github.com/readthedocs/readthedocs.org/pull/11942