### PR TITLE
docs: fix git-lfs changelog overrides the local one

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -379,7 +379,7 @@ It's possible to use ``post_checkout`` user-defined job for this.
          # Download and uncompress the binary
          # https://git-lfs.github.com/
          - wget https://github.com/git-lfs/git-lfs/releases/download/v3.1.4/git-lfs-linux-amd64-v3.1.4.tar.gz
-         - tar xvfz git-lfs-linux-amd64-v3.1.4.tar.gz
+         - tar xvfz git-lfs-linux-amd64-v3.1.4.tar.gz git-lfs
          # Modify LFS config paths to point where git-lfs binary was downloaded
          - git config filter.lfs.process "`pwd`/git-lfs filter-process"
          - git config filter.lfs.smudge  "`pwd`/git-lfs smudge -- %f"


### PR DESCRIPTION
There are no reason to extract the entire archive when we only need `git-lfs` binary.
The archive also contains a `CHANGELOG.md` file, which can override the local one.