### PR TITLE
Docs: fix link to blog post

### DIFF
--- a/docs/user/reference/git-integration.rst
+++ b/docs/user/reference/git-integration.rst
@@ -235,7 +235,7 @@ GitHub App
 
 .. warning::
 
-   Our GitHub App is currently in beta, see our `blog post <https://about.readthedocs.com/blog/2025/06/welcome-to-our-beta-github-app/>`__ for more information.
+   Our GitHub App is currently in beta, see our `blog post <https://about.readthedocs.com/blog/2025/06/announcing-our-github-app-beta/>`__ for more information.
 
 We are in the process of migrating our GitHub OAuth application to a `GitHub App <https://docs.github.com/en/apps/overview>`__.
 We have two GitHub Apps, one for each of our platforms:


### PR DESCRIPTION


<!-- readthedocs-preview docs start -->
---
:books: Documentation previews :books:

- User's documentation (`docs`): https://docs--12270.org.readthedocs.build/12270/

<!-- readthedocs-preview docs end -->

<!-- readthedocs-preview dev start -->
- Developer's documentation (`dev`): https://dev--12270.org.readthedocs.build/12270/

<!-- readthedocs-preview dev end -->