### PR TITLE
Exclude design docs from built documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,6 +84,9 @@ copyright = "Read the Docs, Inc & contributors"
 version = "15.8.0"
 release = version
 exclude_patterns = ["_build", "shared", "_includes"]
+# Exclude design docs from dev documentation
+if docset == "dev":
+    exclude_patterns.append("design")
 default_role = "obj"
 intersphinx_cache_limit = 14  # cache for 2 weeks
 intersphinx_timeout = 3  # 3 seconds timeout

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -12,7 +12,6 @@ or taking the open source Read the Docs codebase for your own custom installatio
    code-of-conduct
    issue-labels
    roadmap
-   design/index
 
 .. toctree::
    :caption: Development


### PR DESCRIPTION
This PR excludes developer design docs from the Sphinx build while keeping the source files in the repository.

## Changes
- Excluded `design/` directory from dev docs build via `exclude_patterns`
- Removed `design/index` from dev documentation toctree
- Design doc `.rst` files remain in `docs/dev/design/` directory for reference

## Next Steps
Redirects will be configured in the RTD dashboard to point old design doc URLs to the corresponding GitHub source files.

---
*Generated by Copilot*