### PR TITLE
Downgrade to Django 4.2.x due to `djstripe`

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -22,6 +22,7 @@ filterwarnings =
     ignore:DateTimeField .* received a naive datetime .* while time zone support is active:RuntimeWarning
     ignore:.*:DeprecationWarning
 
-    ignore:.*:django.utils.deprecation.RemovedInDjango60Warning
+    # TODO: uncomment after upgrading to Django 5.2.x
+    # ignore:.*:django.utils.deprecation.RemovedInDjango60Warning
     ignore:.*:elasticsearch.exceptions.ElasticsearchWarning
     ignore:.*:PendingDeprecationWarning

--- a/readthedocs/oauth/models.py
+++ b/readthedocs/oauth/models.py
@@ -74,7 +74,7 @@ class GitHubAppInstallation(TimeStampedModel):
     )
     target_type = models.CharField(
         help_text=_("Account type that the target_id belongs to (user or organization)"),
-        choices=GitHubAccountType,
+        choices=GitHubAccountType.choices,
         max_length=255,
     )
     extra_data = models.JSONField(

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -105,7 +105,7 @@ dj-pagination==2.5.0
     # via -r requirements/pip.txt
 dj-stripe==2.6.3
     # via -r requirements/pip.txt
-django==5.2
+django==4.2.20
     # via
     #   -r requirements/pip.txt
     #   dj-stripe

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -113,7 +113,7 @@ dj-pagination==2.5.0
     # via -r requirements/pip.txt
 dj-stripe==2.6.3
     # via -r requirements/pip.txt
-django==5.2
+django==4.2.20
     # via
     #   -r requirements/pip.txt
     #   dj-stripe

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -2,7 +2,7 @@
 pip
 virtualenv
 
-django~=5.2.0
+django~=4.2.0
 django-extensions
 django-polymorphic
 django-autoslug

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -68,7 +68,7 @@ dj-pagination==2.5.0
     # via -r requirements/pip.in
 dj-stripe==2.6.3
     # via -r requirements/pip.in
-django==5.2
+django==4.2.20
     # via
     #   -r requirements/pip.in
     #   dj-stripe

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -110,7 +110,7 @@ dj-pagination==2.5.0
     # via -r requirements/pip.txt
 dj-stripe==2.6.3
     # via -r requirements/pip.txt
-django==5.2
+django==4.2.20
     # via
     #   -r requirements/pip.txt
     #   dj-stripe


### PR DESCRIPTION
We need to upgrade `djstripe` first because the admin is broken otherwise.

See https://github.com/readthedocs/readthedocs.org/issues/9706