### PR TITLE
Fix AttributeError when build.version is None in telemetry collection

### DIFF
--- a/readthedocs/telemetry/models.py
+++ b/readthedocs/telemetry/models.py
@@ -93,10 +93,11 @@ class BuildDataManager(models.Manager):
             "success": build.success,
         }
         data["project"] = {"id": build.project.id, "slug": build.project.slug}
-        data["version"] = {
-            "id": build.version.id,
-            "slug": build.version.slug,
-        }
+        if build.version:
+            data["version"] = {
+                "id": build.version.id,
+                "slug": build.version.slug,
+            }
         org = build.project.organizations.first()
         if org:
             data["organization"] = {


### PR DESCRIPTION
## Summary

Fixes an AttributeError that occurs when collecting telemetry data for builds where the version has been deleted.

## Details

The `Build.version` field is nullable (`null=True`, `on_delete=models.SET_NULL`), which means it can be `None` when a version is deleted. The telemetry data collection code was attempting to access `build.version.id` without checking for `None`, causing an AttributeError.

## Fixes

https://read-the-docs.sentry.io/issues/6296397769/