### PR TITLE
Fix mkdocs link

### DIFF
--- a/docs/user/intro/doctools.rst
+++ b/docs/user/intro/doctools.rst
@@ -14,10 +14,10 @@ Below is a list of popular documentation tools that you can use to write your do
 
 .. grid:: 2
 
-    .. grid-item-card::  Material for MkDocs
+    .. grid-item-card::  MkDocs
         :link: mkdocs.html
 
-        Material for MkDocs is a powerful documentation framework on top of MkDocs.
+        MkDocs is a powerful documentation tool for markdown.
 
         Supported formats
              :bdg-success:`md`


### PR DESCRIPTION


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--12019.org.readthedocs.build/en/12019/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--12019.org.readthedocs.build/en/12019/

<!-- readthedocs-preview dev end -->