### PR TITLE
Versions: always keep latest in sync with default branch/tag

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -643,19 +643,7 @@ class Project(models.Model):
             self.repo = self.remote_repository.clone_url
 
         super().save(*args, **kwargs)
-
-        try:
-            if not self.versions.filter(slug=LATEST).exists():
-                self.versions.create_latest()
-        except Exception:
-            log.exception("Error creating default branches")
-
-        # Update `Version.identifier` for `latest` with the default branch the user has selected,
-        # even if it's `None` (meaning to match the `default_branch` of the repository)
-        # NOTE: this code is required to be *after* ``create_latest()``.
-        # It has to be updated after creating LATEST originally.
-        log.debug("Updating default branch.", slug=LATEST, identifier=self.default_branch)
-        self.versions.filter(slug=LATEST, machine=True).update(identifier=self.default_branch)
+        self.update_latest_version()
 
     def delete(self, *args, **kwargs):
         from readthedocs.projects.tasks.utils import clean_project_resources

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -840,6 +840,7 @@ class TestBuildTask(BuildEnvironmentBase):
                     "--prune-tags",
                     "--depth",
                     "50",
+                    "refs/heads/master:refs/remotes/origin/master",
                 ),
                 mock.call(
                     "git",

--- a/readthedocs/rtd_tests/tests/test_project_forms.py
+++ b/readthedocs/rtd_tests/tests/test_project_forms.py
@@ -8,7 +8,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django_dynamic_fixture import get
 
-from readthedocs.builds.constants import EXTERNAL, LATEST, STABLE
+from readthedocs.builds.constants import EXTERNAL, LATEST, LATEST_VERBOSE_NAME, STABLE, TAG, BRANCH
 from readthedocs.builds.models import Version
 from readthedocs.core.forms import RichValidationError
 from readthedocs.oauth.models import RemoteRepository, RemoteRepositoryRelation
@@ -419,7 +419,10 @@ class TestProjectAdvancedForm(TestCase):
 
 class TestProjectAdvancedFormDefaultBranch(TestCase):
     def setUp(self):
-        self.project = get(Project)
+        self.project = get(
+            Project,
+            repo="https://github.com/readthedocs/readthedocs.org/",
+        )
         user_created_stable_version = get(
             Version,
             project=self.project,
@@ -529,6 +532,57 @@ class TestProjectAdvancedFormDefaultBranch(TestCase):
                 for identifier, _ in form.fields["default_branch"].widget.choices
             ],
         )
+
+    @mock.patch("readthedocs.projects.forms.trigger_build")
+    def test_change_default_branch_from_tag_to_branch_and_vice_versa(self, trigger_build):
+        branch = get(
+            Version,
+            project=self.project,
+            slug="branch",
+            type=BRANCH,
+            verbose_name="branch",
+            identifier="branch",
+        )
+        tag = get(
+            Version,
+            project=self.project,
+            slug="tag",
+            type=TAG,
+            verbose_name="tag",
+            identifier="1234abcd",
+        )
+
+        data = {
+            "name": self.project.name,
+            "repo": self.project.repo,
+            "repo_type": self.project.repo_type,
+            "default_version": LATEST,
+            "versioning_scheme": self.project.versioning_scheme,
+            "language": self.project.language,
+            "default_branch": branch.verbose_name,
+        }
+        form = UpdateProjectForm(data, instance=self.project)
+        assert form.is_valid()
+        form.save()
+
+        self.project.refresh_from_db()
+        latest = self.project.get_latest_version()
+        assert latest.slug == LATEST
+        assert latest.verbose_name == LATEST_VERBOSE_NAME
+        assert latest.identifier == branch.verbose_name
+        assert latest.type == BRANCH
+
+        data["default_branch"] = tag.verbose_name
+        form = UpdateProjectForm(data, instance=self.project)
+        assert form.is_valid()
+        form.save()
+
+        self.project.refresh_from_db()
+        latest = self.project.get_latest_version()
+        assert latest.slug == LATEST
+        assert latest.verbose_name == LATEST_VERBOSE_NAME
+        assert latest.identifier == tag.verbose_name
+        assert latest.type == TAG
 
 
 @override_settings(RTD_ALLOW_ORGANIZATIONS=False)


### PR DESCRIPTION
We had two ways of keeping latest in sync with the default branch chosen by the user, one on project save and another one when syncing versions, they are slightly different leading to some inconsistencies. We now always use update_latest_version.

Closes https://github.com/readthedocs/readthedocs.org/issues/12029