### PR TITLE
Do not run `djstripe` checks on builders

### DIFF
--- a/readthedocs/projects/apps.py
+++ b/readthedocs/projects/apps.py
@@ -20,7 +20,7 @@ class ProjectsConfig(AppConfig):
 
         # HACK: remove djstripe initial checks.
         # It performs checks that require access to the database, which make the builders to fail.
-        # Note this code has to be executed _after_ djstripe has been initialized.
+        # Note this is placed in the `projects` app, since it's listed after `djstripe` in `INSTALLED_APPS`, as this code has to be executed _after_ djstripe has been initialized.
         #
         # https://github.com/dj-stripe/dj-stripe/blob/8e536409b815b2a393ef1ba8eac3d27bd69a5664/djstripe/checks.py#L20
         if settings.DEBUG or socket.gethostname().startswith("build-"):

--- a/readthedocs/projects/apps.py
+++ b/readthedocs/projects/apps.py
@@ -1,6 +1,10 @@
 """Project app config."""
 
+import socket
+
 from django.apps import AppConfig
+from django.conf import settings
+from django.core.checks.registry import registry
 
 
 class ProjectsConfig(AppConfig):
@@ -13,3 +17,13 @@ class ProjectsConfig(AppConfig):
         import readthedocs.projects.tasks.builds  # noqa
         import readthedocs.projects.tasks.search  # noqa
         import readthedocs.projects.tasks.utils  # noqa
+
+        # HACK: remove djstripe initial checks.
+        # It performs checks that require access to the database, which make the builders to fail.
+        # Note this code has to be executed _after_ djstripe has been initialized.
+        #
+        # https://github.com/dj-stripe/dj-stripe/blob/8e536409b815b2a393ef1ba8eac3d27bd69a5664/djstripe/checks.py#L20
+        if settings.DEBUG or socket.gethostname().startswith("build-"):
+            registry.registered_checks = {
+                item for item in registry.registered_checks if "djstripe" not in item.tags
+            }


### PR DESCRIPTION
We found this while performing the deploy.
Builders do not have access to the database, and `djstripe` runs some checks
that access the database to know if there are API keys defined there.

References:

* https://github.com/dj-stripe/dj-stripe/blob/main/djstripe/checks.py#L126
* https://github.com/django/django/blob/main/django/core/checks/registry.py#L85
* https://docs.djangoproject.com/en/5.2/topics/checks/