### PR TITLE
Add Vale linter config and styles

### DIFF
--- a/.github/styles/Vale/Terms.yml.txt
+++ b/.github/styles/Vale/Terms.yml.txt
@@ -1,0 +1,5 @@
+extends: substitution
+message: "Use 'Read the Docs' instead of 'RTD'"
+level: warning
+swap:
+  RTD: 'Read the Docs'

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,1 +1,4 @@
-common/vale.ini
+StylesPath = .github/styles
+
+[*]
+BasedOnStyles = Vale


### PR DESCRIPTION
This PR adds configuration for Vale linter to help enforce consistent documentation style and branding standards across the project.

- Added `.vale.ini` configuration file
- Created `.github/styles/Vale/Terms.yml.txt` with custom style rules

This will assist in automatically checking docs for preferred terms like "Read the Docs" instead of abbreviations and other branding improvements.

Closes #5876 
