### PR TITLE
docs: mention Docusaurus requires trailingSlash: true

### DIFF
--- a/docs/user/intro/docusaurus.rst
+++ b/docs/user/intro/docusaurus.rst
@@ -35,6 +35,13 @@ build the site, and copy the output to $READTHEDOCS_OUTPUT:
 
 .. _Docusaurus: https://docusaurus.io/
 
+.. note::
+
+   On Read the Docs, Docusaurus should set 'trailingSlash: true' in
+   'docusaurus.config.js' to avoid routing issues. If you set it to
+   'false', you will  need to define appropriate redirects.
+
+
 Limitations
 -----------
 


### PR DESCRIPTION
Adds a note to the Docusaurus guide stating that `trailingSlash: true` is needed on Read the Docs to avoid routing issues. If `false`, users must configure redirects.

Closes #12345
