### PR TITLE
Support `uv` natively (initial implementation)

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -429,40 +429,36 @@ Take a look at the following example:
 Install dependencies with ``uv``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Projects managed with `uv <https://github.com/astral-sh/uv/>`__ can install `uv` with asdf,
-and then rely on it to set up the environment and install the python project and its dependencies.
-Read the Docs' own build steps expect it by setting the ``UV_PROJECT_ENVIRONMENT`` variable,
-usually reducing the time taken to install compared to pip.
+Read the Docs supports `uv <https://docs.astral.sh/uv/>`__ natively in
+``python.install``.
+For most uv-based projects, prefer the configuration file reference at
+:ref:`config-file/v2:python.install` instead of overriding ``build.jobs``.
 
-The following examples assumes a uv project as described in its
-`projects concept <https://docs.astral.sh/uv/concepts/projects/>`__. As an introduction
-refer to its `Working on projects guide <https://docs.astral.sh/uv/guides/projects/>`__.
-The ``docs`` dependency group which should is pulled in during the ``uv sync`` step (if additional
-extras are required they can be added with the `--extra attribute <https://docs.astral.sh/uv/concepts/projects/sync/#syncing-optional-dependencies>`__).
-
-If a ``uv.lock`` file exists it is respected.
+The following example uses ``uv sync`` with a dependency group named ``docs``.
+If a ``uv.lock`` file exists, it is respected.
 
 .. code-block:: yaml
    :caption: .readthedocs.yaml
 
    version: 2
 
+  build:
+    os: ubuntu-24.04
+    tools:
+      python: "3.13"
+
+  python:
+    install:
+      - method: uv
+        command: sync
+        groups:
+          - docs
+
    sphinx:
       configuration: docs/conf.py
 
-   build:
-      os: ubuntu-24.04
-      tools:
-         python: "3.13"
-      jobs:
-         pre_create_environment:
-            - asdf plugin add uv
-            - asdf install uv latest
-            - asdf global uv latest
-         create_environment:
-            - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
-         install:
-            - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --frozen --group docs
+Use ``build.jobs`` only when you need an advanced uv workflow that isn't covered by
+``python.install``, such as adding specific arguments to the ``uv`` command.
 
 Install dependencies from Dependency Groups
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -431,7 +431,7 @@ Install dependencies with ``uv``
 
 Read the Docs supports `uv <https://docs.astral.sh/uv/>`__ natively in
 ``python.install``.
-For most uv-based projects, prefer the configuration file reference at
+Projects using uv can use the configuration methods referenced at
 :ref:`config-file/v2:python.install` instead of overriding ``build.jobs``.
 
 The following example uses ``uv sync`` with a dependency group named ``docs``.

--- a/docs/user/config-file/index.rst
+++ b/docs/user/config-file/index.rst
@@ -123,7 +123,8 @@ specifying the requirements to install.
 
 - Use ``python.install.path`` to install the project itself as a Python package using pip
 - Use ``python.install.requirements`` to install packages from a requirements file
-- Use ``build.jobs`` to install packages using Poetry or PDM
+- Use ``python.install.method: uv`` to install packages with ``uv sync`` or ``uv pip``
+- Use ``build.jobs`` for Poetry, PDM, or advanced custom install workflows
 
 .. seealso::
 

--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -148,7 +148,7 @@ You can have several of the following methods.
 
 .. note::
 
-   When using ``method: uv``, only one entry is allowed under ``python.install``.
+   When using ``method: uv``, currently only one entry is allowed under ``python.install``.
 
 :Type: ``list``
 :Default: ``[]``

--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -137,11 +137,18 @@ Configuration of the Python environment to be used.
 python.install
 ``````````````
 
-Read the Docs uses :doc:`pip <pip:index>` by  default to install your Python packages, however if you are using a :ref:`Conda <config-file/v2:conda>` environment to manage your build, you'll need to use the Conda ``environment`` file instead.
+Read the Docs uses :doc:`pip <pip:index>` by default to install your Python packages.
+It also supports `uv <https://docs.astral.sh/uv/>`__ through ``python.install``.
+If you are using a :ref:`Conda <config-file/v2:conda>` environment to manage your build,
+you'll need to use the Conda ``environment`` file instead.
 If you have a commercial plan you can also install :doc:`private dependencies </guides/private-python-packages>`.
 
 List of installation methods of packages and requirements.
 You can have several of the following methods.
+
+.. note::
+
+   When using ``method: uv``, only one entry is allowed under ``python.install``.
 
 :Type: ``list``
 :Default: ``[]``
@@ -183,7 +190,7 @@ The path to the package, relative to the root of the project.
 The installation method.
 
 :Key: ``method``
-:Options: ``pip``, ``setuptools`` (deprecated)
+:Options: ``pip``, ``setuptools`` (deprecated), ``uv``
 :Default: ``pip``
 
 `Extra requirements`_ section to install in addition to the `package dependencies`_.
@@ -207,6 +214,93 @@ For example, to run ``pip install .[docs]``:
          path: .
          extra_requirements:
            - docs
+
+uv
+''
+
+Install dependencies using `uv <https://docs.astral.sh/uv/>`__.
+
+Set ``method: uv`` and choose one of the following commands:
+
+- ``command: sync`` to run ``uv sync`` using your ``pyproject.toml`` and, if present, ``uv.lock``
+- ``command: pip`` to run ``uv pip install`` from a requirements file or a local path
+
+The command used by Read the Docs.
+
+:Key: ``command``
+:Options: ``sync``, ``pip``
+:Required: ``true``
+
+Use ``path`` to point uv at a project that is not located at the repository root.
+
+:Key: ``path``
+:Type: ``path``
+:Required: ``false``
+
+With ``command: sync``, you can select dependency groups from ``pyproject.toml``.
+Use either a list of group names or ``all``.
+
+:Key: ``groups``
+:Type: ``list`` or ``all``
+:Required: ``false``
+
+With either uv command, you can install optional dependencies.
+Use either a list of extras or ``all``.
+
+:Key: ``extras``
+:Type: ``list`` or ``all``
+:Required: ``false``
+
+With ``command: pip``, you can install from a requirements file.
+
+:Key: ``requirements``
+:Type: ``path``
+:Required: ``false``
+
+.. note::
+
+    ``command: sync`` doesn't allow ``requirements``.
+    ``command: pip`` requires either ``requirements`` or ``path``.
+    ``groups`` is only supported with ``command: sync``.
+
+For example, to run ``uv sync --group docs``:
+
+.. code-block:: yaml
+
+    version: 2
+
+    python:
+       install:
+          - method: uv
+             command: sync
+             groups:
+                - docs
+
+For example, to run ``uv pip install -r docs/requirements.txt``:
+
+.. code-block:: yaml
+
+    version: 2
+
+    python:
+       install:
+          - method: uv
+             command: pip
+             requirements: docs/requirements.txt
+
+For example, to run ``uv pip install .[docs]``:
+
+.. code-block:: yaml
+
+    version: 2
+
+    python:
+       install:
+          - method: uv
+             command: pip
+             path: .
+             extras:
+                - docs
 
 conda
 ~~~~~

--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -225,8 +225,6 @@ Set ``method: uv`` and choose one of the following commands:
 - ``command: sync`` to run ``uv sync`` using your ``pyproject.toml`` and, if present, ``uv.lock``
 - ``command: pip`` to run ``uv pip install`` from a requirements file or a local path
 
-The command used by Read the Docs.
-
 :Key: ``command``
 :Options: ``sync``, ``pip``
 :Required: ``true``

--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -557,7 +557,7 @@ class BuildConfigV2(BuildConfigBase):
 
         # Case 1: method: uv
         if method == UV:
-            return self._validate_uv_install(key, raw_install)
+            return self._validate_uv_install(key)
 
         # Case 2: requirements file (legacy pip)
         if has_requirements:
@@ -608,7 +608,7 @@ class BuildConfigV2(BuildConfigBase):
             },
         )
 
-    def _validate_uv_install(self, key, raw_install):
+    def _validate_uv_install(self, key):
         """Validate a uv install entry."""
         method_key = key + ".method"
         self.pop_config(method_key)
@@ -633,113 +633,107 @@ class BuildConfigV2(BuildConfigBase):
                 path = validate_path(path, self.base_path)
             python_install["path"] = path
 
+        requirements_key = key + ".requirements"
+        requirements = self.pop_config(requirements_key)
+
+        groups_key = key + ".groups"
+        groups = self.pop_config(groups_key, None)
+
+        extras_key = key + ".extras"
+        extras = self.pop_config(extras_key)
+
         # Validate based on command type
         if command == "sync":
-            self._validate_uv_sync(key, python_install, raw_install)
-        else:  # command == "pip"
-            self._validate_uv_pip(key, python_install, raw_install)
+            # requirements not allowed with sync
+            if requirements is not None:
+                raise ConfigError(
+                    message_id=ConfigError.UV_SYNC_REQUIREMENTS_INVALID,
+                )
 
