### PR TITLE
do not claim pip 25.1 is default

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -491,6 +491,7 @@ Python `Dependency Groups <https://packaging.python.org/en/latest/specifications
 are a way of storing lists of dependencies in your ``pyproject.toml``.
 
 ``pip`` version 25.1+ as well as many other tools support Dependency Groups.
+If you override the `install` step, `pip` is not automatically updated.
 This example uses ``pip`` and installs from a group named ``docs``:
 
 .. code-block:: yaml
@@ -504,6 +505,7 @@ This example uses ``pip`` and installs from a group named ``docs``:
          python: "3.13"
       jobs:
          install:
+            - pip install --upgrade pip
             - pip install --group 'docs'
 
 For more information on relevant ``pip`` usage, see the

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -490,8 +490,7 @@ Install dependencies from Dependency Groups
 Python `Dependency Groups <https://packaging.python.org/en/latest/specifications/dependency-groups/>`_
 are a way of storing lists of dependencies in your ``pyproject.toml``.
 
-``pip`` version 25.1 and later, which is the default for Read the Docs builds,
-as well as many other tools support Dependency Groups.
+``pip`` version 25.1+ as well as many other tools support Dependency Groups.
 This example uses ``pip`` and installs from a group named ``docs``:
 
 .. code-block:: yaml

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -491,7 +491,6 @@ Python `Dependency Groups <https://packaging.python.org/en/latest/specifications
 are a way of storing lists of dependencies in your ``pyproject.toml``.
 
 ``pip`` version 25.1+ as well as many other tools support Dependency Groups.
-If you override the `install` step, `pip` is not automatically updated.
 This example uses ``pip`` and installs from a group named ``docs``:
 
 .. code-block:: yaml
@@ -505,6 +504,7 @@ This example uses ``pip`` and installs from a group named ``docs``:
          python: "3.13"
       jobs:
          install:
+            # Since the install step is overridden, pip is no longer updated automatically.
             - pip install --upgrade pip
             - pip install --group 'docs'
 


### PR DESCRIPTION
using the same .readthedocs.yaml provided in that example, rtd used pip 23.1

<details><summary>Build raw</summary>

```
Read the Docs build information
Build id: 29787419
Project: nwb2bids
Version: 112
Commit: 0e84ccc8c749345a9af7945d514168cf435e4167
Date: 2025-10-01T17:37:54.256358Z
State: finished
Success: False


[rtd-command-info] start-time: 2025-10-01T17:37:54.772413Z, end-time: 2025-10-01T17:37:55.083275Z, duration: 0, exit-code: 0
git clone --depth 1 https://github.com/con/nwb2bids.git .
Cloning into '.'...

[rtd-command-info] start-time: 2025-10-01T17:37:55.127442Z, end-time: 2025-10-01T17:37:55.663081Z, duration: 0, exit-code: 0
git fetch origin --force --prune --prune-tags --depth 50 pull/112/head:external-112
From https://github.com/con/nwb2bids
 * [new ref]         refs/pull/112/head -> external-112
 * [new tag]         v0.3.0             -> v0.3.0
 * [new tag]         v0.4.0             -> v0.4.0

[rtd-command-info] start-time: 2025-10-01T17:37:55.758717Z, end-time: 2025-10-01T17:37:55.805932Z, duration: 0, exit-code: 0
git checkout --force 0e84ccc8c749345a9af7945d514168cf435e4167
Note: switching to '0e84ccc8c749345a9af7945d514168cf435e4167'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 0e84ccc Use dependency groups

[rtd-command-info] start-time: 2025-10-01T17:37:55.842152Z, end-time: 2025-10-01T17:37:55.884702Z, duration: 0, exit-code: 0
cat docs/.readthedocs.yaml
# Read the Docs configuration file
# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details

# Required
version: 2

# Set the OS, Python version, and other tools you might need
build:
  os: ubuntu-24.04
  tools:
    python: "3.13"
  jobs:
    install:
      - pip install --group 'docs' .

# Build documentation in the "docs/" directory with Sphinx
sphinx:
   configuration: docs/conf.py

[rtd-command-info] start-time: 2025-10-01T17:38:01.147036Z, end-time: 2025-10-01T17:38:01.211448Z, duration: 0, exit-code: 0
asdf global python 3.13.3


[rtd-command-info] start-time: 2025-10-01T17:38:01.615787Z, end-time: 2025-10-01T17:38:02.744564Z, duration: 1, exit-code: 0
python -mvirtualenv $READTHEDOCS_VIRTUALENV_PATH
created virtual environment CPython3.13.3.final.0-64 in 807ms
  creator CPython3Posix(dest=/home/docs/checkouts/readthedocs.org/user_builds/nwb2bids/envs/112, clear=False, no_vcs_ignore=False, global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/home/docs/.local/share/virtualenv)
    added seed packages: pip==23.1, setuptools==67.6.1, wheel==0.40.0
  activators BashActivator,CShellActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator

[rtd-command-info] start-time: 2025-10-01T17:38:02.789116Z, end-time: 2025-10-01T17:38:06.456556Z, duration: 3, exit-code: 2
pip install --group 'docs' .
Usage:   
  pip install [options] <requirement specifier> [package-index-options] ...
  pip install [options] -r <requirements file> [package-index-options] ...
  pip install [options] [-e] <vcs project url> ...
  pip install [options] [-e] <local project path> ...
  pip install [options] <archive url/path> ...

no such option: --group

```


</details>