### PR TITLE
Upgrade Django to 5.2.8

### DIFF
--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -103,7 +103,7 @@ dj-pagination==2.5.0
     # via -r requirements/pip.txt
 dj-stripe==2.9.0
     # via -r requirements/pip.txt
-django==5.2.7
+django==5.2.8
     # via
     #   -r requirements/pip.txt
     #   dj-stripe

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -111,7 +111,7 @@ dj-pagination==2.5.0
     # via -r requirements/pip.txt
 dj-stripe==2.9.0
     # via -r requirements/pip.txt
-django==5.2.7
+django==5.2.8
     # via
     #   -r requirements/pip.txt
     #   dj-stripe

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -68,7 +68,7 @@ dj-pagination==2.5.0
     # via -r requirements/pip.in
 dj-stripe==2.9.0
     # via -r requirements/pip.in
-django==5.2.7
+django==5.2.8
     # via
     #   -r requirements/pip.in
     #   dj-stripe

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -108,7 +108,7 @@ dj-pagination==2.5.0
     # via -r requirements/pip.txt
 dj-stripe==2.9.0
     # via -r requirements/pip.txt
-django==5.2.7
+django==5.2.8
     # via
     #   -r requirements/pip.txt
     #   dj-stripe


### PR DESCRIPTION
Refs https://www.djangoproject.com/weblog/2025/nov/05/security-releases/