-        return python_install
-
-    def _validate_uv_sync(self, key, python_install, raw_install):
-        """Validate uv sync specific fields."""
-        # groups (optional)
-        groups_key = key + ".groups"
-        groups = self.pop_config(groups_key)
-        if groups is not None:
-            with self.catch_validation_error(groups_key):
-                if isinstance(groups, list):
-                    if not groups:
+            # groups (optional)
+            if groups is not None:
+                with self.catch_validation_error(groups_key):
+                    if isinstance(groups, list):
+                        if not groups:
+                            raise ConfigError(
+                                message_id=ConfigError.UV_GROUPS_EXTRAS_EMPTY,
+                                format_values={"field": "groups"},
+                            )
+                        groups = validate_list(groups)
+                    elif groups == ALL:
+                        pass  # "all" is valid
+                    else:
                         raise ConfigError(
-                            message_id=ConfigError.UV_GROUPS_EXTRAS_EMPTY,
+                            message_id=ConfigError.UV_GROUPS_EXTRAS_INVALID_TYPE,
                             format_values={"field": "groups"},
                         )
-                    groups = validate_list(groups)
-                elif groups == ALL:
-                    pass  # "all" is valid
-                else:
-                    raise ConfigError(
-                        message_id=ConfigError.UV_GROUPS_EXTRAS_INVALID_TYPE,
-                        format_values={"field": "groups"},
-                    )
-                python_install["groups"] = groups
+                    python_install["groups"] = groups
 
-        # extras (optional)
-        extras_key = key + ".extras"
-        if extras_key.split(".")[-1] in raw_install:
-            extras = self.pop_config(extras_key)
-            with self.catch_validation_error(extras_key):
-                if isinstance(extras, list):
-                    if not extras:
+            # extras (optional)
+            if extras is not None:
+                with self.catch_validation_error(extras_key):
+                    if isinstance(extras, list):
+                        if not extras:
+                            raise ConfigError(
+                                message_id=ConfigError.UV_GROUPS_EXTRAS_EMPTY,
+                                format_values={"field": "extras"},
+                            )
+                        extras = validate_list(extras)
+                    elif extras == ALL:
+                        pass  # "all" is valid
+                    else:
                         raise ConfigError(
-                            message_id=ConfigError.UV_GROUPS_EXTRAS_EMPTY,
+                            message_id=ConfigError.UV_GROUPS_EXTRAS_INVALID_TYPE,
                             format_values={"field": "extras"},
                         )
-                    extras = validate_list(extras)
-                elif extras == ALL:
-                    pass  # "all" is valid
-                else:
-                    raise ConfigError(
-                        message_id=ConfigError.UV_GROUPS_EXTRAS_INVALID_TYPE,
-                        format_values={"field": "extras"},
-                    )
-                python_install["extras"] = extras
+                    python_install["extras"] = extras
 
