### PR TITLE
Update pip-tools workflow to use latest action version and disable cr…

### DIFF
--- a/.github/workflows/pip-tools.yaml
+++ b/.github/workflows/pip-tools.yaml
@@ -25,6 +25,8 @@ jobs:
     if: github.repository_owner == 'readthedocs' # do not run this job on forks
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Update submodules
         run: git submodule update --init
       - uses: actions/setup-python@v6
@@ -42,7 +44,7 @@ jobs:
         run: invoke requirements.update
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         with:
           add-paths: |
             requirements/*.txt


### PR DESCRIPTION
…edentials persistence

Solves this issue:

```
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/readthedocs/readthedocs.org/': The requested URL returned error: 400
```