### PR TITLE
Requirements: pin newrelic

### DIFF
--- a/requirements/deploy.in
+++ b/requirements/deploy.in
@@ -4,6 +4,8 @@
 
 structlog-sentry
 
-newrelic
+# Pinned due to a bug in 10.8.1
+# See https://github.com/newrelic/newrelic-python-agent/issues/1347
+newrelic==10.7.0
 
 ipython

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -264,7 +264,7 @@ markdown==3.7
     # via -r requirements/pip.txt
 matplotlib-inline==0.1.7
     # via ipython
-newrelic==10.8.1
+newrelic==10.7.0
     # via -r requirements/deploy.in
 oauthlib==3.2.2
     # via


### PR DESCRIPTION
There is a bug in New Relic that breaks Celery/Kombu. See https://github.com/newrelic/newrelic-python-agent/issues/1347