### PR TITLE
Remote repository: don't stop at first error while syncing

### DIFF
--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -163,8 +163,16 @@ class UserService(Service):
 
         :raises SyncServiceError: if the access token is invalid or revoked
         """
+        has_error = False
         for service in cls.for_user(user):
-            service.sync()
+            try:
+                service.sync()
+            except SyncServiceError:
+                # Don't stop the sync if one service account fails,
+                # as we should try to sync all accounts.
+                has_error = True
+        if has_error:
+            raise SyncServiceError()
 
     @cached_property
     def session(self):

--- a/readthedocs/rtd_tests/tests/test_oauth_tasks.py
+++ b/readthedocs/rtd_tests/tests/test_oauth_tasks.py
@@ -116,3 +116,23 @@ class SyncRemoteRepositoriesTests(TestCase):
             args=[self.user.pk],
             countdown=0,
         )
+
+    @patch("readthedocs.oauth.services.github.GitHubService.sync")
+    @patch("readthedocs.oauth.services.gitlab.GitLabService.sync")
+    @patch("readthedocs.oauth.services.bitbucket.BitbucketService.sync")
+    def test_sync_dont_stop_if_one_service_account_of_same_type_fails(
+        self, sync_bb, sync_gl, sync_gh
+    ):
+        get(
+            SocialAccount,
+            user=self.user,
+            provider=GitHubOAuth2Adapter.provider_id,
+        )
+        sync_gh.side_effect = SyncServiceError
+        r = sync_remote_repositories(self.user.pk)
+        assert "GitHub" in r["error"]
+        assert "Bitbucket" not in r["error"]
+        assert "GitLab" not in r["error"]
+        sync_bb.assert_called_once()
+        sync_gl.assert_called_once()
+        assert sync_gh.call_count == 2


### PR DESCRIPTION
In https://github.com/readthedocs/readthedocs.org/pull/12016/ now all accounts from the same provider linked to the user are grouped together to do the sync, if one of those accounts fails to sync, we are skipping the rest of the accounts from the same provider.