### PR TITLE
API: don't return credentials for builds without a version

### DIFF
--- a/readthedocs/api/v2/views/model_views.py
+++ b/readthedocs/api/v2/views/model_views.py
@@ -394,6 +394,12 @@ class BuildViewSet(DisableListEndpoint, UpdateModelMixin, UserSelectViewSet):
         This can generate temporary credentials for interacting with S3 only for now.
         """
         build = self.get_object()
+        if not build.version:
+            return Response(
+                {"error": "Build has no associated version"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         credentials_type = request.data.get("type")
 
         if credentials_type == "build_media":


### PR DESCRIPTION
ref https://read-the-docs.sentry.io/issues/7210450073/?alert_rule_id=229005&alert_timestamp=1769096052197&alert_type=email&environment=production&notification_uuid=29c722c8-4c3d-4708-9373-363f3842b2a5&project=148442&referrer=alert_email

Since we were talking about deleting builds after some time, it could make sense to cascade delete builds when a version is deleted.