### PR TITLE
Replace wrong usage of prefetch_related with select_related

### DIFF
--- a/readthedocs/organizations/filters.py
+++ b/readthedocs/organizations/filters.py
@@ -41,7 +41,7 @@ class OrganizationFilterSet(ModelFilterSet):
         return Team.objects.member(
             self.request.user,
             organization=self.organization,
-        ).prefetch_related("organization")
+        ).select_related("organization")
 
 
 class OrganizationSortOrderingFilter(OrderingFilter):

--- a/readthedocs/organizations/migrations/0008_migrate_old_invitations.py
+++ b/readthedocs/organizations/migrations/0008_migrate_old_invitations.py
@@ -19,7 +19,7 @@ def forwards_func(apps, schema_editor):
     Invitation = apps.get_model("invitations", "Invitation")
     ContentType = apps.get_model("contenttypes", "ContentType")
 
-    queryset = TeamInvite.objects.filter(teammember__member__isnull=True).prefetch_related(
+    queryset = TeamInvite.objects.filter(teammember__member__isnull=True).select_related(
         "organization"
     )
     for team_invite in queryset:

--- a/readthedocs/organizations/views/base.py
+++ b/readthedocs/organizations/views/base.py
@@ -172,7 +172,7 @@ class OrganizationOwnerView(OrganizationMixin):
     def get_queryset(self):
         return OrganizationOwner.objects.filter(
             organization=self.get_organization(),
-        ).prefetch_related("owner")
+        ).select_related("owner")
 
     def get_form(self, data=None, files=None, **kwargs):
         kwargs["organization"] = self.get_organization()

--- a/readthedocs/subscriptions/notifications.py
+++ b/readthedocs/subscriptions/notifications.py
@@ -31,7 +31,7 @@ class TrialEndingNotification(SubscriptionNotificationMixin, EmailNotification):
         return (
             djstripe.Subscription.readthedocs.trial_ending()
             .created_days_ago(24)
-            .prefetch_related("customer__rtd_organization")
+            .select_related("customer__rtd_organization")
         )
 
 


### PR DESCRIPTION
prefetch_related should be used for many-to-many and one-to-many relationships, while select_related is for foreign key and one-to-one relationships. Otherwise, we are doing an extra query instead of saving one.