### PR TITLE
Git service: add method to sync user access to remote repositories

### DIFF
--- a/readthedocs/oauth/management/commands/reconnect_remoterepositories.py
+++ b/readthedocs/oauth/management/commands/reconnect_remoterepositories.py
@@ -1,13 +1,13 @@
 import json
 
-from django.db.models import Q, Subquery
 from django.core.management.base import BaseCommand
+from django.db.models import Q, Subquery
 
 from readthedocs.oauth.models import RemoteRepository
 from readthedocs.oauth.services import registry
 from readthedocs.oauth.services.base import SyncServiceError
-from readthedocs.projects.models import Project
 from readthedocs.organizations.models import Organization
+from readthedocs.projects.models import Project
 
 
 class Command(BaseCommand):
@@ -41,11 +41,12 @@ class Command(BaseCommand):
     def _force_owners_social_resync(self, organization):
         for owner in organization.owners.all():
             for service_cls in registry:
-                for service in service_cls.for_user(owner):
-                    try:
-                        service.sync()
-                    except SyncServiceError:
-                        print(f"Service {service} failed while syncing. Skipping...")
+                try:
+                    service_cls.sync_user_access(owner)
+                except SyncServiceError:
+                    print(
+                        f"Service {service_cls.allauth_provider.name} failed while syncing. Skipping..."
+                    )
 
     def _connect_repositories(self, organization, no_dry_run, only_owners):
         connected_projects = []

--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -160,6 +160,7 @@ class UserService(Service):
     def sync_user_access(cls, user):
         """
         Sync the user's access to the provider repositories and organizations.
+
         Since UserService makes use of the user's OAuth token,
         we can just sync the user's repositories in order to
         update the user access to repositories and organizations.

--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -164,6 +164,8 @@ class UserService(Service):
         Since UserService makes use of the user's OAuth token,
         we can just sync the user's repositories in order to
         update the user access to repositories and organizations.
+
+        :raises SyncServiceError: if the access token is invalid or revoked
         """
         for service in cls.for_user(user):
             service.sync()

--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -40,13 +40,18 @@ class Service:
     supports_build_status = False
 
     @classmethod
-    def for_project(self, project):
+    def for_project(cls, project):
         """Return an iterator of services that can be used for the project."""
         raise NotImplementedError
 
     @classmethod
-    def for_user(self, user):
+    def for_user(cls, user):
         """Return an iterator of services that belong to the user."""
+        raise NotImplementedError
+
+    @classmethod
+    def sync_user_access(cls, user):
+        """Sync the user's access to the provider's repositories and organizations."""
         raise NotImplementedError
 
     def sync(self):
@@ -150,6 +155,17 @@ class UserService(Service):
         )
         for account in accounts:
             yield cls(user=user, account=account)
+
+    @classmethod
+    def sync_user_access(cls, user):
+        """
+        Sync the user's access to the provider repositories and organizations.
+        Since UserService makes use of the user's OAuth token,
+        we can just sync the user's repositories in order to
+        update the user access to repositories and organizations.
+        """
+        for service in cls.for_user(user):
+            service.sync()
 
     @cached_property
     def session(self):

--- a/readthedocs/oauth/tasks.py
+++ b/readthedocs/oauth/tasks.py
@@ -45,11 +45,11 @@ def sync_remote_repositories(user_id):
 
     failed_services = set()
     for service_cls in registry:
-        for service in service_cls.for_user(user):
-            try:
-                service.sync()
-            except SyncServiceError:
-                failed_services.add(service_cls.allauth_provider.name)
+        try:
+            service_cls.sync_user_access(user)
+        except SyncServiceError:
+            failed_services.add(service_cls.allauth_provider.name)
+
     if failed_services:
         raise SyncServiceError(
             SyncServiceError.INVALID_OR_REVOKED_ACCESS_TOKEN.format(


### PR DESCRIPTION
Extracted from
https://github.com/readthedocs/readthedocs.org/pull/11942.

Instead of getting a service for the user and manually syncing the repositories, this abstracts syncing the access to the repositories in another method. This is since with GH apps, syncing the access to the repositories is done in a different way.