### PR TITLE
Add visual diff base HTML snapshot for stable PR comparisons

### DIFF
--- a/readthedocs/filetreediff/__init__.py
+++ b/readthedocs/filetreediff/__init__.py
@@ -18,16 +18,24 @@ The process is as follows:
 
 import json
 
+import structlog
+
 from readthedocs.builds.models import Build
 from readthedocs.builds.models import Version
+from readthedocs.filetreediff.dataclasses import BaseSnapshot
 from readthedocs.filetreediff.dataclasses import FileTreeDiff
 from readthedocs.filetreediff.dataclasses import FileTreeDiffFileStatus
 from readthedocs.filetreediff.dataclasses import FileTreeDiffManifest
 from readthedocs.projects.constants import MEDIA_TYPE_DIFF
+from readthedocs.projects.constants import MEDIA_TYPE_HTML
 from readthedocs.storage import build_media_storage
 
 
+log = structlog.get_logger(__name__)
+
 MANIFEST_FILE_NAME = "manifest.json"
+BASE_SNAPSHOT_FILE_NAME = "base_snapshot.json"
+BASE_HTML_DIR_NAME = "base_html"
 
 
 def get_diff(current_version: Version, base_version: Version) -> FileTreeDiff | None:
@@ -116,3 +124,87 @@ def write_manifest(version: Version, manifest: FileTreeDiffManifest):
     )
     with build_media_storage.open(manifest_path, "w") as f:
         json.dump(manifest.as_dict(), f)
+
+
+def get_base_snapshot(version: Version) -> BaseSnapshot | None:
+    """
+    Get the base snapshot for an external (PR) version.
+
+    Returns None if no base snapshot exists yet.
+    """
+    snapshot_path = version.get_storage_path(
+        media_type=MEDIA_TYPE_DIFF,
+        filename=BASE_SNAPSHOT_FILE_NAME,
+    )
+    try:
+        with build_media_storage.open(snapshot_path) as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        return None
+
+    return BaseSnapshot.from_dict(data)
+
+
+def write_base_snapshot(version: Version, snapshot: BaseSnapshot):
+    """Write the base snapshot metadata for an external (PR) version."""
+    snapshot_path = version.get_storage_path(
+        media_type=MEDIA_TYPE_DIFF,
+        filename=BASE_SNAPSHOT_FILE_NAME,
+    )
+    with build_media_storage.open(snapshot_path, "w") as f:
+        json.dump(snapshot.as_dict(), f)
+
+
+def snapshot_base_html(pr_version: Version, base_version: Version):
+    """
+    Copy base version's HTML files into the PR version's diff storage.
+
+    Only copies *.html files -- static assets (CSS, JS, images) are not needed
+    since visual diff only extracts and compares <main> content from HTML pages.
+
+    Also writes a base_snapshot.json with the base build metadata.
+    """
+    latest_base_build = base_version.latest_successful_build
+    if not latest_base_build:
+        log.warning(
+            "No successful build for base version, skipping base HTML snapshot.",
+            base_version_slug=base_version.slug,
+        )
+        return
+
+    # Check if a snapshot already exists for this PR version.
+    existing_snapshot = get_base_snapshot(pr_version)
+    if existing_snapshot is not None:
+        log.info(
+            "Base HTML snapshot already exists, skipping.",
+            pr_version_slug=pr_version.slug,
+            base_build_id=existing_snapshot.base_build_id,
+        )
+        return
+
+    source_path = base_version.get_storage_path(media_type=MEDIA_TYPE_HTML)
+    dest_path = pr_version.get_storage_path(
+        media_type=MEDIA_TYPE_DIFF,
+        filename=BASE_HTML_DIR_NAME,
+    )
+
+    log.info(
+        "Creating base HTML snapshot for PR version.",
+        pr_version_slug=pr_version.slug,
+        base_version_slug=base_version.slug,
+        base_build_id=latest_base_build.id,
+        source_path=source_path,
+        dest_path=dest_path,
+    )
+
+    build_media_storage.rclone_copy_remote_directory(
+        source=source_path,
+        destination=dest_path,
+        include="*.html",
+    )
+
+    snapshot = BaseSnapshot(
+        base_build_id=latest_base_build.id,
+        base_version_slug=base_version.slug,
+    )
+    write_base_snapshot(pr_version, snapshot)

