### PR TITLE
Test: docs-only change to verify CI skip logic

### DIFF
--- a/docs/dev/tests.rst
+++ b/docs/dev/tests.rst
@@ -5,7 +5,8 @@ Testing
 
 .. note::
 
-   CI test jobs are automatically skipped for docs-only changes.
+   CI test jobs are automatically skipped when only files under ``docs/``
+   have changed, saving CI resources on documentation-only pull requests.
 
 Before contributing to Read the Docs, make sure your patch passes our test suite
 and your code style passes our code linting suite.


### PR DESCRIPTION
## Summary

Test PR with only a `docs/` change to verify that the `skip-if-docs-only` command in CircleCI correctly halts test jobs.

**Expected behavior:** `checks` should run, but `tests`, `tests-proxito`, `tests-search`, and `tests-embedapi` should all halt early with success.

https://claude.ai/code/session_01PrHk6hpFk9eDTaNujKYLon