### PR TITLE
GitHub App: block GH app users to re-connect to old OAuth app

### DIFF
--- a/readthedocs/core/adapters.py
+++ b/readthedocs/core/adapters.py
@@ -64,6 +64,7 @@ class AccountAdapter(DefaultAccountAdapter):
 class SocialAccountAdapter(DefaultSocialAccountAdapter):
     def pre_social_login(self, request, sociallogin):
         self._filter_email_addresses(sociallogin)
+        self._block_use_of_old_github_oauth_app(request, sociallogin)
         self._connect_github_app_to_existing_github_account(request, sociallogin)
 
     def _filter_email_addresses(self, sociallogin):
@@ -134,3 +135,35 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
         Only staff users can use the GitHub App for now.
         """
         return user.is_staff
+
+    def _block_use_of_old_github_oauth_app(self, request, sociallogin):
+        """
+        Block the use of the old GitHub OAuth app if the user is already using the new GitHub App.
+
+        This is a temporary measure to block the use of the old GitHub OAuth app
+        until we switch our login to always use the new GitHub App.
+        """
+        provider = sociallogin.account.get_provider()
+
+        # If the provider is not GitHub, nothing to do.
+        if provider.id != GitHubProvider.id:
+            return
+
+        social_account = SocialAccount.objects.filter(
+            provider=GitHubAppProvider.id,
+            uid=sociallogin.account.uid,
+        ).first()
+
+        # If there is no existing GitHub App account, nothing to do.
+        if not social_account:
+            return
+
+        # Show a warning to the user and redirect them to the GitHub App login page.
+        # TODO: only show this warning if the user already removed the old GitHub OAuth app from their account?
+        messages.warning(
+            request,
+            "You already migrated from our old GitHub OAuth app. "
+            "Click below to sign in with the new GitHub App.",
+        )
+        url = reverse("githubapp_login")
+        raise ImmediateHttpResponse(HttpResponseRedirect(url))

--- a/readthedocs/core/tests/test_adapters.py
+++ b/readthedocs/core/tests/test_adapters.py
@@ -201,3 +201,31 @@ class SocialAdapterTest(TestCase):
         response = exc.exception.response
         assert response.status_code == 302
         assert response.url == "/accounts/githubapp/login/"
+
+    def test_allow_using_old_github_app(self):
+        get(
+            SocialAccount,
+            provider=GitHubAppProvider.id,
+            uid="1234",
+            user=self.user,
+        )
+        github_account = get(
+            SocialAccount,
+            provider=GitHubProvider.id,
+            uid="1234",
+            user=self.user,
+        )
+
+        request = mock.MagicMock(user=AnonymousUser())
+        sociallogin = SocialLogin(
+            user=self.user,
+            account=github_account,
+        )
+        self.adapter.pre_social_login(request, sociallogin)
+
+        assert self.user.socialaccount_set.filter(
+            provider=GitHubAppProvider.id
+        ).exists()
+        assert self.user.socialaccount_set.filter(
+            provider=GitHubProvider.id
+        ).exists()


### PR DESCRIPTION
This prevents users already using the new GH app from creating another account by mistake with the old app.