### PR TITLE
Add get_project_active_versions filter

### DIFF
--- a/readthedocs/projects/templatetags/projects_tags.py
+++ b/readthedocs/projects/templatetags/projects_tags.py
@@ -2,6 +2,7 @@
 
 from django import template
 
+from readthedocs.builds.constants import INTERNAL
 from readthedocs.core.permissions import AdminPermission
 from readthedocs.projects.version_handling import comparable_version
 
@@ -26,3 +27,8 @@ def sort_version_aware(versions):
 def is_project_user(user, project):
     """Checks if the user has access to the project."""
     return user in AdminPermission.members(project)
+
+
+@register.simple_tag
+def get_project_active_versions(project, user):
+    return project.versions(manager=INTERNAL).public(user=user, only_active=True)


### PR DESCRIPTION
This is used in https://github.com/readthedocs/ext-theme/pull/704 to fix the number of versions in the project dashboard header.