### PR TITLE
GitHub: show repos from old or new GH integration only

### DIFF
--- a/readthedocs/oauth/querysets.py
+++ b/readthedocs/oauth/querysets.py
@@ -13,7 +13,7 @@ def _has_account_connected_to_github_app(user):
         return False
     return user.socialaccount_set.filter(
         provider=GitHubAppProvider.id,
-    )
+    ).exists()
 
 
 class RelatedUserQuerySet(NoReprQuerySet, models.QuerySet):

--- a/readthedocs/oauth/querysets.py
+++ b/readthedocs/oauth/querysets.py
@@ -9,6 +9,8 @@ from readthedocs.oauth.constants import GITHUB_APP
 
 
 def _has_account_connected_to_github_app(user):
+    if not user:
+        return False
     return user.socialaccount_set.filter(
         provider=GitHubAppProvider.id,
     )

--- a/readthedocs/oauth/querysets.py
+++ b/readthedocs/oauth/querysets.py
@@ -2,8 +2,16 @@
 
 from django.db import models
 
+from readthedocs.allauth.providers.githubapp.provider import GitHubAppProvider
 from readthedocs.core.querysets import NoReprQuerySet
+from readthedocs.oauth.constants import GITHUB
 from readthedocs.oauth.constants import GITHUB_APP
+
+
+def _has_account_connected_to_github_app(user):
+    return user.socialaccount_set.filter(
+        provider=GitHubAppProvider.id,
+    )
 
 
 class RelatedUserQuerySet(NoReprQuerySet, models.QuerySet):
@@ -14,9 +22,19 @@ class RelatedUserQuerySet(NoReprQuerySet, models.QuerySet):
         if not user.is_authenticated:
             return self.none()
         queryset = self.filter(users=user)
-        # TODO: Once we are migrated into GitHub App we should include these repositories/organizations.
-        # Exclude repositories/organizations from the GitHub App for now to avoid duplicated entries.
-        queryset = queryset.exclude(vcs_provider=GITHUB_APP)
+
+        # Exclude repositories/organizations from the old or new GitHub App to avoid duplicated entries.
+        # If the user has already started using the GitHub App,
+        # we shouldn't show repositories from the old GitHub integration.
+        # Otherwise, we should show the repositories from the old GitHub integration only,
+        # this is done to avoid confusion for users that haven't migrated their accounts yet,
+        # but still have access to some repositories from the new GitHub App integration.
+        using_github_app = _has_account_connected_to_github_app(user)
+        if using_github_app and queryset.filter(vcs_provider=GITHUB_APP).exists():
+            queryset = queryset.exclude(vcs_provider=GITHUB)
+        else:
+            queryset = queryset.exclude(vcs_provider=GITHUB_APP)
+
         return queryset
 
     def api_v2(self, *args, **kwargs):
@@ -37,9 +55,19 @@ class RemoteRepositoryQuerySet(RelatedUserQuerySet):
             remote_repository_relations__user=user,
             remote_repository_relations__admin=True,
         )
-        # TODO: Once we are migrated into GitHub App we should include these repositories/organizations.
-        # Exclude repositories/organizations from the GitHub App for now to avoid duplicated entries.
-        queryset = queryset.exclude(vcs_provider=GITHUB_APP)
+
+        # Exclude repositories/organizations from the old or new GitHub App to avoid duplicated entries.
+        # If the user has already started using the GitHub App,
+        # we shouldn't show repositories from the old GitHub integration.
+        # Otherwise, we should show the repositories from the old GitHub integration only,
+        # this is done to avoid confusion for users that haven't migrated their accounts yet,
+        # but still have access to some repositories from the new GitHub App integration.
+        using_github_app = _has_account_connected_to_github_app(user)
+        if using_github_app and queryset.filter(vcs_provider=GITHUB_APP).exists():
+            queryset = queryset.exclude(vcs_provider=GITHUB)
+        else:
+            queryset = queryset.exclude(vcs_provider=GITHUB_APP)
+
         return queryset.distinct()
 
 


### PR DESCRIPTION
This is a better solution other than always excluding repos from the old integration or the new one. This can be safely be deployed.