### PR TITLE
Use Allauth settings for app name and hiding on login/connect forms

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -686,7 +686,13 @@ class CommunityBaseSettings(Settings):
     _SOCIALACCOUNT_PROVIDERS = {
         "github": {
             "APPS": [
-                {"client_id": "123", "secret": "456", "key": ""},
+                {
+                    "name": "GitHub OAuth",
+                    "client_id": "123",
+                    "secret": "456",
+                    "key": "",
+                    "settings": {"hidden": False},
+                },
             ],
             "SCOPE": [
                 "user:email",
@@ -697,7 +703,13 @@ class CommunityBaseSettings(Settings):
         },
         "githubapp": {
             "APPS": [
-                {"client_id": "123", "secret": "456", "key": ""},
+                {
+                    "name": "GitHub App",
+                    "client_id": "123",
+                    "secret": "456",
+                    "key": "",
+                    "settings": {"hidden": False},
+                },
             ],
             # Scope is determined by the GitHub App permissions.
             "SCOPE": [],

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -691,7 +691,12 @@ class CommunityBaseSettings(Settings):
                     "client_id": "123",
                     "secret": "456",
                     "key": "",
-                    "settings": {"hidden": False},
+                    "settings": {
+                        "hidden": False,
+                        "hidden_on_login": False,
+                        "hidden_on_connect": False,
+                        "priority": 10,
+                    },
                 },
             ],
             "SCOPE": [
@@ -708,7 +713,12 @@ class CommunityBaseSettings(Settings):
                     "client_id": "123",
                     "secret": "456",
                     "key": "",
-                    "settings": {"hidden": False},
+                    "settings": {
+                        "hidden": False,
+                        "hidden_on_login": False,
+                        "hidden_on_connect": False,
+                        "priority": 20,
+                    },
                 },
             ],
             # Scope is determined by the GitHub App permissions.
@@ -716,7 +726,7 @@ class CommunityBaseSettings(Settings):
         },
         "gitlab": {
             "APPS": [
-                {"client_id": "123", "secret": "456", "key": ""},
+                {"client_id": "123", "secret": "456", "key": "", "settings": {"priority": 30}},
             ],
             # GitLab returns the primary email only, we can trust it's verified.
             "VERIFIED_EMAIL": True,
@@ -727,7 +737,7 @@ class CommunityBaseSettings(Settings):
         },
         "bitbucket_oauth2": {
             "APPS": [
-                {"client_id": "123", "secret": "456", "key": ""},
+                {"client_id": "123", "secret": "456", "key": "", "settings": {"priority": 40}},
             ],
             # Bitbucket scope/permissions are determined by the Oauth consumer setup on bitbucket.org.
         },


### PR DESCRIPTION
The `settings` attribute isn't super well documented, but it is used
from the template tag for listing providers. We can also use settings
for arbitrary values if we want.

See https://codeberg.org/allauth/django-allauth/src/commit/b74b04a8261486db8a3823c26c188820aed599aa/allauth/socialaccount/templatetags/socialaccount.py#L84