### PR TITLE
Remove allauth warning

### DIFF
--- a/readthedocs/core/adapters.py
+++ b/readthedocs/core/adapters.py
@@ -3,7 +3,7 @@
 import structlog
 from allauth.account.adapter import DefaultAccountAdapter
 from allauth.account.adapter import get_adapter as get_account_adapter
-from allauth.exceptions import ImmediateHttpResponse
+from allauth.core.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.socialaccount.models import SocialAccount
 from allauth.socialaccount.providers.github.provider import GitHubProvider

--- a/readthedocs/core/tests/test_adapters.py
+++ b/readthedocs/core/tests/test_adapters.py
@@ -1,6 +1,6 @@
 from unittest import mock
 
-from allauth.exceptions import ImmediateHttpResponse
+from allauth.core.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import get_adapter as get_social_account_adapter
 from allauth.socialaccount.models import SocialAccount, SocialLogin
 from allauth.socialaccount.providers.github.provider import GitHubProvider


### PR DESCRIPTION
```
warnings.warn("allauth.exceptions is deprecated, use allauth.core.exceptions")
```