### PR TITLE
Subscriptions: improve subscription detection and respect never_disable

### DIFF
--- a/readthedocs/organizations/models.py
+++ b/readthedocs/organizations/models.py
@@ -145,19 +145,28 @@ class Organization(models.Model):
     def get_stripe_subscription(self):
         # Active subscriptions take precedence over non-active subscriptions,
         # otherwise we return the most recently created subscription.
-        active_subscriptions = self.stripe_customer.subscriptions.filter(
-            status=SubscriptionStatus.active
-        )
-        if active_subscriptions:
-            if active_subscriptions.count() > 1:
-                # NOTE: this should never happen, unless we manually
-                # created another subscription for the user or if there
-                # is a bug in our code.
-                log.exception(
-                    "Organization has more than one active subscription",
-                    organization_slug=self.slug,
-                )
-            return active_subscriptions.order_by("created").last()
+        status_priority = [
+            SubscriptionStatus.active,
+            SubscriptionStatus.trialing,
+            SubscriptionStatus.past_due,
+            SubscriptionStatus.unpaid,
+        ]
+        for status in status_priority:
+            subscriptions = self.stripe_customer.subscriptions.filter(status=status)
+            if subscriptions.exists():
+                if subscriptions.count() > 1:
+                    # NOTE: this should never happen, unless we manually
+                    # created another subscription for the user or if there
+                    # is a bug in our code.
+                    log.exception(
+                        "Organization has more than one active subscription",
+                        organization_slug=self.slug,
+                        subscription_status=status,
+                    )
+
+                return subscriptions.order_by("created").last()
+
+        # Fall back to the most recently created subscription.
         return self.stripe_customer.subscriptions.order_by("created").last()
 
     def get_absolute_url(self):

--- a/readthedocs/organizations/models.py
+++ b/readthedocs/organizations/models.py
@@ -162,7 +162,7 @@ class Organization(models.Model):
                     # created another subscription for the user or if there
                     # is a bug in our code.
                     log.exception(
-                        "Organization has more than one active subscription",
+                        "Organization has more than one subscription with the same status",
                         organization_slug=self.slug,
                         subscription_status=status,
                     )

--- a/readthedocs/subscriptions/event_handlers.py
+++ b/readthedocs/subscriptions/event_handlers.py
@@ -127,9 +127,13 @@ def subscription_updated_event(event):
         log.info("Re-enabling organization.", organization_slug=organization.slug)
         organization.disabled = False
 
-    if stripe_subscription.status not in (
-        SubscriptionStatus.active,
-        SubscriptionStatus.trialing,
+    if (
+        stripe_subscription.status
+        not in (
+            SubscriptionStatus.active,
+            SubscriptionStatus.trialing,
+        )
+        and not organization.never_disable
     ):
         log.info(
             "Organization disabled due its subscription is not active anymore.",
@@ -147,7 +151,7 @@ def subscription_updated_event(event):
             organization_slug=organization.slug,
             old_stripe_subscription_id=old_subscription_id,
         )
-        organization.stripe_subscription = stripe_subscription
+        organization.stripe_subscription = new_stripe_subscription
 
     organization.save()
 
@@ -181,6 +185,13 @@ def subscription_canceled(event):
     organization = getattr(stripe_subscription.customer, "rtd_organization", None)
     if not organization:
         log.error("Subscription isn't attached to an organization")
+        return
+
+    if organization.never_disable:
+        log.info(
+            "Organization can't be disabled, skipping notification.",
+            organization_slug=organization.slug,
+        )
         return
 
     log.bind(organization_slug=organization.slug)

--- a/readthedocs/subscriptions/event_handlers.py
+++ b/readthedocs/subscriptions/event_handlers.py
@@ -127,19 +127,18 @@ def subscription_updated_event(event):
         log.info("Re-enabling organization.", organization_slug=organization.slug)
         organization.disabled = False
 
-    if (
-        stripe_subscription.status
-        not in (
-            SubscriptionStatus.active,
-            SubscriptionStatus.trialing,
-        )
-        and not organization.never_disable
-    ):
-        log.info(
-            "Organization disabled due its subscription is not active anymore.",
-            organization_slug=organization.slug,
-        )
-        organization.disabled = True
+    if stripe_subscription.status not in (SubscriptionStatus.active, SubscriptionStatus.trialing):
+        if organization.never_disable:
+            log.info(
+                "Organization can't be disabled, skipping deactivation.",
+                organization_slug=organization.slug,
+            )
+        else:
+            log.info(
+                "Organization disabled due its subscription is not active anymore.",
+                organization_slug=organization.slug,
+            )
+            organization.disabled = True
 
     new_stripe_subscription = organization.get_stripe_subscription()
     if organization.stripe_subscription != new_stripe_subscription:


### PR DESCRIPTION
- Updated the `get_stripe_subscription` method to prioritize certain subscription statuses over others, so unpaid subscriptions are still visible to the user.
- Our webhooks now respect the never_disable setting from the organization, so we don't disable some orgs automatically, we also skip sending notifications. We should mark this attribute only after being contacted by the owners, and marked as false once the issue has been resolved, so we still send notifications next time they don't pay on time.