### PR TITLE
pip tools: use Python 3.12

### DIFF
--- a/.github/workflows/pip-tools.yaml
+++ b/.github/workflows/pip-tools.yaml
@@ -29,7 +29,7 @@ jobs:
         run: git submodule update --init
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install "pg_config" requirement
         run: sudo apt-get install libpq-dev


### PR DESCRIPTION
Upgrade version of Python used for pip-tools.