### PR TITLE
update readthedocs documentation to ubuntu 24.04

### DIFF
--- a/docs/user/config-file/examples/sphinx/.readthedocs.yaml
+++ b/docs/user/config-file/examples/sphinx/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 
 # Set the OS, Python version and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
     python: "3.12"
     # You can also specify other tool versions:


### PR DESCRIPTION
I came from https://docs.readthedocs.com/platform/stable/config-file/v2.html and found that the recommended OS is outdated.
I think that this should always use an up-to-date version, so that new users do not start with an old OS version for their docs.

Of course there are many other links to old OS versions, some also to Ubuntu 20.04, which should be changed as well.