### PR TITLE
Addons: improve serializer performance

### DIFF
--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -472,9 +472,9 @@ class ProjectURLsSerializer(BaseLinksSerializer, serializers.Serializer):
         return None
 
     def get_documentation(self, obj):
-        version_slug = getattr(self.parent, "version_slug", None)
+        version = getattr(self.parent, "version", None)
         resolver = getattr(self.parent, "resolver", Resolver())
-        return obj.get_docs_url(version_slug=version_slug, resolver=resolver)
+        return resolver.resolve_version(project=obj, version=version)
 
 
 class RepositorySerializer(serializers.Serializer):
@@ -838,8 +838,8 @@ class ProjectSerializer(FlexFieldsModelSerializer):
         }
 
     def __init__(self, *args, **kwargs):
-        # Receive a `Version.slug` here to build URLs properly
-        self.version_slug = kwargs.pop("version_slug", None)
+        # Receive a `Version` here to build URLs properly
+        self.version = kwargs.pop("version", None)
 
         # Use a shared resolver to reduce the amount of DB queries while
         # resolving version URLs.

--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -382,6 +382,7 @@ class VersionSerializer(serializers.ModelSerializer):
             if obj.slug == LATEST:
                 alias_version = obj.project.get_original_latest_version()
             if alias_version and alias_version.active:
+                # NOTE: we use __class__, as this serializer can be subclassed.
                 return [self.__class__(alias_version).data]
         return []
 

--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -785,7 +785,7 @@ class TestReadTheDocsConfigJson(TestCase):
                 active=True,
             )
 
-        with self.assertNumQueries(20):
+        with self.assertNumQueries(17):
             r = self.client.get(
                 reverse("proxito_readthedocs_docs_addons"),
                 {
@@ -814,7 +814,7 @@ class TestReadTheDocsConfigJson(TestCase):
                 active=True,
             )
 
-        with self.assertNumQueries(22):
+        with self.assertNumQueries(18):
             r = self.client.get(
                 reverse("proxito_readthedocs_docs_addons"),
                 {
@@ -850,7 +850,7 @@ class TestReadTheDocsConfigJson(TestCase):
                 active=True,
             )
 
-        with self.assertNumQueries(26):
+        with self.assertNumQueries(22):
             r = self.client.get(
                 reverse("proxito_readthedocs_docs_addons"),
                 {
@@ -866,7 +866,7 @@ class TestReadTheDocsConfigJson(TestCase):
         assert r.status_code == 200
 
         # Test parent project has fewer queries
-        with self.assertNumQueries(21):
+        with self.assertNumQueries(17):
             r = self.client.get(
                 reverse("proxito_readthedocs_docs_addons"),
                 {
@@ -892,7 +892,7 @@ class TestReadTheDocsConfigJson(TestCase):
                 language=language,
             )
 
-        with self.assertNumQueries(42):
+        with self.assertNumQueries(39):
             r = self.client.get(
                 reverse("proxito_readthedocs_docs_addons"),
                 {
@@ -1042,7 +1042,7 @@ class TestReadTheDocsConfigJson(TestCase):
                 ],
             ),
         ]
-        with self.assertNumQueries(26):
+        with self.assertNumQueries(25):
             r = self.client.get(
                 reverse("proxito_readthedocs_docs_addons"),
                 {

--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -892,7 +892,7 @@ class TestReadTheDocsConfigJson(TestCase):
                 language=language,
             )
 
-        with self.assertNumQueries(39):
+        with self.assertNumQueries(35):
             r = self.client.get(
                 reverse("proxito_readthedocs_docs_addons"),
                 {

--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -1042,7 +1042,7 @@ class TestReadTheDocsConfigJson(TestCase):
                 ],
             ),
         ]
-        with self.assertNumQueries(27):
+        with self.assertNumQueries(26):
             r = self.client.get(
                 reverse("proxito_readthedocs_docs_addons"),
                 {

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -601,7 +601,7 @@ class AddonsResponseBase:
             translations = ProjectSerializerNoLinks(
                 translations_qs,
                 resolver=resolver,
-                version_slug=version.slug if version else None,
+                version=version,
                 many=True,
             ).data
         else:
@@ -611,7 +611,7 @@ class AddonsResponseBase:
             "current": ProjectSerializerNoLinks(
                 project,
                 resolver=resolver,
-                version_slug=version.slug if version else None,
+                version=version,
             ).data,
             "translations": translations,
         }

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -250,12 +250,7 @@ class ProjectSerializerNoLinks(NoLinksMixin, ProjectSerializer):
 
 
 class VersionSerializerNoLinks(NoLinksMixin, VersionSerializer):
-    def __init__(self, *args, **kwargs):
-        super().__init__(
-            *args,
-            version_serializer=VersionSerializerNoLinks,
-            **kwargs,
-        )
+    pass
 
 
 class BuildSerializerNoLinks(NoLinksMixin, BuildSerializer):

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -248,21 +248,11 @@ class RelatedProjectSerializerNoLinks(NoLinksMixin, RelatedProjectSerializer):
 class ProjectSerializerNoLinks(NoLinksMixin, ProjectSerializer):
     related_project_serializer = RelatedProjectSerializerNoLinks
 
-    def __init__(self, *args, **kwargs):
-        resolver = kwargs.pop("resolver", Resolver())
-        super().__init__(
-            *args,
-            resolver=resolver,
-            **kwargs,
-        )
-
 
 class VersionSerializerNoLinks(NoLinksMixin, VersionSerializer):
     def __init__(self, *args, **kwargs):
-        resolver = kwargs.pop("resolver", Resolver())
         super().__init__(
             *args,
-            resolver=resolver,
             version_serializer=VersionSerializerNoLinks,
             **kwargs,
         )
@@ -399,12 +389,12 @@ class AddonsResponseBase:
                 "current": ProjectSerializerNoLinks(
                     project,
                     resolver=resolver,
-                    version_slug=version.slug if version else None,
+                    version=version,
                 ).data,
                 "translations": ProjectSerializerNoLinks(
                     project_translations,
                     resolver=resolver,
-                    version_slug=version.slug if version else None,
+                    version=version,
                     many=True,
                 ).data,
             },


### PR DESCRIPTION
- Instead of passing the version slug to the project serializer, just pass the actual version, so we can use resolve_version, this reduces one less query.
- We were passing the resolver around some places, but doing this weird thing where removing it from kwargs, and then adding it again. This introduced a bug that was creating a new resolver for each serializer instance instead of re-using the one passed to the initializer.

This took ~10ms off locally

<img width="1550" height="237" alt="Screenshot 2025-07-17 at 16-04-42 Silky - Profiling -" src="https://github.com/user-attachments/assets/5667e02c-fe74-4583-b2db-43a086c994b5" />

Note: I'm running these benchmarks in power saver mode, otherwise my computer is too fast and can't get meaningful comparisons :D