-        # requirements not allowed with sync
-        if "requirements" in raw_install:
-            raise ConfigError(
-                message_id=ConfigError.UV_SYNC_REQUIREMENTS_INVALID,
-            )
-
-    def _validate_uv_pip(self, key, python_install, raw_install):
-        """Validate uv pip specific fields."""
-        # One of requirements or path is required for uv pip
-        requirements_key = key + ".requirements"
-
-        has_requirements = "requirements" in raw_install
-        # Check python_install for path since it was already popped from raw_install
-        has_path = bool(python_install.get("path"))
-
-        if not (has_requirements or has_path):
-            raise ConfigError(
-                message_id=ConfigError.UV_PIP_REQUIREMENTS_OR_PATH_REQUIRED,
-            )
-
-        # If requirements is specified, handle it
-        if has_requirements:
-            with self.catch_validation_error(requirements_key):
-                requirements = validate_path(
-                    self.pop_config(requirements_key),
-                    self.base_path,
+        else:  # command == "pip"
+            # groups not allowed with uv pip
+            if groups is not None:
+                raise ConfigError(
+                    message_id=ConfigError.UV_PIP_GROUPS_NOT_ALLOWED,
                 )
-                python_install["requirements"] = requirements
 
-        # groups not allowed with uv pip
-        if "groups" in raw_install:
-            raise ConfigError(
-                message_id=ConfigError.UV_PIP_GROUPS_NOT_ALLOWED,
-            )
+            if requirements is None and path is None:
+                raise ConfigError(
+                    message_id=ConfigError.UV_PIP_REQUIREMENTS_OR_PATH_REQUIRED,
+                )
 
-        # extras (optional, allowed for local path install)
-        extras_key = key + ".extras"
-        if extras_key.split(".")[-1] in raw_install:
-            extras = self.pop_config(extras_key)
-            with self.catch_validation_error(extras_key):
-                if isinstance(extras, list):
-                    if not extras:
+            if requirements is not None and path is not None:
+                raise ConfigError(
+                    message_id=ConfigError.UV_PIP_REQUIREMENTS_AND_PATH_MUTUALLY_EXCLUSIVE,
+                )
+
+            # If requirements is specified, handle it
+            if requirements is not None:
+                with self.catch_validation_error(requirements_key):
+                    requirements = validate_path(
+                        requirements,
+                        self.base_path,
+                    )
+                    python_install["requirements"] = requirements
+
+            # extras (optional, allowed for local path install)
+            if extras is not None:
+                with self.catch_validation_error(extras_key):
+                    if isinstance(extras, list):
+                        if not extras:
+                            raise ConfigError(
+                                message_id=ConfigError.UV_GROUPS_EXTRAS_EMPTY,
+                                format_values={"field": "extras"},
+                            )
+                        extras = validate_list(extras)
+                    elif extras == ALL:
+                        pass  # "all" is valid
+                    else:
                         raise ConfigError(
-                            message_id=ConfigError.UV_GROUPS_EXTRAS_EMPTY,
+                            message_id=ConfigError.UV_GROUPS_EXTRAS_INVALID_TYPE,
                             format_values={"field": "extras"},
                         )
-                    extras = validate_list(extras)
-                elif extras == ALL:
-                    pass  # "all" is valid
-                else:
-                    raise ConfigError(
-                        message_id=ConfigError.UV_GROUPS_EXTRAS_INVALID_TYPE,
-                        format_values={"field": "extras"},
-                    )
-                python_install["extras"] = extras
+                    python_install["extras"] = extras
+
+        return python_install
 
     def validate_doc_types(self):
         """

--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -584,7 +584,7 @@ class BuildConfigV2(BuildConfigBase):
             with self.catch_validation_error(method_key):
                 method = validate_choice(
                     self.pop_config(method_key, PIP),
-                    [None, PIP, SETUPTOOLS, UV],
+                    [PIP, SETUPTOOLS, UV],
                 )
                 python_install["method"] = method
 
@@ -593,7 +593,7 @@ class BuildConfigV2(BuildConfigBase):
                 extra_requirements = validate_list(
                     self.pop_config(extra_req_key, []),
                 )
-                if extra_requirements and method != PIP:
+                if extra_requirements and python_install["method"] != PIP:
                     raise ConfigError(
                         message_id=ConfigError.USE_PIP_FOR_EXTRA_REQUIREMENTS,
                     )
@@ -645,8 +645,8 @@ class BuildConfigV2(BuildConfigBase):
         """Validate uv sync specific fields."""
         # groups (optional)
         groups_key = key + ".groups"
-        if groups_key.split(".")[-1] in raw_install:
-            groups = self.pop_config(groups_key)
+        groups = self.pop_config(groups_key)
+        if groups is not None:
             with self.catch_validation_error(groups_key):
                 if isinstance(groups, list):
                     if not groups:

--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -29,6 +29,7 @@ from .models import PythonInstall
 from .models import Search
 from .models import Sphinx
 from .models import Submodules
+from .models import UvInstall
 from .parser import ParseError
 from .parser import parse
 from .validation import validate_bool
@@ -46,12 +47,14 @@ __all__ = (
     "BuildConfigV2",
     "PIP",
     "SETUPTOOLS",
+    "UV",
     "LATEST_CONFIGURATION_VERSION",
 )
 
 ALL = "all"
 PIP = "pip"
 SETUPTOOLS = "setuptools"
+UV = "uv"
 CONFIG_FILENAME_REGEX = r"^\.?readthedocs.ya?ml$"
 
 LATEST_CONFIGURATION_VERSION = 2
@@ -214,6 +217,14 @@ class BuildConfigBase:
         return False
 
     @property
+    def is_using_uv(self):
+        """Check if this project has at least one uv install entry."""
+        for install in self.python.install:
+            if isinstance(install, UvInstall):
+                return True
+        return False
+
+    @property
     def python_interpreter(self):
         tool = self.build.tools.get("python")
         if tool and tool.version.startswith("mamba"):
@@ -248,7 +259,6 @@ class BuildConfigV2(BuildConfigBase):
 
     version = "2"
     valid_formats = ["htmlzip", "pdf", "epub"]
-    valid_install_method = [PIP, SETUPTOOLS]
     valid_sphinx_builders = {
         "html": "sphinx",
         "htmldir": "sphinx_htmldir",
@@ -277,7 +287,11 @@ class BuildConfigV2(BuildConfigBase):
         self._config["search"] = self.validate_search()
         if self.deprecate_implicit_keys:
             self.validate_deprecated_implicit_keys()
-        self.validate_keys()
+        # Raises an error saying
+        #  Invalid configuration key: python.install.0.method
+        #  Make sure the key name python.install.0.method is correct.
+        # I need to research more why this is happening
+        # self.validate_keys()
 
     def validate_formats(self):
         """
@@ -529,7 +543,18 @@ class BuildConfigV2(BuildConfigBase):
         with self.catch_validation_error(key):
             validate_dict(raw_install)
 
-        if "requirements" in raw_install:
+        # Detect which type of install this is: uv, requirements file, or path-based
+        method = raw_install.get("method", PIP)
+        has_command = "command" in raw_install
+        has_requirements = "requirements" in raw_install
+        has_path = "path" in raw_install
+
+        # Case 1: method: uv
+        if method == UV or has_command:
+            return self._validate_uv_install(index, key, raw_install)
+
+        # Case 2: requirements file (legacy pip)
+        if has_requirements:
             requirements_key = key + ".requirements"
             with self.catch_validation_error(requirements_key):
                 requirements = validate_path(
@@ -537,7 +562,10 @@ class BuildConfigV2(BuildConfigBase):
                     self.base_path,
                 )
                 python_install["requirements"] = requirements
-        elif "path" in raw_install:
+            return python_install
+
+        # Case 3: path-based install (pip/setuptools)
+        if has_path:
             path_key = key + ".path"
             with self.catch_validation_error(path_key):
                 path = validate_path(
@@ -550,7 +578,7 @@ class BuildConfigV2(BuildConfigBase):
             with self.catch_validation_error(method_key):
                 method = validate_choice(
                     self.pop_config(method_key, PIP),
-                    self.valid_install_method,
+                    [PIP, SETUPTOOLS],
                 )
                 python_install["method"] = method
 
@@ -559,20 +587,150 @@ class BuildConfigV2(BuildConfigBase):
                 extra_requirements = validate_list(
                     self.pop_config(extra_req_key, []),
                 )
-                if extra_requirements and python_install["method"] != PIP:
+                if extra_requirements and method != PIP:
                     raise ConfigError(
                         message_id=ConfigError.USE_PIP_FOR_EXTRA_REQUIREMENTS,
                     )
                 python_install["extra_requirements"] = extra_requirements
-        else:
-            raise ConfigError(
-                message_id=ConfigError.PIP_PATH_OR_REQUIREMENT_REQUIRED,
-                format_values={
-                    "key": key,
-                },
-            )
+            return python_install
+
+        # No valid combination found
+        raise ConfigError(
+            message_id=ConfigError.PIP_PATH_OR_REQUIREMENT_REQUIRED,
+            format_values={
+                "key": key,
+            },
+        )
+
+    def _validate_uv_install(self, index, key, raw_install):
+        """Validate a uv install entry."""
+        python_install = {"method": UV}
+
+        # command is required
+        command_key = key + ".command"
+        with self.catch_validation_error(command_key):
+            command = self.pop_config(command_key)
+            if command is None:
+                raise ConfigError(
+                    message_id=ConfigError.UV_COMMAND_REQUIRED,
+                )
+            command = validate_choice(command, ["sync", "pip"])
+            python_install["command"] = command
+
+        # path (optional, defaults to .)
+        path_key = key + ".path"
+        path = self.pop_config(path_key, ".")
+        with self.catch_validation_error(path_key):
+            if path:
+                path = validate_path(path, self.base_path)
+            python_install["path"] = path
+
+        # Validate based on command type
+        if command == "sync":
+            self._validate_uv_sync(key, python_install, raw_install)
+        else:  # command == "pip"
+            self._validate_uv_pip(key, python_install, raw_install)
 
         return python_install
+
+    def _validate_uv_sync(self, key, python_install, raw_install):
+        """Validate uv sync specific fields."""
+        # groups (optional)
+        groups_key = key + ".groups"
+        if groups_key.split(".")[-1] in raw_install:
+            groups = self.pop_config(groups_key)
+            with self.catch_validation_error(groups_key):
+                if isinstance(groups, list):
+                    if not groups:
+                        raise ConfigError(
+                            message_id=ConfigError.UV_GROUPS_EXTRAS_EMPTY,
+                            format_values={"field": "groups"},
+                        )
+                    groups = validate_list(groups)
+                elif groups == ALL:
+                    pass  # "all" is valid
+                else:
+                    raise ConfigError(
+                        message_id=ConfigError.UV_GROUPS_EXTRAS_INVALID_TYPE,
+                        format_values={"field": "groups"},
+                    )
+                python_install["groups"] = groups
+
+        # extras (optional)
+        extras_key = key + ".extras"
+        if extras_key.split(".")[-1] in raw_install:
+            extras = self.pop_config(extras_key)
+            with self.catch_validation_error(extras_key):
+                if isinstance(extras, list):
+                    if not extras:
+                        raise ConfigError(
+                            message_id=ConfigError.UV_GROUPS_EXTRAS_EMPTY,
+                            format_values={"field": "extras"},
+                        )
+                    extras = validate_list(extras)
+                elif extras == ALL:
+                    pass  # "all" is valid
+                else:
+                    raise ConfigError(
+                        message_id=ConfigError.UV_GROUPS_EXTRAS_INVALID_TYPE,
+                        format_values={"field": "extras"},
+                    )
+                python_install["extras"] = extras
+
+        # requirements not allowed with sync
+        if "requirements" in raw_install:
+            raise ConfigError(
+                message_id=ConfigError.UV_SYNC_REQUIREMENTS_INVALID,
+            )
+
+    def _validate_uv_pip(self, key, python_install, raw_install):
+        """Validate uv pip specific fields."""
+        # One of requirements or path is required for uv pip
+        requirements_key = key + ".requirements"
+
+        has_requirements = "requirements" in raw_install
+        has_path = "path" in raw_install and raw_install.get("path")
+
+        if not (has_requirements or has_path):
+            raise ConfigError(
+                message_id=ConfigError.UV_PIP_REQUIREMENTS_OR_PATH_REQUIRED,
+            )
+
+        # If requirements is specified, handle it
+        if has_requirements:
+            with self.catch_validation_error(requirements_key):
+                requirements = validate_path(
+                    self.pop_config(requirements_key),
+                    self.base_path,
+                )
+                python_install["requirements"] = requirements
+
+        # groups not allowed with uv pip
+        if "groups" in raw_install:
+            raise ConfigError(
+                message_id=ConfigError.UV_PIP_GROUPS_NOT_ALLOWED,
+            )
+
+        # extras (optional, allowed for local path install)
+        extras_key = key + ".extras"
+        if extras_key.split(".")[-1] in raw_install:
+            extras = self.pop_config(extras_key)
+            with self.catch_validation_error(extras_key):
+                if isinstance(extras, list):
+                    if not extras:
+                        raise ConfigError(
+                            message_id=ConfigError.UV_GROUPS_EXTRAS_EMPTY,
+                            format_values={"field": "extras"},
+                        )
+                    extras = validate_list(extras)
+                elif extras == ALL:
+                    pass  # "all" is valid
+                else:
+                    raise ConfigError(
+                        message_id=ConfigError.UV_GROUPS_EXTRAS_INVALID_TYPE,
+                        format_values={"field": "extras"},
+                    )
+                python_install["extras"] = extras
 
     def validate_doc_types(self):
         """

--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -533,6 +533,17 @@ class BuildConfigV2(BuildConfigBase):
             self.validate_python_install(index) for index in range(len(raw_install))
         ]
 
+        # uv entries currently support a single python.install item only.
+        has_uv_install = any(
+            install.get("method") == UV
+            for install in python["install"]
+            if isinstance(install, dict)
+        )
+        if has_uv_install and len(python["install"]) > 1:
+            raise ConfigError(
+                message_id=ConfigError.UV_MULTIPLE_INSTALL_ENTRIES_INVALID,
+            )
+
         return python
 
     def validate_python_install(self, index):

--- a/readthedocs/config/config.py
+++ b/readthedocs/config/config.py
@@ -287,11 +287,7 @@ class BuildConfigV2(BuildConfigBase):
         self._config["search"] = self.validate_search()
         if self.deprecate_implicit_keys:
             self.validate_deprecated_implicit_keys()
-        # Raises an error saying
-        #  Invalid configuration key: python.install.0.method
-        #  Make sure the key name python.install.0.method is correct.
-        # I need to research more why this is happening
-        # self.validate_keys()
+        self.validate_keys()
 
     def validate_formats(self):
         """
@@ -508,7 +504,7 @@ class BuildConfigV2(BuildConfigBase):
         Validates the python key.
 
         validate_build should be called before this, since it initialize the
-        build.image attribute.
+        build attribute.
 
         .. note::
            - ``version`` can be a string or number type.
@@ -556,13 +552,12 @@ class BuildConfigV2(BuildConfigBase):
 
         # Detect which type of install this is: uv, requirements file, or path-based
         method = raw_install.get("method", PIP)
-        has_command = "command" in raw_install
         has_requirements = "requirements" in raw_install
         has_path = "path" in raw_install
 
         # Case 1: method: uv
-        if method == UV or has_command:
-            return self._validate_uv_install(index, key, raw_install)
+        if method == UV:
+            return self._validate_uv_install(key, raw_install)
 
         # Case 2: requirements file (legacy pip)
         if has_requirements:
@@ -589,7 +584,7 @@ class BuildConfigV2(BuildConfigBase):
             with self.catch_validation_error(method_key):
                 method = validate_choice(
                     self.pop_config(method_key, PIP),
-                    [PIP, SETUPTOOLS],
+                    [None, PIP, SETUPTOOLS, UV],
                 )
                 python_install["method"] = method
 
@@ -613,8 +608,10 @@ class BuildConfigV2(BuildConfigBase):
             },
         )
 
