### PR TITLE
Docs: update AWS temporary credentials documentation

### DIFF
--- a/docs/dev/aws-temporary-credentials.rst
+++ b/docs/dev/aws-temporary-credentials.rst
@@ -22,8 +22,8 @@ You can use :ref:`environment variables <settings:AWS configuration>` to set the
 
 .. note::
 
-   If you are part of the development team, you should be able to use the credentials from the ``storage-dev``` user,
-   which is already configured to make use of STS, and the ARN from the ``RTDSTSAssumeRoleDev`` role.
+   If you are part of the development team, you should be able to use the credentials from the ``storage-dev`` user,
+   which is already configured to make use of STS, and the ARN from the ``builder-dev`` role.
 
 .. note::
 


### PR DESCRIPTION
It was decided to use this name for the role in dev.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--12196.org.readthedocs.build/12196/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--12196.org.readthedocs.build/12196/

<!-- readthedocs-preview dev end -->