### PR TITLE
Requirements: pin and downgrade `xmlsec`

### DIFF
--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -476,7 +476,7 @@ wcwidth==0.2.13
     # via
     #   -r requirements/pip.txt
     #   prompt-toolkit
-xmlsec==1.3.15
+xmlsec==1.3.14
     # via
     #   -r requirements/pip.txt
     #   python3-saml

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -513,7 +513,7 @@ wcwidth==0.2.13
     #   prompt-toolkit
 wmctrl==0.5
     # via pdbpp
-xmlsec==1.3.15
+xmlsec==1.3.14
     # via
     #   -r requirements/pip.txt
     #   python3-saml

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -147,3 +147,10 @@ django-cacheops
 
 # Used by Addons for sorting patterns
 bumpver
+
+
+# xmlsec is a dependecy from python3-saml which is required by django-allauth.
+# We have to pin it because the underlying `libxml2-dev` package installed at
+# system level is incompatible with the Python version
+# https://github.com/xmlsec/python-xmlsec/issues/324
+xmlsec==1.3.14

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -341,8 +341,10 @@ virtualenv==20.29.3
     # via -r requirements/pip.in
 wcwidth==0.2.13
     # via prompt-toolkit
-xmlsec==1.3.15
-    # via python3-saml
+xmlsec==1.3.14
+    # via
+    #   -r requirements/pip.in
+    #   python3-saml
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -505,7 +505,7 @@ wcwidth==0.2.13
     # via
     #   -r requirements/pip.txt
     #   prompt-toolkit
-xmlsec==1.3.15
+xmlsec==1.3.14
     # via
     #   -r requirements/pip.txt
     #   python3-saml


### PR DESCRIPTION
xmlsec is a dependecy from python3-saml which is required by django-allauth. We have to pin it because the underlying `libxml2-dev` package installed at system level is incompatible with the Python version

More info https://github.com/xmlsec/python-xmlsec/issues/324