### PR TITLE
New templates: remove `TEMPLATE_ROOT` setting and old template path

### DIFF
--- a/readthedocs/core/context_processors.py
+++ b/readthedocs/core/context_processors.py
@@ -20,7 +20,6 @@ def readthedocs_processor(request):
         "GLOBAL_ANALYTICS_CODE": settings.GLOBAL_ANALYTICS_CODE,
         "DASHBOARD_ANALYTICS_CODE": settings.DASHBOARD_ANALYTICS_CODE,
         "SITE_ROOT": settings.SITE_ROOT + "/",
-        "TEMPLATE_ROOT": settings.TEMPLATE_ROOT + "/",
         "DO_NOT_TRACK_ENABLED": settings.DO_NOT_TRACK_ENABLED,
         "USE_PROMOS": settings.USE_PROMOS,
         "USE_ORGANIZATIONS": settings.RTD_ALLOW_ORGANIZATIONS,

--- a/readthedocs/rtd_tests/tests/test_notifications.py
+++ b/readthedocs/rtd_tests/tests/test_notifications.py
@@ -59,7 +59,6 @@ class NotificationTests(TestCase):
                 "PUBLIC_API_URL": mock.ANY,
                 "SITE_ROOT": mock.ANY,
                 "SUPPORT_EMAIL": "support@readthedocs.org",
-                "TEMPLATE_ROOT": mock.ANY,
                 "USE_PROMOS": mock.ANY,
                 "USE_ORGANIZATIONS": mock.ANY,
             },

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -379,7 +379,6 @@ class CommunityBaseSettings(Settings):
     SITE_ROOT = os.path.dirname(
         os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     )
-    TEMPLATE_ROOT = os.path.join(SITE_ROOT, "readthedocs", "templates")
     DOCROOT = os.path.join(SITE_ROOT, "user_builds")
     LOGS_ROOT = os.path.join(SITE_ROOT, "logs")
     PRODUCTION_ROOT = os.path.join(SITE_ROOT, "prod_artifacts")
@@ -413,16 +412,12 @@ class CommunityBaseSettings(Settings):
 
     @property
     def TEMPLATES(self):
-        dirs = [self.TEMPLATE_ROOT]
-
-        if ext_theme:
-            dirs.insert(
-                0,
-                os.path.join(
-                    os.path.dirname(readthedocsext.theme.__file__),
-                    "templates",
-                ),
-            )
+        dirs = [
+            os.path.join(
+                os.path.dirname(readthedocsext.theme.__file__),
+                "templates",
+            ),
+        ]
 
         # Disable ``cached.Loader`` on development
         # https://docs.djangoproject.com/en/4.2/ref/templates/api/#django.template.loaders.cached.Loader


### PR DESCRIPTION
Simple way to tell Django to not use the templates from the `readthedocs/templates` directory without removing the files yet.

This is a way to test that those files are not used.

Related #12105