### PR TITLE
Search: don't include content from non-content nodes

### DIFF
--- a/readthedocs/search/parsers.py
+++ b/readthedocs/search/parsers.py
@@ -318,6 +318,11 @@ class GenericParser:
            This will mutate the original `body`.
         """
         nodes_to_be_removed = itertools.chain(
+            # Non-content nodes
+            body.css("script"),
+            body.css("style"),
+            body.css("template"),
+            body.css("noscript"),
             # Navigation nodes
             body.css("nav"),
             body.css("[role=navigation]"),


### PR DESCRIPTION
When extracting the text of html documents using `text()`, it will include contents from inline scripts/styles. For inline graphs, we are indexing a lot of content, it timeouts ES when trying to search over those documents.