### PR TITLE
Add cache tags to offline format file downloads

### DIFF
--- a/readthedocs/api/mixins.py
+++ b/readthedocs/api/mixins.py
@@ -18,7 +18,9 @@ class CDNCacheTagsMixin:
     Add cache tags for project and version to the response of this view.
 
     The view inheriting this mixin should implement the
-    `self._get_project` and `self._get_version` methods.
+    `self._get_project` and `self._get_version` methods,
+    or set `self._cache_tags` to a list of cache tags if the project/version is
+    not a class/instance variable.
 
     If `self._get_version` returns `None`,
     only the project level tags are added.
@@ -30,7 +32,7 @@ class CDNCacheTagsMixin:
 
     def dispatch(self, request, *args, **kwargs):
         response = super().dispatch(request, *args, **kwargs)
-        cache_tags = self._get_cache_tags()
+        cache_tags = getattr(self, "_cache_tags", self._get_cache_tags())
         if cache_tags:
             add_cache_tags(response, cache_tags)
         return response

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -547,6 +547,7 @@ class TestDocServingBackends(BaseDocServing):
                 headers={"host": "project.dev.readthedocs.io"},
             )
             self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp["Cache-Tag"], "project,project:latest")
             extension = "zip" if type_ == MEDIA_TYPE_HTMLZIP else type_
             self.assertEqual(
                 resp["X-Accel-Redirect"],
@@ -560,6 +561,7 @@ class TestDocServingBackends(BaseDocServing):
                 headers={"host": "project.dev.readthedocs.io"},
             )
             self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp["Cache-Tag"], "translation,translation:latest")
             extension = "zip" if type_ == MEDIA_TYPE_HTMLZIP else type_
             self.assertEqual(
                 resp["X-Accel-Redirect"],
@@ -604,6 +606,7 @@ class TestDocServingBackends(BaseDocServing):
                 headers={"host": "project.dev.readthedocs.io"},
             )
             self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp["Cache-Tag"], "project,project:latest")
             extension = "zip" if type_ == MEDIA_TYPE_HTMLZIP else type_
             self.assertEqual(
                 resp["X-Accel-Redirect"],


### PR DESCRIPTION
I'm mostly confident in this, however it could be likely that this might
add cache tags in some cases where we don't want them. Feedback on these
sorts of cases would be helpful.

Fixes #12494