### PR TITLE
Build: don't fetch all branches when building default branch

### DIFF
--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -886,6 +886,7 @@ class TestBuildTask(BuildEnvironmentBase):
                     "--prune-tags",
                     "--depth",
                     "50",
+                    "HEAD",
                 ),
                 mock.call(
                     "git",
@@ -1448,6 +1449,7 @@ class TestBuildTask(BuildEnvironmentBase):
                     "--prune-tags",
                     "--depth",
                     "50",
+                    "HEAD",
                 ),
                 mock.call(
                     "git",

--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -288,30 +288,32 @@ class Backend(BaseVCS):
             "--depth",
             str(self.repo_depth),
         ]
-        # Skip adding a remote reference if we are building "latest",
+        # Fetch from HEAD (symlink to the default branch) if we are building "latest",
         # and the user hasn't defined a default branch (which means we need to use the default branch from the repo).
-        omit_remote_reference = self.version.is_machine_latest and not self.project.default_branch
-        if not omit_remote_reference:
+        use_default_branch = self.version.is_machine_latest and not self.project.default_branch
+        if use_default_branch:
+            cmd.append("HEAD")
+        else:
             remote_reference = self.get_remote_fetch_refspec()
             if remote_reference:
                 # TODO: We are still fetching the latest 50 commits.
                 # A PR might have another commit added after the build has started...
                 cmd.append(remote_reference)
 
-        # Log a warning, except for machine versions since it's a known bug that
-        # we haven't stored a remote refspec in Version for those "stable" versions.
-        # This could be the case for an unknown default branch.
-        elif not self.version.machine:
-            # We are doing a fetch without knowing the remote reference.
-            # This is expensive, so log the event.
-            log.warning(
-                "Git fetch: Could not decide a remote reference for version. "
-                "Is it an empty default branch?",
-                project_slug=self.project.slug,
-                verbose_name=self.version.verbose_name,
-                version_type=self.version.type,
-                version_identifier=self.version.identifier,
-            )
+            # Log a warning, except for machine versions since it's a known bug that
+            # we haven't stored a remote refspec in Version for those "stable" versions.
+            # This could be the case for an unknown default branch.
+            elif not self.version.machine:
+                # We are doing a fetch without knowing the remote reference.
+                # This is expensive, so log the event.
+                log.warning(
+                    "Git fetch: Could not decide a remote reference for version. "
+                    "Is it an empty default branch?",
+                    project_slug=self.project.slug,
+                    verbose_name=self.version.verbose_name,
+                    version_type=self.version.type,
+                    version_identifier=self.version.identifier,
+                )
 
         # TODO: Explain or remove the return value
         code, stdout, stderr = self.run(*cmd)


### PR DESCRIPTION
When running `fetch` without a refspec, it fetches all branches and tags. We don't want that. There was also an indentation that I missed last time when I touched this code.