### PR TITLE
Builds: healthcheck permissions

### DIFF
--- a/readthedocs/api/v2/views/model_views.py
+++ b/readthedocs/api/v2/views/model_views.py
@@ -12,6 +12,7 @@ from django.db.models import Case
 from django.db.models import Value
 from django.db.models import When
 from django.http import Http404
+from django.shortcuts import get_object_or_404
 from django.template.loader import render_to_string
 from django.utils import timezone
 from rest_framework import decorators
@@ -307,7 +308,12 @@ class BuildViewSet(DisableListEndpoint, UpdateModelMixin, UserSelectViewSet):
         methods=["post"],
     )
     def healthcheck(self, request, **kwargs):
-        build = self.get_object()
+        # We can't use `self.get_object()` here because it uses `get_queryset()` method that it's filtered by build API key and/or user access.
+        # Since we don't want to check for permissions here (only based on `?builder=` GET attribute) we need to query the db manually here.
+        lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
+        filter_kwargs = {self.lookup_field: self.kwargs[lookup_url_kwarg]}
+        build = get_object_or_404(Build.objects.all(), **filter_kwargs)
+
         builder_hostname = request.GET.get("builder")
         structlog.contextvars.bind_contextvars(
             build_id=build.pk,

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -114,7 +114,7 @@ class APIBuildTests(TestCase):
         self.assertIsNone(build.healthcheck)
 
         client = APIClient()
-        r = client.post(reverse("build-healthcheck", args=(build.pk,)) + "?builder=build-a1b2c3")
+        r = client.post(reverse("build-healthcheck", args=(build.pk,), query={"builder": "build-a1b2c3"}))
         build.refresh_from_db()
 
         self.assertEqual(r.status_code, 204)
@@ -125,7 +125,7 @@ class APIBuildTests(TestCase):
         build.save()
 
         client = APIClient()
-        r = client.post(reverse("build-healthcheck", args=(build.pk,)) + "?builder=build-invalid")
+        r = client.post(reverse("build-healthcheck", args=(build.pk,), query={"builder": "build-invalid"}))
         build.refresh_from_db()
 
         self.assertEqual(r.status_code, 404)
@@ -137,7 +137,7 @@ class APIBuildTests(TestCase):
         build.save()
 
         client = APIClient()
-        r = client.post(reverse("build-healthcheck", args=(build.pk,)) + "?builder=build-a1b2c3")
+        r = client.post(reverse("build-healthcheck", args=(build.pk,), query={"builder": "build-a1b2c3"}))
         build.refresh_from_db()
 
         self.assertEqual(r.status_code, 404)

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -101,6 +101,49 @@ class APIBuildTests(TestCase):
         self.project = get(Project, users=[self.user])
         self.version = self.project.versions.get(slug=LATEST)
 
+    def test_healthcheck(self):
+        # Build cloning state
+        build = get(
+            Build,
+            project=self.project,
+            version=self.version,
+            state=BUILD_STATE_CLONING,
+            builder="build-a1b2c3",
+            success=False,
+        )
+        self.assertIsNone(build.healthcheck)
+
+        client = APIClient()
+        r = client.post(reverse("build-healthcheck", args=(build.pk,)) + "?builder=build-a1b2c3")
+        build.refresh_from_db()
+
+        self.assertEqual(r.status_code, 204)
+        self.assertIsNotNone(build.healthcheck)
+
+        # Build invalid builder
+        build.healthcheck = None
+        build.save()
+
+        client = APIClient()
+        r = client.post(reverse("build-healthcheck", args=(build.pk,)) + "?builder=build-invalid")
+        build.refresh_from_db()
+
+        self.assertEqual(r.status_code, 404)
+        self.assertIsNone(build.healthcheck)
+
+        # Build finished state
+        build.state = BUILD_STATE_FINISHED
+        build.healthcheck = None
+        build.save()
+
+        client = APIClient()
+        r = client.post(reverse("build-healthcheck", args=(build.pk,)) + "?builder=build-a1b2c3")
+        build.refresh_from_db()
+
+        self.assertEqual(r.status_code, 404)
+        self.assertIsNone(build.healthcheck)
+
+
     def test_reset_build(self):
         build = get(
             Build,


### PR DESCRIPTION
We want to skip the default permsissions check here (done at `get_queryset()` method) because it filters the object by build API key and/or user access.

Since we are making an anonymous request without a build API key, we need to skip this check and base it only on the `?builder=` GET attribute.