--- a/readthedocs/filetreediff/dataclasses.py
+++ b/readthedocs/filetreediff/dataclasses.py
@@ -57,6 +57,24 @@ class FileTreeDiffManifest:
         return asdict(self)
 
 
+@dataclass(slots=True)
+class BaseSnapshot:
+    """Snapshot of the base version's state at the time a PR was first built."""
+
+    base_build_id: int
+    base_version_slug: str
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "BaseSnapshot":
+        return cls(
+            base_build_id=data["base_build_id"],
+            base_version_slug=data["base_version_slug"],
+        )
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
 class FileTreeDiffFileStatus(StrEnum):
     """Status of a file in the file tree diff."""
 

--- a/readthedocs/filetreediff/tests/test_filetreediff.py
+++ b/readthedocs/filetreediff/tests/test_filetreediff.py
@@ -5,9 +5,10 @@ from unittest import mock
 from django.test import TestCase
 from django_dynamic_fixture import get
 
-from readthedocs.builds.constants import BUILD_STATE_FINISHED, LATEST
+from readthedocs.builds.constants import BUILD_STATE_FINISHED, EXTERNAL, LATEST
 from readthedocs.builds.models import Build, Version
-from readthedocs.filetreediff import get_diff
+from readthedocs.filetreediff import get_base_snapshot, get_diff, snapshot_base_html, write_base_snapshot
+from readthedocs.filetreediff.dataclasses import BaseSnapshot
 from readthedocs.projects.models import Project
 from readthedocs.rtd_tests.storage import BuildMediaFileSystemStorageTest
 
@@ -148,3 +149,97 @@ class TestsFileTreeDiff(TestCase):
         assert [file.path for file in diff.deleted] == ["deleted.html"]
         assert [file.path for file in diff.modified] == ["tutorials/index.html"]
         assert diff.outdated
+
+
+@mock.patch(
+    "readthedocs.filetreediff.build_media_storage",
+    new=BuildMediaFileSystemStorageTest(),
+)
+class TestBaseSnapshot(TestCase):
+    def setUp(self):
+        self.project = get(Project)
+        self.base_version = self.project.versions.get(slug=LATEST)
+        self.base_build = get(
+            Build,
+            project=self.project,
+            version=self.base_version,
+            state=BUILD_STATE_FINISHED,
+            success=True,
+        )
+        self.pr_version = get(
+            Version,
+            project=self.project,
+            slug="123",
+            active=True,
+            built=True,
+            type=EXTERNAL,
+        )
+
+    def _mock_open(self, content):
+        @contextmanager
+        def f(*args, **kwargs):
+            read_mock = mock.MagicMock()
+            read_mock.read.return_value = content
+            yield read_mock
+
+        return f
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_get_base_snapshot(self, storage_open):
+        snapshot_data = json.dumps(
+            {"base_build_id": self.base_build.id, "base_version_slug": "latest"}
+        )
+        storage_open.return_value = self._mock_open(snapshot_data)()
+        snapshot = get_base_snapshot(self.pr_version)
+        assert snapshot is not None
+        assert snapshot.base_build_id == self.base_build.id
+        assert snapshot.base_version_slug == "latest"
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_get_base_snapshot_not_found(self, storage_open):
+        storage_open.side_effect = FileNotFoundError
+        snapshot = get_base_snapshot(self.pr_version)
+        assert snapshot is None
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_write_base_snapshot(self, storage_open):
+        mock_file = mock.MagicMock()
+        storage_open.return_value.__enter__ = mock.MagicMock(return_value=mock_file)
+        storage_open.return_value.__exit__ = mock.MagicMock(return_value=False)
+
+        snapshot = BaseSnapshot(
+            base_build_id=self.base_build.id,
+            base_version_slug="latest",
+        )
+        write_base_snapshot(self.pr_version, snapshot)
+        storage_open.assert_called_once()
+        mock_file.write.assert_called()
+
+    @mock.patch("readthedocs.filetreediff.build_media_storage")
+    def test_snapshot_base_html(self, mock_storage):
+        mock_storage.open.side_effect = FileNotFoundError
+        snapshot_base_html(self.pr_version, self.base_version)
+        mock_storage.rclone_copy_remote_directory.assert_called_once()
+        call_kwargs = mock_storage.rclone_copy_remote_directory.call_args
+        assert call_kwargs.kwargs.get("include") == "*.html"
+
+    @mock.patch("readthedocs.filetreediff.build_media_storage")
+    def test_snapshot_base_html_skips_if_exists(self, mock_storage):
+        """If a base snapshot already exists, don't re-copy."""
+        snapshot_data = json.dumps(
+            {"base_build_id": self.base_build.id, "base_version_slug": "latest"}
+        )
+        mock_storage.open.return_value.__enter__ = mock.MagicMock(
+            return_value=mock.MagicMock(read=mock.MagicMock(return_value=snapshot_data))
+        )
+        mock_storage.open.return_value.__exit__ = mock.MagicMock(return_value=False)
+
+        snapshot_base_html(self.pr_version, self.base_version)
+        mock_storage.rclone_copy_remote_directory.assert_not_called()
+
+    def test_snapshot_base_html_no_successful_build(self):
+        """If base version has no successful build, skip snapshot."""
+        Build.objects.filter(version=self.base_version).delete()
+        # Should not raise, just skip.
+        with mock.patch("readthedocs.filetreediff.build_media_storage"):
+            snapshot_base_html(self.pr_version, self.base_version)

