### PR TITLE
Rename 'Iranian' to 'Persian' for language code fa

### DIFF
--- a/readthedocs/projects/constants.py
+++ b/readthedocs/projects/constants.py
@@ -147,7 +147,7 @@ LANGUAGES = (
     ("es", "Spanish"),
     ("et", "Estonian"),
     ("eu", "Basque"),
-    ("fa", "Iranian"),
+    ("fa", "Persian"),
     ("fi", "Finnish"),
     ("fj", "Fijian"),
     ("fo", "Faroese"),


### PR DESCRIPTION
## Summary

- Fixes the display name for language code `fa` from "Iranian" to "Persian" (the ISO 639-1 standard name)
- Users could not find Farsi/Persian in the language picker because it was mislabeled

Closes https://github.com/readthedocs/readthedocs.org/issues/12763

## Test plan

- [ ] Verify the language picker shows "Persian" instead of "Iranian"
- [ ] Check if a Django migration is needed for the choices change