### PR TITLE
Dashboard: don't prefetch latest build

### DIFF
--- a/readthedocs/projects/filters.py
+++ b/readthedocs/projects/filters.py
@@ -138,11 +138,7 @@ class ProjectSortOrderingFilter(OrderingFilter):
             else:
                 order_bys.append(field_ordered)
 
-        # Prefetch here not only prefetches the query, but it also changes how `get_latest_build`
-        # works. Normally from templates `project.get_latest_build` only returns
-        # the latest _finished_ build. But with prefetch, _all_ builds are
-        # considered and `get_latest_build` will pop the first off this list of
-        # _all_ builds.
+        # prefetch_latest_build does some extra optimizations to avoid additional queries.
         return qs.prefetch_latest_build().annotate(**annotations).order_by(*order_bys)
 
 

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -5,7 +5,6 @@ import hashlib
 import hmac
 import os
 import re
-from functools import lru_cache
 from shlex import quote
 from urllib.parse import urlparse
 

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1,6 +1,7 @@
 """Project models."""
 
 import fnmatch
+from functools import lru_cache
 import hashlib
 import hmac
 import os
@@ -645,9 +646,6 @@ class Project(models.Model):
         blank=True,
     )
 
-    # Property used for storing the latest build for a project when prefetching
-    LATEST_BUILD_CACHE = "_latest_build"
-
     class Meta:
         ordering = ("slug",)
         verbose_name = _("project")
@@ -1100,23 +1098,17 @@ class Project(models.Model):
                 matches.append(os.path.join(root, match))
         return matches
 
+    @lru_cache(maxsize=1)
     def get_latest_build(self, finished=True):
         """
         Get latest build for project.
 
         :param finished: Return only builds that are in a finished state
         """
-        # Check if there is `_latest_build` attribute in the Queryset.
-        # Used for Database optimization.
-        if hasattr(self, self.LATEST_BUILD_CACHE):
-            if self._latest_build:
-                return self._latest_build[0]
-            return None
-
-        kwargs = {"type": "html"}
+        kwargs = {}
         if finished:
             kwargs["state"] = "finished"
-        return self.builds(manager=INTERNAL).filter(**kwargs).first()
+        return self.builds(manager=INTERNAL).filter(**kwargs).select_related("version").first()
 
     def active_versions(self):
         from readthedocs.builds.models import Version

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1,11 +1,11 @@
 """Project models."""
 
 import fnmatch
-from functools import lru_cache
 import hashlib
 import hmac
 import os
 import re
+from functools import lru_cache
 from shlex import quote
 from urllib.parse import urlparse
 

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1098,17 +1098,10 @@ class Project(models.Model):
                 matches.append(os.path.join(root, match))
         return matches
 
-    @lru_cache(maxsize=1)
-    def get_latest_build(self, finished=True):
-        """
-        Get latest build for project.
-
-        :param finished: Return only builds that are in a finished state
-        """
-        kwargs = {}
-        if finished:
-            kwargs["state"] = "finished"
-        return self.builds(manager=INTERNAL).filter(**kwargs).select_related("version").first()
+    @cached_property
+    def latest_internal_build(self):
+        """Get the latest internal build for the project."""
+        return self.builds(manager=INTERNAL).select_related("version").first()
 
     def active_versions(self):
         from readthedocs.builds.models import Version

--- a/readthedocs/projects/views/base.py
+++ b/readthedocs/projects/views/base.py
@@ -30,7 +30,7 @@ class ProjectOnboardMixin:
 
         # Show for the first few builds, return last build state
         if project.builds.count() <= 5:
-            onboard["build"] = project.get_latest_build(finished=False)
+            onboard["build"] = project.latest_internal_build
             if "github" in project.repo:
                 onboard["provider"] = "github"
             elif "bitbucket" in project.repo:

--- a/readthedocs/rtd_tests/tests/test_project.py
+++ b/readthedocs/rtd_tests/tests/test_project.py
@@ -223,11 +223,11 @@ class TestProject(ProjectMixin, TestCase):
         # Test that External Version is not considered for has_good_build.
         self.assertFalse(self.pip.has_good_build)
 
-    def test_get_latest_build_excludes_external_versions(self):
+    def test_latest_internal_build_excludes_external_versions(self):
         # Delete all versions excluding External Versions.
         self.pip.versions.exclude(type=EXTERNAL).delete()
-        # Test that External Version is not considered for get_latest_build.
-        self.assertEqual(self.pip.get_latest_build(), None)
+        # Test that External Version is not considered for latest_internal_build.
+        self.assertEqual(self.pip.latest_internal_build, None)
 
     def test_git_provider_github(self):
         self.pip.repo = "https://github.com/pypa/pip"

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -399,6 +399,9 @@ class TestPrivateViews(TestCase):
                     state=BUILD_STATE_FINISHED,
                 )
 
+        # This number is bit higher, but for projects with lots of builds
+        # is better to have more queries than optimizing with a prefetch,
+        # see comment in prefetch_latest_build.
         with self.assertNumQueries(27):
             r = self.client.get(reverse(("projects_dashboard")))
         assert r.status_code == 200

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -399,7 +399,7 @@ class TestPrivateViews(TestCase):
                     state=BUILD_STATE_FINISHED,
                 )
 
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(27):
             r = self.client.get(reverse(("projects_dashboard")))
         assert r.status_code == 200
 


### PR DESCRIPTION
get_latest_build was doing something different than the prefetched value, looks like we never actually used this function with `finished=True`, so I went ahead and renamed it and made it a property so we can cache it.