### PR TITLE
Downgrade debug toolbar to 6.1.0

### DIFF
--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -144,7 +144,7 @@ django-crispy-forms==1.14.0
     # via -r requirements/pip.txt
 django-csp==3.8
     # via -r requirements/pip.txt
-django-debug-toolbar==6.2.0
+django-debug-toolbar==6.1.0
     # via -r requirements/pip.txt
 django-elasticsearch-dsl==9.0
     # via -r requirements/pip.txt

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -150,7 +150,7 @@ django-crispy-forms==1.14.0
     # via -r requirements/pip.txt
 django-csp==3.8
     # via -r requirements/pip.txt
-django-debug-toolbar==6.2.0
+django-debug-toolbar==6.1.0
     # via -r requirements/pip.txt
 django-elasticsearch-dsl==9.0
     # via -r requirements/pip.txt

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -117,7 +117,8 @@ django-storages[s3]
 
 
 # Required only in development and linting
-django-debug-toolbar
+# There is a recursion bug with 6.2.0 caching
+django-debug-toolbar==6.1.0
 
 # For enabling content-security-policy
 # Pinned to 3.8 because we need to take some manual actions before upgrading to 4.x

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -107,7 +107,7 @@ django-crispy-forms==1.14.0
     # via -r requirements/pip.in
 django-csp==3.8
     # via -r requirements/pip.in
-django-debug-toolbar==6.2.0
+django-debug-toolbar==6.1.0
     # via -r requirements/pip.in
 django-elasticsearch-dsl==9.0
     # via -r requirements/pip.in

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -145,7 +145,7 @@ django-crispy-forms==1.14.0
     # via -r requirements/pip.txt
 django-csp==3.8
     # via -r requirements/pip.txt
-django-debug-toolbar==6.2.0
+django-debug-toolbar==6.1.0
     # via -r requirements/pip.txt
 django-dynamic-fixture==4.0.1
     # via -r requirements/testing.in


### PR DESCRIPTION
This addresses a bug that was introduced in 6.2.0:

https://read-the-docs.sentry.io/issues/7277140660/

This was resulting in 5xx errors on a number of views. I tested the downgrade on web-extra with 6.1.0 and the 5xx error went away.