--- a/readthedocs/filetreediff/tests/test_filetreediff.py
+++ b/readthedocs/filetreediff/tests/test_filetreediff.py
@@ -215,27 +215,30 @@ class TestBaseSnapshot(TestCase):
         storage_open.assert_called_once()
         mock_file.write.assert_called()
 
+    @mock.patch("readthedocs.filetreediff.write_base_snapshot")
+    @mock.patch("readthedocs.filetreediff.get_base_snapshot")
     @mock.patch("readthedocs.filetreediff.build_media_storage")
-    def test_snapshot_base_html(self, mock_storage):
-        mock_storage.open.side_effect = FileNotFoundError
+    def test_snapshot_base_html(self, mock_storage, mock_get_snapshot, mock_write_snapshot):
+        # No existing snapshot.
+        mock_get_snapshot.return_value = None
         snapshot_base_html(self.pr_version, self.base_version)
         mock_storage.rclone_copy_remote_directory.assert_called_once()
         call_kwargs = mock_storage.rclone_copy_remote_directory.call_args
         assert call_kwargs.kwargs.get("include") == "*.html"
+        mock_write_snapshot.assert_called_once()
 
+    @mock.patch("readthedocs.filetreediff.write_base_snapshot")
+    @mock.patch("readthedocs.filetreediff.get_base_snapshot")
     @mock.patch("readthedocs.filetreediff.build_media_storage")
-    def test_snapshot_base_html_skips_if_exists(self, mock_storage):
+    def test_snapshot_base_html_skips_if_exists(self, mock_storage, mock_get_snapshot, mock_write_snapshot):
         """If a base snapshot already exists, don't re-copy."""
