### PR TITLE
Redirect for `/` and `/welcome` URLs

### DIFF
--- a/readthedocs/core/tests/test_homepage.py
+++ b/readthedocs/core/tests/test_homepage.py
@@ -1,0 +1,44 @@
+from django.urls import reverse
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+
+class HomepageTest(TestCase):
+
+    def test_homepage_auth(self):
+        user = User(username="user")
+        user.set_password("user")
+        user.save()
+        self.client.login(username="user", password="user")
+
+        # Hitting "app.readthedocs.org" at /
+        response = self.client.get(
+            reverse("homepage"),
+        )
+        assert response.headers.get("Location") == reverse("projects_dashboard")
+
+    def test_homepage_unauth(self):
+        # Hitting "app.readthedocs.org" at /
+        response = self.client.get(
+            reverse("homepage"),
+        )
+        assert response.headers.get("Location") == reverse("account_login")
+
+    def test_welcome_auth(self):
+        user = User(username="user")
+        user.set_password("user")
+        user.save()
+        self.client.login(username="user", password="user")
+
+        # Hitting "app.readthedocs.org" at /welcome
+        response = self.client.get(
+            reverse("welcome"),
+        )
+        assert response.headers.get("Location") == reverse("projects_dashboard")
+
+    def test_welcome_unauth(self):
+        # Hitting "app.readthedocs.org" at /welcome
+        response = self.client.get(
+            reverse("welcome"),
+        )
+        assert response.headers.get("Location") == "https://about.readthedocs.com/?ref=readthedocs.org"

--- a/readthedocs/core/views/__init__.py
+++ b/readthedocs/core/views/__init__.py
@@ -36,12 +36,25 @@ class HealthCheckView(CDNCacheControlMixin, View):
         return JsonResponse({"status": 200}, status=200)
 
 
-class HomepageView(TemplateView):
+class HomepageView(View):
+    """Conditionally redirect to dashboard or login page."""
+
+    def get(self, request, *args, **kwargs):
+        # Redirect to user dashboard for logged in users
+        if request.user.is_authenticated:
+            return redirect(reverse("projects_dashboard"))
+
+        # Redirect to login page if unauthed
+        return redirect(reverse("account_login"))
+
+
+class WelcomeView(View):
     """
     Conditionally redirect to website home page or to dashboard.
 
+    User hitting readthedocs.org / readthedocs.com is redirected to this view (at /welcome).
+    This view will redirect the user based on auth/unauthed:
 
-    User hitting readthedocs.org / readthedocs.com
       1. when user is logged in, redirect to dashboard
       2. when user is logged off, redirect to https://about.readthedocs.com/
 
@@ -50,33 +63,20 @@ class HomepageView(TemplateView):
       2. when user is logged off, redirect to login page
     """
 
-    template_name = "homepage.html"
-
     def get(self, request, *args, **kwargs):
-        # Request hitting the old domain (readthedocs.org / readthedocs.com)
-        if request.get_host() == settings.PRODUCTION_DOMAIN.replace("app.", ""):
-            # Redirect to user dashboard for logged in users
-            if request.user.is_authenticated:
-                return redirect("projects_dashboard")
-
-            # Redirect to ``about.`` in production
-            if not settings.DEBUG:
-                query_string = f"?ref={settings.PRODUCTION_DOMAIN}"
-                if request.META["QUERY_STRING"]:
-                    # Small hack to not append `&` to URLs without a query_string
-                    query_string += "&" + request.META["QUERY_STRING"]
-
-                # Do a 302 here so that it varies on logged in status
-                return redirect(f"https://about.readthedocs.com/{query_string}", permanent=False)
-
-        # Request hitting app.readthedocs.org / app.readthedocs.com
-        #
         # Redirect to user dashboard for logged in users
         if request.user.is_authenticated:
-            return redirect("projects_dashboard")
+            return redirect(reverse("projects_dashboard"))
 
-        # Redirect to login page
-        return redirect(reverse("account_login"))
+        # Redirect to ``about.`` in production
+        if not settings.DEBUG:
+            query_string = f"?ref={settings.PRODUCTION_DOMAIN}"
+            if request.META["QUERY_STRING"]:
+                # Small hack to not append `&` to URLs without a query_string
+                query_string += "&" + request.META["QUERY_STRING"]
+
+            # Do a 302 here so that it varies on logged in status
+            return redirect(f"https://about.readthedocs.com/{query_string}", permanent=False)
 
 
 class SupportView(PrivateViewMixin, TemplateView):

--- a/readthedocs/urls.py
+++ b/readthedocs/urls.py
@@ -16,6 +16,7 @@ from impersonate.views import stop_impersonate
 from readthedocs.core.views import ErrorView
 from readthedocs.core.views import HomepageView
 from readthedocs.core.views import SupportView
+from readthedocs.core.views import WelcomeView
 from readthedocs.core.views import do_not_track
 from readthedocs.search.views import GlobalSearchView
 
@@ -33,6 +34,7 @@ handler429 = ErrorView.as_view(status_code=429)
 
 basic_urls = [
     path("", HomepageView.as_view(), name="homepage"),
+    path("welcome/", WelcomeView.as_view(), name="welcome"),
     path("security/", TemplateView.as_view(template_name="security.html")),
     re_path(
         r"^\.well-known/security.txt$",


### PR DESCRIPTION
We will always redirect users hitting `readthedocs.org` and `readthedocs.com` to the `app.` version of it at `/welcome`. From there, we will redirect to the dashboard if logged in or to the website if not.

If the user is logged in:

    readthedocs.org -> app.readthedocs.org/welcome -> app.readthedocs.org

If the user is logged out:

    readthedocs.org -> app.readthedocs.org/welcome -> about.readthedocs.com

On the other hand, people hitting the dashboard app, we will redirect to the login page or to the dashboard.

Closes https://github.com/readthedocs/readthedocs-ops/issues/1625