### PR TITLE
Skip running tests when only docs have changed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ commands:
               circleci-agent step halt
               exit 0
             fi
-            non_docs=$(echo "$changed_files" | grep -v '^docs/')
+            non_docs=$(echo "$changed_files" | grep -v '^docs/' || true)
             if [ -z "$non_docs" ]; then
               echo "Only docs changed — skipping tests."
               circleci-agent step halt


### PR DESCRIPTION
## Summary

- Add an early-exit step to the `tests` and `tests-embedapi` CircleCI jobs that detects docs-only changes by comparing against the merge base with `main`
- When every changed file is under `docs/`, the job halts immediately with a success status via `circleci-agent step halt`, saving CI resources
- The `checks` job (pre-commit, migrations) continues to run on all commits

## How it works

After checkout, a new step runs `git diff --name-only` against the merge base with `origin/main`. If all changed files match `docs/`, the step calls `circleci-agent step halt` which stops the job with a successful status. Otherwise, tests proceed as normal.

## Test plan

- [ ] Verify that a branch with only `docs/` changes skips `tests` and `tests-embedapi` jobs
- [ ] Verify that a branch with non-docs changes (or mixed changes) runs all tests normally
- [ ] Verify that the `checks` job still runs on docs-only changes

https://claude.ai/code/session_019LMRp7zZHjfFQHqWVFmZCW