### PR TITLE
Small improvements on PR previews handling

### DIFF
--- a/readthedocs/core/views/hooks.py
+++ b/readthedocs/core/views/hooks.py
@@ -173,11 +173,7 @@ def close_external_version(project, version_data):
     :rtype: str
     """
     external_version = (
-        project.versions(manager=EXTERNAL)
-        .filter(
-            verbose_name=version_data.id,
-        )
-        .first()
+        project.versions(manager=EXTERNAL).filter(verbose_name=version_data.id).first()
     )
 
     if external_version:

--- a/readthedocs/core/views/hooks.py
+++ b/readthedocs/core/views/hooks.py
@@ -150,6 +150,7 @@ def get_or_create_external_version(project, version_data):
         external_version.identifier = version_data.commit
         # If the PR was previously closed it was marked as closed
         external_version.state = EXTERNAL_VERSION_STATE_OPEN
+        external_version.active = True
         external_version.save()
         log.info(
             "External version updated.",
@@ -175,7 +176,6 @@ def close_external_version(project, version_data):
         project.versions(manager=EXTERNAL)
         .filter(
             verbose_name=version_data.id,
-            identifier=version_data.commit,
         )
         .first()
     )


### PR DESCRIPTION
- When a PR preview is re-opened, make sure to reset its status as active
- When closing a PR we don't need to take into consideration the commit, we act based on the ID only.

Extracted from https://github.com/readthedocs/readthedocs.org/pull/11942/