### PR TITLE
Update broken embed API example URLs

### DIFF
--- a/docs/user/api/v2.rst
+++ b/docs/user/api/v2.rst
@@ -328,6 +328,10 @@ Embed
 
 .. http:get::  /api/v2/embed/
 
+    .. deprecated:: 2024-11
+       The embed API v2 has been deprecated and is no longer available.
+       Use :ref:`embed API v3 <api/v3:embed>` instead.
+
     Retrieve HTML-formatted content from documentation page or section.
 
     .. warning::
@@ -339,53 +343,7 @@ Embed
 
     .. prompt:: bash $
 
-        curl https://app.readthedocs.org/api/v2/embed/?project=docs&version=latest&doc=features&path=features.html
-
-    or
-
-    .. prompt:: bash $
-
         curl https://app.readthedocs.org/api/v2/embed/?url=https://docs.readthedocs.com/platform/stable/reference/features.html
-
-    **Example response**:
-
-    .. sourcecode:: js
-
-        {
-            "content": [
-                "<div class=\"section\" id=\"read-the-docs-features\">\n<h1>Read the Docs..."
-            ],
-            "headers": [
-                {
-                    "Read the Docs features": "#"
-                },
-                {
-                    "Automatic Documentation Deployment": "#automatic-documentation-deployment"
-                },
-                {
-                    "Custom Domains & White Labeling": "#custom-domains-white-labeling"
-                },
-                {
-                    "Versioned Documentation": "#versioned-documentation"
-                },
-                {
-                    "Downloadable Documentation": "#downloadable-documentation"
-                },
-                {
-                    "Full-Text Search": "#full-text-search"
-                },
-                {
-                    "Open Source and Customer Focused": "#open-source-and-customer-focused"
-                }
-            ],
-            "url": "https://docs.readthedocs.com/platform/stable/reference/features",
-            "meta": {
-                "project": "docs",
-                "version": "latest",
-                "doc": "features",
-                "section": "read the docs features"
-            }
-        }
 
     :>json string content: HTML content of the section.
     :>json object headers: section's headers in the document.

--- a/docs/user/api/v3.rst
+++ b/docs/user/api/v3.rst
@@ -2252,16 +2252,16 @@ Embed
 
     .. prompt:: bash $
 
-        curl https://app.readthedocs.org/api/v3/embed/?url=https://docs.readthedocs.com/platform/stable/reference/features.html%23read-the-docs-features
+        curl https://app.readthedocs.org/api/v3/embed/?url=https://docs.readthedocs.com/platform/stable/reference/features.html%23feature-reference
 
     **Example response**:
 
     .. sourcecode:: js
 
        {
-           "url": "https://docs.readthedocs.com/platform/stable/reference/features.html#read-the-docs-features",
-           "fragment": "read-the-docs-features",
-           "content": "<div class=\"section\" id=\"read-the-docs-features\">\n<h1>Read the Docs ...",
+           "url": "https://docs.readthedocs.com/platform/stable/reference/features.html#feature-reference",
+           "fragment": "feature-reference",
+           "content": "<section id=\"feature-reference\">\n<h1>Feature reference ...",
            "external": false
        }
 

--- a/readthedocs/embed/v3/views.py
+++ b/readthedocs/embed/v3/views.py
@@ -56,7 +56,7 @@ class EmbedAPIBase(EmbedAPIMixin, CDNCacheTagsMixin, APIView):
 
     ### Example
 
-    GET https://readthedocs.org/api/v3/embed/?url=https://docs.readthedocs.com/platform/stable/reference/features.html%23full-text-search
+    GET https://readthedocs.org/api/v3/embed/?url=https://docs.readthedocs.com/platform/stable/reference/features.html%23feature-reference
 
     """  # noqa
 


### PR DESCRIPTION
## Summary

- Updates embed API example URLs from `docs.readthedocs.io/en/latest/features.html` to `docs.readthedocs.com/platform/stable/reference/features.html` across the codebase (the old URLs return 404 after docs moved to single-version URLs and the page was relocated)
- Adds a deprecation notice to the embed API v2 documentation (`docs/user/api/v2.rst`), marking it deprecated since 2024-11 and pointing users to embed API v3
- Removes the outdated v2 example response body and simplifies the v2 curl examples down to a single command
- Updates the v3 embed example request and response to use the new URL and `feature-reference` fragment (`docs/user/api/v3.rst`)
- Fixes the embed v3 view docstring example URL in `readthedocs/embed/v3/views.py`

Closes https://github.com/readthedocs/readthedocs.org/issues/12468

## Test plan

- [ ] Verify the new example URLs actually work with the embed API
- [ ] Docs build correctly