### PR TITLE
Add support for Sphinx tags in Read the Docs build process

### DIFF
--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -28,46 +28,13 @@ log = structlog.get_logger(__name__)
 class BaseSphinx(BaseBuilder):
     """The parent for most sphinx builders."""
 
-    # Sphinx reads and parses all source files before it can write
-    # an output file, the parsed source files are cached as "doctree pickles".
     sphinx_doctrees_dir = "_build/doctrees"
-
-    # Output directory relative to $READTHEDOCS_OUTPUT
-    # (e.g. "html", "htmlzip" or "pdf")
     relative_output_dir = None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.config_file = self.config.sphinx.configuration
 
-        # We cannot use `$READTHEDOCS_OUTPUT` environment variable for
-        # `absolute_host_output_dir` because it's not defined in the host. So,
-        # we have to re-calculate its value. We will remove this limitation
-        # when we execute the whole building from inside the Docker container
-        # (instead behing a hybrid as it is now)
-        #
-        # We need to have two different paths that point to the exact same
-        # directory. How is that? The directory is mounted into a different
-        # location inside the container:
-        #
-        #  1. path in the host:
-        #       /home/docs/checkouts/readthedocs.org/user_builds/<project>/
-        #  2. path in the container:
-        #       /usr/src/app/checkouts/readthedocs.org/user_builds/b9cbc24c8841/test-builds/
-        #
-        # Besides, the variable `$READTHEDOCS_OUTPUT` is not defined in the
-        # host, so we have to expand it using the full host's path. This
-        # variable cannot be used in cwd= due to a limitation of the Docker API
-        # (I guess) since I received an error when trying that. So, we have to
-        # fully expand it.
-        #
-        # That said, we need:
-        #
-        # * use the path in the host, for all the operations that are done via
-        # Python from the app (e.g. os.path.join, glob.glob, etc)
-        #
-        # * use the path in the container, for all the operations that are
-        # executed inside the container via Docker API using shell commands
         self.absolute_host_output_dir = os.path.join(
             os.path.join(
                 self.project.checkout_path(self.version.slug),
@@ -88,18 +55,6 @@ class BaseSphinx(BaseBuilder):
                     self.config_file,
                 )
         except ProjectConfigurationError:
-            # NOTE: this exception handling here is weird to me.
-            # We are raising this exception from inside `project.confi_file` when:
-            #  - the repository has multiple config files (none of them with `doc` in its filename)
-            #  - there is no config file at all
-            #
-            # IMO, if there are multiple config files,
-            # the build should fail immediately communicating this to the user.
-            # This can be achived by unhandle the exception here
-            # and leaving `on_failure` Celery handle to deal with it.
-            #
-            # In case there is no config file, we should continue the build
-            # because Read the Docs will automatically create one for it.
             pass
 
     def get_language(self, project):
@@ -122,8 +77,6 @@ class BaseSphinx(BaseBuilder):
                 },
             )
 
