### PR TITLE
GitHub App: use PR endpoint to get PR

### DIFF
--- a/readthedocs/oauth/services/githubapp.py
+++ b/readthedocs/oauth/services/githubapp.py
@@ -543,10 +543,10 @@ class GitHubAppService(Service):
         # NOTE: we use the lazy option to avoid fetching the repository object,
         # since we only need the object to interact with the commit status API.
         gh_repo = self.installation_client.get_repo(int(remote_repo.remote_id), lazy=True)
-        gh_issue = gh_repo.get_issue(int(version.verbose_name))
+        gh_pull = gh_repo.get_pull(int(version.verbose_name))
         existing_gh_comment = None
         comment_marker = f"<!-- readthedocs-{project.pk} -->"
-        for gh_comment in gh_issue.get_comments():
+        for gh_comment in gh_pull.get_issue_comments():
             # Get the comment where the author is us, and the comment belongs to the project.
             # The login of the author is the name of the GitHub App, with the "[bot]" suffix.
             if (
@@ -560,7 +560,7 @@ class GitHubAppService(Service):
         if existing_gh_comment:
             existing_gh_comment.edit(body=comment)
         elif create_new:
-            gh_issue.create_comment(body=comment)
+            gh_pull.create_issue_comment(body=comment)
         else:
             log.debug(
                 "No comment to update, skipping commenting",

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -291,10 +291,11 @@ class GitHubAppTests(TestCase):
     def _get_pull_request_json(self, number: int, repo_full_name, **kwargs):
         user, repo = repo_full_name.split("/")
         default = {
-            "url": f"https://api.github.com/repos/{repo_full_name}/issues/{number}",
+            "url": f"https://api.github.com/repos/{repo_full_name}/pulls/{number}",
             "id": 1,
             "html_url": f"https://github.com/{repo_full_name}/pull/{number}",
             "comments_url": f"https://api.github.com/repos/{repo_full_name}/issues/{number}/comments",
+            "issue_url": f"https://api.github.com/repos/{repo_full_name}/issues/{number}",
             "number": number,
             "state": "open",
             "locked": False,
@@ -1088,7 +1089,7 @@ class GitHubAppTests(TestCase):
             json=self._get_access_token_json(),
         )
         request.get(
-            f"{self.api_url}/repositories/{self.remote_repository.remote_id}/issues/{version.verbose_name}",
+            f"{self.api_url}/repositories/{self.remote_repository.remote_id}/pulls/{version.verbose_name}",
             json=self._get_pull_request_json(
                 number=int(version.verbose_name),
                 repo_full_name=self.remote_repository.full_name,
@@ -1205,7 +1206,7 @@ class GitHubAppTests(TestCase):
             json=self._get_access_token_json(),
         )
         request.get(
-            f"{self.api_url}/repositories/{self.remote_repository.remote_id}/issues/{version.verbose_name}",
+            f"{self.api_url}/repositories/{self.remote_repository.remote_id}/pulls/{version.verbose_name}",
             json=self._get_pull_request_json(
                 number=int(version.verbose_name),
                 repo_full_name=self.remote_repository.full_name,


### PR DESCRIPTION
GH considers every pull request an issue, but not every issue is a pull request... And when it comes to permissions, when you try fetching a PR from a private repository using the issues endpoint, you won't be able to use it if your app doesn't have the issues permission, but if you want to list/post/edit a "normal" comment, you can use the issues endpoint :_