### PR TITLE
Add GitLab error to known errors when the SSH key is read-only

### DIFF
--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -215,6 +215,8 @@ class Backend(BaseVCS):
                 # but since the key can't be used from the builders,
                 # it should be safe to return False.
                 "ERROR: The repository owner has an IP allow list enabled",
+                # Gitlab:
+                "ERROR: This deploy key does not have write access to this project.",
             ]
             for pattern in errors_read_access_only:
                 if pattern in stderr:


### PR DESCRIPTION
ref https://read-the-docs.sentry.io/issues/6721034615/events/cbc8f641367a4d55b1b3edc190730b48/?query=