### PR TITLE
Docs: remove broken PDF download link

### DIFF
--- a/docs/user/downloadable-documentation.rst
+++ b/docs/user/downloadable-documentation.rst
@@ -46,11 +46,9 @@ Examples
 If you want to see an example,
 you can download the Read the Docs documentation in the following formats:
 
-    * `PDF`_
     * `ePub`_
     * `Zipped HTML`_
 
-.. _PDF: https://docs.readthedocs.io/_/downloads/en/latest/pdf/
 .. _ePub: https://docs.readthedocs.io/_/downloads/en/latest/epub/
 .. _Zipped HTML: https://docs.readthedocs.io/_/downloads/en/latest/htmlzip/
 


### PR DESCRIPTION
## Summary
- Remove the broken PDF download link from the offline formats examples section
- Read the Docs no longer builds PDF for its own docs, so the link returns a 404
- The ePub and Zipped HTML download links remain and work correctly

Closes #11277

## Test plan
- [ ] Verify the ePub and Zipped HTML links still render correctly on the built docs page

Made by AI