### PR TITLE
Search: reduce page size in search API pagination

### DIFF
--- a/readthedocs/search/api/pagination.py
+++ b/readthedocs/search/api/pagination.py
@@ -35,9 +35,9 @@ class PaginatorPage:
 class SearchPagination(PageNumberPagination):
     """Paginator for the results of PageSearch."""
 
-    page_size = 25
+    page_size = 15
     page_size_query_param = "page_size"
-    max_page_size = 50
+    max_page_size = 30
 
     def _get_page_number(self, number):
         try:

--- a/readthedocs/search/tests/test_api.py
+++ b/readthedocs/search/tests/test_api.py
@@ -183,8 +183,8 @@ class BaseTestDocumentSearch:
         assert resp.data["count"] == 61
         # Check there are next url
         assert resp.data["next"] is not None
-        # There should be only 50 data as the pagination is 50 by default
-        assert len(resp.data["results"]) == 50
+        # Pagination default page size is 15
+        assert len(resp.data["results"]) == 15
 
         # Check for page 2
         search_params["page"] = 2
@@ -193,10 +193,22 @@ class BaseTestDocumentSearch:
 
         # Check the count is 61 (1 existing and 60 new created)
         assert resp.data["count"] == 61
-        # We don't have more results after this page
+        # We istill have more results.
+        assert resp.data["next"] is not None
+        # Pagination default page size is 15
+        assert len(resp.data["results"]) == 15
+
+        # Check for last page
+        search_params["page"] = 5
+        resp = self.get_search(api_client, search_params)
+        assert resp.status_code == 200
+
+        # Check the count is 61 (1 existing and 60 new created)
+        assert resp.data["count"] == 61
+        # No more results after this
         assert resp.data["next"] is None
-        # There should be only the 11 left
-        assert len(resp.data["results"]) == 11
+        # We have only 1 result in the last page
+        assert len(resp.data["results"]) == 1
 
         # Add `page_size` parameter and check the data is paginated accordingly
         search_params["page_size"] = 5


### PR DESCRIPTION
50 results is a lot, user probably don't even read past the first 10 results. Returning lots of results means:

- More work for ES
- More data to transfer. Each result has sub-results (blocks), which also return the source text together with the highlighted portion.
- More time to render the results in the UI.

The search addon could possibly fetch less results (15? 20?). But just making this a change for all API calls for now (maybe we can be even made this 25). Some silly testing showed improvements of ~10-50ms