### PR TITLE
Add migration for GitHub App

### DIFF
--- a/readthedocs/oauth/migrate.py
+++ b/readthedocs/oauth/migrate.py
@@ -1,0 +1,329 @@
+"""This module contains the logic to help users migrate from the GitHub OAuth App to the GitHub App."""
+
+from dataclasses import dataclass
+
+from allauth.socialaccount.models import SocialAccount
+from allauth.socialaccount.providers.github.provider import GitHubProvider
+from django.conf import settings
+
+from readthedocs.allauth.providers.githubapp.provider import GitHubAppProvider
+from readthedocs.core.permissions import AdminPermission
+from readthedocs.integrations.models import Integration
+from readthedocs.oauth.constants import GITHUB
+from readthedocs.oauth.constants import GITHUB_APP
+from readthedocs.oauth.models import GitHubAccountType
+from readthedocs.oauth.models import RemoteRepository
+from readthedocs.oauth.services import GitHubAppService
+from readthedocs.oauth.services import GitHubService
+from readthedocs.projects.models import Project
+
+
+@dataclass
+class GitHubAccountTarget:
+    login: str
+    id: int
+    type: GitHubAccountType
+
+
+@dataclass
+class InstallationTargetGroup:
+    """Group of repositories that should be installed in the same target (user or organization)."""
+
+    target_id: int
+    target_type: GitHubAccountType
+    target_name: str
+    repository_ids: set[int]
+
+    @property
+    def link(self):
+        """
+        Create a link to install the GitHub App on the target with the required repositories pre-selected.
+
+        See https://docs.github.com/en/apps/creating-github-apps/about-creating-github-apps/migrating-oauth-apps-to-github-apps#prompt-users-to-install-your-github-app.
+        """
+        repository_ids = []
+        for repository_id in self.repository_ids:
+            repository_ids.append(f"&repository_ids[]={repository_id}")
+        repository_ids = "".join(repository_ids)
+
+        base_url = (
+            f"https://github.com/apps/{settings.GITHUB_APP_NAME}/installations/new/permissions"
+        )
+        return f"{base_url}?suggested_target_id={self.target_id}{repository_ids}"
+
+    @property
+    def installed(self):
+        """
+        Check if the app was already installed on the target.
+
+        If we don't have any repositories left to install, the app was already installed,
+        or we don't have any repositories to install the app on.
+        """
+        return not bool(self.repository_ids)
+
+
+@dataclass
+class MigrationTarget:
+    """Information about an individual project that needs to be migrated."""
+
+    project: Project
+    has_installation: bool
+    is_admin: bool
+    target_id: int
+
+    @property
+    def installation_link(self):
+        """
+        Create a link to install the GitHub App on the target repository.
+
+        See https://docs.github.com/en/apps/creating-github-apps/about-creating-github-apps/migrating-oauth-apps-to-github-apps
+        """
+        base_url = (
+            f"https://github.com/apps/{settings.GITHUB_APP_NAME}/installations/new/permissions"
+        )
+        return f"{base_url}?suggested_target_id={self.target_id}&repository_ids[]={self.project.remote_repository.remote_id}"
+
+    @property
+    def can_be_migrated(self):
+        """
+        Check if the project can be migrated.
+
+        The project can be migrated if the user is an admin on the repository and the GitHub App is installed.
+        """
+        return self.is_admin and self.has_installation
+
+
+@dataclass
+class MigrationResult:
+    """Result of a migration operation."""
+
+    webhook_removed: bool
+    ssh_key_removed: bool
+
+
+class MigrationError(Exception):
+    """Error raised when a migration operation fails."""
+
+    pass
+
+
+def get_installation_target_groups_for_user(user) -> list[InstallationTargetGroup]:
+    """Get all targets (accounts and organizations) that the user needs to install the GitHub App on."""
+    # Since we don't save the ID of the owner of each repository, we group all repositories
+    # that we aren't able to identify the owner into the user's account.
+    # GitHub will ignore the repositories that the user doesn't own.
+    default_target_account = _get_default_github_account_target(user)
+
+    targets = {}
+    for project, has_intallation, _ in _get_projects_missing_migration(user):
+        remote_repository = project.remote_repository
+        target_account = _get_github_account_target(remote_repository) or default_target_account
+        if target_account.id not in targets:
+            targets[target_account.id] = InstallationTargetGroup(
+                target_id=target_account.id,
+                target_name=target_account.login,
+                target_type=target_account.type,
+                repository_ids=set(),
+            )
+        if not has_intallation:
+            targets[target_account.id].repository_ids.add(int(remote_repository.remote_id))
+
+    # Include accounts that have already migrated projects,
+    # so they are shown as "Installed" in the UI.
+    for project in get_migrated_projects(user):
+        remote_repository = project.remote_repository
+        target_account = _get_github_account_target(remote_repository) or default_target_account
+        if target_account.id not in targets:
+            targets[target_account.id] = InstallationTargetGroup(
+                target_id=target_account.id,
+                target_name=target_account.login,
+                target_type=GitHubAccountType.USER,
+                repository_ids=set(),
+            )
+
+    return list(targets.values())
+
+
+def _get_default_github_account_target(user):
+    # NOTE: there are some users that have more than one GH account connected.
+    # They will need to migrate each account at a time.
+    account = user.socialaccount_set.filter(provider=GitHubProvider.id).first()
+    if not account:
+        account = user.socialaccount_set.filter(provider=GitHubAppProvider.id).first()
+
+    return GitHubAccountTarget(
+        login=account.extra_data.get("login", "ghost"),
+        id=int(account.uid),
+        type=GitHubAccountType.USER,
+    )
+
+
+def _get_github_account_target(remote_repository):
+    """
+    Get the GitHub account target for a repository.
+
+    This will return the account that owns the repository, if we can identify it.
+    For repositories owned by organizations, we return the organization account,
+    for repositories owned by users, we try to guess the account based on the repository owner
+    (as we don't save the owner ID in the repository).
+    """
+    if remote_repository.organization:
+        return GitHubAccountTarget(
+            login=remote_repository.organization.slug,
+            id=int(remote_repository.organization.remote_id),
+            type=GitHubAccountType.ORGANIZATION,
+        )
+    login = remote_repository.full_name.split("/", 1)[0]
+    account = SocialAccount.objects.filter(
+        provider__in=[GitHubProvider.id, GitHubAppProvider.id], extra_data__login=login
+    ).first()
+    if account:
+        return GitHubAccountTarget(
+            login=login,
+            id=int(account.uid),
+            type=GitHubAccountType.USER,
+        )
+    return None
+
+
+def _get_projects_missing_migration(user):
+    """
+    Get all projects where the user has admin permissions that are still connected to the old GitHub OAuth App.
+
+    Returns a generator with the project, a boolean indicating if the GitHub App is installed on the repository,
+    and a boolean indicating if the user has admin permissions on the repository.
+    """
+    projects = (
+        AdminPermission.projects(user, admin=True)
+        .filter(remote_repository__vcs_provider=GITHUB)
+        .select_related(
+            "remote_repository",
+            "remote_repository__organization",
+        )
+    )
+    for project in projects:
+        remote_repository = project.remote_repository
+        has_installation = RemoteRepository.objects.filter(
+            remote_id=remote_repository.remote_id,
+            vcs_provider=GITHUB_APP,
+            github_app_installation__isnull=False,
+        ).exists()
+        is_admin = (
+            RemoteRepository.objects.for_project_linking(user)
+            .filter(
+                remote_id=project.remote_repository.remote_id,
+                vcs_provider=GITHUB_APP,
+                github_app_installation__isnull=False,
+            )
+            .exists()
+        )
+        yield project, has_installation, is_admin
+
+
+def get_migrated_projects(user):
+    return (
+        AdminPermission.projects(user, admin=True)
+        .filter(remote_repository__vcs_provider=GITHUB_APP)
+        .select_related(
+            "remote_repository",
+        )
+    )
+
+
+def get_valid_projects_missing_migration(user):
+    for project, has_installation, is_admin in _get_projects_missing_migration(user):
+        if has_installation and is_admin:
+            yield project
+
+
+def get_migration_targets(user) -> list[MigrationTarget]:
+    """Get all projects that the user needs to migrate to the GitHub App."""
+    targets = []
+    default_target_account = _get_default_github_account_target(user)
+    for project, has_installation, is_admin in _get_projects_missing_migration(user):
+        remote_repository = project.remote_repository
+        target_account = _get_github_account_target(remote_repository) or default_target_account
+        targets.append(
+            MigrationTarget(
+                project=project,
+                has_installation=has_installation,
+                is_admin=is_admin,
+                target_id=target_account.id,
+            )
+        )
+    return targets
+
+
+def get_old_app_link():
+    """
+    Get the link to the old GitHub OAuth App settings page.
+
+    Useful so users can revoke the old app.
+    """
+    client_id = settings.SOCIALACCOUNT_PROVIDERS["github"]["APPS"][0]["client_id"]
+    return f"https://github.com/settings/connections/applications/{client_id}"
+
+
+def migrate_project_to_github_app(project, user) -> MigrationResult:
+    """
+    Migrate a project to the new GitHub App.
+
+    This will remove the webhook and SSH key from the old GitHub OAuth App and
+    connect the project to the new GitHub App.
+
+    Returns a MigrationResult with the status of the migration.
+    Raises a MigrationError if the project can't be migrated,
+    this should never happen as we don't allow migrating projects
+    that can't be migrated from the UI.
+    """
+    # No remote repository, nothing to migrate.
+    if not project.remote_repository:
+        raise MigrationError("Project isn't connected to a repository")
+
+    service_class = project.get_git_service_class()
+
+    # Already migrated, nothing to do.
+    if service_class == GitHubAppService:
+        return MigrationResult(webhook_removed=True, ssh_key_removed=True)
+
+    # Not a GitHub project, nothing to migrate.
+    if service_class != GitHubService:
+        raise MigrationError("Project isn't connected to a GitHub repository")
+
+    new_remote_repository = RemoteRepository.objects.filter(
+        remote_id=project.remote_repository.remote_id,
+        vcs_provider=GITHUB_APP,
+        github_app_installation__isnull=False,
+    ).first()
+
+    if not new_remote_repository:
+        raise MigrationError("You need to install the GitHub App on the repository")
+
+    new_remote_repository = (
+        RemoteRepository.objects.for_project_linking(user)
+        .filter(
+            remote_id=project.remote_repository.remote_id,
+            vcs_provider=GITHUB_APP,
+            github_app_installation__isnull=False,
+        )
+        .first()
+    )
+    if not new_remote_repository:
+        raise MigrationError("You must have admin permissions on the repository to migrate it")
+
+    webhook_removed = False
+    ssh_key_removed = False
+    for service in service_class.for_project(project):
+        if not webhook_removed and service.remove_webhook(project):
+            webhook_removed = True
+
+        if not ssh_key_removed and service.remove_ssh_key(project):
+            ssh_key_removed = True
+
+    project.integrations.filter(integration_type=Integration.GITHUB_WEBHOOK).delete()
+    project.remote_repository = new_remote_repository
+    project.save()
+    return MigrationResult(
+        webhook_removed=webhook_removed,
+        ssh_key_removed=ssh_key_removed,
+    )

