### PR TITLE
Git services: improve sync repos

### DIFF
--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -144,6 +144,10 @@ class UserService(Service):
     def __init__(self, user, account):
         self.user = user
         self.account = account
+        # Cache organizations to avoid multiple DB hits
+        # when syncing repositories that belong to the same organization.
+        # Used by `create_organization` method in subclasses.
+        self._organizations_cache = {}
         structlog.contextvars.bind_contextvars(
             user_username=self.user.username,
             social_provider=self.allauth_provider.id,

--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -15,6 +15,7 @@ from requests.exceptions import RequestException
 
 from readthedocs.core.permissions import AdminPermission
 from readthedocs.oauth.clients import get_oauth2_client
+from readthedocs.oauth.models import RemoteRepository
 
 
 log = structlog.get_logger(__name__)
@@ -65,6 +66,16 @@ class Service:
         - Updates fields for existing RemoteRepository/Organization
         - Deletes old RemoteRepository/Organization that are no longer present
           in this provider.
+        """
+        raise NotImplementedError
+
+    def update_repository(self, remote_repository: RemoteRepository):
+        """
+        Update a repository using the service API.
+
+        This also updates the user relationship with the repository,
+        if user is an admin or not, and in case the user no longer has access
+        to the repository, the relationship is removed.
         """
         raise NotImplementedError
 

--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -15,7 +15,6 @@ from requests.exceptions import RequestException
 
 from readthedocs.core.permissions import AdminPermission
 from readthedocs.oauth.clients import get_oauth2_client
-from readthedocs.oauth.models import RemoteRepository
 
 
 log = structlog.get_logger(__name__)
@@ -66,16 +65,6 @@ class Service:
         - Updates fields for existing RemoteRepository/Organization
         - Deletes old RemoteRepository/Organization that are no longer present
           in this provider.
-        """
-        raise NotImplementedError
-
-    def update_repository(self, remote_repository: RemoteRepository):
-        """
-        Update a repository using the service API.
-
-        This also updates the user relationship with the repository,
-        if user is an admin or not, and in case the user no longer has access
-        to the repository, the relationship is removed.
         """
         raise NotImplementedError
 

--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -134,7 +134,7 @@ class BitbucketService(UserService):
             )
             self._update_repository_from_fields(repo, fields)
 
-            # The respositories API doesn't return the admin status of the user,
+            # The repositories API doesn't return the admin status of the user,
             # so we default to False, and then update it later using another API call.
             remote_repository_relation = repo.get_remote_repository_relation(
                 self.user, self.account

--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -80,10 +80,10 @@ class BitbucketService(UserService):
 
     def sync_organizations(self):
         """
-        Sync Bitbucket workspaces(our RemoteOrganization) and workspace repositories.
+        Sync Bitbucket workspaces (organizations).
 
-        This method basically only creates the relationships between the
-        workspace (organization) and the user, as all the repositories
+        This method only creates the relationships between the
+        organizations and the user, as all the repositories
         are already created in the sync_repositories method.
         """
         organization_remote_ids = []

--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -182,7 +182,6 @@ class BitbucketService(UserService):
         repo.save()
 
         return repo
-
     def create_organization(self, fields):
         """
         Update or create remote organization from Bitbucket API response.

--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -181,7 +181,6 @@ class BitbucketService(UserService):
 
         repo.save()
 
-        return repo
     def create_organization(self, fields):
         """
         Update or create remote organization from Bitbucket API response.

--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -103,63 +103,6 @@ class BitbucketService(UserService):
 
         return organization_remote_ids, []
 
-    def update_repository(self, remote_repository: RemoteRepository):
-        if not remote_repository.organization:
-            log.warning(
-                "Cannot update repository without organization.",
-                repository=remote_repository.name,
-            )
-            return
-
-        resp = self.session.get(
-            f"{self.base_api_url}/2.0/repositories/{remote_repository.organization.remote_id}/{remote_repository.remote_id}",
-        )
-
-        # NOTE: this could also happen if the repotitory was moved to a different workspace,
-        # as bitbucket requires the workspace UUID to access the repository.
-        # In that case after the user triggers a sync, the repository will be updated accordingly.
-        if resp.status_code in [403, 404]:
-            log.info(
-                "User no longer has access to the repository, removing remote relationship.",
-                remote_repository_id=remote_repository.remote_id,
-            )
-            remote_repository.get_remote_repository_relation(self.user, self.account).delete()
-            return
-
-        if resp.status_code != 200:
-            log.warning(
-                "Error fetching repository from Bitbucket",
-                remote_repository_id=remote_repository.remote_id,
-                status_code=resp.status_code,
-            )
-            return
-
-        data = resp.json()
-        self._update_repository_from_fields(remote_repository, data)
-
-        # Bitbucket doesn't return the admin status of the user,
-        # so we need to infer it by filtering the repositories the user has admin/read access to.
-        is_admin = self._has_access_to_repository(remote_repository, role="admin")
-        has_read_access = self._has_access_to_repository(remote_repository, role="member")
-        relation = remote_repository.get_remote_repository_relation(self.user, self.account)
-        if not has_read_access and not is_admin:
-            log.info(
-                "User no longer has access to the repository, removing remote relationship.",
-                remote_repository_id=remote_repository.remote_id,
-            )
-            relation.delete()
-        else:
-            relation.admin = is_admin
-            relation.save()
-
-    def _has_access_to_repository(self, remote_repository, role):
-        repos = self.paginate(
-            f"{self.base_api_url}/2.0/repositories/",
-            role=role,
-            q=f'uuid="{remote_repository.remote_id}"',
-        )
-        return any(repo["uuid"] == remote_repository.remote_id for repo in repos)
-
     def create_repository(self, fields, privacy=None):
         """
         Update or create a repository from Bitbucket API response.

--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -32,10 +32,6 @@ class BitbucketService(UserService):
     url_pattern = re.compile(r"bitbucket.org")
     https_url_pattern = re.compile(r"^https:\/\/[^@]+@bitbucket.org/")
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._organizations_cache = {}
-
     def sync_repositories(self):
         """Sync repositories from Bitbucket API."""
         remote_ids = []

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -156,8 +156,6 @@ class GitHubService(UserService):
 
         repo.save()
 
-        return repo
-
     def create_organization(self, fields):
         """
         Update or create remote organization from GitHub API response.

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -56,30 +56,22 @@ class GitHubService(UserService):
         return remote_ids
 
     def sync_organizations(self):
-        """Sync organizations from GitHub API."""
+        """
+        Sync organizations from GitHub API.
+
+        This method basically only creates the relationships between the
+        organization and the user, as all the repositories are already
+        created in the sync_repositories method.
+        """
         organization_remote_ids = []
-        repository_remote_ids = []
 
         try:
             orgs = self.paginate(f"{self.base_api_url}/user/orgs", per_page=100)
             for org in orgs:
                 org_details = self.session.get(org["url"]).json()
-                remote_organization = self.create_organization(
-                    org_details,
-                    create_user_relationship=True,
-                )
+                remote_organization = self.create_organization(org_details)
+                remote_organization.get_remote_organization_relation(self.user, self.account)
                 organization_remote_ids.append(remote_organization.remote_id)
-
-                org_url = org["url"]
-                org_repos = self.paginate(
-                    f"{org_url}/repos",
-                    per_page=100,
-                )
-                for repo in org_repos:
-                    remote_repository = self.create_repository(repo)
-                    if remote_repository:
-                        repository_remote_ids.append(remote_repository.remote_id)
-
         except (TypeError, ValueError):
             log.warning("Error syncing GitHub organizations")
             raise SyncServiceError(
@@ -88,7 +80,59 @@ class GitHubService(UserService):
                 )
             )
 
