### PR TITLE
Revert "Requirements: use xmlsec with `--no-binary` option"

### DIFF
--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile --output-file=requirements/deploy.txt requirements/deploy.in
 #
---no-binary xmlsec
-
 amqp==5.3.1
     # via
     #   -r requirements/pip.txt

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile --output-file=requirements/docker.txt requirements/docker.in
 #
---no-binary xmlsec
-
 amqp==5.3.1
     # via
     #   -r requirements/pip.txt

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -150,8 +150,7 @@ bumpver
 
 
 # xmlsec is a dependecy from python3-saml which is required by django-allauth.
-# We have to use --no-binary to build it using `libxml2-dev` package installed at
-# system level. Otherwise, it fails saying there is a version mismatch
+# We have to pin it because the underlying `libxml2-dev` package installed at
+# system level is incompatible with the Python version
 # https://github.com/xmlsec/python-xmlsec/issues/324
-# https://github.com/lxml/lxml/blob/0eb4f0029497957e58a9f15280b3529bdb18d117/doc/FAQ.txt#L623
---no-binary=xmlsec
+xmlsec==1.3.14

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile --output-file=requirements/pip.txt requirements/pip.in
 #
---no-binary xmlsec
-
 amqp==5.3.1
     # via kombu
 annotated-types==0.7.0

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile --output-file=requirements/testing.txt requirements/testing.in
 #
---no-binary xmlsec
-
 alabaster==1.0.0
     # via sphinx
 amqp==5.3.1


### PR DESCRIPTION
This breaks importing xmlsec again

Reverts readthedocs/readthedocs.org#12056