### PR TITLE
Docs: Clarify where to see the traffic analytics

### DIFF
--- a/docs/user/traffic-analytics.rst
+++ b/docs/user/traffic-analytics.rst
@@ -10,8 +10,8 @@ This allows you to understand how your documentation is being used,
 so you can focus on expanding and updating parts people are reading most.
 
 To see a list of the top pages from the last month,
-go to the :guilabel:`Admin` tab of your project,
-and then click on :guilabel:`Traffic analytics`.
+go to the :guilabel:`Settings` tab of your project,
+and then click on :guilabel:`Traffic analytics` under :guilabel:`Maintaining`.
 
 .. figure:: /_static/images/addons-analytics.png
    :width: 50%


### PR DESCRIPTION
In https://docs.readthedocs.com/platform/stable/traffic-analytics.html, the user is instructed to go to the "Admin panel" and then click on "Traffic analytics" to check a project's traffic data.

But the "Admin panel" that it is referring to is actually the "Settings" panel. So I changed it so that its easier for someone reading it to actually find the "Traffic analytics" section.