### PR TITLE
Dashboard: optimize projects queryset

### DIFF
--- a/readthedocs/projects/querysets.py
+++ b/readthedocs/projects/querysets.py
@@ -144,7 +144,6 @@ class ProjectQuerySetBase(NoReprQuerySet, models.QuerySet):
 
         # Prefetch the latest build for each project.
         subquery = Subquery(
-            # Is this project_id or pk?
             Build.internal.filter(project=OuterRef("project_id")).order_by("-date").values("pk")[:1]
         )
         latest_build = Prefetch(
@@ -152,17 +151,7 @@ class ProjectQuerySetBase(NoReprQuerySet, models.QuerySet):
             Build.objects.filter(pk__in=subquery).select_related("version"),
             to_attr=self.model.LATEST_BUILD_CACHE,
         )
-
-        subquery = Subquery(
-            Build.internal.filter(project=OuterRef("project_id"), success=True).values("pk")[:1]
-        )
-        has_good_build = Prefetch(
-            "builds",
-            Build.objects.filter(pk__in=subquery),
-            to_attr="_good_build",
-        )
-
-        return self.prefetch_related(latest_build, has_good_build)
+        return self.prefetch_related(latest_build)
 
     # Aliases
 

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -1,8 +1,6 @@
 from unittest import mock
 
-import pytest
 from allauth.socialaccount.models import SocialAccount
-from django.conf import settings
 from django.contrib.auth.models import User
 from django.http.response import HttpResponseRedirect
 from django.test import TestCase, override_settings
@@ -381,7 +379,6 @@ class TestPrivateViews(TestCase):
         self.project = get(Project, slug="pip", users=[self.user])
 
     def test_dashboard_number_of_queries(self):
-        """Test that the dashboard view doesn't make too many queries."""
         for i in range(10):
             project = get(
                 Project,
@@ -401,8 +398,7 @@ class TestPrivateViews(TestCase):
                     state=BUILD_STATE_FINISHED,
                 )
 
-        # This used to be 35!
-        with self.assertNumQueries(15):
+        with self.assertNumQueries(25):
             r = self.client.get(reverse(("projects_dashboard")))
         assert r.status_code == 200
 

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -398,7 +398,7 @@ class TestPrivateViews(TestCase):
                     state=BUILD_STATE_FINISHED,
                 )
 
-        with self.assertNumQueries(25):
+        with self.assertNumQueries(24):
             r = self.client.get(reverse(("projects_dashboard")))
         assert r.status_code == 200
 


### PR DESCRIPTION
This used to be 35 queries. I found another optimization to make it to constant time, but will open another PR as it may produce a slow query..