### PR TITLE
Projects: redirect old project slugs safely

### DIFF
--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -82,13 +82,7 @@ def project_redirect(request, invalid_project_slug):
     Underscores are replaced by ``-`` and then redirected to that URL.
     """
     new_project_slug = invalid_project_slug.replace("_", "-")
-    new_path = request.path.replace(invalid_project_slug, new_project_slug)
-    return redirect(
-        "{}?{}".format(
-            new_path,
-            request.GET.urlencode(),
-        )
-    )
+    return redirect(reverse("projects_detail", args=[new_project_slug], query=request.GET))
 
 
 class ProjectDetailViewBase(


### PR DESCRIPTION
closes https://github.com/readthedocs/readthedocs.org/security/code-scanning/25

NOTE: THIS ISN'T A VULNERABILITY.
There isn't a payload that will result in an open redirect, as the path that goes before the project doesn't contain any `-` characters, that could be replaced, and the project_slug can only contain alphanumeric characters (so, no `..` or `/` to change the path).