### PR TITLE
Addons: default "Include subprojects" to true on search

### DIFF
--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -546,6 +546,7 @@ class AddonsResponseBase:
                     [
                         "Include subprojects",
                         f"subprojects:{project.slug}/{version.slug}",
+                        True,
                     ]
                 )
             elif project.superprojects.exists():
@@ -554,6 +555,7 @@ class AddonsResponseBase:
                     [
                         "Include subprojects",
                         f"subprojects:{superproject.slug}/{version.slug}",
+                        True,
                     ]
                 )
 


### PR DESCRIPTION
Initial small approach to make the "Include subprojects" filter enabled by default. I'm adding a new field to the search filter to communicate if it's enabled or disabled by default. This value will be able to be changed by the user in the future from the project admin settings.

* Related https://github.com/readthedocs/addons/issues/22