### PR TITLE
Document subproject HTTP header tokens

### DIFF
--- a/docs/user/commercial/sharing.rst
+++ b/docs/user/commercial/sharing.rst
@@ -88,6 +88,18 @@ For example:
 
    curl -H "Authorization: Token $TOKEN" https://docs.example.com/en/latest/example.html
 
+If you want to access a subproject,
+create the HTTP header token on the subproject itself and then request the subproject URL.
+For example,
+if ``plugin`` is a subproject served under ``https://docs.example.com/projects/plugin/``,
+use:
+
+.. prompt:: bash $
+
+   curl -H "Authorization: Token $TOKEN" https://docs.example.com/projects/plugin/en/latest/example.html
+
+An HTTP header token created on the parent project does not grant access to its subprojects.
+
 Basic Authorization
 ~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Document how HTTP header token sharing works with subprojects.

This adds a concrete subproject URL example under the header token section and states that a token created on the parent project does not grant access to subprojects.
