### PR TITLE
Downgrade Redis back to 5.2.1

### DIFF
--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -51,7 +51,9 @@ PyGithub
 dnspython
 
 # Used for Redis cache Django backend (`django.core.cache.backends.redis.RedisCache`)
-redis
+# Note: pinned for now due to issue with 6.0. See:
+# https://github.com/readthedocs/readthedocs.org/issues/12171
+redis==5.2.1
 
 celery
 django-celery-beat

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -257,7 +257,7 @@ pyyaml==6.0.2
     # via -r requirements/pip.in
 qrcode==8.2
     # via django-allauth
-redis==6.0.0
+redis==5.2.1
     # via -r requirements/pip.in
 regex==2024.11.6
     # via -r requirements/pip.in


### PR DESCRIPTION
Downgrade to avoid redis bug, probably with our hostname hack for djstire? See #12171 for the error.