### PR TITLE
Search: don't sort inner hits

### DIFF
--- a/readthedocs/search/api/v2/serializers.py
+++ b/readthedocs/search/api/v2/serializers.py
@@ -8,7 +8,6 @@ Serializers for the ES's search result object.
 
 import re
 from functools import namedtuple
-from operator import attrgetter
 from urllib.parse import urlparse
 
 from rest_framework import serializers


### PR DESCRIPTION
We used to need to do this when we had sections and sphinx domains separated, now they are merged into sections, so no need to sort the results.