### PR TITLE
Builds: feature flag to disable ACKS_LATE per project

### DIFF
--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -20,7 +20,6 @@ from readthedocs.builds.constants import EXTERNAL
 from readthedocs.doc_builder.exceptions import BuildCancelled
 from readthedocs.doc_builder.exceptions import BuildMaxConcurrencyError
 from readthedocs.notifications.models import Notification
-from readthedocs.projects.models import Feature
 from readthedocs.worker import app
 
 
@@ -50,6 +49,7 @@ def prepare_build(
     from readthedocs.api.v2.models import BuildAPIKey
     from readthedocs.builds.models import Build
     from readthedocs.builds.tasks import send_build_notifications
+    from readthedocs.projects.models import Feature
     from readthedocs.projects.models import Project
     from readthedocs.projects.models import WebHookEvent
     from readthedocs.projects.tasks.builds import update_docs_task

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1977,6 +1977,7 @@ class Feature(models.Model):
     SCALE_IN_PROTECTION = "scale_in_prtection"
     USE_S3_SCOPED_CREDENTIALS_ON_BUILDERS = "use_s3_scoped_credentials_on_builders"
     BUILD_HEALTHCHECK = "build_healthcheck"
+    BUILD_NO_ACKS_LATE = "build_no_acks_late"
 
     FEATURES = (
         (
@@ -2054,6 +2055,10 @@ class Feature(models.Model):
         (
             BUILD_HEALTHCHECK,
             _("Build: Use background cURL healthcheck."),
+        ),
+        (
+            BUILD_NO_ACKS_LATE,
+            _("Build: Do not use Celery ASK_LATE config for this project."),
         ),
     )
 


### PR DESCRIPTION
Another attempt to run builds longer than 1h in a reliably way.

Related: #12317