### PR TITLE
Search: limit content to be indexed to 1MB

### DIFF
--- a/readthedocs/search/parsers.py
+++ b/readthedocs/search/parsers.py
@@ -20,8 +20,8 @@ class GenericParser:
     # to avoid filling the index with too much data.
     # The limit may be exceeded if the content is too large,
     # or if the content is malformed.
-    # A raw approximation of bytes based on the number of characters (~1.5 MB).
-    max_content_length = int(1.5 * 1024 * 1024)
+    # A raw approximation of bytes based on the number of characters (~1MB).
+    max_content_length = int(1024 * 1024)
 
     # Block level elements have an implicit line break before and after them.
     # List taken from: https://www.w3schools.com/htmL/html_blocks.asp.


### PR DESCRIPTION
When fixing https://github.com/readthedocs/readthedocs.org/pull/12757, I found a project that was indexing 1.5MB, and when searching over that content, ES timed out, we can reduce this even further if we want. But hopefully, with the other fix, this case will be less common as well.