### PR TITLE
fix(builds): handle files without extension in artifact processing

### DIFF
--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -668,6 +668,12 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
                 # Rename file as "<project_slug>-<version_slug>.<artifact_type>",
                 # which is the filename that Proxito serves for offline formats.
                 filename = list_dir[0]
+                if "." not in filename:
+                    log.warning(
+                        "Skipping artifact file without extension: %s",
+                        filename,
+                    )
+                    continue
                 _, extension = filename.rsplit(".")
                 path = Path(artifact_directory) / filename
                 destination = Path(artifact_directory) / f"{self.data.project.slug}.{extension}"

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -668,13 +668,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
                 # Rename file as "<project_slug>-<version_slug>.<artifact_type>",
                 # which is the filename that Proxito serves for offline formats.
                 filename = list_dir[0]
-                if "." not in filename:
-                    log.warning(
-                        "Skipping artifact file without extension: %s",
-                        filename,
-                    )
-                    continue
-                _, extension = filename.rsplit(".")
+                extension = Path(filename).suffix.lstrip(".")
                 path = Path(artifact_directory) / filename
                 destination = Path(artifact_directory) / f"{self.data.project.slug}.{extension}"
                 assert_path_is_inside_docroot(path)


### PR DESCRIPTION
## Problem

When a build output file has no filename extension, the build crashes with:

```python
_, extension = filename.rsplit(".")
ValueError: not enough values to unpack (expected 2, got 1)
```

This happens because `rsplit(".")` returns only one element when there is no `.` in the filename.

## Fix

Check for `.` in the filename before calling `rsplit`. If the file has no extension, log a warning and skip it instead of crashing the build.

Fixes #12917