### PR TITLE
Downgrade `lxml` to avoid mismatch versions

### DIFF
--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -253,7 +253,7 @@ lexid==2021.1006
     # via
     #   -r requirements/pip.txt
     #   bumpver
-lxml==5.4.0
+lxml==5.3.2
     # via
     #   -r requirements/pip.txt
     #   pyquery

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -266,7 +266,7 @@ lexid==2021.1006
     # via
     #   -r requirements/pip.txt
     #   bumpver
-lxml==5.4.0
+lxml==5.3.2
     # via
     #   -r requirements/pip.txt
     #   pyquery

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -150,3 +150,4 @@ bumpver
 # system level is incompatible with the Python version
 # https://github.com/xmlsec/python-xmlsec/issues/324
 xmlsec==1.3.14
+lxml==5.3.2

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -192,8 +192,9 @@ kombu==5.5.3
     # via celery
 lexid==2021.1006
     # via bumpver
-lxml==5.4.0
+lxml==5.3.2
     # via
+    #   -r requirements/pip.in
     #   pyquery
     #   python3-saml
     #   xmlsec

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -262,7 +262,7 @@ lexid==2021.1006
     # via
     #   -r requirements/pip.txt
     #   bumpver
-lxml==5.4.0
+lxml==5.3.2
     # via
     #   -r requirements/pip.txt
     #   pyquery


### PR DESCRIPTION
https://github.com/readthedocs/readthedocs.org/pull/12166 breaks .com tests on CircleCI due to XML mismatch versions. This PR pins `lxml` as well to avoid that issue.