### PR TITLE
Tests: fix tests con .com

### DIFF
--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -809,7 +809,7 @@ class APITests(TestCase):
         self.assertEqual(resp.status_code, 204)
         self.assertFalse(BuildAPIKey.objects.is_valid(build_api_key))
 
-    @override_settings(BUILD_TIME_LIMIT=900)
+    @override_settings(BUILD_TIME_LIMIT=600)
     def test_expiricy_key(self):
         project = get(Project)
         build_api_key_obj, build_api_key = BuildAPIKey.objects.create_key(project)


### PR DESCRIPTION
This setting is overridden in .com, so this tests fails