-        snapshot_data = json.dumps(
-            {"base_build_id": self.base_build.id, "base_version_slug": "latest"}
+        mock_get_snapshot.return_value = BaseSnapshot(
+            base_build_id=self.base_build.id,
+            base_version_slug="latest",
         )
-        mock_storage.open.return_value.__enter__ = mock.MagicMock(
-            return_value=mock.MagicMock(read=mock.MagicMock(return_value=snapshot_data))
-        )
-        mock_storage.open.return_value.__exit__ = mock.MagicMock(return_value=False)
-
         snapshot_base_html(self.pr_version, self.base_version)
         mock_storage.rclone_copy_remote_directory.assert_not_called()
+        mock_write_snapshot.assert_not_called()
 
     def test_snapshot_base_html_no_successful_build(self):
         """If base version has no successful build, skip snapshot."""

--- a/readthedocs/projects/tasks/search.py
+++ b/readthedocs/projects/tasks/search.py
@@ -9,6 +9,7 @@ from readthedocs.builds.constants import LATEST
 from readthedocs.builds.models import Build
 from readthedocs.builds.models import Version
 from readthedocs.builds.tasks import post_build_overview
+from readthedocs.filetreediff import snapshot_base_html
 from readthedocs.filetreediff import write_manifest
 from readthedocs.filetreediff.dataclasses import FileTreeDiffManifest
 from readthedocs.filetreediff.dataclasses import FileTreeDiffManifestFile
@@ -130,9 +131,16 @@ class IndexFileIndexer(Indexer):
 
 
 class FileManifestIndexer(Indexer):
-    def __init__(self, version: Version, build: Build, post_build_overview: bool = True):
+    def __init__(
+        self,
+        version: Version,
+        build: Build,
+        base_version: Version | None = None,
+        post_build_overview: bool = True,
+    ):
         self.version = version
         self.build = build
+        self.base_version = base_version
         self._hashes = {}
         self.post_build_overview = post_build_overview
 
@@ -148,6 +156,23 @@ class FileManifestIndexer(Indexer):
             ],
         )
         write_manifest(self.version, manifest)