--- a/readthedocs/oauth/notifications.py
+++ b/readthedocs/oauth/notifications.py
@@ -5,6 +5,7 @@ import textwrap
 from django.utils.translation import gettext_lazy as _
 
 from readthedocs.notifications.constants import ERROR
+from readthedocs.notifications.constants import WARNING
 from readthedocs.notifications.messages import Message
 from readthedocs.notifications.messages import registry
 
@@ -14,6 +15,8 @@ MESSAGE_OAUTH_WEBHOOK_NO_ACCOUNT = "oauth:webhook:no-account"
 MESSAGE_OAUTH_WEBHOOK_INVALID = "oauth:webhook:invalid"
 MESSAGE_OAUTH_BUILD_STATUS_FAILURE = "oauth:status:send-failed"
 MESSAGE_OAUTH_DEPLOY_KEY_ATTACHED_FAILED = "oauth:deploy-key:attached-failed"
+MESSAGE_OAUTH_WEBHOOK_NOT_REMOVED = "oauth:migration:webhook-not-removed"
+MESSAGE_OAUTH_DEPLOY_KEY_NOT_REMOVED = "oauth:migration:ssh-key-not-removed"
 
 messages = [
     Message(
@@ -82,6 +85,32 @@ messages = [
             ).strip(),
         ),
         type=ERROR,
+    ),
+    Message(
+        id=MESSAGE_OAUTH_WEBHOOK_NOT_REMOVED,
+        header=_("Failed to remove webhook"),
+        body=_(
+            textwrap.dedent(
+                """
+                Failed to remove webhook from the <a href="https://github.com/{{ repo_full_name }}">{{ repo_full_name }}</a> repository, please remove it manually
+                from the <a href="https://github.com/{{ repo_full_name }}/settings/hooks">repository settings</a> (search for a webhook containing "{{ project_slug }}" in the URL).
+                """
+            ).strip(),
+        ),
+        type=WARNING,
+    ),
+    Message(
+        id=MESSAGE_OAUTH_DEPLOY_KEY_NOT_REMOVED,
+        header=_("Failed to remove deploy key"),
+        body=_(
+            textwrap.dedent(
+                """
+                Failed to remove deploy key from the <a href="https://github.com/{{ repo_full_name }}">{{ repo_full_name }}</a> repository, please remove it manually
+                from the <a href="https://github.com/{{ repo_full_name }}/settings/keys">repository settings</a> (search for a deploy key containing "{{ project_slug }}" in the title).
+                """
+            )
+        ),
+        type=WARNING,
     ),
 ]
 registry.add(messages)

