### PR TITLE
Remove `exit 183` command from config file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,9 +78,3 @@ License
 `MIT`_ © 2025 Read the Docs, Inc. & contributors
 
 .. _MIT: LICENSE
-
-
-Test for WebhookAutomationRules
--------------------------------
-
-This is just a new section to test if a build is triggered.


### PR DESCRIPTION
I moved these rules to `WebhookAutomationRule` for this project. Modifying any of these files on external version should trigger a build.