### PR TITLE
Builds: improve DB query for unhealthy builds

### DIFF
--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -120,7 +120,12 @@ def finish_unhealthy_builds():
     """
     log.debug("Running task to finish inactive builds (no healtcheck received).")
     delta = datetime.timedelta(seconds=settings.RTD_BUILD_HEALTHCHECK_TIMEOUT)
-    query = ~Q(state__in=BUILD_FINAL_STATES) & Q(healthcheck__lt=timezone.now() - delta)
+    query = (
+        # Grab 3 days old at most to use a fast DB index
+        Q(date__gt=timezone.now() - datetime.timedelta(days=3))
+        & ~Q(state__in=BUILD_FINAL_STATES)
+        & Q(healthcheck__lt=timezone.now() - delta)
+    )
 
     projects_finished = set()
     builds_finished = []


### PR DESCRIPTION
Filter by `date` to use one of the fast DB indexes we have in the `Build` model.

Solves https://read-the-docs.sentry.io/issues/6806637157/