### PR TITLE
Fix migration conflict: renumber 0159 to 0160

### DIFF
--- a/readthedocs/projects/migrations/0160_notifications_show_on_external_help_text.py
+++ b/readthedocs/projects/migrations/0160_notifications_show_on_external_help_text.py
@@ -9,7 +9,7 @@ class Migration(migrations.Migration):
     safe = Safe.before_deploy()
 
     dependencies = [
-        ("projects", "0158_add_search_subproject_filter_option"),
+        ("projects", "0159_update_addonsconfig_field_name"),
     ]
 
     operations = [


### PR DESCRIPTION
## Summary

- Two migrations shared number `0159` in `projects/migrations/`, causing a Django migration conflict
- Renumbered `0159_notifications_show_on_external_help_text.py` → `0160` and updated its dependency to `0159_update_addonsconfig_field_name`

Made by AI.