### PR TITLE
Build: don't log `SoftTimeLimitExceeded` in Sentry

### DIFF
--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -282,6 +282,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         MkDocsYAMLParseError,
         ProjectConfigurationError,
         BuildMaxConcurrencyError,
+        SoftTimeLimitExceeded,
     )
 
     # Do not send notifications on failure builds for these exceptions.


### PR DESCRIPTION
Continuation of https://github.com/readthedocs/readthedocs.org/pull/12481