### PR TITLE
Normalize usage of "single sign-on"

### DIFF
--- a/docs/user/commercial/single-sign-on.rst
+++ b/docs/user/commercial/single-sign-on.rst
@@ -1,4 +1,4 @@
-Single Sign-On (SSO)
+Single sign-on (SSO)
 ====================
 
 .. include:: /shared/admonition-rtd-business.rst
@@ -15,7 +15,7 @@ Currently, we support two different types of single sign-on:
 
 .. _sso_git_provider:
 
-Single Sign-on with GitHub, Bitbucket, or GitLab
+Single sign-on with GitHub, Bitbucket, or GitLab
 ------------------------------------------------
 
 Using an identity provider that supports authentication and authorization allows organization owners to manage
@@ -27,7 +27,7 @@ that user just needs to be granted permissions in the Git repository associated 
 Once you enable this option,
 your existing Read the Docs teams will not be used.
 All authentication will be done using your git provider,
-including any two-factor authentication and additional Single Sign-on that they support.
+including any two-factor authentication and additional single sign-on that they support.
 
 Learn how to configure this SSO method with our :doc:`/guides/setup-single-sign-on-github-gitlab-bitbucket`.
 

--- a/docs/user/guides/access/index.rst
+++ b/docs/user/guides/access/index.rst
@@ -1,11 +1,11 @@
 How-to guides: security and access
 ==================================
 
-⏩️ :doc:`Single Sign-On (SSO) with GitHub, GitLab, or Bitbucket </guides/setup-single-sign-on-github-gitlab-bitbucket>`
+⏩️ :doc:`Single sign-on (SSO) with GitHub, GitLab, or Bitbucket </guides/setup-single-sign-on-github-gitlab-bitbucket>`
     When using an :doc:`organization </commercial/organizations>` on  |com_brand|,
     you can configure SSO for your users to authenticate to Read the Docs.
 
-⏩️ :doc:`Single Sign-On (SSO) with Google Workspace </guides/setup-single-sign-on-google-email>`
+⏩️ :doc:`Single sign-on (SSO) with Google Workspace </guides/setup-single-sign-on-google-email>`
     When using an :doc:`organization </commercial/organizations>` on  |com_brand|,
     you can configure SSO for your users to authenticate to Read the Docs.
     This guide is written for Google Workspace.
@@ -34,9 +34,9 @@ How-to guides: security and access
    :maxdepth: 1
    :hidden:
 
-   Single Sign-On (SSO) with GitHub, GitLab, or Bitbucket </guides/setup-single-sign-on-github-gitlab-bitbucket>
-   Single Sign-On (SSO) with Google Workspace </guides/setup-single-sign-on-google-email>
-   Single Sign-On (SSO) with SAML </guides/set-up-single-sign-on-saml>
+   Single sign-on (SSO) with GitHub, GitLab, or Bitbucket </guides/setup-single-sign-on-github-gitlab-bitbucket>
+   Single sign-on (SSO) with Google Workspace </guides/setup-single-sign-on-google-email>
+   Single sign-on (SSO) with SAML </guides/set-up-single-sign-on-saml>
    Managing Read the Docs teams </guides/manage-read-the-docs-teams>
    Manually importing private repositories </guides/importing-private-repositories>
    Using private Git submodules </guides/private-submodules>

--- a/docs/user/guides/manage-read-the-docs-teams.rst
+++ b/docs/user/guides/manage-read-the-docs-teams.rst
@@ -43,7 +43,7 @@ they will be granted access to import a project on that team.
 Automating this process
 -----------------------
 
-You can manage teams more easily using our :doc:`Single Sign-On </commercial/single-sign-on>` features.
+You can manage teams more easily using our :doc:`single sign-on </commercial/single-sign-on>` features.
 
 .. seealso::
 

