### PR TITLE
Use context data instead of one off template tags

### DIFF
--- a/readthedocs/core/templatetags/readthedocs/socialaccounts.py
+++ b/readthedocs/core/templatetags/readthedocs/socialaccounts.py
@@ -41,9 +41,3 @@ def has_github_app_account(account):
         provider=GitHubAppProvider.id,
         uid=account.uid,
     ).exists()
-
-
-@register.filter
-def user_has_github_app_account(user):
-    """Check if a user has a GitHub App account."""
-    return user.socialaccount_set.filter(provider=GitHubAppProvider.id).exists()

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -457,6 +457,12 @@ class ImportView(PrivateViewMixin, TemplateView):
         context["form_manual"] = ProjectManualForm(user=self.request.user)
         context["GITHUB_APP_NAME"] = settings.GITHUB_APP_NAME
 
+        # Provider list for simple lookup of connected services, used for
+        # conditional content
+        context["socialaccount_providers"] = self.request.user.socialaccount_set.values_list(
+            "provider", flat=True
+        )
+
         return context
 
 


### PR DESCRIPTION
We will be inspecting more than just existance of the GHA provider, it's
easier to just have a simple lookup list than tags for each
provider for this. The tag removed is not used anymore now, context data
is used instead.

- Required by ext-theme#648