### PR TITLE
Addons: improve performance when fetching translations

### DIFF
--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -892,7 +892,7 @@ class TestReadTheDocsConfigJson(TestCase):
                 language=language,
             )
 
-        with self.assertNumQueries(43):
+        with self.assertNumQueries(39):
             r = self.client.get(
                 reverse("proxito_readthedocs_docs_addons"),
                 {

--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -892,7 +892,7 @@ class TestReadTheDocsConfigJson(TestCase):
                 language=language,
             )
 
-        with self.assertNumQueries(42):
+        with self.assertNumQueries(43):
             r = self.client.get(
                 reverse("proxito_readthedocs_docs_addons"),
                 {

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -339,7 +339,6 @@ class AddonsResponseBase:
         resolver = Resolver()
         versions_active_built_not_hidden = Version.objects.none()
         sorted_versions_active_built_not_hidden = Version.objects.none()
-        user = request.user
 
         versions_active_built_not_hidden = (
             self._get_versions(request, project).select_related("project").order_by("-slug")

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -604,6 +604,7 @@ class AddonsResponseBase:
             .exclude(pk=project.pk)
             .order_by("language")
             .select_related("main_language_project")
+            .prefetch_related("tags", "domains", "related_projects", "users")
         )
         # NOTE: we check if there are translations first,
         # otherwise evaluating the queryset will be more expensive

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -6,6 +6,7 @@ import packaging
 import structlog
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
+from django.db.models import Q
 from django.http import Http404
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
@@ -377,37 +378,11 @@ class AddonsResponseBase:
                     project.addons.flyout_sorting_latest_stable_at_beginning,
                 )
 
-        main_project = project.main_language_project or project
-
-        # Exclude the current project since we don't want to return itself as a translation
-        project_translations = (
-            Project.objects.public(user=user)
-            .filter(pk__in=main_project.translations.all())
-            .exclude(slug=project.slug)
-        )
-
-        # Include main project as translation if the current project is one of the translations
-        if project != main_project:
-            project_translations |= Project.objects.public(user=user).filter(slug=main_project.slug)
-        project_translations = project_translations.order_by("language").select_related(
-            "main_language_project"
-        )
-
         data = {
             "api_version": "1",
-            "projects": {
-                "current": ProjectSerializerNoLinks(
-                    project,
-                    resolver=resolver,
-                    version_slug=version.slug if version else None,
-                ).data,
-                "translations": ProjectSerializerNoLinks(
-                    project_translations,
-                    resolver=resolver,
-                    version_slug=version.slug if version else None,
-                    many=True,
-                ).data,
-            },
+            "projects": self._get_projects_response(
+                request=request, project=project, version=version, resolver=resolver
+            ),
             "versions": {
                 "current": VersionSerializerNoLinks(
                     version,
@@ -613,6 +588,45 @@ class AddonsResponseBase:
             )
 
         return data
+
+    def _get_projects_response(self, *, request, project, version, resolver):
+        main_project = project.main_language_project or project
+
+        translation_filter = Q(pk__in=main_project.translations.all())
+        # Include main project as translation if the current project is one of the translations
+        if main_project != project:
+            translation_filter |= Q(pk=main_project.pk)
+
+        translations_qs = (
+            Project.objects.public(user=request.user)
+            .filter(translation_filter)
+            # Exclude the current project since we don't want to return itself as a translation
+            .exclude(pk=project.pk)
+            .order_by("language")
+            .select_related("main_language_project")
+        )
+        # NOTE: we check if there are translations first,
+        # otherwise evaluating the queryset will be more expensive
+        # even if there are no results. Django optimizes the queryset
+        # if only we need to check if there are results or not.
+        if translations_qs.exists():
+            translations = ProjectSerializerNoLinks(
+                translations_qs,
+                resolver=resolver,
+                version_slug=version.slug if version else None,
+                many=True,
+            ).data
+        else:
+            translations = []
+
+        return {
+            "current": ProjectSerializerNoLinks(
+                project,
+                resolver=resolver,
+                version_slug=version.slug if version else None,
+            ).data,
+            "translations": translations,
+        }
 
     def _get_filetreediff_response(self, *, request, project, version, resolver):
         """


### PR DESCRIPTION
Did some benchmarking with [django-silk
](https://github.com/jazzband/django-silk)

<img width="456" height="195" alt="Screenshot 2025-07-16 at 17-51-59 Silky - Profiling -" src="https://github.com/user-attachments/assets/f89bd7aa-362e-4a25-92d7-29b927f98a43" />

The main thing is that sorting introduces some overhead to the query, calling exists doesn't require sorting, so it's faster.

```
Query Plan
Limit  (cost=0.14..18.32 rows=1 width=4)
  ->  Limit  (cost=0.14..18.32 rows=1 width=4)
        ->  Nested Loop  (cost=0.14..18.32 rows=1 width=4)
              Join Filter: (projects_project.id = u0.id)
              ->  Seq Scan on projects_project  (cost=0.00..10.15 rows=1 width=4)
                    Filter: ((id <> 28) AND ((privacy_level)::text = 'public'::text))
              ->  Index Scan using projects_project_main_language_project_id_5215229a on projects_project u0  (cost=0.14..8.15 rows=1 width=4)
                    Index Cond: (main_language_project_id = 28) 
```

vs

```
Unique  (cost=27.94..28.16 rows=1 width=10546)
  ->  Sort  (cost=27.94..27.94 rows=1 width=10546)
        Sort Key: projects_project.language, projects_project.id, projects_project.pub_date, projects_project.modified_date, projects_project.name, projects_project.slug, projects_project.description, projects_project.repo, projects_project.repo_type, projects_project.project_url, projects_project.canonical_url, projects_project.versioning_scheme, projects_project.single_version, projects_project.default_version, projects_project.default_branch, projects_project.custom_prefix, projects_project.custom_subproject_prefix, projects_project.external_builds_enabled, projects_project.external_builds_privacy_level, projects_project.show_build_overview_in_comment, projects_project.cdn_enabled, projects_project.analytics_code, projects_project.analytics_disabled, projects_project.container_image, projects_project.container_mem_limit, projects_project.container_time_limit, projects_project.build_queue, projects_project.max_concurrent_builds, projects_project.allow_promos, projects_project.ad_free, projects_project.is_spam, projects_project.show_version_warning, projects_project.readthedocs_yaml_path, projects_project.featured, projects_project.skip, projects_project.delisted, projects_project.programming_language, projects_project.main_language_project_id, projects_project.has_valid_webhook, projects_project.has_valid_clone, projects_project.remote_repository_id, projects_project.documentation_type, projects_project.has_ssh_key_with_write_access, t2.id, t2.pub_date, t2.modified_date, t2.name, t2.slug, t2.description, t2.repo, t2.repo_type, t2.project_url, t2.canonical_url, t2.versioning_scheme, t2.single_version, t2.default_version, t2.default_branch, t2.custom_prefix, t2.custom_subproject_prefix, t2.external_builds_enabled, t2.external_builds_privacy_level, t2.show_build_overview_in_comment, t2.cdn_enabled, t2.analytics_code, t2.analytics_disabled, t2.container_image, t2.container_mem_limit, t2.container_time_limit, t2.build_queue, t2.max_concurrent_builds, t2.allow_promos, t2.ad_free, t2.is_spam, t2.show_version_warning, t2.readthedocs_yaml_path, t2.featured, t2.skip, t2.delisted, t2.privacy_level, t2.language, t2.programming_language, t2.main_language_project_id, t2.has_valid_webhook, t2.has_valid_clone, t2.remote_repository_id, t2.documentation_type, t2.has_ssh_key_with_write_access
        ->  Nested Loop  (cost=0.27..27.93 rows=1 width=10546)
              Join Filter: (projects_project.id = u0.id)
              ->  Nested Loop Left Join  (cost=0.14..19.76 rows=1 width=10546)
                    ->  Seq Scan on projects_project  (cost=0.00..10.15 rows=1 width=5273)
                          Filter: (((slug)::text <> 'test-builds'::text) AND ((privacy_level)::text = 'public'::text))
                    ->  Index Scan using projects_project_pkey on projects_project t2  (cost=0.14..8.15 rows=1 width=5273)
                          Index Cond: (id = projects_project.main_language_project_id)
              ->  Index Scan using projects_project_main_language_project_id_5215229a on projects_project u0  (cost=0.14..8.15 rows=1 width=4)
                    Index Cond: (main_language_project_id = 28)
```

What about when the project has translations?

Looks like times are around the same, but I did manage to reduce the number of queries, which will improve perf only for projects with lots of translations (I do have another suggestion to just remove some fields, but for another PR...)

