### PR TITLE
Remove changefreq and priority from sitemap.xml

### DIFF
--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -1612,27 +1612,9 @@ class TestAdditionalDocViews(BaseDocServing):
             ),
         )
 
-        # Check if STABLE version has 'priority of 1 and changefreq of weekly.
-        self.assertEqual(
-            response.context["versions"][0]["loc"],
-            self.project.get_docs_url(
-                version_slug=stable_version.slug,
-                lang_slug=self.project.language,
-            ),
-        )
-        self.assertEqual(response.context["versions"][0]["priority"], 1)
-        self.assertEqual(response.context["versions"][0]["changefreq"], "weekly")
-
-        # Check if LATEST version has priority of 0.9 and changefreq of daily.
-        self.assertEqual(
-            response.context["versions"][1]["loc"],
-            self.project.get_docs_url(
-                version_slug="latest",
-                lang_slug=self.project.language,
-            ),
-        )
-        self.assertEqual(response.context["versions"][1]["priority"], 0.9)
-        self.assertEqual(response.context["versions"][1]["changefreq"], "daily")
+        # Verify that changefreq and priority are not included in the sitemap.
+        self.assertNotContains(response, "<changefreq>")
+        self.assertNotContains(response, "<priority>")
 
     def test_sitemap_all_private_versions(self):
         self.project.versions.update(active=True, built=True, privacy_level=constants.PRIVATE)

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -1,6 +1,5 @@
 """Views for doc serving."""
 
-import itertools
 from urllib.parse import urlparse
 
 import structlog
@@ -15,8 +14,6 @@ from django.views import View
 from readthedocs.api.mixins import CDNCacheTagsMixin
 from readthedocs.builds.constants import EXTERNAL
 from readthedocs.builds.constants import INTERNAL
-from readthedocs.builds.constants import LATEST
-from readthedocs.builds.constants import STABLE
 from readthedocs.core.mixins import CDNCacheControlMixin
 from readthedocs.core.resolver import Resolver
 from readthedocs.core.unresolver import InvalidExternalVersionError
@@ -843,16 +840,6 @@ class ServeSitemapXMLBase(CDNCacheControlMixin, CDNCacheTagsMixin, View):
         """
         # pylint: disable=too-many-locals
 
-        def priorities_generator():
-            """
-            Generator returning ``priority`` needed by sitemap.xml.
-
-            It generates values from 1 to 0.1 by decreasing in 0.1 on each
-            iteration. After 0.1 is reached, it will keep returning 0.1.
-            """
-            priorities = [1.0, 0.9, 0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2]
-            yield from itertools.chain(priorities, itertools.repeat(0.1))
-
         def hreflang_formatter(lang):
             """
             sitemap hreflang should follow correct format.
@@ -863,20 +850,6 @@ class ServeSitemapXMLBase(CDNCacheControlMixin, CDNCacheTagsMixin, View):
             if "_" in lang:
                 return lang.replace("_", "-")
             return lang
-
-        def changefreqs_generator():
-            """
-            Generator returning ``changefreq`` needed by sitemap.xml.
-
-            It returns ``weekly`` on first iteration, then ``daily`` and then it
-            will return always ``monthly``.
-
-            We are using ``monthly`` as last value because ``never`` is too
-            aggressive. If the tag is removed and a branch is created with the same
-            name, we will want bots to revisit this.
-            """
-            changefreqs = ["weekly", "daily"]
-            yield from itertools.chain(changefreqs, itertools.repeat("monthly"))
 
         project = request.unresolved_domain.project
         public_versions = project.versions(manager=INTERNAL).public(
@@ -893,31 +866,10 @@ class ServeSitemapXMLBase(CDNCacheControlMixin, CDNCacheTagsMixin, View):
 
         sorted_versions = sort_version_aware(public_versions)
 
-        # This is a hack to swap the latest version with
-        # stable version to get the stable version first in the sitemap.
-        # We want stable with priority=1 and changefreq='weekly' and
-        # latest with priority=0.9 and changefreq='daily'
-        # More details on this: https://github.com/rtfd/readthedocs.org/issues/5447
-        if (
-            len(sorted_versions) >= 2
-            and sorted_versions[0].slug == LATEST
-            and sorted_versions[1].slug == STABLE
-        ):
-            sorted_versions[0], sorted_versions[1] = (
-                sorted_versions[1],
-                sorted_versions[0],
-            )
-
         versions = []
-        for version, priority, changefreq in zip(
-            sorted_versions,
-            priorities_generator(),
-            changefreqs_generator(),
-        ):
+        for version in sorted_versions:
             element = {
                 "loc": version.get_subdomain_url(),
-                "priority": priority,
-                "changefreq": changefreq,
                 "languages": [],
             }
 

--- a/readthedocs/templates/sitemap.xml
+++ b/readthedocs/templates/sitemap.xml
@@ -23,8 +23,6 @@ You can learn more about sitemaps, including how to customize them, in our docum
     {% if version.lastmod %}
     <lastmod>{{ version.lastmod }}</lastmod>
     {% endif %}
-    <changefreq>{{ version.changefreq }}</changefreq>
-    <priority>{{ version.priority }}</priority>
   </url>
   {% endfor %}
 </urlset>


### PR DESCRIPTION
## Summary

- Remove `<changefreq>` and `<priority>` elements from generated `sitemap.xml`, as these fields are [largely ignored by crawlers](https://developers.google.com/search/docs/crawling-indexing/sitemaps/build-sitemap#additional-notes-about-xml-sitemaps) and were producing incorrect/misleading values (e.g., `latest` got `weekly` while tagged versions got `daily`)
- Remove the `priorities_generator()`, `changefreqs_generator()`, and the stable/latest swap hack that existed solely to support these fields
- `<lastmod>` (the field crawlers actually use) is preserved

Closes #12448

## Test plan

- [x] Updated `test_sitemap_xml` to assert that `<changefreq>` and `<priority>` are absent from the response
- [ ] Verify sitemap.xml still renders correctly with `<loc>`, `<lastmod>`, and `<xhtml:link>` elements

https://claude.ai/code/session_018u1pTzpJzEMZE4o4rMwxLx