### PR TITLE
Search: improve queries

### DIFF
--- a/readthedocs/search/faceted_search.py
+++ b/readthedocs/search/faceted_search.py
@@ -113,10 +113,15 @@ class RTDFacetedSearch(FacetedSearch):
         is_advanced_query = self.use_advanced_query or self._is_advanced_query(query)
         for operator in self.operators:
             if is_advanced_query:
+                # See all valid options at:
+                # https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-simple-query-string-query.
                 query_string = SimpleQueryString(
                     query=query,
                     fields=fields,
                     default_operator=operator,
+                    # Restrict fuzziness to avoid timeouts with complex queries.
+                    fuzzy_prefix_length=1,
+                    fuzzy_max_expansions=15,
                 )
             else:
                 query_string = self._get_fuzzy_query(
@@ -283,13 +288,13 @@ class PageSearch(RTDFacetedSearch):
 
         if isinstance(self.projects, dict):
             versions_query = [
-                Bool(filter=[Term(project=project), Term(version=version)])
+                Bool(must=[Term(project=project), Term(version=version)])
                 for project, version in self.projects.items()
             ]
             return Bool(should=versions_query)
 
         if isinstance(self.projects, list):
-            return Bool(filter=Terms(project=self.projects))
+            return Terms(project=self.projects)
 
         raise ValueError("projects must be a list or a dict!")
 
@@ -312,13 +317,14 @@ class PageSearch(RTDFacetedSearch):
             query=query,
             path="sections",
             fields=self._section_fields,
+            limit=3,
         )
         queries.append(sections_nested_query)
         bool_query = Bool(should=queries)
 
         projects_query = self._get_projects_query()
         if projects_query:
-            bool_query = Bool(must=[bool_query, projects_query])
+            bool_query = Bool(must=[bool_query], filter=projects_query)
 
         final_query = FunctionScore(
             query=bool_query,
@@ -327,7 +333,7 @@ class PageSearch(RTDFacetedSearch):
         search = search.query(final_query)
         return search
 
-    def _get_nested_query(self, *, query, path, fields):
+    def _get_nested_query(self, *, query, path, fields, limit=3):
         """Generate a nested query with passed parameters."""
         queries = self._get_queries(
             query=query,
@@ -348,7 +354,7 @@ class PageSearch(RTDFacetedSearch):
 
         return Nested(
             path=path,
-            inner_hits={"highlight": highlight},
+            inner_hits={"highlight": highlight, "size": limit},
             query=bool_query,
         )
 


### PR DESCRIPTION
- Set some values for fuzzyness. Search terms like `webdav~` timeout ES, with these settings now the query resolves between 400-800ms. Not great, but at least doesn't kill ES.
- Enforce a limit of 3 results for inner hits (blocks).
- Move the filter query so it's at the top (according to chatgpt this is an improvement).

I tested several queries on ES, and all of them take around 200ms, even the simplest one... Sometimes some queries do take more time (randomly). My guess is that some other slow queries add some overhead to the server, so all queries get affected. Other theories are the index size, and using the wrong tokenizer/analyzer for the type of queries users want.