### PR TITLE
Don't set secret key on builders

### DIFF
--- a/dockerfiles/settings/build.py
+++ b/dockerfiles/settings/build.py
@@ -7,6 +7,10 @@ class BuildDevSettings(DockerBaseSettings):
         return {}
 
     DONT_HIT_DB = True
-
+    SHOW_DEBUG_TOOLBAR = False
+    # The secret key is not needed from the builders.
+    # If you get an error about it missing, you may be doing
+    # something that shouldn't be done from the builders.
+    SECRET_KEY = None
 
 BuildDevSettings.load_settings(__name__)


### PR DESCRIPTION
Did a test locally, and builders work correctly, any attempt to use the secret key will raise an error, since it's empty. There is a PR in ops to remove it from there in production (wish we had settings for builders in this repo instead... a man can dream).

Also, we don't need the debug toolbar in the builders, since they aren't exposed as web service.