### PR TITLE
Tasks: increase time limit sync_remote_repositories_from_sso_organizations

### DIFF
--- a/readthedocs/oauth/tasks.py
+++ b/readthedocs/oauth/tasks.py
@@ -73,7 +73,12 @@ def sync_remote_repositories(user_id, skip_githubapp=False):
         )
 
 
-@app.task(queue="web")
+@app.task(
+    queue="web",
+    # This is a long running task, since it syncs all repositories one by one.
+    time_limit=60 * 60 * 3,  # 3h
+    soft_time_limit=(60 * 60 * 3) - 5 * 60,  # 2h 55m
+)
 def sync_remote_repositories_from_sso_organizations():
     """
     Re-sync all remote repositories from organizations with SSO enabled.


### PR DESCRIPTION
This task takes 2h 10m to complete right now. I didn't see anything in sentry about this task failing (not sure even if that will be reported there). Looks like the default time out is one hour:


https://github.com/readthedocs/readthedocs.org/blob/dcde018f1567a028cb17a2cad4990f489c0d8f8e/readthedocs/settings/base.py#L630

This would be a great use case for async python... Maybe something to explore https://stackoverflow.com/questions/72529998/how-to-use-async-function-inside-celery-task