### PR TITLE
GitHub App: Remove RTD_ALLOW_GITHUB_APP setting

### DIFF
--- a/readthedocs/core/adapters.py
+++ b/readthedocs/core/adapters.py
@@ -7,7 +7,6 @@ from allauth.core.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.socialaccount.models import SocialAccount
 from allauth.socialaccount.providers.github.provider import GitHubProvider
-from django.conf import settings
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.urls import reverse
@@ -103,12 +102,6 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
             uid=sociallogin.account.uid,
         ).first()
 
-        # If there is an existing GH account, we check if that user can use the GH App,
-        # otherwise we check for the current user.
-        user_to_check = social_account.user if social_account else request.user
-        if not self._can_use_github_app(user_to_check):
-            raise ImmediateHttpResponse(HttpResponseRedirect(reverse("account_login")))
-
         # If there isn't an existing GH account, nothing to do,
         # just let allauth create the new account.
         if not social_account:
@@ -128,14 +121,6 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
             raise ImmediateHttpResponse(HttpResponseRedirect(url))
 
         sociallogin.connect(request, social_account.user)
-
-    def _can_use_github_app(self, user):
-        """
-        Check if the user can use the GitHub App.
-
-        Only staff users can use the GitHub App for now.
-        """
-        return settings.RTD_ALLOW_GITHUB_APP or user.is_staff
 
     def _block_use_of_old_github_oauth_app(self, request, sociallogin):
         """

--- a/readthedocs/core/tests/test_adapters.py
+++ b/readthedocs/core/tests/test_adapters.py
@@ -5,7 +5,7 @@ from allauth.socialaccount.adapter import get_adapter as get_social_account_adap
 from allauth.socialaccount.models import SocialAccount, SocialLogin
 from allauth.socialaccount.providers.github.provider import GitHubProvider
 from django.contrib.auth.models import AnonymousUser, User
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django_dynamic_fixture import get
 
 from readthedocs.allauth.providers.githubapp.provider import GitHubAppProvider
@@ -16,37 +16,6 @@ class SocialAdapterTest(TestCase):
         self.user = get(User, username="test")
         self.adapter = get_social_account_adapter()
 
-    @override_settings(RTD_ALLOW_GITHUB_APP=False)
-    def test_dont_allow_using_githubapp_for_non_staff_users(self):
-        assert not SocialAccount.objects.filter(provider=GitHubAppProvider.id).exists()
-
-        # Anonymous user
-        request = mock.MagicMock(user=AnonymousUser())
-        sociallogin = SocialLogin(
-            user=User(email="me@example.com"),
-            account=SocialAccount(provider=GitHubAppProvider.id),
-        )
-        with self.assertRaises(ImmediateHttpResponse) as exc:
-            self.adapter.pre_social_login(request, sociallogin)
-        self.assertEqual(exc.exception.response.status_code, 302)
-
-        assert not SocialAccount.objects.filter(provider=GitHubAppProvider.id).exists()
-
-        # Existing non-staff user
-        assert not self.user.is_staff
-        request = mock.MagicMock(user=self.user)
-        sociallogin = SocialLogin(
-            user=User(email="me@example.com"),
-            account=SocialAccount(provider=GitHubAppProvider.id),
-        )
-        with self.assertRaises(ImmediateHttpResponse) as exc:
-            self.adapter.pre_social_login(request, sociallogin)
-        self.assertEqual(exc.exception.response.status_code, 302)
-        assert not self.user.socialaccount_set.filter(
-            provider=GitHubAppProvider.id
-        ).exists()
-
-    @override_settings(RTD_ALLOW_GITHUB_APP=True)
     def test_allow_using_githubapp_for_all_users(self):
         assert not self.user.is_staff
 

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -931,7 +931,6 @@ class CommunityBaseSettings(Settings):
     GITHUB_APP_NAME = "readthedocs"
     GITHUB_APP_PRIVATE_KEY = ""
     GITHUB_APP_WEBHOOK_SECRET = ""
-    RTD_ALLOW_GITHUB_APP = True
 
     @property
     def GITHUB_APP_CLIENT_ID(self):


### PR DESCRIPTION
We no longer need this, it's default to true on both sites.