### PR TITLE
Fix project access on healthcheck

### DIFF
--- a/readthedocs/api/v2/views/model_views.py
+++ b/readthedocs/api/v2/views/model_views.py
@@ -314,7 +314,7 @@ class BuildViewSet(DisableListEndpoint, UpdateModelMixin, UserSelectViewSet):
         builder_hostname = request.GET.get("builder")
         structlog.contextvars.bind_contextvars(
             build_id=build.pk,
-            project_slug=build.version.project.slug,
+            project_slug=build.project.slug,
             builder_hostname=builder_hostname,
         )
 


### PR DESCRIPTION
Build.version isn't always set,
but we should just access build.project directly.

I checked and we aren't using `build.version.project` anywhere else, so should be safe. 