### PR TITLE
Build: fix API call to update project

### DIFF
--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -214,7 +214,7 @@ class BuildDirector:
             has_ssh_key_with_write_access = self.vcs_repository.has_ssh_key_with_write_access()
             if has_ssh_key_with_write_access != self.data.project.has_ssh_key_with_write_access:
                 self.data.api_client.project(self.data.project.pk).patch(
-                    {"ssh_key_with_write_access": has_ssh_key_with_write_access}
+                    {"has_ssh_key_with_write_access": has_ssh_key_with_write_access}
                 )
             if has_ssh_key_with_write_access:
                 self.attach_notification(


### PR DESCRIPTION
I was checking how many projects still have keys with write access, but found we have 0... the field name was wrong :/