### PR TITLE
Build: don't reset `healthcheck` when updating builds

### DIFF
--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -279,8 +279,11 @@ class BuildAdminSerializer(BuildSerializer):
     commands = BuildCommandSerializer(many=True, read_only=True)
 
     class Meta(BuildSerializer.Meta):
-        # `_config` should be excluded to avoid conflicts with `config`
-        exclude = ("_config",)
+        # `_config` should be excluded to avoid conflicts with `config`.
+        #
+        # `healthcheck` is excluded to avoid updating it to `None` again during building.
+        # See https://github.com/readthedocs/readthedocs.org/issues/12474
+        exclude = ("_config", "healthcheck")
 
 
 class BuildAdminReadOnlySerializer(BuildAdminSerializer):


### PR DESCRIPTION
At different points during the build process (including before finishing it), we update the `Build` object via the API with new values (e.g. state, length, etc) re-using the `APIBuild` object we fetched via the API before starting the build.

Since that object contains `APIBuild.healthcheck` _we are resetting_ the healthcheck before finishing the build.

This commit removes the `healthcheck` field from the `APIBuild` returned, so it's not updated by the build while it's being executed.