-        return organization_remote_ids, repository_remote_ids
+        return organization_remote_ids, []
+
+    def _has_access_to_repository(self, fields):
+        permissions = fields.get("permissions", {})
+        # If the repo is public, the user can still access it,
+        # so wee need to check if the user has any access
+        # to the repository, even if they are not an admin.
+        has_access = any(
+            permissions.get(key, False) for key in ["admin", "maintain", "push", "triage"]
+        )
+        is_admin = permissions.get("admin", False)
+        return has_access, is_admin
+
+    def update_repository(self, remote_repository: RemoteRepository):
+        resp = self.session.get(f"{self.base_api_url}/repositories/{remote_repository.remote_id}")
+
+        # The repo was deleted, or the user does not have access to it.
+        # In any case, we remove the user relationship.
+        if resp.status_code in [403, 404]:
+            log.info(
+                "User no longer has access to the repository, removing remote relationship.",
+                remote_repository=remote_repository.remote_id,
+            )
+            remote_repository.get_remote_repository_relation(self.user, self.account).delete()
+            return
+
+        if resp.status_code != 200:
+            log.warning(
+                "Error fetching repository from GitHub",
+                remote_repository=remote_repository.remote_id,
+                status_code=resp.status_code,
+            )
+            return
+
+        data = resp.json()
+        self._update_repository_from_fields(remote_repository, data)
+
+        has_access, is_admin = self._has_access_to_repository(data)
+        relation = remote_repository.get_remote_repository_relation(
+            self.user,
+            self.account,
+        )
+        if not has_access:
+            # If the user no longer has access to the repository,
+            # we remove the remote relationship.
+            log.info(
+                "User no longer has access to the repository, removing remote relationship.",
+                remote_repository=remote_repository.remote_id,
+            )
+            relation.delete()
+        else:
+            relation.admin = is_admin
+            relation.save()
 
     def create_repository(self, fields, privacy=None):
         """
@@ -96,8 +140,6 @@ class GitHubService(UserService):
 
         :param fields: dictionary of response data from API
         :param privacy: privacy level to support
-        :param organization: remote organization to associate with
-        :type organization: RemoteOrganization
         :rtype: RemoteRepository
         """
         privacy = privacy or settings.DEFAULT_PRIVACY_LEVEL
@@ -111,52 +153,13 @@ class GitHubService(UserService):
                 remote_id=str(fields["id"]),
                 vcs_provider=self.vcs_provider_slug,
             )
