### PR TITLE
Repo sync: don't keep all objects in memory

### DIFF
--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -255,16 +255,15 @@ class UserService(Service):
         - deletes old RemoteRepository/Organization that are not present
           for this user in the current provider
         """
-        remote_repositories = self.sync_repositories()
+        repository_remote_ids = self.sync_repositories()
         (
-            remote_organizations,
-            remote_repositories_organizations,
+            organization_remote_ids,
+            organization_repositories_remote_ids,
         ) = self.sync_organizations()
 
         # Delete RemoteRepository where the user doesn't have access anymore
         # (skip RemoteRepository tied to a Project on this user)
-        all_remote_repositories = remote_repositories + remote_repositories_organizations
-        repository_remote_ids = [r.remote_id for r in all_remote_repositories if r is not None]
+        repository_remote_ids += organization_repositories_remote_ids
         (
             self.user.remote_repository_relations.filter(
                 account=self.account,
@@ -277,7 +276,6 @@ class UserService(Service):
         )
 
         # Delete RemoteOrganization where the user doesn't have access anymore
-        organization_remote_ids = [o.remote_id for o in remote_organizations if o is not None]
         (
             self.user.remote_organization_relations.filter(
                 account=self.account,

--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -34,7 +34,7 @@ class BitbucketService(UserService):
 
     def sync_repositories(self):
         """Sync repositories from Bitbucket API."""
-        remote_repositories = []
+        remote_ids = []
 
         # Get user repos
         try:
@@ -44,7 +44,8 @@ class BitbucketService(UserService):
             )
             for repo in repos:
                 remote_repository = self.create_repository(repo)
-                remote_repositories.append(remote_repository)
+                if remote_repository:
+                    remote_ids.append(remote_repository.remote_id)
 
         except (TypeError, ValueError):
             log.warning("Error syncing Bitbucket repositories")
@@ -74,12 +75,12 @@ class BitbucketService(UserService):
         except (TypeError, ValueError):
             pass
 
-        return remote_repositories
+        return remote_ids
 
     def sync_organizations(self):
         """Sync Bitbucket workspaces(our RemoteOrganization) and workspace repositories."""
-        remote_organizations = []
-        remote_repositories = []
+        organization_remote_ids = []
+        repository_remote_ids = []
 
         try:
             workspaces = self.paginate(
@@ -90,14 +91,15 @@ class BitbucketService(UserService):
                 remote_organization = self.create_organization(workspace)
                 repos = self.paginate(workspace["links"]["repositories"]["href"])
 
-                remote_organizations.append(remote_organization)
+                organization_remote_ids.append(remote_organization.remote_id)
 
                 for repo in repos:
                     remote_repository = self.create_repository(
                         repo,
                         organization=remote_organization,
                     )
-                    remote_repositories.append(remote_repository)
+                    if remote_repository:
+                        repository_remote_ids.append(remote_repository.remote_id)
 
         except ValueError:
             log.warning("Error syncing Bitbucket organizations")
@@ -107,7 +109,7 @@ class BitbucketService(UserService):
                 )
             )
 
-        return remote_organizations, remote_repositories
+        return organization_remote_ids, repository_remote_ids
 
     def create_repository(self, fields, privacy=None, organization=None):
         """

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -38,13 +38,14 @@ class GitHubService(UserService):
 
     def sync_repositories(self):
         """Sync repositories from GitHub API."""
-        remote_repositories = []
+        remote_ids = []
 
         try:
             repos = self.paginate(f"{self.base_api_url}/user/repos", per_page=100)
             for repo in repos:
                 remote_repository = self.create_repository(repo)
-                remote_repositories.append(remote_repository)
+                if remote_repository:
+                    remote_ids.append(remote_repository.remote_id)
         except (TypeError, ValueError):
             log.warning("Error syncing GitHub repositories")
             raise SyncServiceError(
@@ -52,12 +53,12 @@ class GitHubService(UserService):
                     provider=self.vcs_provider_slug
                 )
             )
-        return remote_repositories
+        return remote_ids
 
     def sync_organizations(self):
         """Sync organizations from GitHub API."""
-        remote_organizations = []
-        remote_repositories = []
+        organization_remote_ids = []
+        repository_remote_ids = []
 
         try:
             orgs = self.paginate(f"{self.base_api_url}/user/orgs", per_page=100)
@@ -67,7 +68,7 @@ class GitHubService(UserService):
                     org_details,
                     create_user_relationship=True,
                 )
-                remote_organizations.append(remote_organization)
+                organization_remote_ids.append(remote_organization.remote_id)
 
                 org_url = org["url"]
                 org_repos = self.paginate(
@@ -76,7 +77,8 @@ class GitHubService(UserService):
                 )
                 for repo in org_repos:
                     remote_repository = self.create_repository(repo)
-                    remote_repositories.append(remote_repository)
+                    if remote_repository:
+                        repository_remote_ids.append(remote_repository.remote_id)
 
         except (TypeError, ValueError):
             log.warning("Error syncing GitHub organizations")
@@ -86,7 +88,7 @@ class GitHubService(UserService):
                 )
             )
 
