### PR TITLE
Rename method to match its functionality

### DIFF
--- a/readthedocs/core/templatetags/privacy_tags.py
+++ b/readthedocs/core/templatetags/privacy_tags.py
@@ -24,6 +24,6 @@ def get_public_projects(context, user):
     projects = Project.objects.for_user_and_viewer(
         user=user,
         viewer=context["request"].user,
-    ).prefetch_latest_build()
+    ).annotate_has_successful_build()
     context["public_projects"] = projects
     return ""

--- a/readthedocs/projects/filters.py
+++ b/readthedocs/projects/filters.py
@@ -138,8 +138,8 @@ class ProjectSortOrderingFilter(OrderingFilter):
             else:
                 order_bys.append(field_ordered)
 
-        # prefetch_latest_build does some extra optimizations to avoid additional queries.
-        return qs.prefetch_latest_build().annotate(**annotations).order_by(*order_bys)
+        # annotate_has_successful_build does some extra optimizations to avoid additional queries.
+        return qs.annotate_has_successful_build().annotate(**annotations).order_by(*order_bys)
 
 
 class ProjectListFilterSet(ModelFilterSet):

--- a/readthedocs/projects/querysets.py
+++ b/readthedocs/projects/querysets.py
@@ -133,9 +133,12 @@ class ProjectQuerySetBase(NoReprQuerySet, models.QuerySet):
         feature_value = feature.value if feature else 1
         return project.max_concurrent_builds or max_concurrent_organization or feature_value
 
-    def prefetch_latest_build(self):
+    def annotate_has_successful_build(self):
         """
-        Prefetch and annotate to avoid N+1 queries.
+        Annotate projects with whether they have a successful build.
+
+        Adds a boolean annotation `_has_good_build` to avoid N+1 queries
+        when checking if a project has any successful builds.
 
         .. note::
 

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -401,7 +401,7 @@ class TestPrivateViews(TestCase):
 
         # This number is bit higher, but for projects with lots of builds
         # is better to have more queries than optimizing with a prefetch,
-        # see comment in prefetch_latest_build.
+        # see comment in annotate_has_successful_build.
         with self.assertNumQueries(26):
             r = self.client.get(reverse(("projects_dashboard")))
         assert r.status_code == 200


### PR DESCRIPTION
`prefetch_latest_build` method renamed to `annotate_has_successful_build` to better reflect its purpose of annotating projects.