### PR TITLE
Docker: use `_` for network and volume names

### DIFF
--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -12,8 +12,8 @@ class DockerBaseSettings(CommunityBaseSettings):
 
     DOCKER_ENABLE = True
     RTD_DOCKER_COMPOSE = True
-    RTD_DOCKER_COMPOSE_NETWORK = "community-readthedocs"
-    RTD_DOCKER_COMPOSE_VOLUME = "community-build-user-builds"
+    RTD_DOCKER_COMPOSE_NETWORK = "community_readthedocs"
+    RTD_DOCKER_COMPOSE_VOLUME = "community_build-user-builds"
     RTD_DOCKER_USER = f"{os.geteuid()}:{os.getegid()}"
     BUILD_MEMORY_LIMIT = "2g"
 


### PR DESCRIPTION
Looks like the `-` is only used for the container names, not for networks and volumes. https://github.com/readthedocs/readthedocs.org/pull/12692