### PR TITLE
File Tree Diff: small documentation to mention the file selector

### DIFF
--- a/docs/user/visual-diff.rst
+++ b/docs/user/visual-diff.rst
@@ -20,7 +20,8 @@ Once enabled, a new UI element appears at the top-right of the page showing a dr
 all the files that have changed between the base version (e.g. ``latest``) and the current pull request build.
 
 You can select any of those files from the dropdown to jump directly into that page.
-Once there, you can toggle it on/off by pressing the :guilabel:`Show diff` link from the UI element to show all the chunks and their differences highlighted with red/green background colors.
+Once there, you can toggle it on/off by pressing the :guilabel:`Show diff` link from the UI element, or pressing the `d` key if you have hotkeys enabled.
+Visual diff will show all the sections that have changed and their differences highlighted with red/green background colors.
 Besides, you can jump between each of these chunks by clinking on the up/down arrows.
 
 All the available configuration for the visual diff addon can be found under :guilabel:`Settings > Addons > Visual diff` in the :term:`dashboard`.

--- a/docs/user/visual-diff.rst
+++ b/docs/user/visual-diff.rst
@@ -12,18 +12,29 @@ and focus your review on what has changed in the current page.
 
    Example of Visual diff
 
-Enabling Visual diff
---------------------
+Using Visual diff
+-----------------
 
-Visual diff is only enabled on pull request builds,
-and can be toggled on and off with the ``d`` hotkey.
+Visual diff is enabled by default and it's only available on pull request builds.
+Once enabled, a new UI element appears at the top-right of the page showing a dropdown selector containing
+all the files that have changed between the base version (e.g. ``latest``) and the current pull request build.
+
+You can select any of those files from the dropdown to jump directly into that page.
+Once there, you can toggle it on/off by pressing the :guilabel:`Show diff` link from the UI element to show all the chunks and their differences highlighted with red/green background colors.
+Besides, you can jump between each of these chunks by clinking on the up/down arrows.
+
+All the available configuration for the visual diff addon can be found under :guilabel:`Settings > Addons > Visual diff` in the :term:`dashboard`.
+
 
 Troubleshooting Visual diff
 ---------------------------
 
-Visual diff only works if there are changes on the page,
+Visual diff only works when we detect changes on the page,
 so ensure you are on a page that has changed in the current pull request.
 
-There are also some known issues that currently don't display properly:
+There are also some known issues that currently don't display properly.
+We are working to improve the UX, but so far we've found the following issues:
 
 * **Tables** are shown to have changes when they may not have changed. This is due to do subtly in how HTML tables are rendered, and will be fixed in a future version.
+* **Invisible changes** sometimes are marked as diff due than the underlying HTML changed, but there is no visual change. This could happen if the URL of a link changed, for example.
+* **Chunks background is incorrect** when we are unable to detect the correct main parent element for the chunk.

--- a/docs/user/visual-diff.rst
+++ b/docs/user/visual-diff.rst
@@ -22,7 +22,7 @@ all the files that have changed between the base version (e.g. ``latest``) and t
 You can select any of those files from the dropdown to jump directly into that page.
 Once there, you can toggle it on/off by pressing the :guilabel:`Show diff` link from the UI element, or pressing the `d` key if you have hotkeys enabled.
 Visual diff will show all the sections that have changed and their differences highlighted with red/green background colors.
-Besides, you can jump between each of these chunks by clinking on the up/down arrows.
+Then you can jump between each of these chunks by clinking on the up/down arrows.
 
 All the available configuration for the visual diff addon can be found under :guilabel:`Settings > Addons > Visual diff` in the :term:`dashboard`.
 

--- a/docs/user/visual-diff.rst
+++ b/docs/user/visual-diff.rst
@@ -37,5 +37,5 @@ There are also some known issues that currently don't display properly.
 We are working to improve the UX, but so far we've found the following issues:
 
 * **Tables** are shown to have changes when they may not have changed. This is due to do subtly in how HTML tables are rendered, and will be fixed in a future version.
-* **Invisible changes** sometimes are marked as diff due than the underlying HTML changed, but there is no visual change. This could happen if the URL of a link changed, for example.
+* **Invisible changes** sometimes are marked as diff due than the underlying HTML changing, but there is no visual change. This could happen if the URL of a link changed, for example.
 * **Chunks background is incorrect** when we are unable to detect the correct main parent element for the chunk.


### PR DESCRIPTION
Briefly explanation about how to use visual doc diff.

Closes #12009

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--12011.org.readthedocs.build/en/12011/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--12011.org.readthedocs.build/en/12011/

<!-- readthedocs-preview dev end -->