### PR TITLE
Downgrade django-allauth

### DIFF
--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -130,7 +130,7 @@ django==5.2.4
     #   djangorestframework
     #   drf-extensions
     #   jsonfield
-django-allauth[mfa,saml,socialaccount]==65.10.0
+django-allauth[mfa,saml,socialaccount]==65.9.0
     # via -r requirements/pip.txt
 django-annoying==0.10.8
     # via -r requirements/pip.txt
@@ -269,7 +269,6 @@ newrelic==10.7.0
 oauthlib==3.3.1
     # via
     #   -r requirements/pip.txt
-    #   django-allauth
     #   requests-oauthlib
 orjson==3.11.1
     # via -r requirements/pip.txt
@@ -378,7 +377,9 @@ requests==2.32.4
     #   slumber
     #   stripe
 requests-oauthlib==2.0.0
-    # via -r requirements/pip.txt
+    # via
+    #   -r requirements/pip.txt
+    #   django-allauth
 requests-toolbelt==1.0.0
     # via -r requirements/pip.txt
 rest-framework-generic-relations==2.2.0

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -138,7 +138,7 @@ django==5.2.4
     #   djangorestframework
     #   drf-extensions
     #   jsonfield
-django-allauth[mfa,saml,socialaccount]==65.10.0
+django-allauth[mfa,saml,socialaccount]==65.9.0
     # via -r requirements/pip.txt
 django-annoying==0.10.8
     # via -r requirements/pip.txt
@@ -284,7 +284,6 @@ mdurl==0.1.2
 oauthlib==3.3.1
     # via
     #   -r requirements/pip.txt
-    #   django-allauth
     #   requests-oauthlib
 orjson==3.11.1
     # via -r requirements/pip.txt
@@ -406,7 +405,9 @@ requests==2.32.4
     #   slumber
     #   stripe
 requests-oauthlib==2.0.0
-    # via -r requirements/pip.txt
+    # via
+    #   -r requirements/pip.txt
+    #   django-allauth
 requests-toolbelt==1.0.0
     # via -r requirements/pip.txt
 rest-framework-generic-relations==2.2.0

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -55,7 +55,10 @@ redis
 celery
 django-celery-beat
 
-django-allauth[socialaccount,saml,mfa]
+# 65.10.0 includes a fix that changes when clean_email is called,
+# we were relying on that method not being called on auto-signup for SAML and Google.
+# https://codeberg.org/allauth/django-allauth/commit/a5782aca5e373a48e7408e02d68211d934e821f3
+django-allauth[socialaccount,saml,mfa]==65.9.0
 
 requests-oauthlib
 

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -93,7 +93,7 @@ django==5.2.4
     #   djangorestframework
     #   drf-extensions
     #   jsonfield
-django-allauth[mfa,saml,socialaccount]==65.10.0
+django-allauth[mfa,saml,socialaccount]==65.9.0
     # via -r requirements/pip.in
 django-annoying==0.10.8
     # via -r requirements/pip.in
@@ -200,9 +200,7 @@ lxml==5.3.2
 markdown==3.8.2
     # via -r requirements/pip.in
 oauthlib==3.3.1
-    # via
-    #   django-allauth
-    #   requests-oauthlib
+    # via requests-oauthlib
 orjson==3.11.1
     # via -r requirements/pip.in
 packaging==25.0
@@ -275,7 +273,9 @@ requests==2.32.4
     #   slumber
     #   stripe
 requests-oauthlib==2.0.0
-    # via -r requirements/pip.in
+    # via
+    #   -r requirements/pip.in
+    #   django-allauth
 requests-toolbelt==1.0.0
     # via -r requirements/pip.in
 rest-framework-generic-relations==2.2.0

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -135,7 +135,7 @@ django==5.2.4
     #   djangorestframework
     #   drf-extensions
     #   jsonfield
-django-allauth[mfa,saml,socialaccount]==65.10.0
+django-allauth[mfa,saml,socialaccount]==65.9.0
     # via -r requirements/pip.txt
 django-annoying==0.10.8
     # via -r requirements/pip.txt
@@ -276,7 +276,6 @@ markupsafe==3.0.2
 oauthlib==3.3.1
     # via
     #   -r requirements/pip.txt
-    #   django-allauth
     #   requests-oauthlib
 orjson==3.11.1
     # via -r requirements/pip.txt
@@ -407,7 +406,9 @@ requests==2.32.4
 requests-mock==1.12.1
     # via -r requirements/testing.in
 requests-oauthlib==2.0.0
-    # via -r requirements/pip.txt
+    # via
+    #   -r requirements/pip.txt
+    #   django-allauth
 requests-toolbelt==1.0.0
     # via -r requirements/pip.txt
 rest-framework-generic-relations==2.2.0


### PR DESCRIPTION
We were relying on clean_email not being called on autosignup. That was changed in the latest release, and it's not allowing users to sign up with Google/SAML.

Closes https://github.com/readthedocs/readthedocs-corporate/issues/2029