### PR TITLE
feat: Improve error message for missing mkdocs.yml

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -14,6 +14,7 @@ from readthedocs.core.utils.filesystem import safe_open
 from readthedocs.doc_builder.base import BaseBuilder
 from readthedocs.projects.constants import MKDOCS
 from readthedocs.projects.constants import MKDOCS_HTML
+from readthedocs.projects.exceptions import UserFileNotFound
 
 
 log = structlog.get_logger(__name__)
@@ -52,7 +53,12 @@ class BaseMkdocs(BaseBuilder):
 
         https://www.mkdocs.org/user-guide/configuration/#use_directory_urls
         """
-
+        # Check if the mkdocs.yml file exists before trying to open it.
+        if not os.path.exists(self.yaml_file):
+            raise UserFileNotFound(
+                "MkDocs configuration file is missing. "
+                "A configuration file named `mkdocs.yml` was not found in your repository."
+            )
         # TODO: we should eventually remove this method completely and stop
         # relying on "loading the `mkdocs.yml` file in a safe way just to know
         # if it's a MKDOCS or MKDOCS_HTML documentation type".


### PR DESCRIPTION
This pull request addresses the issue where a generic "Unknown error" is shown when a user's mkdocs.yml configuration file is missing. The new behavior provides a clear, actionable error message, consistent with how similar errors are handled for Sphinx.

Fixes: #12378 

Problem
-When mkdocs.configuration points to a non-existent file, the build fails with a vague "Unknown problem" message.

-This provides a poor user experience as the root cause of the failure is not obvious.

Solution
-The get_final_doctype method in the BaseMkdocs builder (readthedocs/doc_builder/backends/mkdocs.py) has been updated.

-An os.path.exists() check is now performed to verify that the mkdocs.yml file exists before any attempt is made to read it.

-If the file is not found, a UserFileNotFound exception is raised with a clear error message, instructing the user to check for the missing file.