### PR TITLE
Delete outdated warning message

### DIFF
--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -1,7 +1,6 @@
 """Project views for authenticated users."""
 
 import structlog
-from allauth.socialaccount.models import SocialAccount
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.messages.views import SuccessMessageMixin
@@ -15,7 +14,6 @@ from django.middleware.csrf import get_token
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import ListView
 from django.views.generic import TemplateView
@@ -47,7 +45,6 @@ from readthedocs.invitations.models import Invitation
 from readthedocs.notifications.models import Notification
 from readthedocs.oauth.constants import GITHUB
 from readthedocs.oauth.services import GitHubService
-from readthedocs.oauth.services import registry
 from readthedocs.oauth.tasks import attach_webhook
 from readthedocs.oauth.utils import update_webhook
 from readthedocs.projects.filters import ProjectListFilterSet


### PR DESCRIPTION
This was introduced in https://github.com/readthedocs/readthedocs.org/commit/ed0d02b91f1bdad565eb6df7acebb7d01efea18f, likely when the new bitbucket provider was added.

The registry doesn't have Google and SAML listed,
so users with accounts connected to those providers are shown this warning, which is confusing.

I checked the DB on .org and .com, and there are no users with unsupported providers.