### PR TITLE
Remove placeholder search_settings_form.html template

### DIFF
--- a/readthedocs/templates/projects/search_settings_form.html
+++ b/readthedocs/templates/projects/search_settings_form.html
@@ -1,3 +1,0 @@
-{% extends "projects/project_edit_base.html" %}
-
-{# This is just a placeholder to satisfy tests. This template is only implemented in ext-theme #}


### PR DESCRIPTION
Addresses review feedback on #12934.

[@stsewd pointed out](https://github.com/readthedocs/readthedocs.org/pull/12934#discussion_r3077046575) that the placeholder `readthedocs/templates/projects/search_settings_form.html` added in #12934 is not the right fix for the CI failure — the actual fix landed in #12933, which includes the ext-theme commit in the test cache key so newly added ext-theme templates invalidate the cache properly.

This PR removes the stub. The real template lives in ext-theme.

Generated by Claude Code.