-        return remote_organizations, remote_repositories
+        return organization_remote_ids, repository_remote_ids
 
     def create_repository(self, fields, privacy=None):
         """
@@ -105,23 +107,10 @@ class GitHubService(UserService):
                 (fields["private"] is False and privacy == "public"),
             ]
         ):
-            repo, created = RemoteRepository.objects.get_or_create(
+            repo, _ = RemoteRepository.objects.get_or_create(
                 remote_id=str(fields["id"]),
                 vcs_provider=self.vcs_provider_slug,
             )
-
-            # TODO: For debugging: https://github.com/readthedocs/readthedocs.org/pull/9449.
-            if created:
-                _old_remote_repository = RemoteRepository.objects.filter(
-                    full_name=fields["full_name"], vcs_provider=self.vcs_provider_slug
-                ).first()
-                if _old_remote_repository:
-                    log.warning(
-                        "GitHub repository created with different remote_id but exact full_name.",
-                        fields=fields,
-                        old_remote_repository=_old_remote_repository.__dict__,
-                        imported=_old_remote_repository.projects.exists(),
-                    )
 
             owner_type = fields["owner"]["type"]
             organization = None

--- a/readthedocs/rtd_tests/tests/test_oauth_sync.py
+++ b/readthedocs/rtd_tests/tests/test_oauth_sync.py
@@ -194,13 +194,14 @@ class GitHubOAuthSyncTests(TestCase):
         self.assertEqual(RemoteRepository.objects.count(), 0)
         self.assertEqual(RemoteOrganization.objects.count(), 0)
 
-        remote_repositories = self.service.sync_repositories()
+        repository_remote_ids = self.service.sync_repositories()
 
         self.assertEqual(RemoteRepository.objects.count(), 1)
         self.assertEqual(RemoteOrganization.objects.count(), 0)
-        self.assertEqual(len(remote_repositories), 1)
-        remote_repository = remote_repositories[0]
-        self.assertIsInstance(remote_repository, RemoteRepository)
+        self.assertEqual(len(repository_remote_ids), 1)
+
+        remote_repository = RemoteRepository.objects.first()
+        self.assertEqual(repository_remote_ids[0], remote_repository.remote_id)
         self.assertEqual(remote_repository.full_name, "organization/repository")
         self.assertEqual(remote_repository.name, "repository")
         self.assertFalse(remote_repository.remote_repository_relations.first().admin)
@@ -234,15 +235,15 @@ class GitHubOAuthSyncTests(TestCase):
             organization=remote_organization,
             vcs_provider="github",
         )
-        remote_repositories = self.service.sync_repositories()
+        repository_remote_ids = self.service.sync_repositories()
 
         self.assertEqual(RemoteRepository.objects.count(), 1)
         self.assertEqual(RemoteRepositoryRelation.objects.count(), 1)
         self.assertEqual(RemoteOrganization.objects.count(), 1)
 
-        self.assertEqual(len(remote_repositories), 1)
-        remote_repository = remote_repositories[0]
-        self.assertIsInstance(remote_repository, RemoteRepository)
+        self.assertEqual(len(repository_remote_ids), 1)
+        remote_repository = RemoteRepository.objects.first()
+        self.assertEqual(repository_remote_ids[0], remote_repository.remote_id)
         self.assertEqual(remote_repository.full_name, "organization/repository")
         self.assertEqual(remote_repository.name, "repository")
         self.assertEqual(remote_repository.organization.slug, "organization")
@@ -276,15 +277,15 @@ class GitHubOAuthSyncTests(TestCase):
             organization=remote_organization,
             vcs_provider="github",
         )
-        remote_repositories = self.service.sync_repositories()
+        repository_remote_ids = self.service.sync_repositories()
 
         self.assertEqual(RemoteRepository.objects.count(), 1)
         self.assertEqual(RemoteRepositoryRelation.objects.count(), 1)
         self.assertEqual(RemoteOrganization.objects.count(), 1)
 
-        self.assertEqual(len(remote_repositories), 1)
-        remote_repository = remote_repositories[0]
-        self.assertIsInstance(remote_repository, RemoteRepository)
+        self.assertEqual(len(repository_remote_ids), 1)
+        remote_repository = RemoteRepository.objects.first()
+        self.assertEqual(repository_remote_ids[0], remote_repository.remote_id)
         self.assertEqual(remote_repository.full_name, "organization/repository")
         self.assertEqual(remote_repository.name, "repository")
         self.assertIsNone(remote_repository.organization)
@@ -407,14 +408,13 @@ class GitHubOAuthSyncTests(TestCase):
         self.assertEqual(RemoteOrganization.objects.count(), 0)
         self.assertEqual(RemoteOrganizationRelation.objects.count(), 0)
 
-        remote_organizations, remote_repositories = self.service.sync_organizations()
+        organization_remote_ids, repository_remote_ids = self.service.sync_organizations()
 
         self.assertEqual(RemoteRepository.objects.count(), 1)
         self.assertEqual(RemoteRepositoryRelation.objects.count(), 1)
         self.assertEqual(RemoteOrganization.objects.count(), 1)
         self.assertEqual(RemoteOrganizationRelation.objects.count(), 1)
-        self.assertEqual(len(remote_organizations), 1)
-        self.assertEqual(len(remote_repositories), 1)
-        remote_organization = remote_organizations[0]
-        self.assertIsInstance(remote_organization, RemoteOrganization)
-        self.assertEqual(remote_organization.name, "Organization")
+        self.assertEqual(len(organization_remote_ids), 1)
+        self.assertEqual(len(repository_remote_ids), 1)
+        remote_organization = RemoteOrganization.objects.first()
+        self.assertEqual(organization_remote_ids[0], remote_organization.remote_id)


### PR DESCRIPTION
We were keeping all remote repos and org objects into memory, but only using its remote_id, this should help to reduce the memory footprint when syncing users with lots of repos.