### PR TITLE
Remove `DisallowedRedirect` logging configuration

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -1149,6 +1149,10 @@ class CommunityBaseSettings(Settings):
                 "handlers": ["null"],
                 "propagate": False,
             },
+            "django.security.DisallowedRedirect": {
+                "handlers": ["null"],
+                "propagate": False,
+            },
             "elastic_transport.transport": {
                 "handlers": ["null"],
                 "propagate": False,


### PR DESCRIPTION
This is kiling our Sentry and NewRelic and they are just spammers.

<img width="1864" height="586" alt="Screenshot_2025-12-04_10-57-16" src="https://github.com/user-attachments/assets/ac0001d3-f1c4-4a0d-928e-19dcb734644b" />
