### PR TITLE
Add GITHUB_APP_NAME to context processor

### DIFF
--- a/readthedocs/core/context_processors.py
+++ b/readthedocs/core/context_processors.py
@@ -27,6 +27,7 @@ def readthedocs_processor(request):
         "SUPPORT_EMAIL": settings.SUPPORT_EMAIL,
         "PUBLIC_API_URL": settings.PUBLIC_API_URL,
         "ADMIN_URL": settings.ADMIN_URL,
+        "GITHUB_APP_NAME": settings.GITHUB_APP_NAME,
     }
     return exports
 


### PR DESCRIPTION
Needed for https://github.com/readthedocs/ext-theme/pull/655,
which otherwise I need to override the Allauth views for,
and this seems useful in other places if we want to keep linking it.
