### PR TITLE
GitLab: handle when a repository is moved to another group

### DIFF
--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -77,15 +77,19 @@ class GitLabService(UserService):
         return response.json()
 
     def sync_repositories(self):
+        """
+        Sync repositories that the user has access to.
+
+        See https://docs.gitlab.com/api/projects/#list-a-users-projects.
+        """
         remote_repositories = []
         try:
             repos = self.paginate(
-                f"{self.base_api_url}/api/v4/projects",
+                f"{self.base_api_url}/api/v4/users/{self.account.uid}/projects",
                 per_page=100,
                 archived=False,
                 order_by="path",
                 sort="asc",
-                membership=True,
             )
 
             for repo in repos:
@@ -170,7 +174,7 @@ class GitLabService(UserService):
 
         return remote_organizations, remote_repositories
 
-    def create_repository(self, fields, privacy=None, organization=None):
+    def create_repository(self, fields, organization: RemoteOrganization|None = None):
         """
         Update or create a repository from GitLab API response.
 
@@ -185,12 +189,10 @@ class GitLabService(UserService):
         https://gitlab.com/help/user/permissions
 
         :param fields: dictionary of response data from API
-        :param privacy: privacy level to support
         :param organization: remote organization to associate with
-        :type organization: RemoteOrganization
         :rtype: RemoteRepository
         """
-        privacy = privacy or settings.DEFAULT_PRIVACY_LEVEL
+        privacy = settings.DEFAULT_PRIVACY_LEVEL
         repo_is_public = fields["visibility"] == "public"
         if privacy == "private" or (repo_is_public and privacy == "public"):
             repo, _ = RemoteRepository.objects.get_or_create(
@@ -199,13 +201,6 @@ class GitLabService(UserService):
             remote_repository_relation = repo.get_remote_repository_relation(
                 self.user, self.account
             )
-
-            if repo.organization and repo.organization != organization:
-                log.debug(
-                    "Not importing because mismatched orgs",
-                    repository=fields["name"],
-                )
-                return None
 
             repo.organization = organization
             repo.name = fields["name"]
@@ -270,10 +265,7 @@ class GitLabService(UserService):
 
         organization.name = fields.get("name")
         organization.slug = fields.get("path")
-        organization.url = "{url}/{path}".format(
-            url=self.base_api_url,
-            path=fields.get("path"),
-        )
+        organization.url = fields.get("web_url")
         organization.avatar_url = fields.get("avatar_url")
 
         if not organization.avatar_url:


### PR DESCRIPTION
So we are clear, GL has some different names for things we know on GH.

Organizations: They are called groups, and groups can have subgroups (nesting). In our code we represent each group as a remote organization.
Repositories: they are called projects in GitLab.

Now, back to the PR...

If the repository to sync belonged to a different group (e.g, it was moved or transferred), our code would skip syncing that repository, leaving it in a stale state. Looks like it wasn't clear why we added this check in the first place https://github.com/readthedocs/readthedocs.org/pull/3327/files#r153822778. For GH we always keep repos in sync, so it makes sense to do the same for GL, if GL says the repo was moved to a different group, we should trust that.

We were also using the /projects API, and then using the organization check to skip syncing repos that belong to a group instead of the user (we sync projects from all groups the user has access to in a different method, sync_organizations), so I changed it to use the /user/projects endpoint instead.

Also, when creating the URL for the group, we were using the path attribute, which is only the last part of the group path, since groups can be nested, this was creating the wrong link. A group from mygroup/subgroup will link to a group named subgroup, which has nothing to do with the actual group, GL has a property with the correct link. We may want to consider using the full_path for the slug of the org, it does contain `/`, but in the model we are accepting any characters for that field, so it shouldn't be a problem, not sure where else we use the slug.