+
+        # For external (PR) versions, snapshot the base version's HTML files
+        # so visual diff can compare against a stable base even if the base
+        # version is rebuilt.
+        if self.version.is_external and self.base_version is not None:
+            try:
+                snapshot_base_html(
+                    pr_version=self.version,
+                    base_version=self.base_version,
+                )
+            except Exception:
+                log.exception(
+                    "Failed to snapshot base HTML for visual diff.",
+                    pr_version_slug=self.version.slug,
+                    base_version_slug=self.base_version.slug,
+                )
+
         if (
             self.post_build_overview
             and self.version.is_external
@@ -190,18 +215,27 @@ def _get_indexers(
 
     # We compare PR previews against the latest version,
     # unless the project has a specific options_base_version set.
-    base_version = (
+    base_version_slug = (
         version.project.addons.options_base_version.slug
         if version.project.addons.options_base_version
         else LATEST
     )
     create_manifest = (
-        version.is_external or version.slug == base_version or settings.RTD_FILETREEDIFF_ALL
+        version.is_external or version.slug == base_version_slug or settings.RTD_FILETREEDIFF_ALL
     )
     if create_manifest:
+        # Resolve the base version object for external versions
+        # so the manifest indexer can snapshot its HTML for visual diff.
+        base_version_obj = None
+        if version.is_external:
+            base_version_obj = version.project.versions.filter(
+                slug=base_version_slug
+            ).first()
+
         file_manifest_indexer = FileManifestIndexer(
             version=version,
             build=build,
+            base_version=base_version_obj,
             post_build_overview=post_build_overview,
         )
         indexers.append(file_manifest_indexer)

--- a/readthedocs/proxito/tests/test_hosting.py
+++ b/readthedocs/proxito/tests/test_hosting.py
@@ -15,6 +15,7 @@ from django_dynamic_fixture import get
 from readthedocs.builds.constants import BUILD_STATE_FINISHED, EXTERNAL, LATEST
 from readthedocs.builds.models import Build, Version
 from readthedocs.filetreediff.dataclasses import (
+    BaseSnapshot,
     FileTreeDiff,
     FileTreeDiffManifestFile,
     FileTreeDiffFileStatus,
@@ -1237,6 +1238,92 @@ class TestReadTheDocsConfigJson(TestCase):
                 ],
             },
         }
+
+    @mock.patch("readthedocs.proxito.views.hosting.get_base_snapshot")
+    def test_doc_diff_base_url_uses_snapshot_for_external_version(
+        self, get_base_snapshot
+    ):
+        """When a base snapshot exists, doc_diff.base_url should point to the snapshot."""
+        pr_version = get(
+            Version,
+            project=self.project,
+            slug="456",
+            active=True,
+            built=True,
+            privacy_level=PUBLIC,
+            type=EXTERNAL,
+        )
+        get(
+            Build,
+            project=self.project,
+            version=pr_version,
+            commit="d4e5f6",
+            state=BUILD_STATE_FINISHED,
+            success=True,
+        )
+        get_base_snapshot.return_value = BaseSnapshot(
+            base_build_id=self.build.id,
+            base_version_slug="latest",
+        )
+
+        r = self.client.get(
+            reverse("proxito_readthedocs_docs_addons"),
+            {
+                "url": "https://project--456.dev.readthedocs.build/en/456/index.html",
+                "client-version": "0.6.0",
+                "api-version": "1.0.0",
+            },
+            secure=True,
+            headers={
+                "host": "project--456.dev.readthedocs.build",
+            },
+        )
+        assert r.status_code == 200
+        doc_diff = r.json()["addons"]["doc_diff"]
+        assert doc_diff["enabled"] is True
+        # The base_url should point to the snapshot path, not the live version.
+        assert "/_/diff/456/base/index.html" in doc_diff["base_url"]
+        assert "project--456.dev.readthedocs.build" in doc_diff["base_url"]
+
+    @mock.patch("readthedocs.proxito.views.hosting.get_base_snapshot")
+    def test_doc_diff_base_url_falls_back_when_no_snapshot(self, get_base_snapshot):
+        """When no base snapshot exists, doc_diff.base_url should use the live version."""
+        pr_version = get(
+            Version,
+            project=self.project,
+            slug="789",
+            active=True,
+            built=True,
+            privacy_level=PUBLIC,
+            type=EXTERNAL,
+        )
+        get(
+            Build,
+            project=self.project,
+            version=pr_version,
+            commit="g7h8i9",
+            state=BUILD_STATE_FINISHED,
+            success=True,
+        )
+        get_base_snapshot.return_value = None
+
+        r = self.client.get(
+            reverse("proxito_readthedocs_docs_addons"),
+            {
+                "url": "https://project--789.dev.readthedocs.build/en/789/index.html",
+                "client-version": "0.6.0",
+                "api-version": "1.0.0",
+            },
+            secure=True,
+            headers={
+                "host": "project--789.dev.readthedocs.build",
+            },
+        )
+        assert r.status_code == 200
+        doc_diff = r.json()["addons"]["doc_diff"]
+        # Should fall back to the live latest version URL.
+        assert "/en/latest/index.html" in doc_diff["base_url"]
+        assert "project.dev.readthedocs.io" in doc_diff["base_url"]
 
     def test_version_ordering(self):
         for slug in ["1.0", "1.2", "1.12", "2.0", "2020.01.05", "a-slug", "z-slug"]:

--- a/readthedocs/proxito/urls.py
+++ b/readthedocs/proxito/urls.py
@@ -45,6 +45,7 @@ from readthedocs.constants import pattern_opts
 from readthedocs.core.views import HealthCheckView
 from readthedocs.projects.views.public import ProjectDownloadMedia
 from readthedocs.proxito.views.hosting import ReadTheDocsConfigJson
+from readthedocs.proxito.views.serve import ServeBaseHTMLSnapshot
 from readthedocs.proxito.views.serve import ServeDocs
 from readthedocs.proxito.views.serve import ServeError404
 from readthedocs.proxito.views.serve import ServeLLMSTXT
@@ -123,6 +124,17 @@ proxied_urls = [
         f"{DOC_PATH_PREFIX}addons/",
         ReadTheDocsConfigJson.as_view(),
         name="proxito_readthedocs_docs_addons",
+    ),
+    # Serve base HTML snapshots for visual diff.
+    # /_/diff/<version_slug>/base/<filename>
+    re_path(
+        r"^{DOC_PATH_PREFIX}diff/"
+        r"(?P<version_slug>{version_slug})/"
+        r"base/(?P<filename>.+)$".format(
+            DOC_PATH_PREFIX=DOC_PATH_PREFIX, **pattern_opts
+        ),
+        ServeBaseHTMLSnapshot.as_view(),
+        name="proxito_base_html_snapshot",
     ),
 ]
 

--- a/readthedocs/proxito/views/hosting.py
+++ b/readthedocs/proxito/views/hosting.py
@@ -1,6 +1,7 @@
 """Views for hosting features."""
 
 from functools import lru_cache
