### PR TITLE
Admin: add search fields for EmailHook and WebHook models

### DIFF
--- a/readthedocs/projects/admin.py
+++ b/readthedocs/projects/admin.py
@@ -464,6 +464,18 @@ class AddonsConfigAdmin(admin.ModelAdmin):
     list_editable = ("enabled",)
 
 
-admin.site.register(EmailHook)
-admin.site.register(WebHook)
+@admin.register(EmailHook)
+class EmailHookAdmin(admin.ModelAdmin):
+    raw_id_fields = ("project",)
+    list_display = ("email", "project")
+    search_fields = ("email", "project__slug", "project__name")
+
+
+@admin.register(WebHook)
+class WebHookAdmin(admin.ModelAdmin):
+    raw_id_fields = ("project",)
+    list_display = ("url", "project")
+    search_fields = ("url", "project__slug", "project__name")
+
+
 admin.site.register(WebHookEvent)


### PR DESCRIPTION
## Summary
- Add proper admin classes for EmailHook and WebHook with search_fields
- EmailHook is searchable by email, project slug, and project name
- WebHook is searchable by URL, project slug, and project name
- Both use raw_id_fields for the project FK to prevent admin page timeouts (addresses the second point in #10379 about gateway errors when loading webhook/emailhook pages)

Closes #10379

## Test plan
- [ ] Verify EmailHook admin page loads without timeout
- [ ] Verify WebHook admin page loads without timeout
- [ ] Verify search by project slug works on both admin pages

Made by AI