### PR TITLE
Add info on generating docs in `.txt` format

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -602,7 +602,7 @@ Here is an example configuration file:
          html:
            - asciidoctor -D $READTHEDOCS_OUTPUT/html index.asciidoc
 
-Use `text` format
+Generate text format with Sphinx
 ~~~~~~~~~~~~~~~~~
 There might be various reasons why would you want to generate your
 documentation in `text` format (secondary to `html`). One of such reasons

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -616,10 +616,6 @@ configuration are highlighted/emphasized:
    :caption: .readthedocs.yaml
    :emphasize-lines: 11, 37-
 
-   # Read the Docs configuration file for Sphinx projects
-   # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
-
-   # Required
    version: 2
 
    # Optionally build your docs in additional formats such as PDF and ePub

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -601,3 +601,64 @@ Here is an example configuration file:
        build:
          html:
            - asciidoctor -D $READTHEDOCS_OUTPUT/html index.asciidoc
+
+Use `text` format
+~~~~~~~~~~~~~~~~~
+There might be various reasons why would you want to generate your
+documentation in `text` format (secondary to `html`). One of such reasons
+would be generating LLM friendly documentation.
+
+See the following example for how to add generation of additional `text`
+format to your existing documentation. Deviations from standard build
+configuration are highlighted/emphasized:
+
+.. code-block:: yaml
+   :caption: .readthedocs.yaml
+   :emphasize-lines: 11, 37-
+
+   # Read the Docs configuration file for Sphinx projects
+   # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+   # Required
+   version: 2
+
+   # Optionally build your docs in additional formats such as PDF and ePub
+   formats:
+     - pdf
+     - epub
+     - htmlzip
+
+   # Build documentation in the "docs/" directory with Sphinx
+   sphinx:
+     configuration: docs/conf.py
+     # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+     # builder: "dirhtml"
+     # Fail on all warnings to avoid broken references
+     # fail_on_warning: true
+
+   # Optional but recommended, declare the Python requirements required
+   # to build your documentation
+   # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+   python:
+     install:
+     - requirements: docs/requirements.txt
+
+   # Set the OS, Python version and other tools you might need
+   build:
+     os: ubuntu-22.04
+     tools:
+       python: "3.12"
+       # You can also specify other tool versions:
+       # nodejs: "20"
+       # rust: "1.70"
+       # golang: "1.20"
+     jobs:
+       build:
+         # The default commands for generating the HTML and pdf formats will still run.
+         htmlzip:
+           - echo "Override default build command for htmlzip format"
+           - mkdir -p $READTHEDOCS_OUTPUT/html/
+           - sphinx-build -n -b text docs $READTHEDOCS_OUTPUT/html/
+
+The generated ``.txt`` files will be placed in the `html` directory, together
+with ``.html`` files.

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -603,7 +603,8 @@ Here is an example configuration file:
            - asciidoctor -D $READTHEDOCS_OUTPUT/html index.asciidoc
 
 Generate text format with Sphinx
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 There might be various reasons why would you want to generate your
 documentation in `text` format (secondary to `html`). One of such reasons
 would be generating LLM friendly documentation.

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -614,34 +614,21 @@ configuration are highlighted/emphasized:
 
 .. code-block:: yaml
    :caption: .readthedocs.yaml
-   :emphasize-lines: 11, 37-
+   :emphasize-lines: 14-
 
    version: 2
 
-   # Build documentation in the "docs/" directory with Sphinx
    sphinx:
      configuration: docs/conf.py
-     # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
-     # builder: "dirhtml"
-     # Fail on all warnings to avoid broken references
-     # fail_on_warning: true
 
-   # Optional but recommended, declare the Python requirements required
-   # to build your documentation
-   # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
    python:
      install:
      - requirements: docs/requirements.txt
 
-   # Set the OS, Python version and other tools you might need
    build:
      os: ubuntu-22.04
      tools:
        python: "3.12"
-       # You can also specify other tool versions:
-       # nodejs: "20"
-       # rust: "1.70"
-       # golang: "1.20"
      jobs:
        post_build:
          - mkdir -p $READTHEDOCS_OUTPUT/html/

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -649,12 +649,9 @@ configuration are highlighted/emphasized:
        # rust: "1.70"
        # golang: "1.20"
      jobs:
-       build:
-         # The default commands for generating the HTML and pdf formats will still run.
-         htmlzip:
-           - echo "Override default build command for htmlzip format"
-           - mkdir -p $READTHEDOCS_OUTPUT/html/
-           - sphinx-build -n -b text docs $READTHEDOCS_OUTPUT/html/
+       post_build:
+         - mkdir -p $READTHEDOCS_OUTPUT/html/
+         - sphinx-build -n -b text docs $READTHEDOCS_OUTPUT/html/
 
 The generated ``.txt`` files will be placed in the `html` directory, together
 with ``.html`` files.

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -618,12 +618,6 @@ configuration are highlighted/emphasized:
 
    version: 2
 
-   # Optionally build your docs in additional formats such as PDF and ePub
-   formats:
-     - pdf
-     - epub
-     - htmlzip
-
    # Build documentation in the "docs/" directory with Sphinx
    sphinx:
      configuration: docs/conf.py


### PR DESCRIPTION
Closes https://github.com/readthedocs/readthedocs.org/issues/12161

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--12194.org.readthedocs.build/12194/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--12194.org.readthedocs.build/12194/

<!-- readthedocs-preview dev end -->