-
-            owner_type = fields["owner"]["type"]
-            organization = None
-            if owner_type == "Organization":
-                # We aren't creating a remote relationship between the current user
-                # and the organization, since the user can have access to the repository,
-                # but not to the organization.
-                organization = self.create_organization(
-                    fields=fields["owner"],
-                    create_user_relationship=False,
-                )
-
-            # If there is an organization associated with this repository,
-            # attach the organization to the repository.
-            if organization and owner_type == "Organization":
-                repo.organization = organization
-
-            # If the repository belongs to a user,
-            # remove the organization linked to the repository.
-            if owner_type == "User":
-                repo.organization = None
-
-            repo.name = fields["name"]
-            repo.full_name = fields["full_name"]
-            repo.description = fields["description"]
-            repo.ssh_url = fields["ssh_url"]
-            repo.html_url = fields["html_url"]
-            repo.private = fields["private"]
-            repo.vcs = "git"
-            repo.avatar_url = fields.get("owner", {}).get("avatar_url")
-            repo.default_branch = fields.get("default_branch")
-
-            if repo.private:
-                repo.clone_url = fields["ssh_url"]
-            else:
-                repo.clone_url = fields["clone_url"]
-
-            if not repo.avatar_url:
-                repo.avatar_url = self.default_user_avatar_url
-
-            repo.save()
+            self._update_repository_from_fields(repo, fields)
 
             remote_repository_relation = repo.get_remote_repository_relation(
                 self.user, self.account
             )
-            remote_repository_relation.admin = fields.get("permissions", {}).get("admin", False)
+            _, is_admin = self._has_access_to_repository(fields)
+            remote_repository_relation.admin = is_admin
             remote_repository_relation.save()
 
             return repo
@@ -166,7 +169,45 @@ class GitHubService(UserService):
             repository=fields["name"],
         )
 
-    def create_organization(self, fields, create_user_relationship=False):
+    def _update_repository_from_fields(self, repo, fields):
+        owner_type = fields["owner"]["type"]
+        organization = None
+        if owner_type == "Organization":
+            organization = self.create_organization(fields=fields["owner"])
+
+        # If there is an organization associated with this repository,
+        # attach the organization to the repository.
+        if organization and owner_type == "Organization":
+            repo.organization = organization
+
+        # If the repository belongs to a user,
+        # remove the organization linked to the repository.
+        if owner_type == "User":
+            repo.organization = None
+
+        repo.name = fields["name"]
+        repo.full_name = fields["full_name"]
+        repo.description = fields["description"]
+        repo.ssh_url = fields["ssh_url"]
+        repo.html_url = fields["html_url"]
+        repo.private = fields["private"]
+        repo.vcs = "git"
+        repo.avatar_url = fields.get("owner", {}).get("avatar_url")
+        repo.default_branch = fields.get("default_branch")
+
+        if repo.private:
+            repo.clone_url = fields["ssh_url"]
+        else:
+            repo.clone_url = fields["clone_url"]
+
+        if not repo.avatar_url:
+            repo.avatar_url = self.default_user_avatar_url
+
+        repo.save()
+
+        return repo
+
+    def create_organization(self, fields):
         """
         Update or create remote organization from GitHub API response.
 
@@ -180,8 +221,6 @@ class GitHubService(UserService):
             remote_id=str(fields["id"]),
             vcs_provider=self.vcs_provider_slug,
         )
-        if create_user_relationship:
-            organization.get_remote_organization_relation(self.user, self.account)
 
         organization.url = fields.get("html_url")
         # fields['login'] contains GitHub Organization slug

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -63,9 +63,9 @@ class GitHubService(UserService):
         """
         Sync organizations from GitHub API.
 
