### PR TITLE
Build: log "Triggering build." with more data

### DIFF
--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -179,6 +179,10 @@ def prepare_build(
     # Log all the extra options passed to the task
     structlog.contextvars.bind_contextvars(**options)
 
+    # NOTE: call this log here as well to log all the context variables added
+    # inside this function. This is useful when debugging.
+    log.info("Triggering build with specific attributes.")
+
     return (
         update_docs_task.signature(
             args=(

--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -181,7 +181,7 @@ def prepare_build(
 
     # NOTE: call this log here as well to log all the context variables added
     # inside this function. This is useful when debugging.
-    log.info("Triggering build with specific attributes.")
+    log.info("Build created and ready to be executed.")
 
     return (
         update_docs_task.signature(

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -835,8 +835,8 @@ class DockerBuildEnvironment(BaseBuildEnvironment):
                 "Creating Docker container.",
                 container_image=self.container_image,
                 container_id=self.container_id,
-                time_limit=self.container_time_limit,
-                mem_limit=self.container_mem_limit,
+                container_time_limit=self.container_time_limit,
+                container_mem_limit=self.container_mem_limit,
             )
 
             networking_config = None


### PR DESCRIPTION
By calling this log line _after_ `prepare_build` we will be logging more useful infomation like `build_id` on this line together with all the options passed to the task. This is useful for debug.