### PR TITLE
Docs: mention GH releases in changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+.. note::
+
+   Starting on June 30, the changelog is published as a GitHub release
+   and `listed in the repository itself <https://github.com/readthedocs/readthedocs.org/releases>`_.
+
+
 Version 14.0.0
 --------------
 


### PR DESCRIPTION
We are removing the auto-generated changelog using NPM and switching to GitHub releases. See https://github.com/readthedocs/readthedocs-ops/pull/1663