+from urllib.parse import urlunparse
 
 import packaging
 import structlog
@@ -30,6 +31,7 @@ from readthedocs.core.resolver import Resolver
 from readthedocs.core.unresolver import UnresolverError
 from readthedocs.core.unresolver import unresolver
 from readthedocs.core.utils.extend import SettingsOverrideObject
+from readthedocs.filetreediff import get_base_snapshot
 from readthedocs.filetreediff import get_diff
 from readthedocs.projects.constants import ADDONS_FLYOUT_SORTING_CALVER
 from readthedocs.projects.constants import ADDONS_FLYOUT_SORTING_CUSTOM_PATTERN
@@ -549,19 +551,43 @@ class AddonsResponseBase:
                 if project.addons.options_base_version
                 else LATEST
             )
+
+            base_url = None
+            if filename:
+                # For external (PR) versions, prefer the frozen base HTML
+                # snapshot so visual diff remains stable even when the base
+                # version is rebuilt.
+                if version and version.is_external:
+                    base_snapshot = get_base_snapshot(version)
+                    if base_snapshot:
+                        # Build the snapshot URL on the same domain as the
+                        # PR preview to avoid CORS issues.
+                        domain, use_https = resolver._get_project_domain(
+                            project,
+                            external_version_slug=version.slug,
+                        )
+                        protocol = "https" if use_https else "http"
+                        snapshot_path = (
+                            f"/_/diff/{version.slug}/base/{filename}"
+                        )
+                        base_url = urlunparse(
+                            (protocol, domain, snapshot_path, "", "", "")
+                        )
+
+                if not base_url:
+                    # Fallback: use the live base version URL.
+                    base_url = resolver.resolve(
+                        project=project,
+                        version_slug=base_version_slug,
+                        language=project.language,
+                        filename=filename,
+                    )
+
             data["addons"].update(
                 {
                     "doc_diff": {
                         "enabled": project.addons.doc_diff_enabled,
-                        # "http://test-builds-local.devthedocs.org/en/latest/index.html"
-                        "base_url": resolver.resolve(
-                            project=project,
-                            version_slug=base_version_slug,
-                            language=project.language,
-                            filename=filename,
-                        )
-                        if filename
-                        else None,
+                        "base_url": base_url,
                         "inject_styles": True,
                     },
                 }

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -22,6 +22,7 @@ from readthedocs.core.unresolver import TranslationWithoutVersionError
 from readthedocs.core.unresolver import VersionNotFoundError
 from readthedocs.core.unresolver import unresolver
 from readthedocs.core.utils.extend import SettingsOverrideObject
+from readthedocs.projects.constants import MEDIA_TYPE_DIFF
 from readthedocs.projects.constants import MEDIA_TYPE_HTML
 from readthedocs.projects.constants import OLD_LANGUAGES_CODE_MAPPING
 from readthedocs.projects.constants import PRIVATE
@@ -38,6 +39,7 @@ from readthedocs.proxito.views.mixins import InvalidPathError
 from readthedocs.proxito.views.mixins import ServeDocsMixin
 from readthedocs.proxito.views.mixins import ServeRedirectMixin
 from readthedocs.proxito.views.mixins import StorageFileNotFound
+from readthedocs.filetreediff import BASE_HTML_DIR_NAME
 from readthedocs.redirects.exceptions import InfiniteRedirectException
 from readthedocs.storage import build_media_storage
 
@@ -982,3 +984,61 @@ class ServeStaticFiles(CDNCacheControlMixin, CDNCacheTagsMixin, ServeDocsMixin, 
     def _get_version(self):
         # This view isn't attached to a version.
         return None
+
+
+class ServeBaseHTMLSnapshotBase(CDNCacheControlMixin, ServeDocsMixin, View):
+    """
+    Serve base HTML snapshot files for visual diff.
+
+    These are frozen copies of the base version's HTML files stored alongside
+    the PR version's diff data. Used by the visual diff JS client to compare
+    against a stable base even when the base version is rebuilt.
+    """
+
+    # Snapshot content is immutable for a given PR version,
+    # so it can be cached.
+    cache_response = True
+
+    def get(self, request, version_slug, filename):
+        unresolved_domain = request.unresolved_domain
+        if not unresolved_domain:
+            raise Http404
+
+        project = unresolved_domain.project
+
+        version = project.versions.filter(
+            slug=version_slug,
+        ).first()
+        if not version or not version.is_external:
+            raise Http404
+
+        if not self.allowed_user(request, version):
+            return self.get_unauthed_response(request, project)
+
+        if not filename or filename.endswith("/"):
+            filename += "index.html"
+
+        base_storage_path = version.get_storage_path(
+            media_type=MEDIA_TYPE_DIFF,
+            filename=BASE_HTML_DIR_NAME,
+        )
+
+        try:
+            storage_path = build_media_storage.join(
+                base_storage_path, filename.lstrip("/")
+            )
+        except ValueError:
+            raise Http404
+
+        if not build_media_storage.exists(storage_path):
+            raise Http404
+
+        return self._serve_file(
+            request=request,
+            storage_path=storage_path,
+            storage_backend=build_media_storage,
+        )
+
+
+class ServeBaseHTMLSnapshot(SettingsOverrideObject):
+    _default_class = ServeBaseHTMLSnapshotBase

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -22,6 +22,7 @@ from readthedocs.core.unresolver import TranslationWithoutVersionError
 from readthedocs.core.unresolver import VersionNotFoundError
 from readthedocs.core.unresolver import unresolver
 from readthedocs.core.utils.extend import SettingsOverrideObject
+from readthedocs.filetreediff import BASE_HTML_DIR_NAME
 from readthedocs.projects.constants import MEDIA_TYPE_DIFF
 from readthedocs.projects.constants import MEDIA_TYPE_HTML
 from readthedocs.projects.constants import OLD_LANGUAGES_CODE_MAPPING
@@ -39,7 +40,6 @@ from readthedocs.proxito.views.mixins import InvalidPathError
 from readthedocs.proxito.views.mixins import ServeDocsMixin
 from readthedocs.proxito.views.mixins import ServeRedirectMixin
 from readthedocs.proxito.views.mixins import StorageFileNotFound
-from readthedocs.filetreediff import BASE_HTML_DIR_NAME
 from readthedocs.redirects.exceptions import InfiniteRedirectException
 from readthedocs.storage import build_media_storage
 

--- a/readthedocs/rtd_tests/tests/test_build_storage.py
+++ b/readthedocs/rtd_tests/tests/test_build_storage.py
@@ -193,3 +193,51 @@ class TestBuildMediaStorage(TestCase):
         with override_settings(DOCROOT=tmp_docroot):
             with pytest.raises(SuspiciousFileOperation, match="outside the docroot"):
                 self.storage.rclone_sync_directory(tmp_dir, "files")
+
+    def test_copy_remote_directory(self):
+        """Test copying files between two remote storage paths."""
+        # First, sync some files to storage.
+        with override_settings(DOCROOT=files_dir):
+            self.storage.rclone_sync_directory(files_dir, "source")
+
+        # Copy from source to destination within storage.
+        self.storage.rclone_copy_remote_directory("source", "destination")
+
+        # Both should have the same tree.
+        tree = [
+            ("api", ["index.html"]),
+            "404.html",
+            "api.fjson",
+            "conf.py",
+            "index.html",
+            "test.html",
+        ]
+        self.assertFileTree("source", tree)
+        self.assertFileTree("destination", tree)
+
+    def test_copy_remote_directory_with_include_filter(self):
+        """Test that --include filter only copies matching files."""
+        with override_settings(DOCROOT=files_dir):
+            self.storage.rclone_sync_directory(files_dir, "source")
+
+        # Copy only *.html files.
+        self.storage.rclone_copy_remote_directory(
+            "source", "destination", include="*.html"
+        )
+
+        # Destination should only have HTML files.
+        html_tree = [
+            ("api", ["index.html"]),
+            "404.html",
+            "index.html",
+            "test.html",
+        ]
+        self.assertFileTree("destination", html_tree)
+
+    def test_copy_remote_directory_suspicious_paths(self):
+        with pytest.raises(SuspiciousFileOperation):
+            self.storage.rclone_copy_remote_directory("", "destination")
+        with pytest.raises(SuspiciousFileOperation):
+            self.storage.rclone_copy_remote_directory("source", "")
+        with pytest.raises(SuspiciousFileOperation):
+            self.storage.rclone_copy_remote_directory("/", "destination")

--- a/readthedocs/storage/mixins.py
+++ b/readthedocs/storage/mixins.py
@@ -52,6 +52,25 @@ class RTDBaseStorage:
         self._check_suspicious_path(source)
         return self._rclone.sync(source, destination)
 
+    def rclone_copy_remote_directory(self, source, destination, include=None):
+        """
+        Copy a directory from one remote path to another using rclone copy.
+
+        Both source and destination are remote storage paths (not local filesystem).
+        On S3, this uses server-side CopyObject without downloading data.
+
+        :param source: Remote path to the source directory.
+        :param destination: Remote path to the destination directory.
+        :param include: Optional glob pattern to filter files (e.g. "*.html").
+        """
+        if source in ("", "/") or destination in ("", "/"):
+            raise SuspiciousFileOperation("Copying all storage cannot be right")
+
+        options = []
+        if include:
+            options.append(f"--include={include}")
+        return self._rclone.copy_remote(source, destination, options=options)
+
     def delete_directory(self, path):
         raise NotImplementedError
 

--- a/readthedocs/storage/rclone.py
+++ b/readthedocs/storage/rclone.py
@@ -123,6 +123,25 @@ class BaseRClone:
         """
         return self.execute("sync", args=[source, self.get_target(destination)])
 
+    def copy_remote(self, source, destination, options=None):
+        """
+        Run the `rclone copy` command between two remote paths.
+
+        This performs a server-side copy (e.g. S3 CopyObject)
+        without downloading data to the local machine.
+
+        See https://rclone.org/commands/rclone_copy/.
+
+        :params source: Remote path to the source directory.
+        :params destination: Remote path to the destination directory.
+        :params options: Additional options to pass to rclone (e.g. --include).
+        """
+        return self.execute(
+            "copy",
+            args=[self.get_target(source), self.get_target(destination)],
+            options=options,
+        )
+
 
 class RCloneLocal(BaseRClone):
     """


### PR DESCRIPTION
## Summary

- Extends #12922 (file tree diff manifest snapshot) to also snapshot the base version's **rendered HTML** so visual diff (`doc_diff`) remains stable when the base branch advances
- On first PR build, copies `*.html` files from the base version into the PR's `diff/` storage (`external/diff/{project}/{pr_slug}/base_html/`)
- Adds a new proxito route (`/_/diff/{version}/base/{path}`) to serve these frozen snapshots
- Updates `doc_diff.base_url` in the addons API to point to the snapshot URL for external versions, falling back to the live base URL when no snapshot exists

## Design decisions

- **Only `*.html` files** are copied (via rclone `--include=*.html`), skipping static assets — visual diff only needs the rendered HTML to extract `<main>` content
- **PR-colocated storage** — the snapshot lives inside the PR version's existing `diff/` storage tree, so cleanup is automatic when the PR version is deleted (no reference counting needed)
- **S3-to-S3 server-side copy** — new `rclone copy_remote()` method avoids downloading data to the builder; uses S3 CopyObject API
- **Idempotent** — if a snapshot already exists, subsequent PR builds skip the copy

## Depends on

- #12922 — Snapshot base manifest on first PR build to fix stale branch diffs

## Test plan

- [ ] Verify `doc_diff.base_url` points to snapshot path for PR versions with a base snapshot
- [ ] Verify fallback to live base URL when no snapshot exists
- [ ] Verify `rclone copy_remote` with `--include=*.html` only copies HTML files
- [ ] Verify snapshot cleanup happens automatically when PR version is deleted
- [ ] Verify rebase clears the snapshot (follow-up, aligns with #12923)

https://claude.ai/code/session_01MczHXuiDZUFE8TLFhV1xXs