### PR TITLE
Search: avoid timeout when querying sync_id when indexing

### DIFF
--- a/readthedocs/projects/tasks/search.py
+++ b/readthedocs/projects/tasks/search.py
@@ -227,7 +227,7 @@ def _process_files(*, version: Version, indexers: list[Indexer]):
     # which makes the query slower, we don't need any specific order here, just the current sync_id.
     # Next step is to not rely on the DB for this https://github.com/readthedocs/readthedocs.org/issues/10734.
     imported_file_build_id = next(
-        version.imported_files.values_list("build", flat=True)[:1].iteator(), None
+        iter(version.imported_files.values_list("build", flat=True)[:1]), None
     )
     sync_id = imported_file_build_id + 1 if imported_file_build_id else 1
 


### PR DESCRIPTION
Using order by makes the query slow

```
In [16]: v.imported_files.values_list("build", flat=True)[:1]
Out[16]: SELECT "projects_importedfile"."build" AS "build"
  FROM "projects_importedfile"
 WHERE "projects_importedfile"."version_id" = 5816538
 LIMIT 1

Execution time: 0.000705s [Database: default]

In [18]: v.imported_files.values_list("build", flat=True).first()
SELECT "projects_importedfile"."build" AS "build"
  FROM "projects_importedfile"
 WHERE "projects_importedfile"."version_id" = 5816538
 ORDER BY "projects_importedfile"."id" ASC
 LIMIT 1

Execution time: 13.684593s [Database: default]

```

Fixes https://read-the-docs.sentry.io/issues/6429115276/?project=148442&query=is%3Aunresolved%20%21logger%3Acsp%20timeout&referrer=issue-stream

We can also start using a random number as suggested in #10734, build_id is just a number different from the current one, to tell apart the current objects from the old ones, we no longer use the actual id of the build.