### PR TITLE
Docs: document --backupdb argument for inv docker.manage

### DIFF
--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -151,7 +151,8 @@ save some work while typing docker compose commands. This section explains these
     Executes a Django management command in a container.
 
     * ``--backupdb`` creates a database backup before running the command.
-      The backup is saved to ``dump.sql`` in the current directory.
+      The backup is saved to the current directory with a timestamped filename:
+      ``dump_<DD-MM-YYYY>_<HH_MM_SS>__<git-hash>.sql``
 
     .. tip::
 
@@ -172,8 +173,8 @@ save some work while typing docker compose commands. This section explains these
           # Start only the database container
           inv docker.compose 'start database'
 
-          # Copy the backup file into the container
-          docker cp dump.sql community_database_1:/tmp/dump.sql
+          # Copy the backup file into the container (replace with your actual filename)
+          docker cp dump_24-11-2025_10_30_00__abc1234.sql community_database_1:/tmp/dump.sql
 
           # Open a shell in the database container
           inv docker.shell --container database


### PR DESCRIPTION
Closes #7761

## Summary

- Documents the `--backupdb` argument for `inv docker.manage`
- Describes the backup filename pattern: `dump_<DD-MM-YYYY>_<HH_MM_SS>__<git-hash>.sql`
- Adds restore instructions with step-by-step commands

Note: #8708 proposes a `restoredb` invoke task to automate restoration. The manual workflow documented here can coexist with that automation if it lands.

## Test plan

- [x] Built docs locally with `make PROJECT=dev html` - renders correctly
- [x] Tested `inv docker.manage --backupdb showmigrations` - backup file created with documented pattern

Generated with [Claude Code](https://claude.com/claude-code)
Steered and reviewed by @nikblanchet (mostly human)