--- a/docs/user/guides/set-up-single-sign-on-saml.rst
+++ b/docs/user/guides/set-up-single-sign-on-saml.rst
@@ -1,4 +1,4 @@
-How to set up Single Sign-On (SSO) with SAML
+How to set up single sign-on (SSO) with SAML
 ============================================
 
 .. include:: /shared/admonition-rtd-business.rst
@@ -10,7 +10,7 @@ How to set up Single Sign-On (SSO) with SAML
 
    **At the moment only Okta is supported as a SAML identity provider.**
 
-This how-to guide will provide instructions on how to enable :abbr:`SSO (Single Sign-on)` using Okta as a SAML identity provider.
+This how-to guide will provide instructions on how to enable :abbr:`SSO (single sign-on)` using Okta as a SAML identity provider.
 If you want more information on this feature, please read :doc:`/commercial/single-sign-on`
 
 Prerequisites
@@ -146,4 +146,4 @@ and disable login on Read the Docs completely for that user.
    :doc:`/guides/manage-read-the-docs-teams`
      Additional user management options
    :doc:`/commercial/single-sign-on`
-     Information about choosing a Single Sign-on approach
+     Information about choosing a single sign-on approach

--- a/docs/user/guides/setup-single-sign-on-github-gitlab-bitbucket.rst
+++ b/docs/user/guides/setup-single-sign-on-github-gitlab-bitbucket.rst
@@ -1,9 +1,9 @@
-How to setup Single Sign-On (SSO) with GitHub, GitLab, or Bitbucket
+How to setup single sign-on (SSO) with GitHub, GitLab, or Bitbucket
 ===================================================================
 
 .. include:: /shared/admonition-rtd-business.rst
 
-This how-to guide will provide instructions on how to enable :abbr:`SSO (Single Sign-on)` with GitHub, GitLab, or Bitbucket.
+This how-to guide will provide instructions on how to enable :abbr:`SSO (single sign-on)` with GitHub, GitLab, or Bitbucket.
 If you want more information on this feature,
 please read :doc:`/commercial/single-sign-on`
 
@@ -74,5 +74,5 @@ Instead of revoking access completely,
 downgrade their permissions to *read only*.
 
 .. seealso::
-    To learn more about choosing a Single Sign-on approach,
+    To learn more about choosing a single sign-on approach,
     please read :doc:`/commercial/single-sign-on`.

--- a/docs/user/guides/setup-single-sign-on-google-email.rst
+++ b/docs/user/guides/setup-single-sign-on-google-email.rst
@@ -1,9 +1,9 @@
-How to setup Single Sign-On (SSO) with Google Workspace
+How to setup single sign-on (SSO) with Google Workspace
 =======================================================
 
 .. include:: /shared/admonition-rtd-business.rst
 
-This how-to guide will provide instructions on how to enable :abbr:`SSO (Single Sign-on)` with Google Workspace.
+This how-to guide will provide instructions on how to enable :abbr:`SSO (single sign-on)` with Google Workspace.
 If you want more information on this feature,
 please read :doc:`/commercial/single-sign-on`
 
@@ -94,4 +94,4 @@ and disable login on Read the Docs completely for that user.
    :doc:`/guides/manage-read-the-docs-teams`
      Additional user management options
    :doc:`/commercial/single-sign-on`
-     Information about choosing a Single Sign-on approach
+     Information about choosing a single sign-on approach

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -233,7 +233,7 @@ Our Business hosting has everything your business needs:
   Manage permissions across multiple teams.
 
 :doc:`/commercial/single-sign-on`
-  Stay secure with Single Sign On.
+  Stay secure with single sign-on.
 
 :doc:`/commercial/sharing`
   Share your private docs easily with contractors or customers.


### PR DESCRIPTION
There are a few different casing issues and punctuation styles, this
reduces down to "single sign-on" for all of our usage.

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--12256.org.readthedocs.build/12256/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--12256.org.readthedocs.build/12256/

<!-- readthedocs-preview dev end -->