-        This method basically only creates the relationships between the
-        organization and the user, as all the repositories are already
-        created in the sync_repositories method.
+        This method only creates the relationships between the
+        organizations and the user, as all the repositories
+        are already created in the sync_repositories method.
         """
         organization_remote_ids = []
 

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -36,10 +36,6 @@ class GitHubService(UserService):
     url_pattern = re.compile(r"github\.com")
     supports_build_status = True
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._organizations_cache = {}
-
     def sync_repositories(self):
         """Sync repositories from GitHub API."""
         remote_ids = []

--- a/readthedocs/oauth/services/githubapp.py
+++ b/readthedocs/oauth/services/githubapp.py
@@ -240,6 +240,9 @@ class GitHubAppService(Service):
         ).values_list("remote_id", flat=True)
         self.installation.delete_repositories(repos_to_delete)
 
+    def update_repository(self, remote_repository: RemoteRepository):
+        return self.update_or_create_repositories([remote_repository.remote_id])
+
     def update_or_create_repositories(self, repository_ids: list[int]):
         """Update or create repositories from the given list of repository IDs."""
         repositories_to_delete = []

--- a/readthedocs/oauth/services/githubapp.py
+++ b/readthedocs/oauth/services/githubapp.py
@@ -240,9 +240,6 @@ class GitHubAppService(Service):
         ).values_list("remote_id", flat=True)
         self.installation.delete_repositories(repos_to_delete)
 
-    def update_repository(self, remote_repository: RemoteRepository):
-        return self.update_or_create_repositories([remote_repository.remote_id])
-
     def update_or_create_repositories(self, repository_ids: list[int]):
         """Update or create repositories from the given list of repository IDs."""
         repositories_to_delete = []

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -112,6 +112,13 @@ class GitLabService(UserService):
         return remote_ids
 
     def sync_organizations(self):
+        """
+        Sync GitLab groups (organizations).
+
+        This method only creates the relationships between the
+        organizations and the user, as all the repositories
+        are already created in the sync_repositories method.
+        """
         organization_remote_ids = []
 
         try:

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -51,10 +51,6 @@ class GitLabService(UserService):
 
     vcs_provider_slug = GITLAB
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._organizations_cache = {}
-
     def _get_repo_id(self, project):
         """
         Get the ID or URL-encoded path of the project.

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -85,7 +85,8 @@ class GitLabService(UserService):
         remote_ids = []
         try:
             repos = self.paginate(
-                f"{self.base_api_url}/api/v4/users/{self.account.uid}/projects",
+                f"{self.base_api_url}/api/v4/projects",
+                membership=True,
                 per_page=100,
                 archived=False,
                 order_by="path",
@@ -108,7 +109,6 @@ class GitLabService(UserService):
 
     def sync_organizations(self):
         organization_remote_ids = []
-        repository_remote_ids = []
 
         try:
             orgs = self.paginate(
@@ -120,52 +120,8 @@ class GitLabService(UserService):
             )
             for org in orgs:
                 remote_organization = self.create_organization(org)
-                org_repos = self.paginate(
-                    "{url}/api/v4/groups/{id}/projects".format(
-                        url=self.base_api_url,
-                        id=org["id"],
-                    ),
-                    per_page=100,
-                    archived=False,
-                    order_by="path",
-                    sort="asc",
-                )
-
+                remote_organization.get_remote_organization_relation(self.user, self.account)
                 organization_remote_ids.append(remote_organization.remote_id)
-
-                for repo in org_repos:
-                    # TODO: Optimize this so that we don't re-fetch project data
-                    # Details: https://github.com/readthedocs/readthedocs.org/issues/7743
-                    try:
-                        # The response from /groups/{id}/projects API does not contain
-                        # admin permission fields for GitLab projects.
-                        # So, fetch every single project data from the API
-                        # which contains the admin permission fields.
-                        resp = self.session.get(
-                            "{url}/api/v4/projects/{id}".format(
-                                url=self.base_api_url, id=repo["id"]
-                            )
-                        )
-
-                        if resp.status_code == 200:
-                            repo_details = resp.json()
-                            remote_repository = self.create_repository(
-                                repo_details, organization=remote_organization
-                            )
-                            if remote_repository:
-                                repository_remote_ids.append(remote_repository.remote_id)
-                        else:
-                            log.warning(
-                                "GitLab project does not exist or user does not have permissions.",
-                                repository=repo["name_with_namespace"],
-                            )
-
-                    except Exception:
-                        log.exception(
-                            "Error creating GitLab repository",
-                            repository=repo["name_with_namespace"],
-                        )
-
         except (TypeError, ValueError):
             log.warning("Error syncing GitLab organizations")
             raise SyncServiceError(
@@ -174,7 +130,66 @@ class GitLabService(UserService):
                 )
             )
 
