### PR TITLE
Fix bugs with organization form and slug input

### DIFF
--- a/readthedocs/organizations/tests/test_forms.py
+++ b/readthedocs/organizations/tests/test_forms.py
@@ -143,7 +143,7 @@ class OrganizationTeamMemberFormTests(OrganizationTestCase):
 
 
 class OrganizationSignupTest(OrganizationTestCase):
-    def test_create_organization_with_empy_slug(self):
+    def test_create_organization_with_empty_slug(self):
         data = {
             "name": "往事",
             "email": "test@example.org",
@@ -151,7 +151,19 @@ class OrganizationSignupTest(OrganizationTestCase):
         form = forms.OrganizationSignupForm(data, user=self.user)
         self.assertFalse(form.is_valid())
         self.assertEqual(
-            "Invalid organization name: no slug generated", form.errors["name"][0]
+            "This field is required.", form.errors["slug"][0]
+        )
+
+    def test_create_organization_with_invalid_unicode_slug(self):
+        data = {
+            "name": "往事",
+            "email": "test@example.org",
+            "slug": "-",
+        }
+        form = forms.OrganizationSignupForm(data, user=self.user)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            "Invalid slug, use more valid characters.", form.errors["slug"][0]
         )
 
     def test_create_organization_with_big_name(self):
@@ -165,17 +177,20 @@ class OrganizationSignupTest(OrganizationTestCase):
 
     def test_create_organization_with_existent_slug(self):
         data = {
-            "name": "mozilla",
+            "name": "Fauxzilla",
             "email": "test@example.org",
+            "slug": "mozilla",
         }
         form = forms.OrganizationSignupForm(data, user=self.user)
         # there is already an organization with the slug ``mozilla`` (lowercase)
         self.assertFalse(form.is_valid())
+        self.assertEqual("Slug is already used by another organization", form.errors["slug"][0])
 
     def test_create_organization_with_nonexistent_slug(self):
         data = {
             "name": "My New Organization",
             "email": "test@example.org",
+            "slug": "my-new-organization",
         }
         form = forms.OrganizationSignupForm(data, user=self.user)
         self.assertTrue(form.is_valid())
@@ -191,3 +206,13 @@ class OrganizationSignupTest(OrganizationTestCase):
         form = forms.OrganizationSignupForm(data, user=self.user)
         self.assertFalse(form.is_valid())
         self.assertIn("consisting of letters, numbers", form.errors["slug"][0])
+
+    def test_create_organization_with_dns_invalid_slug(self):
+        data = {
+            "name": "My Org",
+            "email": "test@example.org",
+            "slug": "-invalid_slug-",
+        }
+        form = forms.OrganizationSignupForm(data, user=self.user)
+        self.assertFalse(form.is_valid())
+        self.assertIn("Invalid slug, use suggested slug 'invalid-slug' instead", form.errors["slug"][0])

--- a/readthedocs/organizations/tests/test_views.py
+++ b/readthedocs/organizations/tests/test_views.py
@@ -361,6 +361,7 @@ class OrganizationSignupTestCase(TestCase):
         data = {
             "name": "Testing Organization",
             "email": "billing@email.com",
+            "slug": "testing-organization",
         }
         resp = self.client.post(reverse("organization_create"), data=data)
         self.assertEqual(Organization.objects.count(), 1)


### PR DESCRIPTION
Found today that we introduced some bugs on the organization form,
namely we aren't validating the user provided slug, only validating the
user provided name rendered to a slug.

This also ensures we're slugging for DNS safely, as this is just
prepended to project URLs without much validation.

Closes https://github.com/readthedocs/readthedocs.org/issues/12305