### PR TITLE
Build: use 24h for build API token expiry date

### DIFF
--- a/readthedocs/api/v2/models.py
+++ b/readthedocs/api/v2/models.py
@@ -1,6 +1,5 @@
 from datetime import timedelta
 
-from django.conf import settings
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -24,9 +23,13 @@ class BuildAPIKeyManager(BaseAPIKeyManager):
 
         and can be revoked at any time by hitting the /api/v2/revoke/ endpoint.
         """
-        delta = (
-            project.container_time_limit or settings.BUILD_TIME_LIMIT
-        ) * 1.25 + settings.RTD_BUILDS_RETRY_DELAY * settings.RTD_BUILDS_MAX_RETRIES
+        # delta = (
+        #     project.container_time_limit or settings.BUILD_TIME_LIMIT
+        # ) * 1.25 + settings.RTD_BUILDS_RETRY_DELAY * settings.RTD_BUILDS_MAX_RETRIES
+        #
+        # Use 24 hours for now since we are hitting the expiry date and we shouldn't
+        # https://github.com/readthedocs/readthedocs.org/issues/12467
+        delta = 60 * 60 * 24  # 24h
         expiry_date = timezone.now() + timedelta(seconds=delta)
         name_max_length = self.model._meta.get_field("name").max_length
         return super().create_key(


### PR DESCRIPTION
We are still hitting issues with expired tokens. This commit increases the expiry date to 24hs as an initial test to try to mitigate this issue and have more data about the surrounding problems.

Closes https://github.com/readthedocs/readthedocs.org/issues/12467