-        return organization_remote_ids, repository_remote_ids
+        return organization_remote_ids, []
+
+    def _has_access_to_repository(self, fields):
+        project_access_level = group_access_level = self.PERMISSION_NO_ACCESS
+
+        project_access = fields.get("permissions", {}).get("project_access", {})
+        if project_access:
+            project_access_level = project_access.get("access_level", self.PERMISSION_NO_ACCESS)
+
+        group_access = fields.get("permissions", {}).get("group_access", {})
+        if group_access:
+            group_access_level = group_access.get("access_level", self.PERMISSION_NO_ACCESS)
+
+        has_access = (
+            group_access != self.PERMISSION_NO_ACCESS or project_access != self.PERMISSION_NO_ACCESS
+        )
+        project_admin = project_access_level in (self.PERMISSION_MAINTAINER, self.PERMISSION_OWNER)
+        group_admin = group_access_level in (self.PERMISSION_MAINTAINER, self.PERMISSION_OWNER)
+        return has_access, project_admin or group_admin
+
+    def update_repository(self, remote_repository: RemoteRepository):
+        resp = self.session.get(
+            f"{self.base_api_url}/api/v4/projects/{remote_repository.remote_id}"
+        )
+
+        if resp.status_code in [403, 404]:
+            log.info(
+                "User no longer has access to the repository, removing remote relationship.",
+                remote_repository_id=remote_repository.remote_id,
+            )
+            remote_repository.get_remote_repository_relation(self.user, self.account).delete()
+            return
+
+        if resp.status_code != 200:
+            log.warning(
+                "Error fetching repository from GitLab",
+                remote_repository_id=remote_repository.remote_id,
+                status_code=resp.status_code,
+            )
+            return
+
+        data = resp.json()
+        self._update_repository_from_fields(remote_repository, data)
+
+        has_access, is_admin = self._has_access_to_repository(data)
+        relation = remote_repository.get_remote_repository_relation(
+            self.user,
+            self.account,
+        )
+        if not has_access:
+            # If the user no longer has access to the repository,
+            # we remove the remote relationship.
+            log.info(
+                "User no longer has access to the repository, removing remote relationship.",
+                remote_repository=remote_repository.remote_id,
+            )
+            relation.delete()
+        else:
+            relation.admin = is_admin
+            relation.save()
 
     def create_repository(
         self, fields, privacy=None, organization: RemoteOrganization | None = None
@@ -203,49 +218,13 @@ class GitLabService(UserService):
             repo, _ = RemoteRepository.objects.get_or_create(
                 remote_id=fields["id"], vcs_provider=self.vcs_provider_slug
             )
+            self._update_repository_from_fields(repo, fields, organization=organization)
+
             remote_repository_relation = repo.get_remote_repository_relation(
                 self.user, self.account
             )
-
-            repo.organization = organization
-            repo.name = fields["name"]
-            repo.full_name = fields["path_with_namespace"]
-            repo.description = fields["description"]
-            repo.ssh_url = fields["ssh_url_to_repo"]
-            repo.html_url = fields["web_url"]
-            repo.vcs = "git"
-            repo.private = not repo_is_public
-            repo.default_branch = fields.get("default_branch")
-
-            owner = fields.get("owner") or {}
-            repo.avatar_url = fields.get("avatar_url") or owner.get("avatar_url")
-
-            if not repo.avatar_url:
-                repo.avatar_url = self.default_user_avatar_url
-
-            if repo.private:
-                repo.clone_url = repo.ssh_url
-            else:
-                repo.clone_url = fields["http_url_to_repo"]
-
-            repo.save()
-
-            project_access_level = group_access_level = self.PERMISSION_NO_ACCESS
-
-            project_access = fields.get("permissions", {}).get("project_access", {})
-            if project_access:
-                project_access_level = project_access.get("access_level", self.PERMISSION_NO_ACCESS)
-
-            group_access = fields.get("permissions", {}).get("group_access", {})
-            if group_access:
-                group_access_level = group_access.get("access_level", self.PERMISSION_NO_ACCESS)
-
-            remote_repository_relation.admin = any(
-                [
-                    project_access_level in (self.PERMISSION_MAINTAINER, self.PERMISSION_OWNER),
-                    group_access_level in (self.PERMISSION_MAINTAINER, self.PERMISSION_OWNER),
-                ]
-            )
+            _, is_admin = self._has_access_to_repository(fields)
+            remote_repository_relation.admin = is_admin
             remote_repository_relation.save()
 
             return repo
@@ -255,6 +234,50 @@ class GitLabService(UserService):
             repository=fields["path_with_namespace"],
             visibility=fields["visibility"],
         )