-    def _validate_uv_install(self, index, key, raw_install):
+    def _validate_uv_install(self, key, raw_install):
         """Validate a uv install entry."""
+        method_key = key + ".method"
+        self.pop_config(method_key)
         python_install = {"method": UV}
 
         # command is required
@@ -628,9 +625,9 @@ class BuildConfigV2(BuildConfigBase):
             command = validate_choice(command, ["sync", "pip"])
             python_install["command"] = command
 
-        # path (optional, defaults to .)
+        # path (optional, None when not provided by user)
         path_key = key + ".path"
-        path = self.pop_config(path_key, ".")
+        path = self.pop_config(path_key)
         with self.catch_validation_error(path_key):
             if path:
                 path = validate_path(path, self.base_path)
@@ -700,7 +697,8 @@ class BuildConfigV2(BuildConfigBase):
         requirements_key = key + ".requirements"
 
         has_requirements = "requirements" in raw_install
-        has_path = "path" in raw_install and raw_install.get("path")
+        # Check python_install for path since it was already popped from raw_install
+        has_path = bool(python_install.get("path"))
 
         if not (has_requirements or has_path):
             raise ConfigError(

--- a/readthedocs/config/exceptions.py
+++ b/readthedocs/config/exceptions.py
@@ -22,6 +22,7 @@ class ConfigError(BuildUserError):
     SYNTAX_INVALID = "config:base:invalid-syntax"
     CONDA_KEY_REQUIRED = "config:conda:required"
     UV_COMMAND_REQUIRED = "config:python:uv-command-required"
+    UV_MULTIPLE_INSTALL_ENTRIES_INVALID = "config:python:uv-multiple-install-entries-invalid"
     UV_SYNC_REQUIREMENTS_INVALID = "config:python:uv-sync-requirements-invalid"
     UV_PIP_REQUIREMENTS_OR_PATH_REQUIRED = "config:python:uv-pip-requirements-or-path-required"
     UV_PIP_GROUPS_NOT_ALLOWED = "config:python:uv-pip-groups-not-allowed"

--- a/readthedocs/config/exceptions.py
+++ b/readthedocs/config/exceptions.py
@@ -21,6 +21,12 @@ class ConfigError(BuildUserError):
     INVALID_KEY_NAME = "config:base:invalid-key-name"
     SYNTAX_INVALID = "config:base:invalid-syntax"
     CONDA_KEY_REQUIRED = "config:conda:required"
+    UV_COMMAND_REQUIRED = "config:python:uv-command-required"
+    UV_SYNC_REQUIREMENTS_INVALID = "config:python:uv-sync-requirements-invalid"
+    UV_PIP_REQUIREMENTS_OR_PATH_REQUIRED = "config:python:uv-pip-requirements-or-path-required"
+    UV_PIP_GROUPS_NOT_ALLOWED = "config:python:uv-pip-groups-not-allowed"
+    UV_GROUPS_EXTRAS_EMPTY = "config:python:uv-groups-extras-empty"
+    UV_GROUPS_EXTRAS_INVALID_TYPE = "config:python:uv-groups-extras-invalid-type"
 
     SPHINX_CONFIG_MISSING = "config:sphinx:missing-config"
     MKDOCS_CONFIG_MISSING = "config:mkdocs:missing-config"

--- a/readthedocs/config/exceptions.py
+++ b/readthedocs/config/exceptions.py
@@ -25,6 +25,9 @@ class ConfigError(BuildUserError):
     UV_MULTIPLE_INSTALL_ENTRIES_INVALID = "config:python:uv-multiple-install-entries-invalid"
     UV_SYNC_REQUIREMENTS_INVALID = "config:python:uv-sync-requirements-invalid"
     UV_PIP_REQUIREMENTS_OR_PATH_REQUIRED = "config:python:uv-pip-requirements-or-path-required"
+    UV_PIP_REQUIREMENTS_AND_PATH_MUTUALLY_EXCLUSIVE = (
+        "config:python:uv-pip-requirements-and-path-mutually-exclusive"
+    )
     UV_PIP_GROUPS_NOT_ALLOWED = "config:python:uv-pip-groups-not-allowed"
     UV_GROUPS_EXTRAS_EMPTY = "config:python:uv-groups-extras-empty"
     UV_GROUPS_EXTRAS_INVALID_TYPE = "config:python:uv-groups-extras-invalid-type"

--- a/readthedocs/config/models.py
+++ b/readthedocs/config/models.py
@@ -76,7 +76,7 @@ class PythonInstallRequirements(ConfigBaseModel):
 
 class PythonInstall(ConfigBaseModel):
     path: str
-    method: Literal["pip", "setuptools"] | None = "pip"
+    method: Literal["pip", "setuptools"] = "pip"
     extra_requirements: list[str] = []
 
 

--- a/readthedocs/config/models.py
+++ b/readthedocs/config/models.py
@@ -76,7 +76,7 @@ class PythonInstallRequirements(ConfigBaseModel):
 
 class PythonInstall(ConfigBaseModel):
     path: str
-    method: Literal["pip", "setuptools"] = "pip"
+    method: Literal["pip", "setuptools"] | None = "pip"
     extra_requirements: list[str] = []
 
 

--- a/readthedocs/config/models.py
+++ b/readthedocs/config/models.py
@@ -80,8 +80,17 @@ class PythonInstall(ConfigBaseModel):
     extra_requirements: list[str] = []
 
 
+class UvInstall(ConfigBaseModel):
+    method: Literal["uv"]
+    command: Literal["sync", "pip"]
+    path: str | None = None
+    requirements: str | None = None
+    groups: list[str] | Literal["all"] | None = None
+    extras: list[str] | Literal["all"] | None = None
+
+
 class Python(ConfigBaseModel):
-    install: list[PythonInstall | PythonInstallRequirements] = []
+    install: list[PythonInstall | PythonInstallRequirements | UvInstall] = []
 
 
 class Conda(ConfigBaseModel):

--- a/readthedocs/config/notifications.py
+++ b/readthedocs/config/notifications.py
@@ -253,6 +253,84 @@ messages = [
         ),
         type=ERROR,
     ),
+    Message(
+        id=ConfigError.UV_COMMAND_REQUIRED,
+        header=_("Missing required key"),
+        body=_(
+            textwrap.dedent(
+                """
+            The key <code>python.install.command</code> is required when using <code>method: uv</code>.
+            Allowed values are <code>sync</code> or <code>pip</code>.
+            """
+            ).strip(),
+        ),
+        type=ERROR,
+    ),
+    Message(
+        id=ConfigError.UV_SYNC_REQUIREMENTS_INVALID,
+        header=_("Invalid configuration for uv sync"),
+        body=_(
+            textwrap.dedent(
+                """
+            The key <code>python.install.requirements</code> is not allowed with <code>command: sync</code>.
+            Use <code>command: pip</code> instead when specifying a requirements file.
+            """
+            ).strip(),
+        ),
+        type=ERROR,
+    ),
+    Message(
+        id=ConfigError.UV_PIP_REQUIREMENTS_OR_PATH_REQUIRED,
+        header=_("Missing configuration key"),
+        body=_(
+            textwrap.dedent(
+                """
+            When using <code>method: uv</code> with <code>command: pip</code>,
+            one of the following keys is required: <code>python.install.path</code> or <code>python.install.requirements</code>.
+            """
+            ).strip(),
+        ),
+        type=ERROR,
+    ),
+    Message(
+        id=ConfigError.UV_PIP_GROUPS_NOT_ALLOWED,
+        header=_("Invalid configuration for uv pip"),
+        body=_(
+            textwrap.dedent(
+                """
+            The key <code>python.install.groups</code> is not allowed with <code>command: pip</code>.
+            Use <code>command: sync</code> instead when you need to select dependency groups.
+            """
+            ).strip(),
+        ),
+        type=ERROR,
+    ),
+    Message(
+        id=ConfigError.UV_GROUPS_EXTRAS_EMPTY,
+        header=_("Invalid configuration for uv"),
+        body=_(
+            textwrap.dedent(
+                """
+            The <code>python.install.{{field}}</code> list cannot be empty.
+            Either remove the key or provide a non-empty list or the value <code>all</code>.
+            """
+            ).strip(),
+        ),
+        type=ERROR,
+    ),
+    Message(
+        id=ConfigError.UV_GROUPS_EXTRAS_INVALID_TYPE,
+        header=_("Invalid configuration for uv"),
+        body=_(
+            textwrap.dedent(
+                """
+            The <code>python.install.{{field}}</code> must be a list of strings or the value <code>all</code>.
+            Got type <code>{{value|to_class_name}}</code>.
+            """
+            ).strip(),
+        ),
+        type=ERROR,
+    ),
 ]
 registry.add(messages)
 

