### PR TITLE
Add Project queryset `prefetch_latest_build()` to project filter

### DIFF
--- a/readthedocs/projects/filters.py
+++ b/readthedocs/projects/filters.py
@@ -138,7 +138,12 @@ class ProjectSortOrderingFilter(OrderingFilter):
             else:
                 order_bys.append(field_ordered)
 
-        return qs.annotate(**annotations).order_by(*order_bys)
+        # Prefetch here not only prefetches the query, but it also changes how `get_latest_build`
+        # works. Normally from templates `project.get_latest_build` only returns
+        # the latest _finished_ build. But with prefetch, _all_ builds are
+        # considered and `get_latest_build` will pop the first off this list of
+        # _all_ builds.
+        return qs.prefetch_latest_build().annotate(**annotations).order_by(*order_bys)
 
 
 class ProjectListFilterSet(ModelFilterSet):


### PR DESCRIPTION
This was missing from the queryset, causing the templates to use
`Project.get_latest_build(finished=True)`, effectively. When using
`prefetch_latest_build()`, the response from `get_latest_build` is the
first build of _any_ build state.

- Refs https://github.com/readthedocs/ext-theme/pull/607
- Refs https://github.com/readthedocs/readthedocs.org/issues/11840