### PR TITLE
Addons: improve performance when versions have downloads

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -5,6 +5,7 @@ import hashlib
 import hmac
 import os
 import re
+from functools import cache
 from shlex import quote
 from urllib.parse import urlparse
 
@@ -885,6 +886,7 @@ class Project(models.Model):
         """Return whether or not this project supports translations."""
         return self.versioning_scheme == MULTIPLE_VERSIONS_WITH_TRANSLATIONS
 
+    @cache
     def subdomain(self, use_canonical_domain=True):
         """Get project subdomain from resolver."""
         return Resolver().get_domain_without_protocol(

--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -384,6 +384,36 @@ class TestReadTheDocsConfigJson(TestCase):
         }
         assert r.json()["versions"]["current"]["downloads"] == expected
 
+    def test_number_of_queries_versions_with_downloads(self):
+        for i in range(10):
+            fixture.get(
+                Version,
+                project=self.project,
+                privacy_level=PUBLIC,
+                slug=f"offline-{i}",
+                verbose_name=f"offline-{i}",
+                built=True,
+                has_pdf=True,
+                has_epub=True,
+                has_htmlzip=True,
+                active=True,
+            )
+
+        with self.assertNumQueries(24):
+            r = self.client.get(
+                reverse("proxito_readthedocs_docs_addons"),
+                {
+                    "url": "https://project.dev.readthedocs.io/en/offline/",
+                    "client-version": "0.6.0",
+                    "api-version": "1.0.0",
+                },
+                secure=True,
+                headers={
+                    "host": "project.dev.readthedocs.io",
+                },
+            )
+            assert r.status_code == 200
+
     def test_flyout_single_version_project(self):
         self.version.has_pdf = True
         self.version.has_epub = True

--- a/readthedocs/subscriptions/products.py
+++ b/readthedocs/subscriptions/products.py
@@ -116,7 +116,7 @@ def get_feature(obj, feature_type) -> RTDProductFeature:
     from readthedocs.projects.models import Project
 
     if isinstance(obj, Project):
-        organization = obj.organizations.first()
+        organization = obj.organizations.select_related("stripe_subscription").first()
     elif isinstance(obj, Organization):
         organization = obj
     else:


### PR DESCRIPTION
This call wasn't cached, so it was creating a new resolver for each download type of each version, resulting in several queries being done (71 in the test I created).