### PR TITLE
Build: don't hang build when checking Azure repos

### DIFF
--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -196,7 +196,7 @@ class Backend(BaseVCS):
             # Azure DevOps is known to not fail immediately when trying to push
             # with an SSH key without write access, but instead it hangs until
             # it times out (this happens randomly).
-            cmd = ["timeout", "3s", "git", "push", "--dry-run", remote_name]
+            cmd = ["timeout", "10s", "git", "push", "--dry-run", remote_name]
             code, stdout, stderr = self.run(*cmd, record=False, demux=True)
 
             if code == 0:


### PR DESCRIPTION
Had a customer with some of their builds timing out, looks like the push operation randomly hangs on Azure, so I'm adding a timeout here. `timeout` is installed by default in all ubuntu images.