+
+    def _update_repository_from_fields(self, repo, fields, organization=None):
+        # If the namespace is a group, we can use it as the organization
+        if fields.get("namespace", {}).get("kind") == "group":
+            # If an organization was passed, use it, so we save one query.
+            if not organization:
+                organization = self.create_organization(fields["namespace"])
+            repo.organization = organization
+        else:
+            repo.organization = None
+
+        repo.name = fields["name"]
+        repo.full_name = fields["path_with_namespace"]
+        repo.description = fields["description"]
+        repo.ssh_url = fields["ssh_url_to_repo"]
+        repo.html_url = fields["web_url"]
+        repo.vcs = "git"
+        repo.private = fields["visibility"] == "private"
+        repo.default_branch = fields.get("default_branch")
+
+        owner = fields.get("owner") or {}
+        repo.avatar_url = self._make_absolute_url(
+            fields.get("avatar_url") or owner.get("avatar_url")
+        )
+
+        if not repo.avatar_url:
+            repo.avatar_url = self.default_user_avatar_url
+
+        if repo.private:
+            repo.clone_url = repo.ssh_url
+        else:
+            repo.clone_url = fields["http_url_to_repo"]
+
+        repo.save()
+
+    def _make_absolute_url(self, url):
+        """
+        Make sure the URL is absolute to gitlab.com.
+
+        If the URL is relative, prepend the base API URL.
+        """
+        if url and not url.startswith("http"):
+            return f"https://gitlab.com{url}"
+        return url
 
     def create_organization(self, fields):
         """
@@ -266,12 +289,11 @@ class GitLabService(UserService):
         organization, _ = RemoteOrganization.objects.get_or_create(
             remote_id=fields["id"], vcs_provider=self.vcs_provider_slug
         )
-        organization.get_remote_organization_relation(self.user, self.account)
 
         organization.name = fields.get("name")
         organization.slug = fields.get("full_path")
         organization.url = fields.get("web_url")
-        organization.avatar_url = fields.get("avatar_url")
+        organization.avatar_url = self._make_absolute_url(fields.get("avatar_url"))
 
         if not organization.avatar_url:
             organization.avatar_url = self.default_user_avatar_url

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -1908,7 +1908,8 @@ class BitbucketOAuthTests(TestCase):
         self.project.repo = "https://bitbucket.org/testuser/testrepo/"
         self.project.save()
         self.org = RemoteOrganization.objects.create(
-            slug="rtfd",
+            remote_id="{61fc5cf6-d054-47d2-b4a9-061ccf858379}",
+            slug="teamsinspace",
             vcs_provider=BITBUCKET,
         )
         self.privacy = settings.DEFAULT_PRIVACY_LEVEL
@@ -1927,6 +1928,41 @@ class BitbucketOAuthTests(TestCase):
                     "url": "https://readthedocs.io/api/v2/webhook/test/99999999/",
                 },
             ]
+        }
+        self.team_response_data = {
+            "slug": self.org.slug,
+            "name": "Teams In Space",
+            "uuid": self.org.remote_id,
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/workspaces/teamsinspace",
+                },
+                "repositories": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/teamsinspace",
+                },
+                "html": {"href": "https://bitbucket.org/teamsinspace"},
+                "avatar": {
+                    "href": "https://bitbucket-assetroot.s3.amazonaws.com/c/photos/2014/Sep/24/teamsinspace-avatar-3731530358-7_avatar.png",
+                },
+                "members": {
+                    "href": "https://api.bitbucket.org/2.0/workspaces/teamsinspace/members",
+                },
+                "owners": {
+                    "href": "https://api.bitbucket.org/2.0/workspaces/teamsinspace/members?q=permission%3D%22owner%22",
+                },
+                "hooks": {
+                    "href": "https://api.bitbucket.org/2.0/workspaces/teamsinspace/hooks",
+                },
+                "snippets": {
+                    "href": "https://api.bitbucket.org/2.0/snippets/teamsinspace/",
+                },
+                "projects": {
+                    "href": "https://api.bitbucket.org/2.0/workspaces/teamsinspace/projects",
+                },
+            },
+            "created_on": "2014-04-08T00:00:14.070969+00:00",
+            "type": "workspace",
+            "is_private": True,
         }
         self.repo_response_data = {
             "scm": "hg",
@@ -1971,6 +2007,7 @@ class BitbucketOAuthTests(TestCase):
             "created_on": "2011-12-20T16:35:06.480042+00:00",
             "full_name": "tutorials/tutorials.bitbucket.org",
             "has_issues": True,
+            "workspace": self.team_response_data,
             "owner": {
                 "username": "tutorials",
                 "display_name": "tutorials account",
@@ -1997,46 +2034,9 @@ class BitbucketOAuthTests(TestCase):
             },
         }
 
-        self.team_response_data = {
-            "slug": "teamsinspace",
-            "name": "Teams In Space",
-            "uuid": "{61fc5cf6-d054-47d2-b4a9-061ccf858379}",
-            "links": {
-                "self": {
-                    "href": "https://api.bitbucket.org/2.0/workspaces/teamsinspace",
-                },
-                "repositories": {
-                    "href": "https://api.bitbucket.org/2.0/repositories/teamsinspace",
-                },
-                "html": {"href": "https://bitbucket.org/teamsinspace"},
-                "avatar": {
-                    "href": "https://bitbucket-assetroot.s3.amazonaws.com/c/photos/2014/Sep/24/teamsinspace-avatar-3731530358-7_avatar.png",
-                },
-                "members": {
-                    "href": "https://api.bitbucket.org/2.0/workspaces/teamsinspace/members",
-                },
-                "owners": {
-                    "href": "https://api.bitbucket.org/2.0/workspaces/teamsinspace/members?q=permission%3D%22owner%22",
-                },
-                "hooks": {
-                    "href": "https://api.bitbucket.org/2.0/workspaces/teamsinspace/hooks",
-                },
-                "snippets": {
-                    "href": "https://api.bitbucket.org/2.0/snippets/teamsinspace/",
-                },
-                "projects": {
-                    "href": "https://api.bitbucket.org/2.0/workspaces/teamsinspace/projects",
-                },
-            },
-            "created_on": "2014-04-08T00:00:14.070969+00:00",
-            "type": "workspace",
-            "is_private": True,
-        }
-
     def test_make_project_pass(self):
         repo = self.service.create_repository(
             self.repo_response_data,
-            organization=self.org,
             privacy=self.privacy,
         )
         self.assertIsInstance(repo, RemoteRepository)
@@ -2072,7 +2072,6 @@ class BitbucketOAuthTests(TestCase):
         self.repo_response_data["mainbranch"] = None
         repo = self.service.create_repository(
             self.repo_response_data,
-            organization=self.org,
             privacy=self.privacy,
         )
         self.assertIsInstance(repo, RemoteRepository)
@@ -2107,7 +2106,6 @@ class BitbucketOAuthTests(TestCase):
         data["is_private"] = True
         repo = self.service.create_repository(
             data,
-            organization=self.org,
             privacy=self.privacy,
         )
         self.assertIsNone(repo)
@@ -2119,7 +2117,7 @@ class BitbucketOAuthTests(TestCase):
         """
         data = self.repo_response_data.copy()
         data["is_private"] = False
-        repo = self.service.create_repository(data, organization=self.org)
+        repo = self.service.create_repository(data)
         self.assertIsNotNone(repo)
 
     def test_make_organization(self):
@@ -2466,11 +2464,14 @@ class GitLabOAuthTests(TestCase):
         self.assertEqual(repo_id, "testorga%2Fsubgroup%2Ftestrepo")
 
     def test_make_project_pass(self):
-        repo = self.service.create_repository(
-            self.repo_response_data,
-            organization=self.org,
-            privacy=self.privacy,
-        )
+        self.repo_response_data["namespace"] = {
+            "kind": "group",
+            "name": "Test Orga",
+            "path": "testorga",
+            "id": self.org.remote_id,
+            "full_path": self.org.slug,
+        }
+        repo = self.service.create_repository(self.repo_response_data, privacy=self.privacy)
         self.assertIsInstance(repo, RemoteRepository)
         self.assertEqual(repo.name, "testrepo")
         self.assertEqual(repo.full_name, "testorga/testrepo")
