### PR TITLE
Development: always use webpack on development

### DIFF
--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -91,7 +91,7 @@ Set up your environment
 
    .. prompt:: bash
 
-      inv docker.up  --ext-theme --webpack --init
+      inv docker.up  --init
 
    .. warning::
 
@@ -140,8 +140,6 @@ save some work while typing docker compose commands. This section explains these
     * ``--http-domain`` configures an external domain for the environment (useful for Ngrok or other http proxy).
       Note that https proxies aren't supported.
       There will also be issues with "suspicious domain" failures on Proxito.
-    * ``--ext-theme`` to use the new dashboard templates
-    * ``--webpack`` to start the Webpack dev server for the new dashboard templates
 
 ``inv docker.shell``
     Opens a shell in a container (web by default).

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -61,9 +61,7 @@ class DockerBaseSettings(CommunityBaseSettings):
         return os.path.join(super().DOCROOT, socket.gethostname())
 
     # New templates
-    @property
-    def RTD_EXT_THEME_DEV_SERVER_ENABLED(self):
-        return os.environ.get("RTD_EXT_THEME_DEV_SERVER_ENABLED") is not None
+    RTD_EXT_THEME_DEV_SERVER_ENABLED = True
 
     @property
     def RTD_EXT_THEME_DEV_SERVER(self):


### PR DESCRIPTION
The Docker development environment always starts the `webpack` container since we removed the legacy dashboard.

This PR makes the `webpack` server to be used by default when calling `inv docker.up`.