### PR TITLE
Domains: don't run CNAME checks on domain updates

### DIFF
--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -1020,7 +1020,9 @@ class DomainForm(forms.ModelForm):
             if invalid_domain and domain_string.endswith(invalid_domain):
                 raise forms.ValidationError(f"{invalid_domain} is not a valid domain.")
 
-        self._check_for_suspicious_cname(domain_string)
+        # Run this check only on domain creation.
+        if not self.instance.pk:
+            self._check_for_suspicious_cname(domain_string)
 
         return domain_string
 


### PR DESCRIPTION
This check only makes sense when adding a new domain, not when updating. And on .com, the target CNAME is a domain that points to another CNAME, so the check always fails after a valid domain is added. The domain field is set to read-only, so this is fine.