### PR TITLE
Redirects: extract :splat string into a constant

### DIFF
--- a/readthedocs/redirects/constants.py
+++ b/readthedocs/redirects/constants.py
@@ -11,6 +11,8 @@ EXACT_REDIRECT = "exact"
 CLEAN_URL_TO_HTML_REDIRECT = "clean_url_to_html"
 HTML_TO_CLEAN_URL_REDIRECT = "html_to_clean_url"
 
+SPLAT_PLACEHOLDER = ":splat"
+
 TYPE_CHOICES = (
     (PAGE_REDIRECT, _("Page Redirect")),
     (EXACT_REDIRECT, _("Exact Redirect")),

--- a/readthedocs/redirects/models.py
+++ b/readthedocs/redirects/models.py
@@ -15,6 +15,7 @@ from readthedocs.redirects.constants import EXACT_REDIRECT
 from readthedocs.redirects.constants import HTML_TO_CLEAN_URL_REDIRECT
 from readthedocs.redirects.constants import HTTP_STATUS_CHOICES
 from readthedocs.redirects.constants import PAGE_REDIRECT
+from readthedocs.redirects.constants import SPLAT_PLACEHOLDER
 from readthedocs.redirects.constants import TYPE_CHOICES
 from readthedocs.redirects.validators import validate_redirect
 
@@ -263,7 +264,7 @@ class Redirect(models.Model):
                 return None
 
             splat = current_path[len(self.from_url_without_rest) :]
-            to_url = self.to_url.replace(":splat", splat)
+            to_url = self.to_url.replace(SPLAT_PLACEHOLDER, splat)
             return to_url
         return self.to_url
 
@@ -282,8 +283,8 @@ class Redirect(models.Model):
         We do this by checking if we will redirect to a subdirectory of the current path,
         and if the current path already starts with the path we will redirect to.
         """
-        if self.from_url.endswith("*") and ":splat" in self.to_url:
-            to_url_without_splat = self.to_url.split(":splat", maxsplit=1)[0]
+        if self.from_url.endswith("*") and SPLAT_PLACEHOLDER in self.to_url:
+            to_url_without_splat = self.to_url.split(SPLAT_PLACEHOLDER, maxsplit=1)[0]
 
             redirects_to_subpath = to_url_without_splat.startswith(self.from_url_without_rest)
             if redirects_to_subpath and current_path.startswith(to_url_without_splat):

--- a/readthedocs/redirects/validators.py
+++ b/readthedocs/redirects/validators.py
@@ -6,6 +6,7 @@ from readthedocs.redirects.constants import CLEAN_URL_TO_HTML_REDIRECT
 from readthedocs.redirects.constants import EXACT_REDIRECT
 from readthedocs.redirects.constants import HTML_TO_CLEAN_URL_REDIRECT
 from readthedocs.redirects.constants import PAGE_REDIRECT
+from readthedocs.redirects.constants import SPLAT_PLACEHOLDER
 from readthedocs.subscriptions.constants import TYPE_REDIRECTS_LIMIT
 from readthedocs.subscriptions.products import get_feature
 
@@ -27,9 +28,9 @@ def validate_redirect(*, project, pk, redirect_type, from_url, to_url, error_cla
             raise error_class("The $rest wildcard has been removed in favor of *.")
         if "*" in from_url and not from_url.endswith("*"):
             raise error_class("The * wildcard must be at the end of the path.")
-        if ":splat" in to_url and not from_url.endswith("*"):
+        if SPLAT_PLACEHOLDER in to_url and not from_url.endswith("*"):
             raise error_class(
-                "The * wildcard must be at the end of from_url to use the :splat placeholder in to_url."
+                f"The * wildcard must be at the end of from_url to use the {SPLAT_PLACEHOLDER} placeholder in to_url."
             )
 
     if redirect_type in [CLEAN_URL_TO_HTML_REDIRECT, HTML_TO_CLEAN_URL_REDIRECT]:


### PR DESCRIPTION
## Summary
- Add SPLAT_PLACEHOLDER constant to redirects/constants.py
- Replace all :splat string literals in redirects/models.py and redirects/validators.py with the constant
- Test fixtures in test files keep the literal string since they represent user input

Per @humitos in the review of PR #11038: "It would be good to make this :splat a constant."

Closes #11043

## Test plan
- [x] All 16 redirect tests pass
- [x] Pre-existing test failure in test_old_redirects.py is unrelated (confirmed by running on main)

Made by AI