### PR TITLE
Builds: set `length` on unhealthy builds

### DIFF
--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -126,6 +126,10 @@ def finish_unhealthy_builds():
     builds_finished = []
     builds = Build.objects.filter(query)[:50]
     for build in builds:
+        if build.commands.exists():
+            # Try to update the build length if there is at least one command
+            build.length = (timezone.now() - build.commands.first().start_time).seconds
+
         build.success = False
         build.state = BUILD_STATE_CANCELLED
         build.save()

--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -128,7 +128,11 @@ def finish_unhealthy_builds():
     for build in builds:
         if build.commands.exists():
             # Try to update the build length if there is at least one command
-            build.length = (build.commands.last().start_time - build.commands.first().start_time).seconds
+            first_command = build.commands.first()
+            last_command = build.commands.last()
+            build.length = (
+                (last_command.end_time or last_command.start_time) - first_command.start_time
+            ).seconds
 
         build.success = False
         build.state = BUILD_STATE_CANCELLED

--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -128,7 +128,7 @@ def finish_unhealthy_builds():
     for build in builds:
         if build.commands.exists():
             # Try to update the build length if there is at least one command
-            build.length = (timezone.now() - build.commands.first().start_time).seconds
+            build.length = (build.commands.last().start_time - build.commands.first().start_time).seconds
 
         build.success = False
         build.state = BUILD_STATE_CANCELLED

--- a/readthedocs/rtd_tests/tests/test_projects_tasks.py
+++ b/readthedocs/rtd_tests/tests/test_projects_tasks.py
@@ -13,7 +13,7 @@ from readthedocs.builds.constants import (
     BUILD_STATE_TRIGGERED,
     EXTERNAL,
 )
-from readthedocs.builds.models import Build, Version
+from readthedocs.builds.models import Build, BuildCommandResult, Version
 from readthedocs.projects.models import Feature, Project
 from readthedocs.projects.tasks.utils import finish_unhealthy_builds, send_external_build_status
 
@@ -93,6 +93,8 @@ class TestFinishInactiveBuildsTask(TestCase):
             healthcheck=timezone.now() - datetime.timedelta(minutes=15),
         )
 
+        get(BuildCommandResult, build=build_3, start_time=timezone.now())
+
         finish_unhealthy_builds()
 
         build_1.refresh_from_db()
@@ -103,5 +105,6 @@ class TestFinishInactiveBuildsTask(TestCase):
 
         build_3.refresh_from_db()
         self.assertEqual(build_3.state, BUILD_STATE_CANCELLED)
+        self.assertIsNotNone(build_3.length)
         self.assertEqual(build_3.success, False)
         self.assertEqual(build_3.notifications.count(), 1)


### PR DESCRIPTION
Infer the build length by using the first command's start time.