@@ -2493,19 +2494,20 @@ class GitLabOAuthTests(TestCase):
         self.assertFalse(repo.private)
 
     def test_make_private_project_fail(self):
-        repo = self.service.create_repository(
-            self.get_private_repo_data(),
-            organization=self.org,
-            privacy=self.privacy,
-        )
+        data = self.get_private_repo_data()
+        repo = self.service.create_repository(data, privacy=self.privacy)
         self.assertIsNone(repo)
 
     def test_make_private_project_success(self):
-        repo = self.service.create_repository(
-            self.get_private_repo_data(),
-            organization=self.org,
-            privacy=constants.PRIVATE,
-        )
+        data = self.get_private_repo_data()
+        data["namespace"] = {
+            "kind": "group",
+            "name": "Test Orga",
+            "path": "testorga",
+            "id": self.org.remote_id,
+            "full_path": self.org.slug,
+        }
+        repo = self.service.create_repository(data, privacy=constants.PRIVATE)
         self.assertIsInstance(repo, RemoteRepository)
         self.assertTrue(repo.private, True)
 
@@ -2527,7 +2529,7 @@ class GitLabOAuthTests(TestCase):
         """
         data = self.repo_response_data.copy()
         data["visibility"] = "public"
-        repo = self.service.create_repository(data, organization=self.org)
+        repo = self.service.create_repository(data)
         self.assertIsNotNone(repo)
 
     @mock.patch("readthedocs.oauth.services.gitlab.structlog")
@@ -2797,10 +2799,7 @@ class GitLabOAuthTests(TestCase):
         )
 
     def test_project_moved_from_user_to_group(self):
-        repo = self.service.create_repository(
-            self.repo_response_data,
-            organization=None,
-        )
+        repo = self.service.create_repository(self.repo_response_data)
         assert repo.organization is None
         assert repo.full_name == "testorga/testrepo"
         assert not repo.private
@@ -2810,10 +2809,14 @@ class GitLabOAuthTests(TestCase):
         assert relationship.user == self.user
         assert relationship.account == self.service.account
 
-        repo_b = self.service.create_repository(
-            self.repo_response_data,
-            organization=self.org,
-        )
+        self.repo_response_data["namespace"] = {
+            "kind": "group",
+            "name": "Test Orga",
+            "path": "testorga",
+            "id": self.org.remote_id,
+            "full_path": self.org.slug,
+        }
+        repo_b = self.service.create_repository(self.repo_response_data)
         assert repo_b == repo
         repo.refresh_from_db()
         assert repo.organization == self.org
@@ -2823,10 +2826,14 @@ class GitLabOAuthTests(TestCase):
         assert relationship.account == self.service.account
 
     def test_project_moved_from_group_to_user(self):
-        repo = self.service.create_repository(
-            self.repo_response_data,
-            organization=self.org,
-        )
+        self.repo_response_data["namespace"] = {
+            "kind": "group",
+            "name": "Test Orga",
+            "path": "testorga",
+            "id": self.org.remote_id,
+            "full_path": self.org.slug,
+        }
+        repo = self.service.create_repository(self.repo_response_data)
         assert repo.organization == self.org
         assert repo.full_name == "testorga/testrepo"
         assert not repo.private
@@ -2836,10 +2843,14 @@ class GitLabOAuthTests(TestCase):
         assert relationship.user == self.user
         assert relationship.account == self.service.account
 
-        repo_b = self.service.create_repository(
-            self.repo_response_data,
-            organization=None,
-        )
+        self.repo_response_data["namespace"] = {
+            "kind": "user",
+            "name": "Test User",
+            "path": "testuser",
+            "id": 1,
+            "full_path": "testuser",
+        }
+        repo_b = self.service.create_repository(self.repo_response_data)
         assert repo_b == repo
         repo.refresh_from_db()
         assert repo.organization is None
@@ -2849,10 +2860,14 @@ class GitLabOAuthTests(TestCase):
         assert relationship.account == self.service.account
 
     def test_project_moved_between_groups(self):
-        repo = self.service.create_repository(
-            self.repo_response_data,
-            organization=self.org,
-        )
+        self.repo_response_data["namespace"] = {
+            "kind": "group",
+            "name": "Test Orga",
+            "path": "testorga",
+            "id": self.org.remote_id,
+            "full_path": self.org.slug,
+        }
+        repo = self.service.create_repository(self.repo_response_data)
         assert repo.organization == self.org
         assert repo.full_name == "testorga/testrepo"
         assert not repo.private
@@ -2862,19 +2877,21 @@ class GitLabOAuthTests(TestCase):
         assert relationship.user == self.user
         assert relationship.account == self.service.account
 
-        another_group = RemoteOrganization.objects.create(
-            slug="anothergroup",
-            name="Another Group",
+        self.repo_response_data["namespace"] = {
+            "kind": "group",
+            "name": "Another Group",
+            "path": "anothergroup",
+            "id": "2",
+            "full_path": "anothergroup",
+        }
+
+        repo_b = self.service.create_repository(self.repo_response_data)
+        assert repo_b == repo
+        repo.refresh_from_db()
+        another_group = RemoteOrganization.objects.get(
             remote_id="2",
             vcs_provider=GITLAB,
         )
-
-        repo_b = self.service.create_repository(
-            self.repo_response_data,
-            organization=another_group,
-        )
-        assert repo_b == repo
-        repo.refresh_from_db()
         assert repo.organization == another_group
         relationship = repo.remote_repository_relations.first()
         assert relationship.admin

--- a/readthedocs/rtd_tests/tests/test_oauth_sync.py
+++ b/readthedocs/rtd_tests/tests/test_oauth_sync.py
@@ -360,49 +360,6 @@ class GitHubOAuthSyncTests(TestCase):
         }
         mock_request.get("https://api.github.com/orgs/organization", json=payload)
 
-        payload = [
-            {
-                "id": 11111,
-                "node_id": "a1b2c3",
-                "name": "repository",
-                "full_name": "organization/repository",
-                "private": False,
-                "owner": {
-                    "login": "organization",
-                    "id": 11111,
-                    "node_id": "a1b2c3",
-                    "avatar_url": "https://avatars3.githubusercontent.com/u/11111?v=4",
-                    "gravatar_id": "",
-                    "url": "https://api.github.com/users/organization",
-                    "type": "User",
-                    "site_admin": False,
-                },
-                "html_url": "https://github.com/organization/repository",
-                "description": "",
-                "fork": True,
-                "url": "https://api.github.com/repos/organization/repository",
-                "created_at": "2019-06-14T14:11:29Z",
-                "updated_at": "2019-06-15T15:05:33Z",
-                "pushed_at": "2019-06-15T15:11:19Z",
-                "git_url": "git://github.com/organization/repository.git",
-                "ssh_url": "git@github.com:organization/repository.git",
-                "clone_url": "https://github.com/organization/repository.git",
-                "svn_url": "https://github.com/organization/repository",
-                "homepage": None,
-                "language": "Python",
-                "archived": False,
-                "disabled": False,
-                "open_issues_count": 0,
-                "default_branch": "master",
-                "permissions": {
-                    "admin": False,
-                    "push": True,
-                    "pull": True,
-                },
-            }
-        ]
-        mock_request.get("https://api.github.com/orgs/organization/repos", json=payload)
-
         self.assertEqual(RemoteRepository.objects.count(), 0)
         self.assertEqual(RemoteRepositoryRelation.objects.count(), 0)
         self.assertEqual(RemoteOrganization.objects.count(), 0)
@@ -410,11 +367,11 @@ class GitHubOAuthSyncTests(TestCase):
 
         organization_remote_ids, repository_remote_ids = self.service.sync_organizations()
 
-        self.assertEqual(RemoteRepository.objects.count(), 1)
-        self.assertEqual(RemoteRepositoryRelation.objects.count(), 1)
+        self.assertEqual(RemoteRepository.objects.count(), 0)
+        self.assertEqual(RemoteRepositoryRelation.objects.count(), 0)
         self.assertEqual(RemoteOrganization.objects.count(), 1)
         self.assertEqual(RemoteOrganizationRelation.objects.count(), 1)
         self.assertEqual(len(organization_remote_ids), 1)
-        self.assertEqual(len(repository_remote_ids), 1)
+        self.assertEqual(len(repository_remote_ids), 0)
         remote_organization = RemoteOrganization.objects.first()
         self.assertEqual(organization_remote_ids[0], remote_organization.remote_id)


### PR DESCRIPTION
Common changes across providers:

- A new method to just update a remote repository from the data returned by the API was added, this is in order to make it easy to re-use this method when support for updating a single repo is added (will do this in another PR on top of this one).
- We were iterating over repositories twice for GitHub and BB, once by listing all the repositories the user has access to, and then again by iterating over all the repositories from the organizations the user has access to, this was also incorrectly adding a relationship between the user and repositories the use didn't actually have access, as that endpoint will return all public repositories, even if the user doesn't belong to it.
- sync_organizations now basically just creates the user-organization relation only.
- Since several repositories can belong to the same organization, we don't really need to update the same organization over and over again, just once, so a cache was introduced for it. This is also a reason why the creation of the user-organization relationship was moved outside `create_organization`.

Specific changes:

- For Bitbucket, we weren't updating a repository if the workspace it belongs was changed, we now update those. This is the same problem we had with Gitlab https://github.com/readthedocs/readthedocs.org/pull/12233.
- For Bitbucket, we were creating the repo-user relationship and then updating that relationship for the repositories where the user is an admin. This wasn't resetting the admin status to false for repos the user no longer had that permission, we now always default to admin=False, and then we update the repositories where the user is admin in the other call.
- In Bitbucket, we don't have organizations, we have projects and workspaces, we are using workspaces as our organizations. But in BB, every repository is linked to a workspace (a user can be a workspace), so we always create an organization for each repository.
- Since all other providers are fetching all repositories in the `sync_repositories` method, I changed Gitlab do also do that. In order to do that I reverted to use the previous /projects endpoint (https://github.com/readthedocs/readthedocs.org/pull/12233).
- GitLab sometimes returns avatars with a relative URL `/~/uploads...` instead of including the domain as well, so we are normalizing all URLs from Gitlab now.