### PR TITLE
Celery: increase the "visibility timeout" from 1h to 5h

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -507,6 +507,12 @@ class CommunityBaseSettings(Settings):
     CELERYD_PREFETCH_MULTIPLIER = 1
     CELERY_CREATE_MISSING_QUEUES = True
 
+    # https://github.com/readthedocs/readthedocs.org/issues/12317#issuecomment-3070950434
+    # https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/redis.html#visibility-timeout
+    BROKER_TRANSPORT_OPTIONS = {
+        'visibility_timeout': 18000,  # 5 hours
+    }
+
     CELERY_DEFAULT_QUEUE = "celery"
     CELERYBEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
     CELERYBEAT_SCHEDULE = {


### PR DESCRIPTION
This is the time Celery waits for the worker to ack the task. After this time, Celery will re-deliver this task to another worker.

```
In [1]: from readthedocs.worker import app

In [2]: app.conf.get("BROKER_TRANSPORT_OPTIONS")
Out[2]: {'visibility_timeout': 18000}
```


Closes #12317