### PR TITLE
Unpin newrelic to use the latest version in the next upgrade

### DIFF
--- a/requirements/deploy.in
+++ b/requirements/deploy.in
@@ -4,8 +4,6 @@
 
 structlog-sentry
 
-# Pinned due to a bug in 10.8.1
-# See https://github.com/newrelic/newrelic-python-agent/issues/1347
-newrelic==10.7.0
+newrelic
 
 ipython


### PR DESCRIPTION
The issue we had was fixed already.