### PR TITLE
Add get_pattern helper function to constants.py

### DIFF
--- a/readthedocs/constants.py
+++ b/readthedocs/constants.py
@@ -16,3 +16,17 @@ pattern_opts = {
     "integer_pk": r"[\d]+",
     "downloadable_type": "|".join(re.escape(type_) for type_ in DOWNLOADABLE_MEDIA_TYPES),
 }
+
+def get_pattern(name: str) -> str:
+    """
+    Return a regex pattern from pattern_opts by name.
+    Raises KeyError if the pattern does not exist.
+    """
+    return pattern_opts[name]
+
+
+def list_patterns() -> list[str]:
+    """
+    Return a list of all available pattern names.
+    """
+    return list(pattern_opts.keys())


### PR DESCRIPTION
This PR introduces a small helper function `get_pattern(name)` in `constants.py` that allows safely retrieving regex patterns from the existing `pattern_opts` dictionary by name. The addition is minimal, self-contained, and does not affect any 
existing functionality in the project. It is intended as a safe first contribution for learning and testing purposes.

Example usage:
    pattern = get_pattern("project_slug")

