### PR TITLE
Build: allow users to use Ubuntu 26.04 as build image

### DIFF
--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -269,7 +269,7 @@ Image names refer to the operating system Read the Docs uses to build them.
    Arbitrary Docker images are not supported.
 
 :Type: ``string``
-:Options: ``ubuntu-20.04``, ``ubuntu-22.04``, ``ubuntu-24.04``, ``ubuntu-lts-latest``
+:Options: ``ubuntu-20.04`` (deprecated), ``ubuntu-22.04``, ``ubuntu-24.04``, ``ubuntu-26.04``, ``ubuntu-lts-latest``
 :Required: ``true``
 
 .. note::

--- a/readthedocs/builds/constants_docker.py
+++ b/readthedocs/builds/constants_docker.py
@@ -26,6 +26,7 @@ RTD_DOCKER_BUILD_SETTINGS = {
         "ubuntu-20.04": f"{DOCKER_DEFAULT_IMAGE}:ubuntu-20.04",
         "ubuntu-22.04": f"{DOCKER_DEFAULT_IMAGE}:ubuntu-22.04",
         "ubuntu-24.04": f"{DOCKER_DEFAULT_IMAGE}:ubuntu-24.04",
+        "ubuntu-26.04": f"{DOCKER_DEFAULT_IMAGE}:ubuntu-26.04",
     },
     # Mapping of build.tools options to specific versions.
     "tools": {

--- a/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
+++ b/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
@@ -52,6 +52,7 @@
             "ubuntu-20.04",
             "ubuntu-22.04",
             "ubuntu-24.04",
+            "ubuntu-26.04",
             "ubuntu-lts-latest"
           ]
         },


### PR DESCRIPTION
We are not making it the default yet since we want to make sure it works well.

Closes https://github.com/readthedocs/readthedocs.org/issues/12690