### PR TITLE
Dashboard: cache get_queryset

### DIFF
--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -1,5 +1,7 @@
 """Project views for authenticated users."""
 
+from functools import lru_cache
+
 import structlog
 from django.conf import settings
 from django.contrib import messages
@@ -149,6 +151,10 @@ class ProjectDashboard(FilterContextMixin, PrivateViewMixin, ListView):
                 dismissable=True,
             )
 
+    # NOTE: This method is called twice, on .org it doesn't matter,
+    # as the queryset is straightforward, but on .com it
+    # does some extra work that results in several queries.
+    @lru_cache(maxsize=1)
     def get_queryset(self):
         return Project.objects.dashboard(self.request.user)
 


### PR DESCRIPTION
On .org this doesn't reduce the number of queries, but it does for .com