### PR TITLE
Celery: don't use a `signal` object, but a string instead

### DIFF
--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -1,7 +1,6 @@
 """Common utility functions."""
 
 import re
-import signal
 
 import structlog
 from django.conf import settings
@@ -279,7 +278,7 @@ def cancel_build(build):
         build_task_id=build.task_id,
         terminate=terminate,
     )
-    app.control.revoke(build.task_id, signal=signal.SIGINT, terminate=terminate)
+    app.control.revoke(build.task_id, signal="SIGINT", terminate=terminate)
 
 
 def send_email_from_object(email: EmailMultiAlternatives | EmailMessage):


### PR DESCRIPTION
I've started noticing this some days ago and today I tried to debug it a little. I didn't find anything in our side, so I opened an issue at django-structlog.

https://github.com/jrobichaud/django-structlog/issues/870

However, it ended up being our fault, so I'm updating our code here to avoid keep failing and log this line properly.