### PR TITLE
Tasks: remove user_pk from task calls

### DIFF
--- a/readthedocs/projects/views/mixins.py
+++ b/readthedocs/projects/views/mixins.py
@@ -137,9 +137,7 @@ class ProjectImportMixin:
         from readthedocs.oauth.tasks import attach_webhook
 
         task_promise = chain(
-            # TODO: Remove user_pk on the next release,
-            # it's used just to keep backward compatibility with the old task signature.
-            attach_webhook.si(project.pk, user.pk),
+            attach_webhook.si(project.pk),
             update_docs,
         )
         async_result = task_promise.apply_async()

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -945,9 +945,6 @@ class IntegrationCreate(IntegrationMixin, CreateView):
             attach_webhook(
                 project_pk=self.get_project().pk,
                 integration=self.object,
-                # TODO: Remove user_pk on the next release,
-                # it's used just to keep backward compatibility with the old task signature.
-                user_pk=None,
             )
         return HttpResponseRedirect(self.get_success_url())
 
@@ -1016,12 +1013,7 @@ class IntegrationWebhookSync(IntegrationMixin, GenericView):
             # This is a brute force form of the webhook sync, if a project has a
             # webhook or a remote repository object, the user should be using
             # the per-integration sync instead.
-            attach_webhook(
-                project_pk=self.get_project().pk,
-                # TODO: Remove user_pk on the next release,
-                # it's used just to keep backward compatibility with the old task signature.
-                user_pk=None,
-            )
+            attach_webhook(project_pk=self.get_project().pk)
         return HttpResponseRedirect(self.get_success_url())
 
     def get_success_url(self):

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -469,7 +469,6 @@ class TestPrivateViews(TestCase):
         attach_webhook.assert_called_once_with(
             project_pk=self.project.pk,
             integration=integration.first(),
-            user_pk=None,
         )
 
     @mock.patch("readthedocs.projects.views.private.attach_webhook")


### PR DESCRIPTION
After this change is deployed, we should be able to remove user_pk from the signature