### PR TITLE
GitHub App: don't sync all repos when a new repo is added

### DIFF
--- a/readthedocs/oauth/tasks.py
+++ b/readthedocs/oauth/tasks.py
@@ -483,12 +483,9 @@ class GitHubAppWebhookHandler:
             return
 
         if action == "added":
-            if self.data["repository_selection"] == "all":
-                installation.service.sync()
-            else:
-                installation.service.update_or_create_repositories(
-                    [repo["id"] for repo in self.data["repositories_added"]]
-                )
+            installation.service.update_or_create_repositories(
+                [repo["id"] for repo in self.data["repositories_added"]]
+            )
             return
 
         if action == "removed":

--- a/readthedocs/oauth/tests/test_githubapp_webhook.py
+++ b/readthedocs/oauth/tests/test_githubapp_webhook.py
@@ -283,8 +283,8 @@ class TestGitHubAppWebhook(TestCase):
         assert r.status_code == 200
         update_or_create_repositories.assert_called_once_with([1234, 5678])
 
-    @mock.patch.object(GitHubAppService, "sync")
-    def test_installation_repositories_added_all(self, sync):
+    @mock.patch.object(GitHubAppService, "update_or_create_repositories")
+    def test_installation_repositories_added_all(self, update_or_create_repositories):
         payload = {
             "action": "added",
             "installation": {
@@ -293,10 +293,24 @@ class TestGitHubAppWebhook(TestCase):
                 "target_type": self.installation.target_type,
             },
             "repository_selection": "all",
+            "repositories_added": [
+                {
+                    "id": 1234,
+                    "name": "repo1",
+                    "full_name": "user/repo1",
+                    "private": False,
+                },
+                {
+                    "id": 5678,
+                    "name": "repo2",
+                    "full_name": "user/repo2",
+                    "private": True,
+                },
+            ],
         }
         r = self.post_webhook("installation_repositories", payload)
         assert r.status_code == 200
-        sync.assert_called_once()
+        update_or_create_repositories.assert_called_once_with([1234, 5678])
 
     def test_installation_repositories_removed(self):
         assert self.installation.repositories.count() == 1


### PR DESCRIPTION
This was initially done:

- In case GH doesn't send all repos, if they are too many. But I didn't find any mention on the limits, only on the limit of the payload itself.
- It's faster to use .sync when syncing several repos, as we will make fewer API calls. But this is only valid when the number of repos added is very large, which I don't think it should be that frequent. Like when a user initially doesn't grant access to all repos, but then it does (but again, this shouldn't happen too often).

We are having a problem with a user that has 2K repos, and every time it adds an extra repo, we try to sync all repos, which we shouldn't do. We would still have a problem when trying to sync all repositories of a large org/user, but we can try to solve that in another PR (also another point to not point users to grant access to all repos).

ref https://read-the-docs.sentry.io/issues/7252103570/?project=148442&query=%21logger%3A%22csp%22%20is%3Aunresolved%20RateLimitExceededException&referrer=issue-stream