### PR TITLE
Project: use latest version or its alias for syncing versions

### DIFF
--- a/readthedocs/core/views/hooks.py
+++ b/readthedocs/core/views/hooks.py
@@ -102,12 +102,9 @@ def trigger_sync_versions(project):
         return None
 
     try:
-        version_identifier = project.get_default_branch()
-        version = project.versions.filter(
-            identifier=version_identifier,
-        ).first()
+        version = project.get_original_latest_version() or project.get_latest_version()
         if not version:
-            log.info("Unable to sync from version.", version_identifier=version_identifier)
+            log.info("Unable to sync versions, project doesn't have a valid latest version.")
             return None
 
         if project.has_feature(Feature.SKIP_SYNC_VERSIONS):


### PR DESCRIPTION
We should refactor this task so  it doesn't require a version, but that's a bigger change...

I'm doing small refactors to rely less on get_default_branch, as that contains some extra logic that we already run to have latest always in sync.