### PR TITLE
Integrations: don't send build status for builds without a version

### DIFF
--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -382,6 +382,8 @@ def send_build_status(build_pk, commit, status):
     :param status: build status failed, pending, or success to be sent.
     """
     build = Build.objects.filter(pk=build_pk).select_related("version").first()
+    # Bulds without a verion shouldn't send status, it can happen when
+    # a build from a deleted version is being processed (race condition).
     if not build or not build.version:
         return
 


### PR DESCRIPTION
There is a race condition when deleting a version. Not really sure how this happens, like we only delete external versions when a project is deleted or when the delete_closed_external_versions task is called... If a project is deleted, the build should be deleted as well, and we don't even have that many versions left to delete to say that two tasks are overlapping. Anyway, it doesn't make sense to report a build status over a build that doesn't have a version. 

Fixes https://read-the-docs.sentry.io/issues/5762982757/?project=161479&query=%21logger%3Acsp%20is%3Aunresolved&referrer=issue-stream