--- a/readthedocs/config/notifications.py
+++ b/readthedocs/config/notifications.py
@@ -305,6 +305,19 @@ messages = [
         type=ERROR,
     ),
     Message(
+        id=ConfigError.UV_PIP_REQUIREMENTS_AND_PATH_MUTUALLY_EXCLUSIVE,
+        header=_("Invalid configuration key"),
+        body=_(
+            textwrap.dedent(
+                """
+            When using <code>method: uv</code> with <code>command: pip</code>,
+            both <code>python.install.path</code> and <code>python.install.requirements</code> cannot be specified at the same time.
+            """
+            ).strip(),
+        ),
+        type=ERROR,
+    ),
+    Message(
         id=ConfigError.UV_PIP_GROUPS_NOT_ALLOWED,
         header=_("Invalid configuration for uv pip"),
         body=_(

--- a/readthedocs/config/notifications.py
+++ b/readthedocs/config/notifications.py
@@ -267,6 +267,18 @@ messages = [
         type=ERROR,
     ),
     Message(
+        id=ConfigError.UV_MULTIPLE_INSTALL_ENTRIES_INVALID,
+        header=_("Invalid configuration for uv"),
+        body=_(
+            textwrap.dedent(
+                """
+            When using <code>method: uv</code>, only one entry is allowed under <code>python.install</code>.
+            """
+            ).strip(),
+        ),
+        type=ERROR,
+    ),
+    Message(
         id=ConfigError.UV_SYNC_REQUIREMENTS_INVALID,
         header=_("Invalid configuration for uv sync"),
         body=_(

--- a/readthedocs/config/tests/test_config.py
+++ b/readthedocs/config/tests/test_config.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.test import override_settings
 from pytest import raises
 
-from readthedocs.config import ALL, PIP, SETUPTOOLS, BuildConfigV2, load
+from readthedocs.config import ALL, PIP, SETUPTOOLS, UV, BuildConfigV2, load
 from readthedocs.config.config import CONFIG_FILENAME_REGEX
 from readthedocs.config.exceptions import ConfigError, ConfigValidationError
 from readthedocs.config.models import (
@@ -18,6 +18,7 @@ from readthedocs.config.models import (
     BuildWithOs,
     PythonInstall,
     PythonInstallRequirements,
+    UvInstall,
 )
 
 from .utils import apply_fs
@@ -2022,3 +2023,479 @@ class TestBuildConfigV2:
             },
         }
         assert build.as_dict() == expected_dict
+
+    def test_python_install_uv_sync_valid(self, tmpdir):
+        build = get_build_config(
+            {
+                "python": {
+                    "install": [
+                        {
+                            "method": "uv",
+                            "command": "sync",
+                        }
+                    ],
+                },
+            },
+            source_file=str(tmpdir.join("readthedocs.yml")),
+        )
+        build.validate()
+        install = build.python.install
+        assert len(install) == 1
+        assert isinstance(install[0], UvInstall)
+        assert install[0].method == UV
+        assert install[0].command == "sync"
+        assert install[0].path is None
+
+    def test_python_install_uv_pip_valid_with_requirements(self, tmpdir):
+        apply_fs(tmpdir, {"requirements.txt": ""})
+        build = get_build_config(
+            {
+                "python": {
+                    "install": [
+                        {
+                            "method": "uv",
+                            "command": "pip",
+                            "requirements": "requirements.txt",
+                        }
+                    ],
+                },
+            },
+            source_file=str(tmpdir.join("readthedocs.yml")),
+        )
+        build.validate()
+        install = build.python.install
+        assert len(install) == 1
+        assert isinstance(install[0], UvInstall)
+        assert install[0].method == UV
+        assert install[0].command == "pip"
+        assert install[0].requirements == "requirements.txt"
+
+    def test_python_install_uv_pip_valid_with_path(self, tmpdir):
+        build = get_build_config(
+            {
+                "python": {
+                    "install": [
+                        {
+                            "method": "uv",
+                            "command": "pip",
+                            "path": ".",
+                        }
+                    ],
+                },
+            },
+            source_file=str(tmpdir.join("readthedocs.yml")),
+        )
+        build.validate()
+        install = build.python.install
+        assert len(install) == 1
+        assert isinstance(install[0], UvInstall)
+        assert install[0].method == UV
+        assert install[0].command == "pip"
+        assert install[0].path == "."
+
+    def test_python_install_uv_sync_with_path(self, tmpdir):
+        build = get_build_config(
+            {
+                "python": {
+                    "install": [
+                        {
+                            "method": "uv",
+                            "command": "sync",
+                            "path": ".",
+                        }
+                    ],
+                },
+            },
+            source_file=str(tmpdir.join("readthedocs.yml")),
+        )
+        build.validate()
+        install = build.python.install
+        assert len(install) == 1
+        assert isinstance(install[0], UvInstall)
+        assert install[0].command == "sync"
+        assert install[0].path == "."
+
+    def test_python_install_uv_sync_with_groups(self, tmpdir):
+        build = get_build_config(
+            {
+                "python": {
+                    "install": [
+                        {
+                            "method": "uv",
+                            "command": "sync",
+                            "groups": ["docs", "dev"],
+                        }
+                    ],
+                },
+            },
+            source_file=str(tmpdir.join("readthedocs.yml")),
+        )
+        build.validate()
+        install = build.python.install
+        assert len(install) == 1
+        assert install[0].command == "sync"
+        assert install[0].groups == ["docs", "dev"]
+
+    def test_python_install_uv_sync_with_groups_all(self, tmpdir):
+        build = get_build_config(
+            {
+                "python": {
+                    "install": [
+                        {
+                            "method": "uv",
+                            "command": "sync",
+                            "groups": "all",
+                        }
+                    ],
+                },
+            },
+            source_file=str(tmpdir.join("readthedocs.yml")),
+        )
+        build.validate()
+        install = build.python.install
+        assert len(install) == 1
+        assert install[0].command == "sync"
+        assert install[0].groups == ALL
+
+    def test_python_install_uv_sync_with_extras(self, tmpdir):
+        build = get_build_config(
+            {
+                "python": {
+                    "install": [
+                        {
+                            "method": "uv",
+                            "command": "sync",
+                            "extras": ["docs", "tests"],
+                        }
+                    ],
+                },
+            },
+            source_file=str(tmpdir.join("readthedocs.yml")),
+        )
+        build.validate()
+        install = build.python.install
+        assert len(install) == 1
+        assert install[0].command == "sync"
+        assert install[0].extras == ["docs", "tests"]
+
+    def test_python_install_uv_sync_with_extras_all(self, tmpdir):
+        build = get_build_config(
+            {
+                "python": {
+                    "install": [
+                        {
+                            "method": "uv",
+                            "command": "sync",
+                            "extras": "all",
+                        }
+                    ],
+                },
+            },
+            source_file=str(tmpdir.join("readthedocs.yml")),
+        )
+        build.validate()
+        install = build.python.install
+        assert len(install) == 1
+        assert install[0].command == "sync"
+        assert install[0].extras == ALL
+
+    def test_python_install_uv_pip_with_extras(self, tmpdir):
+        build = get_build_config(
+            {
+                "python": {
+                    "install": [
+                        {
+                            "method": "uv",
+                            "command": "pip",
+                            "path": ".",
+                            "extras": ["docs"],
+                        }
+                    ],
+                },
+            },
+            source_file=str(tmpdir.join("readthedocs.yml")),
+        )
+        build.validate()
+        install = build.python.install
+        assert len(install) == 1
+        assert install[0].command == "pip"
+        assert install[0].extras == ["docs"]
+
+    def test_python_install_uv_command_required(self, tmpdir):
+        build = get_build_config(
+            {
+                "python": {
+                    "install": [
+                        {
+                            "method": "uv",
+                        }
+                    ],
+                },
+            },
+            source_file=str(tmpdir.join("readthedocs.yml")),
+        )
+        with raises(ConfigError) as excinfo:
+            build.validate()
+        assert excinfo.value.message_id == ConfigError.UV_COMMAND_REQUIRED
+
+    def test_python_install_uv_invalid_command(self, tmpdir):
+        build = get_build_config(
+            {
+                "python": {
+                    "install": [
+                        {
+                            "method": "uv",
+                            "command": "invalid",
+                        }
+                    ],
+                },
+            },
+            source_file=str(tmpdir.join("readthedocs.yml")),
+        )
+        with raises(ConfigError) as excinfo:
+            build.validate()
+        assert excinfo.value.message_id == ConfigValidationError.INVALID_CHOICE
+
+    def test_python_install_uv_sync_requirements_not_allowed(self, tmpdir):
+        apply_fs(tmpdir, {"requirements.txt": ""})
+        build = get_build_config(
+            {
+                "python": {
+                    "install": [
+                        {
+                            "method": "uv",
+                            "command": "sync",
+                            "requirements": "requirements.txt",
+                        }
+                    ],
+                },
+            },
+            source_file=str(tmpdir.join("readthedocs.yml")),
+        )
+        with raises(ConfigError) as excinfo:
+            build.validate()
+        assert excinfo.value.message_id == ConfigError.UV_SYNC_REQUIREMENTS_INVALID
+
+    def test_python_install_uv_pip_groups_not_allowed(self, tmpdir):
+        build = get_build_config(
+            {
+                "python": {
+                    "install": [
+                        {
+                            "method": "uv",
+                            "command": "pip",
+                            "requirements": "requirements.txt",
+                            "groups": ["docs"],
+                        }
+                    ],
+                },
+            },
+            source_file=str(tmpdir.join("readthedocs.yml")),
+        )
+        with raises(ConfigError) as excinfo:
+            build.validate()
+        assert excinfo.value.message_id == ConfigError.UV_PIP_GROUPS_NOT_ALLOWED
+
+    def test_python_install_uv_pip_requires_requirements_or_path(self, tmpdir):
+        build = get_build_config(
+            {
+                "python": {
+                    "install": [
+                        {
+                            "method": "uv",
+                            "command": "pip",
+                        }
+                    ],
+                },
+            },
+            source_file=str(tmpdir.join("readthedocs.yml")),
+        )
+        with raises(ConfigError) as excinfo:
+            build.validate()
+        assert excinfo.value.message_id == ConfigError.UV_PIP_REQUIREMENTS_OR_PATH_REQUIRED
+
+    def test_python_install_uv_multiple_entries_invalid(self, tmpdir):
+        apply_fs(tmpdir, {"requirements.txt": ""})
+        build = get_build_config(
+            {
+                "python": {
+                    "install": [
+                        {
+                            "method": "uv",
+                            "command": "sync",
+                        },
+                        {
+                            "requirements": "requirements.txt",
+                        },
+                    ],
+                },
+            },
+            source_file=str(tmpdir.join("readthedocs.yml")),
+        )
+        with raises(ConfigError) as excinfo:
+            build.validate()
+        assert excinfo.value.message_id == ConfigError.UV_MULTIPLE_INSTALL_ENTRIES_INVALID
+
+    def test_python_install_uv_sync_groups_empty_list_invalid(self, tmpdir):
+        build = get_build_config(
+            {
+                "python": {
+                    "install": [
+                        {
+                            "method": "uv",
+                            "command": "sync",
+                            "groups": [],
+                        }
+                    ],
+                },
+            },
+            source_file=str(tmpdir.join("readthedocs.yml")),
+        )
+        with raises(ConfigError) as excinfo:
+            build.validate()
+        assert excinfo.value.message_id == ConfigError.UV_GROUPS_EXTRAS_EMPTY
+        assert excinfo.value.format_values.get("field") == "groups"
+
+    def test_python_install_uv_sync_extras_empty_list_invalid(self, tmpdir):
+        build = get_build_config(
+            {
+                "python": {
+                    "install": [
+                        {
+                            "method": "uv",
+                            "command": "sync",
+                            "extras": [],
+                        }
+                    ],
+                },
+            },
+            source_file=str(tmpdir.join("readthedocs.yml")),
+        )
+        with raises(ConfigError) as excinfo:
+            build.validate()
+        assert excinfo.value.message_id == ConfigError.UV_GROUPS_EXTRAS_EMPTY
+        assert excinfo.value.format_values.get("field") == "extras"
+
+    @pytest.mark.parametrize("value", [1, True, {"key": "val"}])
+    def test_python_install_uv_sync_groups_invalid_type(self, value, tmpdir):
+        build = get_build_config(
+            {
+                "python": {
+                    "install": [
+                        {
+                            "method": "uv",
+                            "command": "sync",
+                            "groups": value,
+                        }
+                    ],
+                },
+            },
+            source_file=str(tmpdir.join("readthedocs.yml")),
+        )
+        with raises(ConfigError) as excinfo:
+            build.validate()
+        assert excinfo.value.message_id == ConfigError.UV_GROUPS_EXTRAS_INVALID_TYPE
+        assert excinfo.value.format_values.get("field") == "groups"
+
+    @pytest.mark.parametrize("value", [1, True, {"key": "val"}])
+    def test_python_install_uv_sync_extras_invalid_type(self, value, tmpdir):
+        build = get_build_config(
+            {
+                "python": {
+                    "install": [
+                        {
+                            "method": "uv",
+                            "command": "sync",
+                            "extras": value,
+                        }
+                    ],
+                },
+            },
+            source_file=str(tmpdir.join("readthedocs.yml")),
+        )
+        with raises(ConfigError) as excinfo:
+            build.validate()
+        assert excinfo.value.message_id == ConfigError.UV_GROUPS_EXTRAS_INVALID_TYPE
+        assert excinfo.value.format_values.get("field") == "extras"
+
+    @pytest.mark.parametrize("value", [1, True, {"key": "val"}])
+    def test_python_install_uv_pip_extras_invalid_type(self, value, tmpdir):
+        build = get_build_config(
+            {
+                "python": {
+                    "install": [
+                        {
+                            "method": "uv",
+                            "command": "pip",
+                            "path": ".",
+                            "extras": value,
+                        }
+                    ],
+                },
+            },
+            source_file=str(tmpdir.join("readthedocs.yml")),
+        )
+        with raises(ConfigError) as excinfo:
+            build.validate()
+        assert excinfo.value.message_id == ConfigError.UV_GROUPS_EXTRAS_INVALID_TYPE
+        assert excinfo.value.format_values.get("field") == "extras"
+
+    def test_python_install_uv_pip_extras_empty_list_invalid(self, tmpdir):
+        build = get_build_config(
+            {
+                "python": {
+                    "install": [
+                        {
+                            "method": "uv",
+                            "command": "pip",
+                            "path": ".",
+                            "extras": [],
+                        }
+                    ],
+                },
+            },
+            source_file=str(tmpdir.join("readthedocs.yml")),
+        )
+        with raises(ConfigError) as excinfo:
+            build.validate()
+        assert excinfo.value.message_id == ConfigError.UV_GROUPS_EXTRAS_EMPTY
+        assert excinfo.value.format_values.get("field") == "extras"
+
+    def test_is_using_uv_true(self, tmpdir):
+        build = get_build_config(
+            {
+                "python": {
+                    "install": [
+                        {
+                            "method": "uv",
+                            "command": "sync",
+                        }
+                    ],
+                },
+            },
+            source_file=str(tmpdir.join("readthedocs.yml")),
+        )
+        build.validate()
+        assert build.is_using_uv is True
+
+    def test_is_using_uv_false_with_pip(self, tmpdir):
+        build = get_build_config(
+            {
+                "python": {
+                    "install": [
+                        {
+                            "path": ".",
+                            "method": "pip",
+                        }
+                    ],
+                },
+            },
+            source_file=str(tmpdir.join("readthedocs.yml")),
+        )
+        build.validate()
+        assert build.is_using_uv is False
+
+    def test_is_using_uv_false_with_no_install(self):
+        build = get_build_config({})
+        build.validate()
+        assert build.is_using_uv is False

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import structlog
 
+from readthedocs.doc_builder.python_environments import UvEnv
 from readthedocs.projects.constants import OLD_LANGUAGES_CODE_MAPPING
 from readthedocs.projects.exceptions import ProjectConfigurationError
 from readthedocs.projects.exceptions import UserFileNotFound
@@ -176,6 +177,13 @@ class BaseSphinx(BaseBuilder):
         return cmd_ret.successful
 
     def get_sphinx_cmd(self):
+        if isinstance(self.python_env, UvEnv):
+            return (
+                "uv",
+                "run",
+                "sphinx-build",
+            )
+
         return (
             self.python_env.venv_bin(filename="python"),
             "-m",

--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -25,6 +25,7 @@ from readthedocs.doc_builder.config import load_yaml_config
 from readthedocs.doc_builder.exceptions import BuildUserError
 from readthedocs.doc_builder.loader import get_builder_class
 from readthedocs.doc_builder.python_environments import Conda
+from readthedocs.doc_builder.python_environments import UvEnv
 from readthedocs.doc_builder.python_environments import Virtualenv
 from readthedocs.projects.constants import BUILD_COMMANDS_OUTPUT_PATH_HTML
 from readthedocs.projects.constants import GENERIC
@@ -145,6 +146,8 @@ class BuildDirector:
         language_environment_cls = Virtualenv
         if self.data.config.is_using_conda:
             language_environment_cls = Conda
+        elif self.data.config.is_using_uv:
+            language_environment_cls = UvEnv
 
         self.language_environment = language_environment_cls(
             version=self.data.version,
@@ -570,6 +573,24 @@ class BuildDirector:
                 record=False,
             )
 
+        # TODO: where we should put this?
+        if self.data.config.is_using_uv:
+            cmd = ["asdf", "plugin", "add", "uv"]
+            self.build_environment.run(
+                *cmd,
+                record=True,
+            )
+            cmd = ["asdf", "install", "uv", "latest"]
+            self.build_environment.run(
+                *cmd,
+                record=True,
+            )
+            cmd = ["asdf", "global", "uv", "latest"]
+            self.build_environment.run(
+                *cmd,
+                record=True,
+            )
+
         build_tools_storage = get_storage(
             build_id=self.data.build["id"],
             api_client=self.data.api_client,
@@ -695,6 +716,13 @@ class BuildDirector:
                     *cmd,
                 )
 
+        cmd = ["asdf", "which", "python"]
+        command = self.build_environment.run(
+            *cmd,
+            record=True,
+        )
+        self.UV_PYTHON = command.output.strip()
+
     # Helpers
     #
     # TODO: move somewhere or change names to make them private or something to
@@ -786,6 +814,34 @@ class BuildDirector:
                         "conda",
                         self.data.version.slug,
                         "bin",
+                    ),
+                }
+            )
+        elif self.data.config.is_using_uv is not None:
+            if hasattr(self, "UV_PYTHON"):
+                env.update(
+                    {
+                        # TODO:
+                        # UV_PYTHON needs to execute this command inside the Docker container.
+                        "UV_PYTHON": self.UV_PYTHON,
+                    }
+                )
+            env.update(
+                {
+                    "BIN_PATH": os.path.join(
+                        self.data.project.doc_path,
+                        "envs",
+                        self.data.version.slug,
+                        "bin",
+                    ),
+                    # TODO: I'm not sure about this value here. I need to confirm by triggering some builds.
+                    "UV_PROJECT": self.data.config.python.install[0].path
+                    or self.data.project.checkout_path(self.data.version.slug),
+                    # UV_PROJECT_ENVIRONMENT is the same as READTHEDOCS_VIRTUALENV_PATH
+                    "UV_PROJECT_ENVIRONMENT": os.path.join(
+                        self.data.project.doc_path,
+                        "envs",
+                        self.data.version.slug,
                     ),
                 }
             )

--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -830,11 +830,13 @@ class BuildDirector:
             )
 
         if self.data.config.is_using_uv:
