### PR TITLE
Repo sync: use project queue for syncing

### DIFF
--- a/readthedocs/core/views/hooks.py
+++ b/readthedocs/core/views/hooks.py
@@ -120,6 +120,8 @@ def trigger_sync_versions(project):
         )
 
         options = {}
+        # Use custom queue if defined, as some repositories need to
+        # be synced from a specific queue (like IP restricted ones).
         if project.build_queue:
             options["queue"] = project.build_queue
 

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -2032,7 +2032,7 @@ class IntegrationsTests(TestCase):
         self, sync_repository_task, trigger_build
     ):
         """
-        Check that the custom queue isn't used for sync_repository_task.
+        Check that the custom queue is used for sync_repository_task.
         """
         client = APIClient()
         self.project.build_queue = "specific-build-queue"
@@ -2064,7 +2064,7 @@ class IntegrationsTests(TestCase):
             kwargs={
                 "build_api_key": mock.ANY,
             },
-            # No queue
+            queue="specific-build-queue",
         )
 
     def test_github_webhook_for_branches(self, trigger_build):


### PR DESCRIPTION
Some projects require using the custom queue/builder for interacting with git