### PR TITLE
Update Pixi build customization example

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -526,7 +526,7 @@ Take a look at the following example:
    build:
       os: ubuntu-24.04
       tools:
-          python: "latest" # so RTD stops complaining, see issue xxx
+          python: "latest"
       jobs:
          create_environment:
             - asdf plugin add pixi


### PR DESCRIPTION
Hey! Was very happy to find a pixi example (thanks @pavelzw from #12155 :)) ) 

The example as it is though is broken saying "Missing configuration option At least one of the following configuration options is required: build.tools or build.commands." .

Adding 
```diff
+      tools:
+          python: "latest"
```
does placate the error message, but this doesn't really make sense since Pixi manages its own Python.

Can we update the example linking to a relevant issue if there is one?