### PR TITLE
Build overview: link to commit comparison

### DIFF
--- a/readthedocs/templates/core/build-overview.md
+++ b/readthedocs/templates/core/build-overview.md
@@ -10,7 +10,7 @@ make sure to adjust the tags accordingly, as they introduce newlines.
 
 ### Files changed
 
-> Comparing with [{{ base_version.verbose_name }}]({{ base_version.get_absolute_url }}) ({{ base_version_build.commit }})
+> Comparing with [{{ base_version.verbose_name }}]({{ base_version.get_absolute_url }}) ({{ base_version_build.commit }}...{{ current_version_build.commit }})
 
 {% if diff.files %}
 <details>


### PR DESCRIPTION
The text says we are comparing against a commit, so why not link to the commit comparison page.

GH will render this as 4617dfaece7b3f1c8a3aba267be6cbb40c574646...ea12f920cfda8d76bfeed15f6c7ede3610a4119e