### PR TITLE
Partial revert of #12369 for celery visibility timeout

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -640,7 +640,7 @@ class CommunityBaseSettings(Settings):
     # https://github.com/readthedocs/readthedocs.org/issues/12317#issuecomment-3070950434
     # https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/redis.html#visibility-timeout
     BROKER_TRANSPORT_OPTIONS = {
-        'visibility_timeout': BUILD_TIME_LIMIT * 1.15,  # 15% more than the build time limit
+        'visibility_timeout': 18000, # 5 hours
     }
 
     CELERY_DEFAULT_QUEUE = "celery"


### PR DESCRIPTION
We are noticing all builds restarting at 17.25m (15m * 115%), reverting this back to 5hours for now. In theory, tasks are being executed with ack_late=False so they should immediately acknowledge the task and avoid the visibility timeout entirely. But in practice this doesn't seem to happen and the build task acts like ack_late=True with a 17.25min visibility timeout, duplicating the build task on another builder.

- Related https://github.com/readthedocs/readthedocs.org/pull/12369
- We discussed the potential for low timeout bugs at https://github.com/readthedocs/readthedocs.org/pull/12393
- This bug is identical to https://github.com/readthedocs/readthedocs.org/issues/12317 except the timeout is 17m now instead of 1h