### PR TITLE
Upload staticfiles to S3

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -1031,6 +1031,15 @@ class CommunityBaseSettings(Settings):
     AWS_STS_ASSUME_ROLE_ARN = "arn:aws:iam::1234:role/SomeRole"
 
     @property
+    def STORAGES(self):
+        # https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html
+        return {
+            "staticfiles": {
+                "BACKEND": self.RTD_STATICFILES_STORAGE,
+            },
+        }
+
+    @property
     def USING_AWS(self):
         """Return True if we are using AWS as our storage/cloud provider."""
         return self.S3_PROVIDER == "AWS"

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -166,7 +166,7 @@ django-safemigrate==5.3
     # via -r requirements/pip.txt
 django-simple-history==3.8.0
     # via -r requirements/pip.txt
-django-storages[boto3]==1.14.6
+django-storages[s3]==1.14.6
     # via -r requirements/pip.txt
 django-structlog==2.2.0
     # via -r requirements/pip.txt

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -174,7 +174,7 @@ django-safemigrate==5.3
     # via -r requirements/pip.txt
 django-simple-history==3.8.0
     # via -r requirements/pip.txt
-django-storages[boto3]==1.14.6
+django-storages[s3]==1.14.6
     # via -r requirements/pip.txt
 django-structlog==2.2.0
     # via -r requirements/pip.txt

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -116,7 +116,7 @@ django-cors-headers
 # User agent parsing - used for analytics purposes
 user-agents
 
-django-storages[boto3]
+django-storages[s3]
 
 
 # Required only in development and linting

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -129,7 +129,7 @@ django-safemigrate==5.3
     # via -r requirements/pip.in
 django-simple-history==3.8.0
     # via -r requirements/pip.in
-django-storages[boto3]==1.14.6
+django-storages[s3]==1.14.6
     # via -r requirements/pip.in
 django-structlog==2.2.0
     # via -r requirements/pip.in

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -173,7 +173,7 @@ django-safemigrate==5.3
     # via -r requirements/pip.txt
 django-simple-history==3.8.0
     # via -r requirements/pip.txt
-django-storages[boto3]==1.14.6
+django-storages[s3]==1.14.6
     # via -r requirements/pip.txt
 django-structlog==2.2.0
     # via -r requirements/pip.txt


### PR DESCRIPTION
Django 4.2 deprecated the way that storages are handled and introduced `STORAGES` setting. Then Django 5.2 removed the old pattern and our staticfiles were broken after the upgrade.

This commit makes a very simple usage of `STORAGES` to define the `staticfiles` storage so these files go to S3.

Note that I'm not changing the underlying configuration of the other storages we use (build media, build tools, etc) for now; but we could upgrade our code to follow the new pattern if we want to.

I tested this from `web-extra` and now the message is different:

```
docs@web-extra-i-0ef973eb0da33af39(org):~/checkouts/readthedocs.org$ django-admin collectstatic

You have requested to collect static files at the destination
location as specified in your settings.

This will overwrite existing files!
Are you sure you want to do this?

Type 'yes' to continue, or 'no' to cancel: yes

329 static files copied.
docs@web-extra-i-0ef973eb0da33af39(org):~/checkouts/readthedocs.org$
```

Besides, I can see the ext-theme files in the static S3 bucket now.

Closes #12211