### PR TITLE
Standardize on AGENTS.md for AI agent instructions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,3 +1,1 @@
-# Read the Docs developement guide for AI agents
-
-Follow the instructions from https://github.com/readthedocs/common/blob/main/.github/copilot-instructions.md.
+../AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,1 @@
-# Read the Docs developement guide for AI agents
-
-Follow the instructions from https://github.com/readthedocs/common/blob/main/.github/copilot-instructions.md.
+common/AGENTS.md


### PR DESCRIPTION
## Summary
- Symlink `AGENTS.md` → `common/AGENTS.md` and `.claude/CLAUDE.md` → `../AGENTS.md`
- Update common submodule to include the new `AGENTS.md`
- Depends on readthedocs/common#295

Made by AI