### PR TITLE
Add doc tools to frontpage

### DIFF
--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -162,6 +162,9 @@ We have a few places for you to get started:
 :doc:`/tutorial/index`
   Follow the Read the Docs tutorial.
 
+:doc:`/intro/doctools`
+  Quick start for MkDocs and Docusaurus.
+
 :doc:`/examples`
   Start your journey with an example project to hit the ground running.
 


### PR DESCRIPTION


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--12179.org.readthedocs.build/12179/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--12179.org.readthedocs.build/12179/

<!-- readthedocs-preview dev end -->