### PR TITLE
Search: Update ES to 8.19.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
           # Don't skip search tests.
           TOX_POSARGS: ''
           PYTEST_COVERAGE: --cov-report=xml --cov-config .coveragerc --cov=. --cov-append
-      - image: 'docker.elastic.co/elasticsearch/elasticsearch:8.10.2'
+      - image: 'docker.elastic.co/elasticsearch/elasticsearch:8.19.7'
         name: search
         environment:
           discovery.type: single-node

--- a/readthedocs/search/faceted_search.py
+++ b/readthedocs/search/faceted_search.py
@@ -3,16 +3,16 @@ import re
 import structlog
 from django.conf import settings
 from elasticsearch import Elasticsearch
-from elasticsearch_dsl import FacetedSearch
-from elasticsearch_dsl import TermsFacet
-from elasticsearch_dsl.query import Bool
-from elasticsearch_dsl.query import FunctionScore
-from elasticsearch_dsl.query import MultiMatch
-from elasticsearch_dsl.query import Nested
-from elasticsearch_dsl.query import SimpleQueryString
-from elasticsearch_dsl.query import Term
-from elasticsearch_dsl.query import Terms
-from elasticsearch_dsl.query import Wildcard
+from elasticsearch.dsl import FacetedSearch
+from elasticsearch.dsl import TermsFacet
+from elasticsearch.dsl.query import Bool
+from elasticsearch.dsl.query import FunctionScore
+from elasticsearch.dsl.query import MultiMatch
+from elasticsearch.dsl.query import Nested
+from elasticsearch.dsl.query import SimpleQueryString
+from elasticsearch.dsl.query import Term
+from elasticsearch.dsl.query import Terms
+from elasticsearch.dsl.query import Wildcard
 
 from readthedocs.search.documents import PageDocument
 from readthedocs.search.documents import ProjectDocument

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -199,14 +199,10 @@ elastic-transport==8.17.1
     # via
     #   -r requirements/pip.txt
     #   elasticsearch
-    #   elasticsearch-dsl
 elasticsearch==8.19.2
     # via
     #   -r requirements/pip.txt
     #   django-elasticsearch-dsl
-    #   elasticsearch-dsl
-elasticsearch-dsl==8.18.0
-    # via -r requirements/pip.txt
 executing==2.2.1
     # via stack-data
 fido2==2.0.0
@@ -342,7 +338,6 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   celery
     #   elasticsearch
-    #   elasticsearch-dsl
 python-ipware==3.0.0
     # via
     #   -r requirements/pip.txt
@@ -427,7 +422,6 @@ typing-extensions==4.15.0
     #   -r requirements/pip.txt
     #   cron-descriptor
     #   elasticsearch
-    #   elasticsearch-dsl
     #   psycopg
     #   psycopg-pool
     #   pydantic

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -207,14 +207,10 @@ elastic-transport==8.17.1
     # via
     #   -r requirements/pip.txt
     #   elasticsearch
-    #   elasticsearch-dsl
 elasticsearch==8.19.2
     # via
     #   -r requirements/pip.txt
     #   django-elasticsearch-dsl
-    #   elasticsearch-dsl
-elasticsearch-dsl==8.18.0
-    # via -r requirements/pip.txt
 executing==2.2.1
     # via stack-data
 fancycompleter==0.11.1
@@ -370,7 +366,6 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   celery
     #   elasticsearch
-    #   elasticsearch-dsl
 python-ipware==3.0.0
     # via
     #   -r requirements/pip.txt
@@ -454,7 +449,6 @@ typing-extensions==4.15.0
     #   -r requirements/pip.txt
     #   cron-descriptor
     #   elasticsearch
-    #   elasticsearch-dsl
     #   psycopg
     #   psycopg-pool
     #   pydantic

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -62,7 +62,6 @@ requests-oauthlib
 
 # Search
 elasticsearch~=8.0
-elasticsearch-dsl~=8.0
 django-elasticsearch-dsl~=8.0
 
 selectolax

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -157,16 +157,11 @@ drf-extensions==0.8.0
 drf-flex-fields==1.0.2
     # via -r requirements/pip.in
 elastic-transport==8.17.1
-    # via
-    #   elasticsearch
-    #   elasticsearch-dsl
+    # via elasticsearch
 elasticsearch==8.19.2
     # via
     #   -r requirements/pip.in
     #   django-elasticsearch-dsl
-    #   elasticsearch-dsl
-elasticsearch-dsl==8.18.0
-    # via -r requirements/pip.in
 fido2==2.0.0
     # via django-allauth
 filelock==3.20.0
@@ -247,7 +242,6 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   celery
     #   elasticsearch
-    #   elasticsearch-dsl
 python-ipware==3.0.0
     # via django-ipware
 python3-saml==1.16.0
@@ -308,7 +302,6 @@ typing-extensions==4.15.0
     # via
     #   cron-descriptor
     #   elasticsearch
-    #   elasticsearch-dsl
     #   psycopg
     #   psycopg-pool
     #   pydantic

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -210,14 +210,10 @@ elastic-transport==8.17.1
     # via
     #   -r requirements/pip.txt
     #   elasticsearch
-    #   elasticsearch-dsl
 elasticsearch==8.19.2
     # via
     #   -r requirements/pip.txt
     #   django-elasticsearch-dsl
-    #   elasticsearch-dsl
-elasticsearch-dsl==8.18.0
-    # via -r requirements/pip.txt
 execnet==2.1.1
     # via pytest-xdist
 fido2==2.0.0
@@ -369,7 +365,6 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   celery
     #   elasticsearch
-    #   elasticsearch-dsl
 python-ipware==3.0.0
     # via
     #   -r requirements/pip.txt
@@ -465,7 +460,6 @@ typing-extensions==4.15.0
     #   -r requirements/pip.txt
     #   cron-descriptor
     #   elasticsearch
-    #   elasticsearch-dsl
     #   psycopg
     #   psycopg-pool
     #   pydantic


### PR DESCRIPTION
elasticsearch-dsl was incorporated into elasticsearch, so there is no need for the extra dependency. django-es already migrated to the new package. Other than that, there aren't any breaking changes, we already have the latest versions of the clients installed, and everything is working locally.