### PR TITLE
Add spam score and owner ban status columns to Project admin

### DIFF
--- a/readthedocs/projects/admin.py
+++ b/readthedocs/projects/admin.py
@@ -294,9 +294,9 @@ class ProjectAdmin(ExtraSimpleHistoryAdmin):
         score = obj._spam_score
         if score is None:
             return "-"
-        if score >= getattr(settings, "RTD_SPAM_THRESHOLD_DELETE_PROJECT", 999):
+        if score >= settings.RTD_SPAM_THRESHOLD_DELETE_PROJECT:
             return format_html('<span style="color: red; font-weight: bold;">{}</span>', score)
-        if score >= getattr(settings, "RTD_SPAM_THRESHOLD_DENY_ON_ROBOTS", 999):
+        if score >= settings.RTD_SPAM_THRESHOLD_DENY_ON_ROBOTS:
             return format_html('<span style="color: orange; font-weight: bold;">{}</span>', score)
         if score >= 1:
             return format_html('<span style="color: goldenrod;">{}</span>', score)


### PR DESCRIPTION
## Summary
Enhanced the Project admin interface to display spam-related information and owner ban status, improving visibility into project moderation data.

## Key Changes
- **Extended list_display**: Added four new columns to the Project admin list view:
  - `is_spam`: Existing field for spam status
  - `spam_score_display`: New custom display method showing spam score with color-coded severity
  - `owner_banned_display`: New custom display method indicating if any project owner has a banned profile
  - `pub_date`: Publication date for additional context

- **Enhanced queryset**: Implemented `get_queryset()` method to optimize data retrieval:
  - Annotates `_spam_score` by summing spam rule values (when spamfighting extension is installed)
  - Falls back to `None` when spamfighting is not available
  - Annotates `_owner_banned` using a subquery to check if any project owner has a banned UserProfile

- **Custom display methods**:
  - `spam_score_display()`: Shows spam score with color-coded styling based on configurable thresholds:
    - Red for scores at or above `RTD_SPAM_THRESHOLD_DELETE_PROJECT`
    - Orange for scores at or above `RTD_SPAM_THRESHOLD_DENY_ON_ROBOTS`
    - Goldenrod for scores >= 1
    - Dash ("-") for null scores
  - `owner_banned_display()`: Boolean display for owner ban status with sortable ordering

## Implementation Details
- Uses Django ORM annotations (`Sum`, `Exists`, `OuterRef`) for efficient database queries
- Conditionally includes spam score annotation based on installed apps
- Supports sorting by both spam score and owner ban status
- Uses `format_html()` for safe HTML rendering of colored score displays

https://claude.ai/code/session_01YNFCKy4TdRtkAxpakAGot6