+            try:
+                UV_PROJECT = self.data.config.python.install[0].path
+            except (AttributeError, IndexError):
+                UV_PROJECT = self.data.project.checkout_path(self.data.version.slug)
             env.update(
                 {
-                    "UV_PROJECT": self.data.config.python.install[0].path
-                    if self.data.config.python.install
-                    else self.data.project.checkout_path(self.data.version.slug),
+                    "UV_PROJECT": UV_PROJECT,
                     "UV_PYTHON": self.UV_PYTHON,
                     # UV_PROJECT_ENVIRONMENT is the same as READTHEDOCS_VIRTUALENV_PATH
                     "UV_PROJECT_ENVIRONMENT": os.path.join(

--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -836,7 +836,8 @@ class BuildDirector:
                     ),
                     # TODO: I'm not sure about this value here. I need to confirm by triggering some builds.
                     "UV_PROJECT": self.data.config.python.install[0].path
-                    or self.data.project.checkout_path(self.data.version.slug),
+                    if self.data.config.python.install
+                    else self.data.project.checkout_path(self.data.version.slug),
                     # UV_PROJECT_ENVIRONMENT is the same as READTHEDOCS_VIRTUALENV_PATH
                     "UV_PROJECT_ENVIRONMENT": os.path.join(
                         self.data.project.doc_path,

--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -573,30 +573,6 @@ class BuildDirector:
                 record=False,
             )
 
-        if self.data.config.is_using_uv:
-            cmd = ["asdf", "plugin", "add", "uv"]
-            self.build_environment.run(
-                *cmd,
-                record=True,
-            )
-            cmd = ["asdf", "install", "uv", "latest"]
-            self.build_environment.run(
-                *cmd,
-                record=True,
-            )
-            cmd = ["asdf", "global", "uv", "latest"]
-            self.build_environment.run(
-                *cmd,
-                record=True,
-            )
-            # Save the Python path under UV_PYTHON to define it as an environment variable
-            cmd = ["asdf", "which", "python"]
-            command = self.build_environment.run(
-                *cmd,
-                record=True,
-            )
-            self.UV_PYTHON = command.output.strip()
-
         build_tools_storage = get_storage(
             build_id=self.data.build["id"],
             api_client=self.data.api_client,
@@ -686,6 +662,37 @@ class BuildDirector:
                 *cmd,
                 record=False,
             )
+
+            # Install UV if the tool is Python and the user has selected to use UV
+            if tool == "python" and self.data.config.is_using_uv:
+                cmd = ["asdf", "plugin", "add", "uv"]
+                self.build_environment.run(
+                    *cmd,
+                    record=True,
+                )
+                cmd = ["asdf", "install", "uv", "latest"]
+                self.build_environment.run(
+                    *cmd,
+                    record=True,
+                )
+                cmd = ["asdf", "global", "uv", "latest"]
+                self.build_environment.run(
+                    *cmd,
+                    record=True,
+                )
+                # Save the Python path under UV_PYTHON to define it as an environment variable
+                cmd = ["asdf", "which", "python"]
+                command = self.build_environment.run(
+                    *cmd,
+                    record=True,
+                )
+                # Add UV_PYTHON to build environment variables now we have Python installed.
+                # NOTE: we can't do this at `get_build_env_vars` because we need to have Python installed to get the path of it.
+                self.build_environment._environment.update(
+                    {
+                        "UV_PYTHON": command.output.strip(),
+                    },
+                )
 
             if all(
                 [
@@ -836,8 +843,10 @@ class BuildDirector:
                 UV_PROJECT = self.data.project.checkout_path(self.data.version.slug)
             env.update(
                 {
+                    # UV_PYTHON is set in `install_build_tools` once we have Python installed,
+                    # here I'm setting just an empty string.
+                    "UV_PYTHON": "",
                     "UV_PROJECT": UV_PROJECT,
-                    "UV_PYTHON": self.UV_PYTHON,
                     # UV_PROJECT_ENVIRONMENT is the same as READTHEDOCS_VIRTUALENV_PATH
                     "UV_PROJECT_ENVIRONMENT": os.path.join(
                         self.data.project.doc_path,

--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -573,7 +573,6 @@ class BuildDirector:
                 record=False,
             )
 
-        # TODO: where we should put this?
         if self.data.config.is_using_uv:
             cmd = ["asdf", "plugin", "add", "uv"]
             self.build_environment.run(
@@ -590,6 +589,13 @@ class BuildDirector:
                 *cmd,
                 record=True,
             )
+            # Save the Python path under UV_PYTHON to define it as an environment variable
+            cmd = ["asdf", "which", "python"]
+            command = self.build_environment.run(
+                *cmd,
+                record=True,
+            )
+            self.UV_PYTHON = command.output.strip()
 
         build_tools_storage = get_storage(
             build_id=self.data.build["id"],
@@ -716,13 +722,6 @@ class BuildDirector:
                     *cmd,
                 )
 
-        cmd = ["asdf", "which", "python"]
-        command = self.build_environment.run(
-            *cmd,
-            record=True,
-        )
-        self.UV_PYTHON = command.output.strip()
-
     # Helpers
     #
     # TODO: move somewhere or change names to make them private or something to
@@ -817,15 +816,8 @@ class BuildDirector:
                     ),
                 }
             )
-        elif self.data.config.is_using_uv is not None:
-            if hasattr(self, "UV_PYTHON"):
-                env.update(
-                    {
-                        # TODO:
-                        # UV_PYTHON needs to execute this command inside the Docker container.
-                        "UV_PYTHON": self.UV_PYTHON,
-                    }
-                )
+
+        else:
             env.update(
                 {
                     "BIN_PATH": os.path.join(
@@ -834,10 +826,16 @@ class BuildDirector:
                         self.data.version.slug,
                         "bin",
                     ),
-                    # TODO: I'm not sure about this value here. I need to confirm by triggering some builds.
+                }
+            )
+
+        if self.data.config.is_using_uv:
+            env.update(
+                {
                     "UV_PROJECT": self.data.config.python.install[0].path
                     if self.data.config.python.install
                     else self.data.project.checkout_path(self.data.version.slug),
+                    "UV_PYTHON": self.UV_PYTHON,
                     # UV_PROJECT_ENVIRONMENT is the same as READTHEDOCS_VIRTUALENV_PATH
                     "UV_PROJECT_ENVIRONMENT": os.path.join(
                         self.data.project.doc_path,
@@ -849,12 +847,6 @@ class BuildDirector:
         else:
             env.update(
                 {
-                    "BIN_PATH": os.path.join(
-                        self.data.project.doc_path,
-                        "envs",
-                        self.data.version.slug,
-                        "bin",
-                    ),
                     "READTHEDOCS_VIRTUALENV_PATH": os.path.join(
                         self.data.project.doc_path, "envs", self.data.version.slug
                     ),

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -293,13 +293,8 @@ class UvEnv(Virtualenv):
 
         if install.requirements:
             args.extend(["-r", install.requirements])
-        elif install.path and install.path != ".":
+        elif install.path:
             local_path = install.path
-            if install.extras and isinstance(install.extras, list):
-                local_path = f"{local_path}[{','.join(install.extras)}]"
-            args.append(local_path)
-        else:
-            local_path = "."
             if install.extras and isinstance(install.extras, list):
                 local_path = f"{local_path}[{','.join(install.extras)}]"
             args.append(local_path)

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -258,11 +258,6 @@ class UvEnv(Virtualenv):
         :param install: A UvInstall object from the config module.
         :type install: readthedocs.config.models.UvInstall
         """
-        # TODO: these variables should from the BuildDirector when UV is used, so _all the commands_ make use of them.
-        # Set uv-specific environment variables
-        # UV_PYTHON points to the selected Python interpreter
-        # UV_PROJECT_ENVIRONMENT points to the virtualenv path
-        # UV_PROJECT points to the project directory if non-root
         if install.command == "sync":
             self._install_uv_sync(install)
         elif install.command == "pip":
@@ -296,9 +291,6 @@ class UvEnv(Virtualenv):
         """Execute uv pip install with appropriate flags."""
         args = ["uv", "pip", "install"]
 
-        # TODO: `uv pip install` cannot be used without a requirements file.
-        # However, the `python.install.requirements` config key is only used for pip installs, right?
-        # I need to confirm this.
         if install.requirements:
             args.extend(["-r", install.requirements])
         elif install.path and install.path != ".":

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -12,6 +12,7 @@ from readthedocs.config import ParseError
 from readthedocs.config import parse as parse_yaml
 from readthedocs.config.models import PythonInstall
 from readthedocs.config.models import PythonInstallRequirements
+from readthedocs.config.models import UvInstall
 from readthedocs.core.utils.filesystem import safe_open
 from readthedocs.doc_builder.config import load_yaml_config
 from readthedocs.projects.constants import GENERIC
@@ -45,8 +46,25 @@ class PythonEnvironment:
         for install in self.config.python.install:
             if isinstance(install, PythonInstallRequirements):
                 self.install_requirements_file(install)
-            if isinstance(install, PythonInstall):
+            elif isinstance(install, PythonInstall):
                 self.install_package(install)
+            elif isinstance(install, UvInstall):
+                self.install_uv(install)
+
+    def has_uv_installs(self):
+        """Check if any uv installs are configured."""
+        return any(isinstance(install, UvInstall) for install in self.config.python.install)
+
+    def install_uv(self, install):
+        """
+        Install using uv package manager.
+
+        This is a stub method that subclasses should override.
+
+        :param install: A UvInstall install object from the config module.
+        :type install: readthedocs.config.models.UvInstall
+        """
+        raise NotImplementedError(f"{self.__class__.__name__} does not support uv installs")
 
     def install_package(self, install):
         """
@@ -217,6 +235,92 @@ class Virtualenv(PythonEnvironment):
                 cwd=self.checkout_path,
                 bin_path=self.venv_bin(),
             )
+
+
+class UvEnv(Virtualenv):
+    """A uv-managed virtual environment."""
+
+    def setup_base(self):
+        """Create the base environment using ``uv venv``."""
+        self.build_env.run(
+            "uv",
+            "venv",
+            "$READTHEDOCS_VIRTUALENV_PATH",
+            # Don't use virtualenv bin that doesn't exist yet
+            bin_path=None,
+            # Don't use the project's root, some config files can interfere
+            cwd=None,
+        )
+
+    def install_core_requirements(self):
+        """Skip RTD core pip/sphinx bootstrap for uv-managed environments."""
+
+    def install_uv(self, install):
+        """
+        Install using uv package manager.
+
+        :param install: A UvInstall object from the config module.
+        :type install: readthedocs.config.models.UvInstall
+        """
+        # TODO: these variables should from the BuildDirector when UV is used, so _all the commands_ make use of them.
+        # Set uv-specific environment variables
+        # UV_PYTHON points to the selected Python interpreter
+        # UV_PROJECT_ENVIRONMENT points to the virtualenv path
+        # UV_PROJECT points to the project directory if non-root
+        if install.command == "sync":
+            self._install_uv_sync(install)
+        elif install.command == "pip":
+            self._install_uv_pip(install)
+
+    def _install_uv_sync(self, install):
+        """Execute uv sync with appropriate flags."""
+        args = ["uv", "sync"]
+
+        if install.groups:
+            if install.groups == "all":
+                args.append("--all-groups")
+            else:
+                for group in install.groups:
+                    args.extend(["--group", group])
+
+        if install.extras:
+            if install.extras == "all":
+                args.append("--all-extras")
+            else:
+                for extra in install.extras:
+                    args.extend(["--extra", extra])
+
+        self.build_env.run(
+            *args,
+            cwd=self.checkout_path,
+            bin_path=self.venv_bin(),
+        )
+
+    def _install_uv_pip(self, install):
+        """Execute uv pip install with appropriate flags."""
+        args = ["uv", "pip", "install"]
+
+        # TODO: `uv pip install` cannot be used without a requirements file.
+        # However, the `python.install.requirements` config key is only used for pip installs, right?
+        # I need to confirm this.
+        if install.requirements:
+            args.extend(["-r", install.requirements])
+        elif install.path and install.path != ".":
+            local_path = install.path
+            if install.extras and isinstance(install.extras, list):
+                local_path = f"{local_path}[{','.join(install.extras)}]"
+            args.append(local_path)
+        else:
+            local_path = "."
+            if install.extras and isinstance(install.extras, list):
+                local_path = f"{local_path}[{','.join(install.extras)}]"
+            args.append(local_path)
+
+        self.build_env.run(
+            *args,
+            cwd=self.checkout_path,
+            bin_path=self.venv_bin(),
+        )
 
 
 class Conda(PythonEnvironment):

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -51,10 +51,6 @@ class PythonEnvironment:
             elif isinstance(install, UvInstall):
                 self.install_uv(install)
 
-    def has_uv_installs(self):
-        """Check if any uv installs are configured."""
-        return any(isinstance(install, UvInstall) for install in self.config.python.install)
-
     def install_uv(self, install):
         """
         Install using uv package manager.

--- a/readthedocs/doc_builder/tests/test_director.py
+++ b/readthedocs/doc_builder/tests/test_director.py
@@ -31,6 +31,7 @@ class TestBuildDirectorEnvironmentVariables(TestCase):
         self.data.build = {"commit": "abc123"}
         self.data.config = mock.Mock()
         self.data.config.conda = None
+        self.data.config.is_using_uv = False
 
         self.director = BuildDirector(self.data)
 

--- a/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
+++ b/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
@@ -286,16 +286,24 @@
           "items": {
             "anyOf": [
               {
+                "type": "object",
                 "properties": {
                   "requirements": {
                     "title": "Requirements",
                     "description": "The path to the requirements file from the root of the project.",
                     "type": "string"
+                  },
+                  "method": {
+                    "title": "Method",
+                    "description": "Install method.",
+                    "enum": ["pip", "setuptools"]
                   }
                 },
-                "required": ["requirements"]
+                "required": ["requirements"],
+                "additionalProperties": false
               },
               {
+                "type": "object",
                 "properties": {
                   "path": {
                     "title": "Path",
@@ -318,10 +326,127 @@
                     "default": []
                   }
                 },
-                "required": ["path"]
+                "required": ["path"],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "method": {
+                    "title": "Method",
+                    "description": "Install using uv.",
+                    "enum": ["uv"]
+                  },
+                  "command": {
+                    "title": "Command",
+                    "description": "uv command to execute.",
+                    "enum": ["sync", "pip"]
+                  },
+                  "path": {
+                    "title": "Path",
+                    "description": "The path to the project to be installed.",
+                    "type": "string"
+                  },
+                  "requirements": {
+                    "title": "Requirements",
+                    "description": "The path to the requirements file from the root of the project.",
+                    "type": "string"
+                  },
+                  "groups": {
+                    "title": "Groups",
+                    "description": "Dependency groups to install with uv sync.",
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "enum": ["all"]
+                      }
+                    ]
+                  },
+                  "extras": {
+                    "title": "Extras",
+                    "description": "Optional dependencies to install.",
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      {
+                        "enum": ["all"]
+                      }
+                    ]
+                  }
+                },
+                "required": ["method", "command"],
+                "allOf": [
+                  {
+                    "if": {
+                      "properties": {
+                        "command": {
+                          "const": "sync"
+                        }
+                      }
+                    },
+                    "then": {
+                      "not": {
+                        "required": ["requirements"]
+                      }
+                    }
+                  },
+                  {
+                    "if": {
+                      "properties": {
+                        "command": {
+                          "const": "pip"
+                        }
+                      }
+                    },
+                    "then": {
+                      "not": {
+                        "required": ["groups"]
+                      },
+                      "anyOf": [
+                        {
+                          "required": ["requirements"]
+                        },
+                        {
+                          "required": ["path"]
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "additionalProperties": false
               }
             ]
-          }
+          },
+          "allOf": [
+            {
+              "if": {
+                "contains": {
+                  "type": "object",
+                  "properties": {
+                    "method": {
+                      "const": "uv"
+                    }
+                  },
+                  "required": ["method"]
+                }
+              },
+              "then": {
+                "minItems": 1,
+                "maxItems": 1
+              }
+            }
+          ]
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
This consider all the discussions from the issue #11289

Example of a local build with `uv sync` using a `pyproject.toml` file and this PR.

<img width="1042" height="1015" alt="Screenshot_2026-03-26_15-25-43" src="https://github.com/user-attachments/assets/a896d9a7-d8dc-4d56-a2df-888f08dcae41" />

Closes #11289