### PR TITLE
Docs: handle versions when "instant loading" feature enabled

### DIFF
--- a/docs/user/intro/mkdocs.rst
+++ b/docs/user/intro/mkdocs.rst
@@ -159,7 +159,7 @@ To integrate the :ref:`flyout-menu:Addons flyout menu` version menu into your si
         </div>`;
 
             // Check if we already added versions and remove them if so.
-            // This happens when using "Instant loading" feature.
+            // This happens when using the "Instant loading" feature.
             // See https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#instant-loading
             const currentVersions = document.querySelector(".md-version");
             if (currentVersions !== null) {

--- a/docs/user/intro/mkdocs.rst
+++ b/docs/user/intro/mkdocs.rst
@@ -158,6 +158,13 @@ To integrate the :ref:`flyout-menu:Addons flyout menu` version menu into your si
         </ul>
         </div>`;
 
+            // Check if we already added versions and remove them if so.
+            // This happens when using "Instant loading" feature.
+            // See https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#instant-loading
+            const currentVersions = document.querySelector(".md-version");
+            if (currentVersions !== null) {
+              currentVersions.remove();
+            }
             document.querySelector(".md-header__topic").insertAdjacentHTML("beforeend", versioning);
         });
 


### PR DESCRIPTION
Closes #12032

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--12142.org.readthedocs.build/12142/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--12142.org.readthedocs.build/12142/

<!-- readthedocs-preview dev end -->