### PR TITLE
AGENTS.md: don't use a symlink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,3 @@
-common/.github/copilot-instructions.md
+# Read the Docs developement guide for AI agents
+
+Follow the instructions from https://github.com/readthedocs/common/blob/main/.github/copilot-instructions.md.


### PR DESCRIPTION
Copilot doesn't clone submodules,
so this file is never present in the repo, and the symlink is broken.


closes https://github.com/readthedocs/readthedocs.org/issues/12727