### PR TITLE
Remove cacheops

### DIFF
--- a/dockerfiles/settings/proxito.py
+++ b/dockerfiles/settings/proxito.py
@@ -6,12 +6,6 @@ from .docker_compose import DockerBaseSettings
 class ProxitoDevSettings(CommunityProxitoSettingsMixin, DockerBaseSettings):
     DONT_HIT_DB = False
 
-    # Disabled because of issues like
-    # ResponseError: Error running script (call to f_1880dea5c524f6a37a650f715fa630416a2fe1fd):
-    # @user_script:50: @user_script: 50: Wrong number of args calling Redis command From Lua script
-    # (this issue goes away after a few reloads)
-    CACHEOPS_ENABLED = False
-
     # El Proxito does not have django-debug-toolbar installed
     @property
     def DEBUG_TOOLBAR_CONFIG(self):

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -306,7 +306,6 @@ class CommunityBaseSettings(Settings):
             # but we still need to include it even when not enabled, since it has objects
             # related to the user model that Django needs to know about when deleting users.
             "impersonate",
-            "cacheops",
         ]
         if ext:
             apps.append("readthedocsext.cdn")
@@ -1044,44 +1043,5 @@ class CommunityBaseSettings(Settings):
     RTD_SPAM_THRESHOLD_REMOVE_FROM_SEARCH_INDEX = 500
     RTD_SPAM_THRESHOLD_DELETE_PROJECT = 1000
     RTD_SPAM_MAX_SCORE = 9999
-
-    CACHEOPS_ENABLED = False
-    CACHEOPS_TIMEOUT = 60 * 60  # seconds
-    CACHEOPS_OPS = {"get", "fetch"}
-    CACHEOPS_DEGRADE_ON_FAILURE = True
-    CACHEOPS = {
-        # readthedocs.projects.*
-        "projects.project": {
-            "ops": CACHEOPS_OPS,
-            "timeout": CACHEOPS_TIMEOUT,
-        },
-        "projects.feature": {
-            "ops": CACHEOPS_OPS,
-            "timeout": CACHEOPS_TIMEOUT,
-        },
-        "projects.projectrelationship": {
-            "ops": CACHEOPS_OPS,
-            "timeout": CACHEOPS_TIMEOUT,
-        },
-        "projects.domain": {
-            "ops": CACHEOPS_OPS,
-            "timeout": CACHEOPS_TIMEOUT,
-        },
-        # readthedocs.builds.*
-        "builds.version": {
-            "ops": CACHEOPS_OPS,
-            "timeout": CACHEOPS_TIMEOUT,
-        },
-        # readthedocs.organizations.*
-        "organizations.organization": {
-            "ops": CACHEOPS_OPS,
-            "timeout": CACHEOPS_TIMEOUT,
-        },
-        # readthedocs.subscriptions.*
-        "subscriptions.planfeature": {
-            "ops": CACHEOPS_OPS,
-            "timeout": CACHEOPS_TIMEOUT,
-        },
-    }
 
     S3_PROVIDER = "AWS"

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -169,7 +169,6 @@ class DockerBaseSettings(CommunityBaseSettings):
         },
     }
 
-    CACHEOPS_REDIS = f"redis://:redispassword@cache:6379/1"
     BROKER_URL = f"redis://:redispassword@cache:6379/0"
 
     CELERY_ALWAYS_EAGER = False

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -129,8 +129,6 @@ django-annoying==0.10.8
     # via -r requirements/pip.txt
 django-autoslug==1.9.9
     # via -r requirements/pip.txt
-django-cacheops==7.1
-    # via -r requirements/pip.txt
 django-celery-beat==2.7.0
     # via -r requirements/pip.txt
 django-cors-headers==4.7.0

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -139,8 +139,6 @@ django-annoying==0.10.8
     # via -r requirements/pip.txt
 django-autoslug==1.9.9
     # via -r requirements/pip.txt
-django-cacheops==7.1
-    # via -r requirements/pip.txt
 django-celery-beat==2.7.0
     # via -r requirements/pip.txt
 django-cors-headers==4.7.0

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -145,8 +145,6 @@ dparse
 
 gunicorn
 
-django-cacheops
-
 # Used by Addons for sorting patterns
 bumpver
 

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -93,8 +93,6 @@ django-annoying==0.10.8
     # via -r requirements/pip.in
 django-autoslug==1.9.9
     # via -r requirements/pip.in
-django-cacheops==7.1
-    # via -r requirements/pip.in
 django-celery-beat==2.7.0
     # via -r requirements/pip.in
 django-cors-headers==4.7.0

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -134,8 +134,6 @@ django-annoying==0.10.8
     # via -r requirements/pip.txt
 django-autoslug==1.9.9
     # via -r requirements/pip.txt
-django-cacheops==7.1
-    # via -r requirements/pip.txt
 django-celery-beat==2.7.0
     # via -r requirements/pip.txt
 django-cors-headers==4.7.0


### PR DESCRIPTION
Looks like we never ended up using this dependency. Ref https://github.com/readthedocs/readthedocs.org/pull/10075.