### PR TITLE
Build: obfuscate private variables

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -242,8 +242,8 @@ class BuildCommand(BuildCommandResultMixin):
             for name, spec in self.build_env.project._environment_variables.items():
                 if not spec["public"]:
                     value = spec["value"]
-                    sanitized_value = f"{value[:4]}****"
-                    sanitized = sanitized.replace(value, sanitized_value)
+                    obfuscated_value = f"{value[:4]}****"
+                    sanitized = sanitized.replace(value, obfuscated_value)
 
         return sanitized
 

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -8,6 +8,7 @@ from django.test import TestCase, override_settings
 from django_dynamic_fixture import get
 from docker.errors import APIError as DockerAPIError
 
+from readthedocs.projects.models import APIProject
 from readthedocs.builds.models import Version
 from readthedocs.doc_builder.environments import (
     BuildCommand,
@@ -41,7 +42,7 @@ class TestLocalBuildEnvironment(TestCase):
         api_client.command().patch.return_value = {
             "id": 1,
         }
-        project = get(Project)
+        project = APIProject(**get(Project).__dict__)
         build_env = LocalBuildEnvironment(
             project=project,
             build={
@@ -258,7 +259,7 @@ class TestBuildCommand(TestCase):
 
     def test_output(self):
         """Test output command."""
-        project = get(Project)
+        project = APIProject(**get(Project).__dict__)
         api_client = mock.MagicMock()
         build_env = LocalBuildEnvironment(
             project=project,

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -310,7 +310,7 @@ class TestBuildCommand(TestCase):
         for output, sanitized in checks:
             self.assertEqual(cmd.sanitize_output(output), sanitized)
 
-    def test_sanitize_output_private_variables(self):
+    def test_obfuscate_output_private_variables(self):
         build_env = mock.MagicMock()
         build_env.project = mock.MagicMock()
         build_env.project._environment_variables = mock.MagicMock()

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -310,6 +310,34 @@ class TestBuildCommand(TestCase):
         for output, sanitized in checks:
             self.assertEqual(cmd.sanitize_output(output), sanitized)
 
+    def test_sanitize_output_private_variables(self):
+        build_env = mock.MagicMock()
+        build_env.project = mock.MagicMock()
+        build_env.project._environment_variables = mock.MagicMock()
+        build_env.project._environment_variables.items.return_value = [
+            (
+                "PUBLIC",
+                {
+                    "public": True,
+                    "value": "public-value",
+                },
+            ),
+            (
+                "PRIVATE",
+                {
+                    "public": False,
+                    "value": "private-value",
+                },
+            ),
+        ]
+        cmd = BuildCommand(["/bin/bash", "-c", "echo"], build_env=build_env)
+        checks = (
+            ("public-value", "public-value"),
+            ("private-value", "priv****"),
+        )
+        for output, sanitized in checks:
+            self.assertEqual(cmd.sanitize_output(output), sanitized)
+
     @patch("subprocess.Popen")
     def test_unicode_output(self, mock_subprocess):
         """Unicode output from command."""


### PR DESCRIPTION
Replace the value of private variables with the first 4 chars of it and `****`. This is a protection to avoid leaking private variables by mistake.

The same pattern is used in the dashboard when listing these variables.

Closes https://github.com/readthedocs/readthedocs-corporate/issues/2004