### PR TITLE
Update dev site build step

### DIFF
--- a/docs/dev/docs.rst
+++ b/docs/dev/docs.rst
@@ -64,6 +64,6 @@ you may want to verify those changes locally before pushing upstream.
    .. code-block:: console
 
       (.venv) $ cd docs
-      (.venv) $ RTD_DOCSET=dev make livehtml
+      (.venv) $ PROJECT=dev make livehtml
 
 #. Check the changes locally at http://127.0.0.1:4444/ (rebuilds each time you edit and save a file).


### PR DESCRIPTION
Need to set `PROJECT=dev`, instead of `RTD_DOCSET=dev`

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--12190.org.readthedocs.build/12190/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--12190.org.readthedocs.build/12190/

<!-- readthedocs-preview dev end -->