### PR TITLE
Upgrade redis to its latest version (`6.2.0`)

### DIFF
--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -361,7 +361,7 @@ qrcode==8.2
     # via
     #   -r requirements/pip.txt
     #   django-allauth
-redis==5.2.1
+redis==6.2.0
     # via -r requirements/pip.txt
 regex==2024.11.6
     # via -r requirements/pip.txt

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -389,7 +389,7 @@ qrcode==8.2
     # via
     #   -r requirements/pip.txt
     #   django-allauth
-redis==5.2.1
+redis==6.2.0
     # via -r requirements/pip.txt
 regex==2024.11.6
     # via -r requirements/pip.txt

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -50,10 +50,7 @@ PyGithub
 
 dnspython
 
-# Used for Redis cache Django backend (`django.core.cache.backends.redis.RedisCache`)
-# Note: pinned for now due to issue with 6.0. See:
-# https://github.com/readthedocs/readthedocs.org/issues/12171
-redis==5.2.1
+redis
 
 celery
 django-celery-beat

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -259,7 +259,7 @@ pyyaml==6.0.2
     # via -r requirements/pip.in
 qrcode==8.2
     # via django-allauth
-redis==5.2.1
+redis==6.2.0
     # via -r requirements/pip.in
 regex==2024.11.6
     # via -r requirements/pip.in

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -385,7 +385,7 @@ qrcode==8.2
     # via
     #   -r requirements/pip.txt
     #   django-allauth
-redis==5.2.1
+redis==6.2.0
     # via -r requirements/pip.txt
 regex==2024.11.6
     # via -r requirements/pip.txt


### PR DESCRIPTION
I tried this locally with

```python
    BROKER_USE_SSL = {
        'ssl_cert_reqs': ssl.CERT_NONE,
    }
```

and the error reported in the issue is not present anymore but I'm not able to trigger builds 🤷🏼 

Closes #12171