### PR TITLE
GitLab: Use full path for GitLab groups/organizations

### DIFF
--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -269,7 +269,7 @@ class GitLabService(UserService):
         organization.get_remote_organization_relation(self.user, self.account)
 
         organization.name = fields.get("name")
-        organization.slug = fields.get("path")
+        organization.slug = fields.get("full_path")
         organization.url = "{url}/{path}".format(
             url=self.base_api_url,
             path=fields.get("path"),

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -2043,7 +2043,7 @@ class GitLabOAuthTests(TestCase):
         "web_url": "https://gitlab.com/groups/testorga",
         "request_access_enabled": False,
         "full_name": "Test Orga",
-        "full_path": "testorga",
+        "full_path": "group/testorga",
         "parent_id": None,
     }
 
@@ -2144,7 +2144,7 @@ class GitLabOAuthTests(TestCase):
     def test_make_organization(self):
         org = self.service.create_organization(self.group_response_data)
         self.assertIsInstance(org, RemoteOrganization)
-        self.assertEqual(org.slug, "testorga")
+        self.assertEqual(org.slug, "group/testorga")
         self.assertEqual(org.name, "Test Orga")
         self.assertEqual(
             org.avatar_url,


### PR DESCRIPTION
name has only the last part of the group namespace. For example, for a group under the `group/subgroup` namespace, path would be `subgroup`, and full_path would be `group/subgroup`. The slug is a charfield, so it's okay to have `/`, looks like we aren't using this field for anything important, so don't think we need to resync all organizations.

ref https://github.com/readthedocs/readthedocs.org/pull/12233