### PR TITLE
Properly return when no org found

### DIFF
--- a/readthedocs/subscriptions/event_handlers.py
+++ b/readthedocs/subscriptions/event_handlers.py
@@ -309,6 +309,7 @@ def customer_updated_event(event, **kwargs):
     organization = Organization.objects.filter(stripe_id=stripe_customer["id"]).first()
     if not organization:
         log.error("Customer isn't attached to an organization.")
+        return
 
     new_email = stripe_customer["email"]
     if organization.email != new_email:


### PR DESCRIPTION
We were hitting an exception on the organization.email,
if there wasn't an organization.

Fixes https://read-the-docs.sentry.io/issues/6978188036
