### PR TITLE
Document usage of custom .readthedocs.yaml path (#12577)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,20 +23,9 @@ Think of it as *Continuous Documentation*, or Docs as Code.
 Documentation for Read the Docs
 -------------------------------
 
-Using a custom .readthedocs.yaml path
--------------------------------------
+You will find complete documentation for setting up your project in `the Read the Docs documentation`_.
 
-The `.readthedocs.yaml` file is the main configuration file for Read the Docs projects. By default, it is recognized at the root of your repository.
-
-For monorepos containing multiple documentation projects in the same repository, it is possible to place a `.readthedocs.yaml` file in each project's subfolder. This allows each project to have its own build configuration.
-
-.. warning::
-   Changing the configuration file path will apply to all versions of your documentation. Different versions may not build correctly if the path is changed.
-
-After adding a custom configuration file in a subfolder, make sure the relevant versions of your documentation are rebuilt.
-
-For more details and step-by-step instructions, see the official Read the Docs guide:
-https://docs.readthedocs.com/platform/stable/guides/setup/monorepo.html
+.. _the Read the Docs documentation: https://docs.readthedocs.com/
 
 Get in touch
 ------------

--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -6,6 +6,13 @@ This file is named ``.readthedocs.yaml`` and should be placed in the top level o
 
 The ``.readthedocs.yaml``  file can contain a number of settings that are not accessible through the Read the Docs website.
 
+.. note::
+
+   When using a monorepo, it is possible to place the ``.readthedocs.yaml`` file
+   in a subdirectory and configure a custom path from the project settings
+   dashboard. See the :doc:`/guides/setup/monorepo` documentation for more details.
+
+
 Because the file is stored in Git,
 the configuration will apply to the exact version that is being built.
 **This allows you to store different configurations for different versions of your documentation.**


### PR DESCRIPTION
Adds documentation for using a custom .readthedocs.yaml path when the project is located inside a subdirectory. This addresses the request from issue #12577.

Details

Documents how to place the configuration file in a non-root folder.

Adds an example showing the correct path usage.

Clarifies current behavior and limitations.

Related issue: #12577