### PR TITLE
Build overview: don't require FTD addon to create manifest

### DIFF
--- a/readthedocs/projects/tasks/search.py
+++ b/readthedocs/projects/tasks/search.py
@@ -195,9 +195,8 @@ def _get_indexers(
         else LATEST
     )
     create_manifest = (
-        version.project.addons.filetreediff_enabled
-        or version.project.show_build_overview_in_comment
-    ) and (version.is_external or version.slug == base_version or settings.RTD_FILETREEDIFF_ALL)
+        version.is_external or version.slug == base_version or settings.RTD_FILETREEDIFF_ALL
+    )
     if create_manifest:
         file_manifest_indexer = FileManifestIndexer(
             version=version,


### PR DESCRIPTION
Users may choose to not use the addon, but still want to have the comment on PRs. Had a costumer with not build overviews because of this.