### PR TITLE
Remove global storage secrets from builders

### DIFF
--- a/dockerfiles/settings/build.py
+++ b/dockerfiles/settings/build.py
@@ -12,5 +12,8 @@ class BuildDevSettings(DockerBaseSettings):
     # If you get an error about it missing, you may be doing
     # something that shouldn't be done from the builders.
     SECRET_KEY = None
+    SECRET_KEY_FALLBACKS = []
+    AWS_ACCESS_KEY_ID = None
+    AWS_SECRET_ACCESS_KEY = None
 
 BuildDevSettings.load_settings(__name__)

--- a/readthedocs/projects/tasks/storage.py
+++ b/readthedocs/projects/tasks/storage.py
@@ -2,7 +2,6 @@ from enum import StrEnum
 from enum import auto
 
 import structlog
-from django.conf import settings
 from django.core.files.storage import storages
 
 from readthedocs.doc_builder.exceptions import BuildAppError
@@ -27,11 +26,9 @@ def get_storage(*, build_id, api_client, storage_type: StorageType):
         so we need to dynamically create the storage class instance
     """
     storage_class = _get_storage_class(storage_type)
-    extra_kwargs = {}
-    if settings.USING_AWS:
-        extra_kwargs = _get_s3_scoped_credentials(
-            build_id=build_id, api_client=api_client, storage_type=storage_type
-        )
+    extra_kwargs = _get_s3_scoped_credentials(
+        build_id=build_id, api_client=api_client, storage_type=storage_type
+    )
     return storage_class(**extra_kwargs)
 
 


### PR DESCRIPTION
We get the credentials from an API now.

Closes https://github.com/readthedocs/readthedocs-ops/issues/1631