### PR TITLE
Refactor tags/branches data to use dataclass instead of dicts (fixes #7798)

### DIFF
--- a/readthedocs/api/v2/utils.py
+++ b/readthedocs/api/v2/utils.py
@@ -15,6 +15,7 @@ from readthedocs.builds.constants import NON_REPOSITORY_VERSIONS
 from readthedocs.builds.constants import STABLE
 from readthedocs.builds.constants import STABLE_VERBOSE_NAME
 from readthedocs.builds.constants import TAG
+from readthedocs.builds.datatypes import VersionData
 from readthedocs.builds.models import RegexAutomationRule
 from readthedocs.builds.models import Version
 
@@ -168,10 +169,13 @@ def _set_or_create_version(project, slug, version_id, verbose_name, type_):
 
 
 def _get_deleted_versions_qs(project, tags_data, branches_data):
+    # Convert to VersionData if not already
+    tags_data = [VersionData(**v) if not isinstance(v, VersionData) else v for v in tags_data]
+    branches_data = [VersionData(**v) if not isinstance(v, VersionData) else v for v in branches_data]
     # We use verbose_name for tags
     # because several tags can point to the same identifier.
-    versions_tags = [version["verbose_name"] for version in tags_data]
-    versions_branches = [version["identifier"] for version in branches_data]
+    versions_tags = [version.verbose_name for version in tags_data]
+    versions_branches = [version.identifier for version in branches_data]
 
     to_delete_qs = (
         project.versions(manager=INTERNAL)
@@ -196,6 +200,9 @@ def delete_versions_from_db(project, tags_data, branches_data):
 
     :returns: The slug of the deleted versions from the database.
     """
+    # Convert to VersionData if not already
+    tags_data = [VersionData(**v) if not isinstance(v, VersionData) else v for v in tags_data]
+    branches_data = [VersionData(**v) if not isinstance(v, VersionData) else v for v in branches_data]
     to_delete_qs = _get_deleted_versions_qs(
         project=project,
         tags_data=tags_data,
@@ -212,6 +219,9 @@ def delete_versions_from_db(project, tags_data, branches_data):
 
 def get_deleted_active_versions(project, tags_data, branches_data):
     """Return the slug of active versions that were deleted from the repository."""
+    # Convert to VersionData if not already
+    tags_data = [VersionData(**v) if not isinstance(v, VersionData) else v for v in tags_data]
+    branches_data = [VersionData(**v) if not isinstance(v, VersionData) else v for v in branches_data]
     to_delete_qs = _get_deleted_versions_qs(
         project=project,
         tags_data=tags_data,

--- a/readthedocs/builds/datatypes.py
+++ b/readthedocs/builds/datatypes.py
@@ -1,0 +1,6 @@
+from dataclasses import dataclass
+
+@dataclass
+class VersionData:
+    identifier: str
+    verbose_name: str 

--- a/readthedocs/projects/tasks/mixins.py
+++ b/readthedocs/projects/tasks/mixins.py
@@ -6,6 +6,8 @@ from readthedocs.builds import tasks as build_tasks
 from readthedocs.builds.constants import LATEST_VERBOSE_NAME
 from readthedocs.builds.constants import STABLE_VERBOSE_NAME
 from readthedocs.builds.models import APIVersion
+from readthedocs.builds.datatypes import VersionData
+import dataclasses
 
 from ..exceptions import RepositoryError
 from ..models import Feature
@@ -50,18 +52,12 @@ class SyncRepositoryMixin:
         )
 
         tags_data = [
-            {
-                "identifier": v.identifier,
-                "verbose_name": v.verbose_name,
-            }
+            VersionData(identifier=v.identifier, verbose_name=v.verbose_name)
             for v in tags
         ]
 
         branches_data = [
-            {
-                "identifier": v.identifier,
-                "verbose_name": v.verbose_name,
-            }
+            VersionData(identifier=v.identifier, verbose_name=v.verbose_name)
             for v in branches
         ]
 
@@ -74,8 +70,8 @@ class SyncRepositoryMixin:
 
         build_tasks.sync_versions_task.delay(
             project_pk=self.data.project.pk,
-            tags_data=tags_data,
-            branches_data=branches_data,
+            tags_data=[dataclasses.asdict(v) for v in tags_data],
+            branches_data=[dataclasses.asdict(v) for v in branches_data],
         )
 
     def validate_duplicate_reserved_versions(self, tags_data, branches_data):
@@ -88,7 +84,7 @@ class SyncRepositoryMixin:
 
         :param data: Dict containing the versions from tags and branches
         """
-        version_names = [version["verbose_name"] for version in tags_data + branches_data]
+        version_names = [version.verbose_name for version in tags_data + branches_data]
         counter = Counter(version_names)
         for reserved_name in [STABLE_VERBOSE_NAME, LATEST_VERBOSE_NAME]:
             if counter[reserved_name] > 1:


### PR DESCRIPTION
Description

This PR refactors the handling of tags and branches data throughout the codebase to use a dataclass (VersionData) instead of plain dictionaries. This improves type safety, code readability, and reduces the risk of bugs related to key typos or inconsistent data structures.

Key Changes

Introduced a VersionData dataclass to represent tags and branches data (identifier and verbose_name).
Updated all code that creates, passes, or consumes tags/branches data to use the dataclass instead of dictionaries.
Before passing tags/branches data to Celery tasks, the dataclasses are serialized to dicts; inside the Celery task, they are deserialized back to dataclasses.
Updated all validation and utility functions to use dataclass attributes.
Ensured full compatibility with Celery serialization.

Motivation

Previously, tags and branches were passed as lists of dictionaries, which was error-prone and harder to maintain. Using a dataclass provides a clear contract for the data structure and makes the codebase more robust.

Related Issue
Fixes #7798

How to Test

Run the test suite to ensure all affected code paths work as expected.
Trigger any Celery tasks that use tags/branches data to confirm serialization works correctly.