### PR TITLE
Search: use default pooling

### DIFF
--- a/readthedocs/search/faceted_search.py
+++ b/readthedocs/search/faceted_search.py
@@ -1,8 +1,6 @@
 import re
 
 import structlog
-from django.conf import settings
-from elasticsearch import Elasticsearch
 from elasticsearch.dsl import FacetedSearch
 from elasticsearch.dsl import TermsFacet
 from elasticsearch.dsl.query import Bool


### PR DESCRIPTION
django-elastic-search already creates a connection in the way that ES recommends to make use of a pool connection https://www.elastic.co/guide/en/elasticsearch/client/python-api/8.19/_configuration.html https://github.com/django-es/django-elasticsearch-dsl/blob/49cea31ca1e6c19eda868c4026f505bbdeffe9f7/django_elasticsearch_dsl/apps.py#L14-L14.

We should be monitor this when deployed and be ready to rollback if needed.