### PR TITLE
Update uv build-customization example

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -469,14 +469,10 @@ Take a look at the following example:
             - asdf plugin add uv
             - asdf install uv latest
             - asdf global uv latest
-            - uv venv
+            - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --all-extras --group docs
          install:
-            - uv pip install -r requirements.txt
-         build:
-            html:
-               - uv run sphinx-build -T -b html docs $READTHEDOCS_OUTPUT/html
+            - "true" # or, if necessary: uv pip install -r requirements.txt
 
-MkDocs projects could use ``NO_COLOR=1 uv run mkdocs build --strict --site-dir $READTHEDOCS_OUTPUT/html`` instead.
 
 Update Conda version
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Avoid having to tinker with build-steps for uv setup by telling it to set up the environment where readthedocs expects it and then leaving activation and build commands up to readthedocs defaults.

Example run: https://app.readthedocs.org/projects/pandas-indexing/builds/27353735/