### PR TITLE
Fix build status notification: remove stray HTML, add troubleshooting link

### DIFF
--- a/readthedocs/oauth/notifications.py
+++ b/readthedocs/oauth/notifications.py
@@ -69,9 +69,10 @@ messages = [
             textwrap.dedent(
                 """
         Could not send {{provider_name}} build status report for "{{instance.name}}".
-        Make sure you have the correct {{provider_name}} repository permissions</a> and
+        Make sure you have the correct {{provider_name}} repository permissions and
         your <a href="{{url_connect_account}}">{{provider_name}} account</a>
         is connected to Read the Docs.
+        See <a href="https://docs.readthedocs.com/platform/stable/guides/pull-requests.html#troubleshooting">our troubleshooting guide</a> for more information.
             """
             ).strip(),
         ),


### PR DESCRIPTION
## Summary

- Removes a stray `</a>` closing tag that had no matching opening tag in the build status failure notification
- Adds a link to the [PR troubleshooting guide](https://docs.readthedocs.com/platform/stable/guides/pull-requests.html#troubleshooting) so users know where to look for help

Closes https://github.com/readthedocs/readthedocs.org/issues/11866

## Test plan

- [ ] Verify the notification renders correctly with the new link
- [ ] Check the troubleshooting URL is valid