### PR TITLE
Add documentation for Markdown for AI agents feature

### DIFF
--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -54,6 +54,7 @@ Read the Docs: documentation simplified
    /reference/404-not-found
    /reference/robots
    /reference/llms-txt
+   /reference/markdown-for-agents
 
 .. toctree::
    :maxdepth: 2

--- a/docs/user/reference/agent-skills.rst
+++ b/docs/user/reference/agent-skills.rst
@@ -57,3 +57,6 @@ See the `Read the Docs Skills repository <https://github.com/readthedocs/skills>
 
    :doc:`/api/index`
      Read the Read the Docs API documentation.
+
+   :doc:`/reference/markdown-for-agents`
+     Read the Docs serves a Markdown version of documentation pages to AI agents via content negotiation.

--- a/docs/user/reference/llms-txt.rst
+++ b/docs/user/reference/llms-txt.rst
@@ -73,3 +73,6 @@ This gives you more control over which version serves the file.
 .. seealso::
 
    :doc:`/guides/redirects`
+
+   :doc:`/reference/markdown-for-agents`
+     Read the Docs also serves a Markdown version of your documentation pages to AI agents that request it, via content negotiation.

--- a/docs/user/reference/markdown-for-agents.rst
+++ b/docs/user/reference/markdown-for-agents.rst
@@ -20,16 +20,16 @@ For example, a request with ``Accept: text/markdown`` will return a Markdown res
 
 .. code-block:: bash
 
-   $ curl -iL https://docs.readthedocs.io/en/stable/ -H "Accept: text/markdown"
+   $ curl -i https://docs.readthedocs.com/platform/stable/intro/sphinx.html -H "Accept: text/markdown"
    HTTP/2 200
    content-type: text/markdown; charset=utf-8
    vary: accept
-   x-markdown-tokens: 1678
+   x-markdown-tokens: 1657
    content-signal: ai-train=yes, search=yes, ai-input=yes
 
    ---
-   description: Automate building, versioning, and hosting of your technical documentation continuously on Read the Docs.
-   title: Read the Docs: documentation simplified
+   description: Hosting Sphinx documentation on Read the Docs.
+   title: Deploying Sphinx on Read the Docs
    ---
 
    ...

--- a/docs/user/reference/markdown-for-agents.rst
+++ b/docs/user/reference/markdown-for-agents.rst
@@ -20,15 +20,16 @@ For example, a request with ``Accept: text/markdown`` will return a Markdown res
 
 .. code-block:: bash
 
-   $ curl -i https://docs.readthedocs.com/platform/stable/reference/markdown-for-agents.html -H "Accept: text/markdown"
+   $ curl -i https://docs.readthedocs.com/platform/stable/ -H "Accept: text/markdown"
    HTTP/2 200
    content-type: text/markdown; charset=utf-8
    vary: accept
-   x-markdown-tokens: ...
+   x-markdown-tokens: 1496
    content-signal: ai-train=yes, search=yes, ai-input=yes
 
    ---
-   title: Markdown for AI agents
+   description: Automate building, versioning, and hosting of your technical documentation continuously on Read the Docs.
+   title: Read the Docs: documentation simplified
    ---
 
    ...

--- a/docs/user/reference/markdown-for-agents.rst
+++ b/docs/user/reference/markdown-for-agents.rst
@@ -20,16 +20,15 @@ For example, a request with ``Accept: text/markdown`` will return a Markdown res
 
 .. code-block:: bash
 
-   $ curl -i https://docs.readthedocs.com/platform/stable/intro/sphinx.html -H "Accept: text/markdown"
+   $ curl -i https://docs.readthedocs.com/platform/stable/reference/markdown-for-agents.html -H "Accept: text/markdown"
    HTTP/2 200
    content-type: text/markdown; charset=utf-8
    vary: accept
-   x-markdown-tokens: 1657
+   x-markdown-tokens: ...
    content-signal: ai-train=yes, search=yes, ai-input=yes
 
    ---
-   description: Hosting Sphinx documentation on Read the Docs.
-   title: Deploying Sphinx on Read the Docs
+   title: Markdown for AI agents
    ---
 
    ...

--- a/docs/user/reference/markdown-for-agents.rst
+++ b/docs/user/reference/markdown-for-agents.rst
@@ -3,7 +3,7 @@ Markdown for AI agents
 
 Read the Docs serves a Markdown version of documentation pages to AI agents that request it,
 using HTTP content negotiation.
-This makes documentation more efficient for LLMs to consume,
+This makes documentation more efficient for language models to consume,
 since Markdown is smaller and easier to parse than rendered HTML.
 
 This feature is **enabled automatically** on all documentation domains hosted on Read the Docs,
@@ -41,7 +41,7 @@ Benefits
 --------
 
 * **Smaller payloads**: Markdown is more compact than HTML, which reduces bandwidth and context usage for AI agents.
-* **Better readability for LLMs**: Markdown is easier for language models to parse than HTML with styling and navigation markup.
+* **Better readability for language models**: Markdown is easier for language models to parse than HTML with styling and navigation markup.
 * **No configuration required**: The feature works automatically on all documentation hosted on Read the Docs.
 * **Transparent for readers**: Browsers continue to receive the regular HTML version of your documentation.
 

--- a/docs/user/reference/markdown-for-agents.rst
+++ b/docs/user/reference/markdown-for-agents.rst
@@ -1,22 +1,19 @@
 Markdown for AI agents
 ======================
 
-Read the Docs serves a Markdown version of documentation pages to AI agents that request it,
+Read the Docs serves a Markdown version of documentation pages to clients that request it,
 using HTTP content negotiation.
-This makes documentation more efficient for language models to consume,
-since Markdown is smaller and easier to parse than rendered HTML.
+Markdown is smaller and easier to parse than rendered HTML,
+which makes it a better format for AI agents and language models to consume.
 
 This feature is **enabled automatically** on all documentation domains hosted on Read the Docs,
 with no configuration required.
+Browsers continue to receive the regular HTML version of your documentation.
 
-How it works
-------------
+Example
+-------
 
-When a client makes a request with an ``Accept`` header that prefers Markdown,
-Read the Docs returns a Markdown representation of the page instead of the HTML version.
-The Markdown is generated on the fly from the built HTML output of your documentation.
-
-For example, a request with ``Accept: text/markdown`` will return a Markdown response:
+A request with ``Accept: text/markdown`` returns a Markdown response:
 
 .. code-block:: bash
 
@@ -34,21 +31,7 @@ For example, a request with ``Accept: text/markdown`` will return a Markdown res
 
    ...
 
-The original HTML page is still served for normal browser requests.
-Only clients that explicitly request Markdown via the ``Accept`` header will receive the Markdown version.
-
-Benefits
---------
-
-* **Smaller payloads**: Markdown is more compact than HTML, which reduces bandwidth and context usage for AI agents.
-* **Better readability for language models**: Markdown is easier for language models to parse than HTML with styling and navigation markup.
-* **No configuration required**: The feature works automatically on all documentation hosted on Read the Docs.
-* **Transparent for readers**: Browsers continue to receive the regular HTML version of your documentation.
-
-Implementation
---------------
-
-This feature is implemented by `Cloudflare`_, which generates the Markdown representation from the HTML response.
+This feature is powered by `Cloudflare`_.
 See the `Cloudflare blog post on Markdown for agents`_ for more details about how the conversion works.
 
 .. seealso::

--- a/docs/user/reference/markdown-for-agents.rst
+++ b/docs/user/reference/markdown-for-agents.rst
@@ -10,9 +10,6 @@ This feature is **enabled automatically** on all documentation domains hosted on
 with no configuration required.
 Browsers continue to receive the regular HTML version of your documentation.
 
-Example
--------
-
 A request with ``Accept: text/markdown`` returns a Markdown response:
 
 .. code-block:: bash

--- a/docs/user/reference/markdown-for-agents.rst
+++ b/docs/user/reference/markdown-for-agents.rst
@@ -1,0 +1,63 @@
+Markdown for AI agents
+======================
+
+Read the Docs serves a Markdown version of documentation pages to AI agents that request it,
+using HTTP content negotiation.
+This makes documentation more efficient for LLMs to consume,
+since Markdown is smaller and easier to parse than rendered HTML.
+
+This feature is **enabled automatically** on all documentation domains hosted on Read the Docs,
+with no configuration required.
+
+How it works
+------------
+
+When a client makes a request with an ``Accept`` header that prefers Markdown,
+Read the Docs returns a Markdown representation of the page instead of the HTML version.
+The Markdown is generated on the fly from the built HTML output of your documentation.
+
+For example, a request with ``Accept: text/markdown`` will return a Markdown response:
+
+.. code-block:: bash
+
+   $ curl -iL https://docs.readthedocs.io/en/stable/ -H "Accept: text/markdown"
+   HTTP/2 200
+   content-type: text/markdown; charset=utf-8
+   vary: accept
+   x-markdown-tokens: 1678
+   content-signal: ai-train=yes, search=yes, ai-input=yes
+
+   ---
+   description: Automate building, versioning, and hosting of your technical documentation continuously on Read the Docs.
+   title: Read the Docs: documentation simplified
+   ---
+
+   ...
+
+The original HTML page is still served for normal browser requests.
+Only clients that explicitly request Markdown via the ``Accept`` header will receive the Markdown version.
+
+Benefits
+--------
+
+* **Smaller payloads**: Markdown is more compact than HTML, which reduces bandwidth and context usage for AI agents.
+* **Better readability for LLMs**: Markdown is easier for language models to parse than HTML with styling and navigation markup.
+* **No configuration required**: The feature works automatically on all documentation hosted on Read the Docs.
+* **Transparent for readers**: Browsers continue to receive the regular HTML version of your documentation.
+
+Implementation
+--------------
+
+This feature is implemented by `Cloudflare`_, which generates the Markdown representation from the HTML response.
+See the `Cloudflare blog post on Markdown for agents`_ for more details about how the conversion works.
+
+.. seealso::
+
+   :doc:`/reference/llms-txt`
+     Serve a custom ``llms.txt`` file to guide AI agents to the most relevant pages of your documentation.
+
+   :doc:`/reference/agent-skills`
+     Use Read the Docs Agent Skills to help AI agents work with Read the Docs APIs and configuration.
+
+.. _Cloudflare: https://www.cloudflare.com/
+.. _Cloudflare blog post on Markdown for agents: https://blog.cloudflare.com/markdown-for-agents/


### PR DESCRIPTION
## Summary

Document the Markdown content negotiation feature that is now enabled
on all documentation domains. When a client sends `Accept: text/markdown`,
Read the Docs (via Cloudflare) returns a Markdown representation of the
page instead of HTML, which is more efficient for AI agents to consume.

Adds a new reference page under `docs/user/reference/markdown-for-agents.rst`
and cross-links it from `llms-txt.rst` and `agent-skills.rst`.

Refs #12512

_Generated by Claude Code._