### PR TITLE
Build: delete old `finish_inactive_builds`

### DIFF
--- a/readthedocs/rtd_tests/tests/test_project.py
+++ b/readthedocs/rtd_tests/tests/test_project.py
@@ -30,7 +30,6 @@ from readthedocs.projects.constants import (
 )
 from readthedocs.projects.exceptions import ProjectConfigurationError
 from readthedocs.projects.models import Project
-from readthedocs.projects.tasks.utils import finish_inactive_builds
 
 
 class ProjectMixin:

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -651,13 +651,6 @@ class CommunityBaseSettings(Settings):
             "schedule": crontab(minute="*"),
             "options": {"queue": "web"},
         },
-        # TODO: delete `quarter-finish-inactive-builds` once we are fully
-        # migrated into build healthcheck
-        "quarter-finish-inactive-builds": {
-            "task": "readthedocs.projects.tasks.utils.finish_inactive_builds",
-            "schedule": crontab(minute="*/15"),
-            "options": {"queue": "web"},
-        },
         "every-day-delete-old-search-queries": {
             "task": "readthedocs.search.tasks.delete_old_search_queries_from_db",
             "schedule": crontab(minute=0, hour=0),


### PR DESCRIPTION
We are using healthcheck for all the projects now and it has its own task to finish unhealthy builds.