### PR TITLE
Logs: add `build_id` attribute to `set_builder_scale_in_protection`

### DIFF
--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -430,6 +430,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         # once we don't need to rely on `self.data.project`.
         if self.data.project.has_feature(Feature.SCALE_IN_PROTECTION):
             set_builder_scale_in_protection.delay(
+                build_id=self.data.build_pk,
                 builder=socket.gethostname(),
                 protected_from_scale_in=True,
             )
@@ -783,6 +784,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         # Disable scale-in protection on this instance
         if self.data.project.has_feature(Feature.SCALE_IN_PROTECTION):
             set_builder_scale_in_protection.delay(
+                build_id=self.data.build_pk,
                 builder=socket.gethostname(),
                 protected_from_scale_in=False,
             )

--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -192,7 +192,7 @@ def send_external_build_status(version_type, build_pk, commit, status):
 
 
 @app.task(queue="web")
-def set_builder_scale_in_protection(builder, protected_from_scale_in):
+def set_builder_scale_in_protection(build_id, builder, protected_from_scale_in):
     """
     Set scale-in protection on this builder ``builder``.
 
@@ -200,6 +200,7 @@ def set_builder_scale_in_protection(builder, protected_from_scale_in):
     This is pretty useful for long running tasks.
     """
     structlog.contextvars.bind_contextvars(
+        build_id=build_id,
         builder=builder,
         protected_from_scale_in=protected_from_scale_in,
     )


### PR DESCRIPTION
This will help us to know what builds weren't unable to set AWS scale-in protection. It could give us some insights about why these builds were killed.