### PR TITLE
Remove mention of Gitter from contributor docs

### DIFF
--- a/docs/dev/contribute.rst
+++ b/docs/dev/contribute.rst
@@ -19,11 +19,9 @@ communication channels:
 
 - Ask usage questions ("How do I?") on `StackOverflow`_.
 - Report bugs, suggest features, or view the source code `on GitHub`_.
-- Discuss development topics on `Gitter`_.
 
 .. _StackOverFlow: https://stackoverflow.com/questions/tagged/read-the-docs
 .. _on GitHub: https://github.com/readthedocs/readthedocs.org
-.. _Gitter: https://gitter.im/readthedocs/community
 
 Contributing
 ------------


### PR DESCRIPTION
@ericholscher mentioned that it's not very active, and we can remove the mention. :)

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--12188.org.readthedocs.build/12188/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--12188.org.readthedocs.build/12188/

<!-- readthedocs-preview dev end -->