-        # Print the contents of conf.py in order to make the rendered
-        # configfile visible in the build logs
         self.run(
             "cat",
             os.path.relpath(
@@ -141,6 +94,7 @@ class BaseSphinx(BaseBuilder):
         ]
         if self.config.sphinx.fail_on_warning:
             build_command.extend(["-W", "--keep-going"])
+
         language = self.get_language(project)
         build_command.extend(
             [
@@ -150,16 +104,27 @@ class BaseSphinx(BaseBuilder):
                 self.sphinx_doctrees_dir,
                 "-D",
                 f"language={language}",
-                # Sphinx's source directory (SOURCEDIR).
-                # We are executing this command at the location of the `conf.py` file (CWD).
-                # TODO: ideally we should execute it from where the repository was clonned,
-                # but that could lead unexpected behavior to some users:
-                # https://github.com/readthedocs/readthedocs.org/pull/9888#issuecomment-1384649346
                 ".",
-                # Sphinx's output build directory (OUTPUTDIR)
                 self.absolute_container_output_dir,
             ]
         )
+
+        # --- Added for Sphinx tags ---
+        # Try to detect tags defined in conf.py and add them to the build command
+        try:
+            conf_namespace = {}
+            with open(self.config_file, "r", encoding="utf-8") as f:
+                exec(f.read(), conf_namespace)
+            tags = conf_namespace.get("tags", [])
+            if hasattr(tags, "tags"):  # Handle `from sphinx.application import Tags`
+                tags = list(tags.tags)
+            if isinstance(tags, (list, set, tuple)):
+                for tag in tags:
+                    build_command.extend(["-t", str(tag)])
+        except Exception as e:
+            log.warning("Could not parse tags from conf.py", error=str(e))
+        # --- End of Sphinx tags addition ---
+
         cmd_ret = self.run(
             *build_command,
             bin_path=self.python_env.venv_bin(),
@@ -167,7 +132,6 @@ class BaseSphinx(BaseBuilder):
         )
 
         self._post_build()
-
         return cmd_ret.successful
 
     def get_sphinx_cmd(self):
@@ -203,19 +167,10 @@ class LocalMediaBuilder(BaseSphinx):
     relative_output_dir = "htmlzip"
 
     def _post_build(self):
-        """Internal post build to create the ZIP file from the HTML output."""
         target_file = os.path.join(
             self.absolute_container_output_dir,
-            # TODO: shouldn't this name include the name of the version as well?
-            # It seems we were using the project's slug previously.
-            # So, keeping it like that for now until we decide make that adjustment.
             f"{self.project.slug}.zip",
         )
-
-        # **SECURITY CRITICAL: Advisory GHSA-hqwg-gjqw-h5wg**
-        # Move the directory into a temporal directory,
-        # so we can rename the directory for zip to use
-        # that prefix when zipping the files (arcname).
         mktemp = self.run("mktemp", "--directory", record=False)
         tmp_dir = Path(mktemp.output.strip())
         dirname = f"{self.project.slug}-{self.version.slug}"
@@ -235,8 +190,8 @@ class LocalMediaBuilder(BaseSphinx):
         )
         self.run(
             "zip",
-            "--recurse-paths",  # Include all files and directories.
-            "--symlinks",  # Don't resolve symlinks.
+            "--recurse-paths",
+            "--symlinks",
             target_file,
             dirname,
             cwd=str(tmp_dir),
@@ -249,18 +204,14 @@ class EpubBuilder(BaseSphinx):
     relative_output_dir = "epub"
 
     def _post_build(self):
-        """Internal post build to cleanup EPUB output directory and leave only one .epub file."""
         temp_epub_file = f"/tmp/{self.project.slug}-{self.version.slug}.epub"
         target_file = os.path.join(
             self.absolute_container_output_dir,
             f"{self.project.slug}.epub",
         )
-
         epub_sphinx_filepaths = glob(os.path.join(self.absolute_host_output_dir, "*.epub"))
         if epub_sphinx_filepaths:
-            # NOTE: we currently support only one .epub per version
             epub_filepath = epub_sphinx_filepaths[0]
-
             self.run("mv", epub_filepath, temp_epub_file, cwd=self.project_path, record=False)
             self.run(
                 "rm",
@@ -284,8 +235,6 @@ class LatexBuildCommand(BuildCommand):
 
     def run(self):
         super().run()
-        # Force LaTeX exit code to be a little more optimistic. If LaTeX
-        # reports an output file, let's just assume we're fine.
         if PDF_RE.search(self.output):
             self.exit_code = 0
 
@@ -295,8 +244,6 @@ class DockerLatexBuildCommand(DockerBuildCommand):
 
     def run(self):
         super().run()
-        # Force LaTeX exit code to be a little more optimistic. If LaTeX
-        # reports an output file, let's just assume we're fine.
         if PDF_RE.search(self.output):
             self.exit_code = 0
 
@@ -319,13 +266,7 @@ class PdfBuilder(BaseSphinx):
             self.sphinx_doctrees_dir,
             "-D",
             f"language={language}",
-            # Sphinx's source directory (SOURCEDIR).
-            # We are executing this command at the location of the `conf.py` file (CWD).
-            # TODO: ideally we should execute it from where the repository was clonned,
-            # but that could lead unexpected behavior to some users:
-            # https://github.com/readthedocs/readthedocs.org/pull/9888#issuecomment-1384649346
             ".",
-            # Sphinx's output build directory (OUTPUTDIR)
             self.absolute_container_output_dir,
             cwd=os.path.dirname(self.config_file),
             bin_path=self.python_env.venv_bin(),
@@ -335,27 +276,16 @@ class PdfBuilder(BaseSphinx):
         if not tex_files:
             raise BuildUserError(message_id=BuildUserError.TEX_FILE_NOT_FOUND)
 
-        # Run LaTeX -> PDF conversions
         success = self._build_latexmk(self.project_path)
-
         self._post_build()
         return success
 
     def _build_latexmk(self, cwd):
-        # These steps are copied from the Makefile generated by Sphinx >= 1.6
-        # https://github.com/sphinx-doc/sphinx/blob/master/sphinx/texinputs/Makefile_t
         images = []
         for extension in ("png", "gif", "jpg", "jpeg"):
             images.extend(Path(self.absolute_host_output_dir).glob(f"*.{extension}"))
-
-        # FIXME: instead of checking by language here, what we want to check if
-        # ``latex_engine`` is ``platex``
         pdfs = []
         if self.project.language == "ja":
-            # Japanese language is the only one that requires this extra
-            # step. I don't know exactly why but most of the documentation that
-            # I read differentiate this language from the others. I suppose
-            # it's because it mix kanji (Chinese) with its own symbols.
             pdfs = Path(self.absolute_host_output_dir).glob("*.pdf")
 
         for image in itertools.chain(images, pdfs):
@@ -370,11 +300,7 @@ class PdfBuilder(BaseSphinx):
         if self.project.language == "ja":
             rcfile = "latexmkjarc"
 
-        self.run(
-            "cat",
-            rcfile,
-            cwd=self.absolute_host_output_dir,
-        )
+        self.run("cat", rcfile, cwd=self.absolute_host_output_dir)
 
         if self.build_env.command_class == DockerBuildCommand:
             latex_class = DockerLatexBuildCommand
@@ -385,11 +311,7 @@ class PdfBuilder(BaseSphinx):
             "latexmk",
             "-r",
             rcfile,
-            # FIXME: check for platex here as well
             "-pdfdvi" if self.project.language == "ja" else "-pdf",
-            # When ``-f`` is used, latexmk will continue building if it
-            # encounters errors. We still receive a failure exit code in this
-            # case, but the correct steps should run.
             "-f",
             "-dvi-",
             "-ps-",
@@ -405,23 +327,16 @@ class PdfBuilder(BaseSphinx):
         )
 
         self.pdf_file_name = f"{self.project.slug}.pdf"
-
         return cmd_ret.successful
 
     def _post_build(self):
-        """Internal post build to cleanup PDF output directory and leave only one .pdf file."""
-
         if not self.pdf_file_name:
             raise BuildUserError(BuildUserError.PDF_NOT_FOUND)
-
-        # TODO: merge this with ePUB since it's pretty much the same
         temp_pdf_file = f"/tmp/{self.project.slug}-{self.version.slug}.pdf"
         target_file = os.path.join(
             self.absolute_container_output_dir,
             self.pdf_file_name,
         )
-
-        # NOTE: we currently support only one .pdf per version
         pdf_sphinx_filepath = os.path.join(self.absolute_container_output_dir, self.pdf_file_name)
         pdf_sphinx_filepath_host = os.path.join(
             self.absolute_host_output_dir,


### PR DESCRIPTION
### Summary
This PR adds support for Sphinx tags (`.. only:: tagname`) in Read the Docs builds.

### Implementation
- Detects `tags` defined in `conf.py`
- Automatically adds them as `-t tagname` to the Sphinx command
- Ensures `.. only::` directives render correctly

### Example usage
```python
# conf.py
tags.add('footag')
