### PR TITLE
Use requested version for triggered build response

### DIFF
--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -433,7 +433,7 @@ class BuildsCreateViewSet(BuildsViewSet, CreateModelMixin):
         data = {
             "build": BuildSerializer(build).data,
             "project": ProjectSerializer(project).data,
-            "version": VersionSerializer(build.version).data,
+            "version": VersionSerializer(version).data,
         }
 
         if build:


### PR DESCRIPTION
## Summary
- serialize the triggered build response using the requested version instead of the build's version

## Fixes
https://read-the-docs.sentry.io/issues/6296397769/


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69148d12c8a08320b6a4ac8267d089b4)