### PR TITLE
Add example usage of pydoctor in the build customization page

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -631,6 +631,36 @@ Here is an example configuration file:
          html:
            - asciidoctor -D $READTHEDOCS_OUTPUT/html index.asciidoc
 
+Using pydoctor
+~~~~~~~~~~~~~~
+
+`Pydoctor <https://github.com/twisted/pydoctor>`_ is an easy-to-use standalone API documentation tool for Pythonn.  
+
+Here is an example configuration file:
+
+.. code-block:: yaml
+   :caption: .readthedocs.yaml
+
+   version: 2
+   build:
+     os: "ubuntu-22.04"
+     jobs:
+       install:
+         - pip install pydoctor
+       build:
+         html:
+           - |
+             pydoctor \
+               --project-name='my project' \
+               --project-version=${READTHEDOCS_GIT_IDENTIFIER} \
+               --project-url=${READTHEDOCS_GIT_CLONE_URL%*.git} \
+               --html-viewsource-base=${READTHEDOCS_GIT_CLONE_URL%*.git}/tree/${READTHEDOCS_GIT_COMMIT_HASH} \
+               --html-base-url=${READTHEDOCS_CANONICAL_URL} \
+               --html-output $READTHEDOCS_OUTPUT/html/ \
+               --docformat=restructuredtext \
+               --intersphinx=https://docs.python.org/3/objects.inv \
+               ./src/my_project
+
 Generate text format with Sphinx
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -650,14 +650,11 @@ Here is an example configuration file:
          html:
            - |
              pydoctor \
-               --project-name='my project' \
                --project-version=${READTHEDOCS_GIT_IDENTIFIER} \
                --project-url=${READTHEDOCS_GIT_CLONE_URL%*.git} \
                --html-viewsource-base=${READTHEDOCS_GIT_CLONE_URL%*.git}/tree/${READTHEDOCS_GIT_COMMIT_HASH} \
                --html-base-url=${READTHEDOCS_CANONICAL_URL} \
                --html-output $READTHEDOCS_OUTPUT/html/ \
-               --docformat=restructuredtext \
-               --intersphinx=https://docs.python.org/3/objects.inv \
                ./src/my_project
 
 Generate text format with Sphinx

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -635,7 +635,6 @@ Using pydoctor
 ~~~~~~~~~~~~~~
 
 `Pydoctor <https://github.com/twisted/pydoctor>`_ is an easy-to-use standalone API documentation tool for Python.  
-
 Here is an example configuration file:
 
 .. code-block:: yaml

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -634,7 +634,7 @@ Here is an example configuration file:
 Using pydoctor
 ~~~~~~~~~~~~~~
 
-`Pydoctor <https://github.com/twisted/pydoctor>`_ is an easy-to-use standalone API documentation tool for Pythonn.  
+`Pydoctor <https://github.com/twisted/pydoctor>`_ is an easy-to-use standalone API documentation tool for Python.  
 
 Here is an example configuration file:
 

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -634,7 +634,7 @@ Here is an example configuration file:
 Using pydoctor
 ~~~~~~~~~~~~~~
 
-`Pydoctor <https://github.com/twisted/pydoctor>`_ is an easy-to-use standalone API documentation tool for Python.  
+`Pydoctor <https://github.com/twisted/pydoctor>`_ is an easy-to-use standalone API documentation tool for Python.
 Here is an example configuration file:
 
 .. code-block:: yaml


### PR DESCRIPTION
This adds a complete example of using [pydoctor](https://github.com/twisted/pydoctor). 
The generated docs will include links to the source code and the standard library types when relevant. 

<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--12259.org.readthedocs.build/12259/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--12259.org.readthedocs.build/12259/

<!-- readthedocs-preview dev end -->