--- a/readthedocs/profiles/tests/test_views.py
+++ b/readthedocs/profiles/tests/test_views.py
@@ -1,0 +1,684 @@
+from unittest import mock
+
+import pytest
+import requests_mock
+from allauth.socialaccount.models import SocialAccount, SocialToken
+from allauth.socialaccount.providers.github.provider import GitHubProvider
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django_dynamic_fixture import get
+
+from readthedocs.allauth.providers.githubapp.provider import GitHubAppProvider
+from readthedocs.notifications.models import Notification
+from readthedocs.oauth.constants import GITHUB, GITHUB_APP
+from readthedocs.oauth.migrate import InstallationTargetGroup, MigrationTarget
+from readthedocs.oauth.models import (
+    GitHubAccountType,
+    GitHubAppInstallation,
+    RemoteOrganization,
+    RemoteOrganizationRelation,
+    RemoteRepository,
+    RemoteRepositoryRelation,
+)
+from readthedocs.oauth.notifications import (
+    MESSAGE_OAUTH_DEPLOY_KEY_NOT_REMOVED,
+    MESSAGE_OAUTH_WEBHOOK_NOT_REMOVED,
+)
+from readthedocs.oauth.services.github import GitHubService
+from readthedocs.projects.models import Project
+
+
+@pytest.mark.skipif(
+    not settings.RTD_EXT_THEME_ENABLED, reason="Not applicable for the old theme"
+)
+@override_settings(GITHUB_APP_NAME="readthedocs")
+class TestMigrateToGitHubAppView(TestCase):
+    def setUp(self):
+        self.user = get(User)
+        self.social_account_github = get(
+            SocialAccount,
+            provider=GitHubProvider.id,
+            user=self.user,
+            uid="1234",
+            extra_data={"login": "user"},
+        )
+        get(
+            SocialToken,
+            account=self.social_account_github,
+        )
+        self.social_account_github_app = get(
+            SocialAccount,
+            provider=GitHubAppProvider.id,
+            user=self.user,
+            uid="1234",
+            extra_data={"login": "user"},
+        )
+        self.github_app_installation = get(
+            GitHubAppInstallation,
+            installation_id=1111,
+            target_id=int(self.social_account_github_app.uid),
+            target_type=GitHubAccountType.USER,
+        )
+
+        # Project with remote repository where the user is admin.
+        self.remote_repository_a = get(
+            RemoteRepository,
+            name="repo-a",
+            full_name="user/repo-a",
+            html_url="https://github.com/user/repo-a",
+            remote_id="1111",
+            vcs_provider=GITHUB,
+        )
+        get(
+            RemoteRepositoryRelation,
+            user=self.user,
+            account=self.social_account_github,
+            remote_repository=self.remote_repository_a,
+            admin=True,
+        )
+        self.project_with_remote_repository = get(
+            Project,
+            users=[self.user],
+            remote_repository=self.remote_repository_a,
+        )
+
+        # Project with remote repository where the user is not admin.
+        self.remote_repository_b = get(
+            RemoteRepository,
+            name="repo-b",
+            full_name="user/repo-b",
+            html_url="https://github.com/user/repo-b",
+            remote_id="2222",
+            vcs_provider=GITHUB,
+        )
+        get(
+            RemoteRepositoryRelation,
+            user=self.user,
+            account=self.social_account_github,
+            remote_repository=self.remote_repository_b,
+            admin=False,
+        )
+        self.project_with_remote_repository_no_admin = get(
+            Project,
+            users=[self.user],
+            remote_repository=self.remote_repository_b,
+        )
+
+        # Project with remote repository where the user doesn't have permissions at all.
+        self.remote_repository_c = get(
+            RemoteRepository,
+            name="repo-c",
+            full_name="user2/repo-c",
+            html_url="https://github.com/user2/repo-c",
+            remote_id="3333",
+            vcs_provider=GITHUB,
+        )
+        get(
+            RemoteRepositoryRelation,
+            user=self.user,
+            account=self.social_account_github,
+            remote_repository=self.remote_repository_c,
+            admin=False,
+        )
+        self.project_with_remote_repository_no_member = get(
+            Project,
+            users=[self.user],
+            remote_repository=self.remote_repository_c,
+        )
+
+        # Project connected to a remote repository that belongs to an organization.
+        self.remote_organization = get(
+            RemoteOrganization,
+            slug="org",
+            name="Organization",
+            remote_id="9999",
+            vcs_provider=GITHUB,
+        )
+        get(
+            RemoteOrganizationRelation,
+            user=self.user,
+            account=self.social_account_github,
+        )
+        self.remote_repository_d = get(
+            RemoteRepository,
+            name="repo-d",
+            full_name="org/repo-d",
+            html_url="https://github.com/org/repo-d",
+            remote_id="4444",
+            organization=self.remote_organization,
+        )
+        get(
+            RemoteRepositoryRelation,
+            user=self.user,
+            account=self.social_account_github,
+            remote_repository=self.remote_repository_d,
+            admin=True,
+        )
+        self.project_with_remote_organization = get(
+            Project,
+            users=[self.user],
+            remote_repository=self.remote_repository_d,
+        )
+        self.github_app_organization_installation = get(
+            GitHubAppInstallation,
+            installation_id=2222,
+            target_id=int(self.remote_organization.remote_id),
+            target_type=GitHubAccountType.ORGANIZATION,
+        )
+
+        # Project without a remote repository.
+        self.project_without_remote_repository = get(
+            Project,
+            users=[self.user],
+            repo="https://github.com/user/repo-e",
+        )
+
+        self.url = reverse("migrate_to_github_app")
+        self.client.force_login(self.user)
+
+    def _create_github_app_remote_repository(self, remote_repository):
+        new_remote_repository = get(
+            RemoteRepository,
+            name=remote_repository.name,
+            full_name=remote_repository.full_name,
+            html_url=remote_repository.html_url,
+            remote_id=remote_repository.remote_id,
+            vcs_provider=GITHUB_APP,
+            github_app_installation=self.github_app_installation,
+        )
+        if remote_repository.organization:
+            new_remote_repository.organization = get(
+                RemoteOrganization,
+                slug=remote_repository.organization.slug,
+                name=remote_repository.organization.name,
+                remote_id=remote_repository.organization.remote_id,
+                vcs_provider=GITHUB_APP,
+            )
+            new_remote_repository.github_app_installation = (
+                self.github_app_organization_installation
+            )
+            new_remote_repository.save()
+        for relation in remote_repository.remote_repository_relations.all():
+            github_app_account = relation.user.socialaccount_set.get(
+                provider=GitHubAppProvider.id
+            )
+            get(
+                RemoteRepositoryRelation,
+                user=relation.user,
+                account=github_app_account,
+                remote_repository=new_remote_repository,
+                admin=relation.admin,
+            )
+        return new_remote_repository
+
+    def test_user_without_github_account(self):
+        self.user.socialaccount_set.all().delete()
+        response = self.client.get(self.url)
+        assert response.status_code == 302
+        response = self.client.get(reverse("projects_dashboard"))
+        content = response.content.decode()
+        print(content)
+        assert (
+            "You don\\u0026#x27\\u003Bt have any GitHub account connected." in content
+        )
+
+    def test_user_without_github_account_but_with_github_app_account(self):
+        self.user.socialaccount_set.exclude(provider=GitHubAppProvider.id).delete()
+        response = self.client.get(self.url)
+        assert response.status_code == 302
+        response = self.client.get(reverse("projects_dashboard"))
+        assert (
+            "You have already migrated your account to the new GitHub App"
+            in response.content.decode()
+        )
+
+    @requests_mock.Mocker(kw="request")
+    def test_migration_page_initial_state(self, request):
+        request.get("https://api.github.com/user", status_code=200)
+
+        self.user.socialaccount_set.filter(provider=GitHubAppProvider.id).delete()
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        context = response.context
+
+        assert context["step"] == "overview"
+        assert context["has_multiple_github_accounts"] is False
+        assert context["step_connect_completed"] is False
+        assert context["installation_target_groups"] == [
+            InstallationTargetGroup(
+                target_id=int(self.social_account_github.uid),
+                target_type=GitHubAccountType.USER,
+                target_name="user",
+                repository_ids={1111, 2222, 3333},
+            ),
+            InstallationTargetGroup(
+                target_id=int(self.remote_organization.remote_id),
+                target_type=GitHubAccountType.ORGANIZATION,
+                target_name="org",
+                repository_ids={4444},
+            ),
+        ]
+        assert context["github_app_name"] == "readthedocs"
+        assert context["migration_targets"] == [
+            MigrationTarget(
+                project=self.project_with_remote_repository,
+                has_installation=False,
+                is_admin=False,
+                target_id=int(self.social_account_github.uid),
+            ),
+            MigrationTarget(
+                project=self.project_with_remote_repository_no_admin,
+                has_installation=False,
+                is_admin=False,
+                target_id=int(self.social_account_github.uid),
+            ),
+            MigrationTarget(
+                project=self.project_with_remote_repository_no_member,
+                has_installation=False,
+                is_admin=False,
+                target_id=int(self.social_account_github.uid),
+            ),
+            MigrationTarget(
+                project=self.project_with_remote_organization,
+                has_installation=False,
+                is_admin=False,
+                target_id=int(self.remote_organization.remote_id),
+            ),
+        ]
+        assert list(context["migrated_projects"]) == []
+        assert (
+            context["old_application_link"]
+            == "https://github.com/settings/connections/applications/123"
+        )
+        assert context["step_revoke_completed"] is False
+        assert context["old_github_account"] == self.social_account_github
+
+    @requests_mock.Mocker(kw="request")
+    def test_migration_page_step_connect_done(self, request):
+        request.get("https://api.github.com/user", status_code=200)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        context = response.context
+
+        assert context["step"] == "overview"
+        assert context["has_multiple_github_accounts"] is False
+        assert context["step_connect_completed"] is True
+        assert context["installation_target_groups"] == [
+            InstallationTargetGroup(
+                target_id=int(self.social_account_github.uid),
+                target_type=GitHubAccountType.USER,
+                target_name="user",
+                repository_ids={1111, 2222, 3333},
+            ),
+            InstallationTargetGroup(
+                target_id=int(self.remote_organization.remote_id),
+                target_type=GitHubAccountType.ORGANIZATION,
+                target_name="org",
+                repository_ids={4444},
+            ),
+        ]
+        assert context["github_app_name"] == "readthedocs"
+        assert context["migration_targets"] == [
+            MigrationTarget(
+                project=self.project_with_remote_repository,
+                has_installation=False,
+                is_admin=False,
+                target_id=int(self.social_account_github.uid),
+            ),
+            MigrationTarget(
+                project=self.project_with_remote_repository_no_admin,
+                has_installation=False,
+                is_admin=False,
+                target_id=int(self.social_account_github.uid),
+            ),
+            MigrationTarget(
+                project=self.project_with_remote_repository_no_member,
+                has_installation=False,
+                is_admin=False,
+                target_id=int(self.social_account_github.uid),
+            ),
+            MigrationTarget(
+                project=self.project_with_remote_organization,
+                has_installation=False,
+                is_admin=False,
+                target_id=int(self.remote_organization.remote_id),
+            ),
+        ]
+        assert list(context["migrated_projects"]) == []
+        assert (
+            context["old_application_link"]
+            == "https://github.com/settings/connections/applications/123"
+        )
+        assert context["step_revoke_completed"] is False
+        assert context["old_github_account"] == self.social_account_github
+
+    @requests_mock.Mocker(kw="request")
+    def test_migration_page_step_install_done(self, request):
+        request.get("https://api.github.com/user", status_code=200)
+
+        self._create_github_app_remote_repository(self.remote_repository_a)
+        self._create_github_app_remote_repository(self.remote_repository_b)
+        self._create_github_app_remote_repository(self.remote_repository_d)
+
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        context = response.context
+
+        assert context["step"] == "overview"
+        assert context["has_multiple_github_accounts"] is False
+        assert context["step_connect_completed"] is True
+        assert context["installation_target_groups"] == [
+            InstallationTargetGroup(
+                target_id=int(self.social_account_github.uid),
+                target_type=GitHubAccountType.USER,
+                target_name="user",
+                repository_ids={3333},
+            ),
+            InstallationTargetGroup(
+                target_id=int(self.remote_organization.remote_id),
+                target_type=GitHubAccountType.ORGANIZATION,
+                target_name="org",
+                repository_ids=set(),
+            ),
+        ]
+        assert context["github_app_name"] == "readthedocs"
+        assert context["migration_targets"] == [
+            MigrationTarget(
+                project=self.project_with_remote_repository,
+                has_installation=True,
+                is_admin=True,
+                target_id=int(self.social_account_github.uid),
+            ),
+            MigrationTarget(
+                project=self.project_with_remote_repository_no_admin,
+                has_installation=True,
+                is_admin=False,
+                target_id=int(self.social_account_github.uid),
+            ),
+            MigrationTarget(
+                project=self.project_with_remote_repository_no_member,
+                has_installation=False,
+                is_admin=False,
+                target_id=int(self.social_account_github.uid),
+            ),
+            MigrationTarget(
+                project=self.project_with_remote_organization,
+                has_installation=True,
+                is_admin=True,
+                target_id=int(self.remote_organization.remote_id),
+            ),
+        ]
+        assert list(context["migrated_projects"]) == []
+        assert (
+            context["old_application_link"]
+            == "https://github.com/settings/connections/applications/123"
+        )
+        assert context["step_revoke_completed"] is False
+        assert context["old_github_account"] == self.social_account_github
+
+    @requests_mock.Mocker(kw="request")
+    @mock.patch.object(GitHubService, "remove_webhook")
+    @mock.patch.object(GitHubService, "remove_ssh_key")
+    def test_migration_page_step_migrate_one_project(
+        self, remove_ssh_key, remove_webhook, request
+    ):
+        request.get("https://api.github.com/user", status_code=200)
+
+        remove_ssh_key.return_value = True
+        remove_webhook.return_value = True
+
+        self._create_github_app_remote_repository(self.remote_repository_a)
+        self._create_github_app_remote_repository(self.remote_repository_b)
+        self._create_github_app_remote_repository(self.remote_repository_d)
+
+        response = self.client.post(
+            self.url, data={"project": self.project_with_remote_repository.slug}
+        )
+        assert response.status_code == 302
+        response = self.client.get(self.url)
+        context = response.context
+
+        assert context["step"] == "overview"
+        assert context["has_multiple_github_accounts"] is False
+        assert context["step_connect_completed"] is True
+        assert context["installation_target_groups"] == [
+            InstallationTargetGroup(
+                target_id=int(self.social_account_github.uid),
+                target_type=GitHubAccountType.USER,
+                target_name="user",
+                repository_ids={3333},
+            ),
+            InstallationTargetGroup(
+                target_id=int(self.remote_organization.remote_id),
+                target_type=GitHubAccountType.ORGANIZATION,
+                target_name="org",
+                repository_ids=set(),
+            ),
+        ]
+        assert context["github_app_name"] == "readthedocs"
+        assert context["migration_targets"] == [
+            MigrationTarget(
+                project=self.project_with_remote_repository_no_admin,
+                has_installation=True,
+                is_admin=False,
+                target_id=int(self.social_account_github.uid),
+            ),
+            MigrationTarget(
+                project=self.project_with_remote_repository_no_member,
+                has_installation=False,
+                is_admin=False,
+                target_id=int(self.social_account_github.uid),
+            ),
+            MigrationTarget(
+                project=self.project_with_remote_organization,
+                has_installation=True,
+                is_admin=True,
+                target_id=int(self.remote_organization.remote_id),
+            ),
+        ]
+        assert list(context["migrated_projects"]) == [
+            self.project_with_remote_repository,
+        ]
+        assert (
+            context["old_application_link"]
+            == "https://github.com/settings/connections/applications/123"
+        )
+        assert context["step_revoke_completed"] is False
+        assert context["old_github_account"] == self.social_account_github
+
+    @requests_mock.Mocker(kw="request")
+    @mock.patch.object(GitHubService, "remove_webhook")
+    @mock.patch.object(GitHubService, "remove_ssh_key")
+    def test_migration_page_step_migrate_all_projects(
+        self, remove_ssh_key, remove_webhook, request
+    ):
+        request.get("https://api.github.com/user", status_code=200)
+
+        remove_ssh_key.return_value = True
+        remove_webhook.return_value = True
+
+        self._create_github_app_remote_repository(self.remote_repository_a)
+        self._create_github_app_remote_repository(self.remote_repository_b)
+        self._create_github_app_remote_repository(self.remote_repository_d)
+
+        response = self.client.post(self.url)
+        assert response.status_code == 302
+        response = self.client.get(self.url)
+        context = response.context
+
+        assert context["step"] == "overview"
+        assert context["has_multiple_github_accounts"] is False
+        assert context["step_connect_completed"] is True
+        assert context["installation_target_groups"] == [
+            InstallationTargetGroup(
+                target_id=int(self.social_account_github.uid),
+                target_type=GitHubAccountType.USER,
+                target_name="user",
+                repository_ids={3333},
+            ),
+        ]
+        assert context["github_app_name"] == "readthedocs"
+        assert context["migration_targets"] == [
+            MigrationTarget(
+                project=self.project_with_remote_repository_no_admin,
+                has_installation=True,
+                is_admin=False,
+                target_id=int(self.social_account_github.uid),
+            ),
+            MigrationTarget(
+                project=self.project_with_remote_repository_no_member,
+                has_installation=False,
+                is_admin=False,
+                target_id=int(self.social_account_github.uid),
+            ),
+        ]
+        assert list(context["migrated_projects"]) == [
+            self.project_with_remote_repository,
+            self.project_with_remote_organization,
+        ]
+        assert (
+            context["old_application_link"]
+            == "https://github.com/settings/connections/applications/123"
+        )
+        assert context["step_revoke_completed"] is False
+        assert context["old_github_account"] == self.social_account_github
+
+    @requests_mock.Mocker(kw="request")
+    @mock.patch.object(GitHubService, "remove_webhook")
+    @mock.patch.object(GitHubService, "remove_ssh_key")
+    def test_migration_page_step_migrate_one_project_with_errors(
+        self, remove_ssh_key, remove_webhook, request
+    ):
+        request.get("https://api.github.com/user", status_code=200)
+
+        remove_ssh_key.return_value = False
+        remove_webhook.return_value = False
+
+        self._create_github_app_remote_repository(self.remote_repository_a)
+        self._create_github_app_remote_repository(self.remote_repository_b)
+        self._create_github_app_remote_repository(self.remote_repository_d)
+
+        response = self.client.post(
+            self.url, data={"project": self.project_with_remote_repository.slug}
+        )
+        assert response.status_code == 302
+        response = self.client.get(self.url)
+        context = response.context
+
+        assert context["step"] == "overview"
+        assert context["has_multiple_github_accounts"] is False
+        assert context["step_connect_completed"] is True
+        assert context["installation_target_groups"] == [
+            InstallationTargetGroup(
+                target_id=int(self.social_account_github.uid),
+                target_type=GitHubAccountType.USER,
+                target_name="user",
+                repository_ids={3333},
+            ),
+            InstallationTargetGroup(
+                target_id=int(self.remote_organization.remote_id),
+                target_type=GitHubAccountType.ORGANIZATION,
+                target_name="org",
+                repository_ids=set(),
+            ),
+        ]
+        assert context["github_app_name"] == "readthedocs"
+        assert context["migration_targets"] == [
+            MigrationTarget(
+                project=self.project_with_remote_repository_no_admin,
+                has_installation=True,
+                is_admin=False,
+                target_id=int(self.social_account_github.uid),
+            ),
+            MigrationTarget(
+                project=self.project_with_remote_repository_no_member,
+                has_installation=False,
+                is_admin=False,
+                target_id=int(self.social_account_github.uid),
+            ),
+            MigrationTarget(
+                project=self.project_with_remote_organization,
+                has_installation=True,
+                is_admin=True,
+                target_id=int(self.remote_organization.remote_id),
+            ),
+        ]
+        assert list(context["migrated_projects"]) == [
+            self.project_with_remote_repository,
+        ]
+        assert (
+            context["old_application_link"]
+            == "https://github.com/settings/connections/applications/123"
+        )
+        assert context["step_revoke_completed"] is False
+        assert context["old_github_account"] == self.social_account_github
+
+        notifications = Notification.objects.for_user(self.user, self.user)
+        assert notifications.count() == 2
+        assert notifications.filter(
+            message_id=MESSAGE_OAUTH_WEBHOOK_NOT_REMOVED
+        ).exists()
+        assert notifications.filter(
+            message_id=MESSAGE_OAUTH_DEPLOY_KEY_NOT_REMOVED
+        ).exists()
+
+    @requests_mock.Mocker(kw="request")
+    def test_migration_page_step_revoke_done(self, request):
+        request.get("https://api.github.com/user", status_code=401)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        context = response.context
+
+        assert context["step"] == "overview"
+        assert context["has_multiple_github_accounts"] is False
+        assert context["step_connect_completed"] is True
+        assert context["installation_target_groups"] == [
+            InstallationTargetGroup(
+                target_id=int(self.social_account_github.uid),
+                target_type=GitHubAccountType.USER,
+                target_name="user",
+                repository_ids={1111, 2222, 3333},
+            ),
+            InstallationTargetGroup(
+                target_id=int(self.remote_organization.remote_id),
+                target_type=GitHubAccountType.ORGANIZATION,
+                target_name="org",
+                repository_ids={4444},
+            ),
+        ]
+        assert context["github_app_name"] == "readthedocs"
+        assert context["migration_targets"] == [
+            MigrationTarget(
+                project=self.project_with_remote_repository,
+                has_installation=False,
+                is_admin=False,
+                target_id=int(self.social_account_github.uid),
+            ),
+            MigrationTarget(
+                project=self.project_with_remote_repository_no_admin,
+                has_installation=False,
+                is_admin=False,
+                target_id=int(self.social_account_github.uid),
+            ),
+            MigrationTarget(
+                project=self.project_with_remote_repository_no_member,
+                has_installation=False,
+                is_admin=False,
+                target_id=int(self.social_account_github.uid),
+            ),
+            MigrationTarget(
+                project=self.project_with_remote_organization,
+                has_installation=False,
+                is_admin=False,
+                target_id=int(self.remote_organization.remote_id),
+            ),
+        ]
+        assert list(context["migrated_projects"]) == []
+        assert (
+            context["old_application_link"]
+            == "https://github.com/settings/connections/applications/123"
+        )
+        assert context["step_revoke_completed"] is True
+        assert context["old_github_account"] == self.social_account_github

