### PR TITLE
API: don't rely on the version object for builds

### DIFF
--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -225,7 +225,7 @@ class BuildCommandReadOnlySerializer(BuildCommandSerializer):
     command = serializers.SerializerMethodField()
 
     def get_command(self, obj):
-        return normalize_build_command(obj.command, obj.build.project.slug, obj.build.version.slug)
+        return normalize_build_command(obj.command, obj.build.project.slug, obj.build.get_version_slug())
 
 
 class BuildSerializer(serializers.ModelSerializer):

--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -225,7 +225,9 @@ class BuildCommandReadOnlySerializer(BuildCommandSerializer):
     command = serializers.SerializerMethodField()
 
     def get_command(self, obj):
-        return normalize_build_command(obj.command, obj.build.project.slug, obj.build.get_version_slug())
+        return normalize_build_command(
+            obj.command, obj.build.project.slug, obj.build.get_version_slug()
+        )
 
 
 class BuildSerializer(serializers.ModelSerializer):

--- a/readthedocs/api/v2/views/model_views.py
+++ b/readthedocs/api/v2/views/model_views.py
@@ -355,7 +355,7 @@ class BuildViewSet(DisableListEndpoint, UpdateModelMixin, UserSelectViewSet):
                         buildcommand["command"] = normalize_build_command(
                             buildcommand["command"],
                             instance.project.slug,
-                            instance.version.slug,
+                            instance.get_version_slug(),
                         )
                 except Exception:
                     log.exception(

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -707,6 +707,29 @@ class APIBuildTests(TestCase):
         build = resp.data
         self.assertEqual(len(build["results"]), 1)
 
+    def test_build_without_version(self):
+        build = get(
+            Build,
+            project=self.project,
+            version=None,
+            state=BUILD_STATE_FINISHED,
+            exit_code=0,
+        )
+        command = "python -m pip install --upgrade --no-cache-dir pip setuptools<58.3.0"
+        get(
+            BuildCommandResult,
+            build=build,
+            command=command,
+            output="Running...",
+            exit_code=0,
+        )
+        client = APIClient()
+        client.force_authenticate(user=self.user)
+        r = client.get(reverse("build-detail", args=(build.pk,)))
+        assert r.status_code == 200
+        assert r.data["version"] is None
+        assert r.data["commands"][0]["command"] == command
+
 
 class APITests(TestCase):
     fixtures = ["eric.json", "test_data.json"]


### PR DESCRIPTION
If a version is deleted, we still keep its builds around, so we can't rely on the version being present. Ref https://read-the-docs.sentry.io/issues/3961831199/?project=148442