--- a/readthedocs/profiles/urls/private.py
+++ b/readthedocs/profiles/urls/private.py
@@ -41,6 +41,11 @@ account_urls = [
         views.AccountAdvertisingEdit.as_view(),
         name="account_advertising",
     ),
+    path(
+        "migrate-to-github-app/",
+        views.MigrateToGitHubAppView.as_view(),
+        name="migrate_to_github_app",
+    ),
 ]
 
 urlpatterns += account_urls


### PR DESCRIPTION
Can be tested together with https://github.com/readthedocs/ext-theme/pull/570, there is a video there showing the workflow.

What this does is groups all repositories the user has linked to a project, and works over that. The actions the user takes are as follows:

- Connect its account to our new GH app, we validate that the new account matches the account from the old integration.
- Install our app into the organization/users that the user has repositories imported from. Users that are part of projects where they don't have access to the repository owner/organization, can omit those, so the proper owner can migrate those, or in the case of organizations, they can request for an admin to approve the installation.
- Users can migrate their projects to the new GitHub app only if the app is installed in the proper repository, and if they have admin access to the repository.
- The migration basically consists of removing the old webhooks/ssh keys from the repo as they are no longer needed, and after that changing the remote repository to the one from the GH app.
- After all that is done, the next step is to revoke access to our old OAuth app, the user must do this, as we can't do that on behalf of the user. This step is recommended but not necessary required (we do make it required in our migration page, so we aren't responsible for lingering accounts).
- The final step is basically disconnecting the old GH OAuth app from the social accounts of the user, once that is done, we no longer can migrate the project on behalf of the user (or at least the part about removing the ssh key and webhook), connecting the project to the new remote repository can still be done, but users can also do that.

Extracted from https://github.com/readthedocs/readthedocs.org/pull/11942/