### PR TITLE
oauth: fix Bitbucket sync after cross-workspace API deprecation

### DIFF
--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -37,11 +37,15 @@ class BitbucketService(UserService):
         Paginate the workspaces the user is a member of.
 
         Bitbucket deprecated the cross-workspace ``/2.0/repositories/?role=<role>``
-        endpoint on 2026-04-14, so listing repositories now has to be done per
-        workspace.
+        endpoint on 2026-04-14, so listing repositories now has to be done per workspace.
         See https://developer.atlassian.com/cloud/bitbucket/changelog/#CHANGE-3022.
+
+        See https://developer.atlassian.com/cloud/bitbucket/rest/api-group-workspaces/#api-user-workspaces-get.
         """
-        return self.paginate(f"{self.base_api_url}/2.0/user/workspaces/")
+        return (
+            workspace_access["workspace"]
+            for workspace_access in self.paginate(f"{self.base_api_url}/2.0/user/workspaces/")
+        )
 
     def sync_repositories(self):
         """Sync repositories from Bitbucket API, one workspace at a time."""

--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -32,7 +32,7 @@ class BitbucketService(UserService):
     url_pattern = re.compile(r"bitbucket.org")
     https_url_pattern = re.compile(r"^https:\/\/[^@]+@bitbucket.org/")
 
-    def _get_workspaces(self):
+    def _get_workspaces_base(self):
         """
         Paginate the workspaces the user is a member of.
 
@@ -41,6 +41,9 @@ class BitbucketService(UserService):
         See https://developer.atlassian.com/cloud/bitbucket/changelog/#CHANGE-3022.
 
         See https://developer.atlassian.com/cloud/bitbucket/rest/api-group-workspaces/#api-user-workspaces-get.
+
+        NOTE: this endpoint doesn't return all the fields from the workspace object as the repositories endpoint does,
+        if you need more fields, you need to query the workspace endpoint for each workspace slug.
         """
         return (
             workspace_access["workspace"]
@@ -52,7 +55,9 @@ class BitbucketService(UserService):
         remote_ids = []
 
         try:
-            workspace_slugs = [workspace["slug"] for workspace in self._get_workspaces()]
+            workspace_slugs = [
+                workspace_base["slug"] for workspace_base in self._get_workspaces_base()
+            ]
         except (TypeError, ValueError, KeyError):
             log.warning("Error syncing Bitbucket workspaces")
             raise SyncServiceError(
@@ -116,7 +121,10 @@ class BitbucketService(UserService):
         organization_remote_ids = []
 
         try:
-            for workspace in self._get_workspaces():
+            for workspace_base in self._get_workspaces_base():
+                workspace = self.session.get(
+                    f"{self.base_api_url}/2.0/workspaces/{workspace_base['slug']}"
+                ).json()
                 remote_organization = self.create_organization(workspace)
                 remote_organization.get_remote_organization_relation(self.user, self.account)
                 organization_remote_ids.append(remote_organization.remote_id)

--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -32,40 +32,28 @@ class BitbucketService(UserService):
     url_pattern = re.compile(r"bitbucket.org")
     https_url_pattern = re.compile(r"^https:\/\/[^@]+@bitbucket.org/")
 
-    def _get_workspace_slugs(self):
+    def _get_workspaces(self):
         """
-        Return the slugs of the workspaces the user is a member of.
+        Paginate the workspaces the user is a member of.
 
         Bitbucket deprecated the cross-workspace ``/2.0/repositories/?role=<role>``
         endpoint on 2026-04-14, so listing repositories now has to be done per
         workspace. See
         https://developer.atlassian.com/cloud/bitbucket/changelog/#CHANGE-3022.
         """
-        workspaces = self.paginate(
+        return self.paginate(
             f"{self.base_api_url}/2.0/workspaces/",
             role="member",
         )
-        for workspace in workspaces:
-            slug = workspace.get("slug")
-            if slug:
-                yield slug
 
     def sync_repositories(self):
-        """
-        Sync repositories from Bitbucket API.
-
-        Because Bitbucket deprecated the cross-workspace
-        ``/2.0/repositories/?role=<role>`` endpoint, we have to enumerate
-        the user's workspaces first and query each workspace individually.
-        """
+        """Sync repositories from Bitbucket API, one workspace at a time."""
         remote_ids = []
         admin_remote_ids = []
 
         try:
-            workspace_slugs = list(self._get_workspace_slugs())
-        except SyncServiceError:
-            raise
-        except (TypeError, ValueError):
+            workspace_slugs = [workspace["slug"] for workspace in self._get_workspaces()]
+        except (TypeError, ValueError, KeyError):
             log.warning("Error syncing Bitbucket workspaces")
             raise SyncServiceError(
                 SyncServiceError.INVALID_OR_REVOKED_ACCESS_TOKEN.format(
@@ -73,7 +61,6 @@ class BitbucketService(UserService):
                 )
             )
 
-        # Get user repos, iterating over each workspace.
         for workspace_slug in workspace_slugs:
             try:
                 repos = self.paginate(
@@ -84,8 +71,6 @@ class BitbucketService(UserService):
                     remote_repository = self.create_repository(repo)
                     if remote_repository:
                         remote_ids.append(remote_repository.remote_id)
-            except SyncServiceError:
-                raise
             except (TypeError, ValueError):
                 log.warning(
                     "Error syncing Bitbucket repositories for workspace.",
@@ -97,9 +82,8 @@ class BitbucketService(UserService):
                     )
                 )
 
-            # Because privileges aren't returned with repository data, run query
-            # again for repositories that user has admin role for, and update
-            # existing repositories.
+            # Privileges aren't returned with repository data, so we query
+            # again for repositories the user has the admin role on.
             try:
                 admin_repos = self.paginate(
                     f"{self.base_api_url}/2.0/repositories/{workspace_slug}",
@@ -133,15 +117,11 @@ class BitbucketService(UserService):
         organization_remote_ids = []
 
         try:
-            workspaces = self.paginate(
-                f"{self.base_api_url}/2.0/workspaces/",
-                role="member",
-            )
-            for workspace in workspaces:
+            for workspace in self._get_workspaces():
                 remote_organization = self.create_organization(workspace)
                 remote_organization.get_remote_organization_relation(self.user, self.account)
                 organization_remote_ids.append(remote_organization.remote_id)
-        except ValueError:
+        except (TypeError, ValueError):
             log.warning("Error syncing Bitbucket organizations")
             raise SyncServiceError(
                 SyncServiceError.INVALID_OR_REVOKED_ACCESS_TOKEN.format(

--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -32,45 +32,93 @@ class BitbucketService(UserService):
     url_pattern = re.compile(r"bitbucket.org")
     https_url_pattern = re.compile(r"^https:\/\/[^@]+@bitbucket.org/")
 
+    def _get_workspace_slugs(self):
+        """
+        Return the slugs of the workspaces the user is a member of.
+
+        Bitbucket deprecated the cross-workspace ``/2.0/repositories/?role=<role>``
+        endpoint on 2026-04-14, so listing repositories now has to be done per
+        workspace. See
+        https://developer.atlassian.com/cloud/bitbucket/changelog/#CHANGE-3022.
+        """
+        workspaces = self.paginate(
+            f"{self.base_api_url}/2.0/workspaces/",
+            role="member",
+        )
+        for workspace in workspaces:
+            slug = workspace.get("slug")
+            if slug:
+                yield slug
+
     def sync_repositories(self):
-        """Sync repositories from Bitbucket API."""
+        """
+        Sync repositories from Bitbucket API.
+
+        Because Bitbucket deprecated the cross-workspace
+        ``/2.0/repositories/?role=<role>`` endpoint, we have to enumerate
+        the user's workspaces first and query each workspace individually.
+        """
         remote_ids = []
+        admin_remote_ids = []
 
-        # Get user repos
         try:
-            repos = self.paginate(
-                "https://bitbucket.org/api/2.0/repositories/",
-                role="member",
-            )
-            for repo in repos:
-                remote_repository = self.create_repository(repo)
-                if remote_repository:
-                    remote_ids.append(remote_repository.remote_id)
-
+            workspace_slugs = list(self._get_workspace_slugs())
+        except SyncServiceError:
+            raise
         except (TypeError, ValueError):
-            log.warning("Error syncing Bitbucket repositories")
+            log.warning("Error syncing Bitbucket workspaces")
             raise SyncServiceError(
                 SyncServiceError.INVALID_OR_REVOKED_ACCESS_TOKEN.format(
                     provider=self.allauth_provider.name
                 )
             )
 
-        # Because privileges aren't returned with repository data, run query
-        # again for repositories that user has admin role for, and update
-        # existing repositories.
-        try:
-            resp = self.paginate(
-                "https://bitbucket.org/api/2.0/repositories/",
-                role="admin",
-            )
+        # Get user repos, iterating over each workspace.
+        for workspace_slug in workspace_slugs:
+            try:
+                repos = self.paginate(
+                    f"{self.base_api_url}/2.0/repositories/{workspace_slug}",
+                    role="member",
+                )
+                for repo in repos:
+                    remote_repository = self.create_repository(repo)
+                    if remote_repository:
+                        remote_ids.append(remote_repository.remote_id)
+            except SyncServiceError:
+                raise
+            except (TypeError, ValueError):
+                log.warning(
+                    "Error syncing Bitbucket repositories for workspace.",
+                    workspace=workspace_slug,
+                )
+                raise SyncServiceError(
+                    SyncServiceError.INVALID_OR_REVOKED_ACCESS_TOKEN.format(
+                        provider=self.allauth_provider.name
+                    )
+                )
+
+            # Because privileges aren't returned with repository data, run query
+            # again for repositories that user has admin role for, and update
+            # existing repositories.
+            try:
+                admin_repos = self.paginate(
+                    f"{self.base_api_url}/2.0/repositories/{workspace_slug}",
+                    role="admin",
+                )
+                admin_remote_ids.extend(repo["uuid"] for repo in admin_repos)
+            except (TypeError, ValueError):
+                log.warning(
+                    "Error syncing Bitbucket admin repositories for workspace.",
+                    workspace=workspace_slug,
+                )
+
+        if admin_remote_ids:
             RemoteRepositoryRelation.objects.filter(
                 user=self.user,
                 account=self.account,
                 remote_repository__vcs_provider=self.vcs_provider_slug,
-                remote_repository__remote_id__in=[r["uuid"] for r in resp],
+                remote_repository__remote_id__in=admin_remote_ids,
             ).update(admin=True)
-        except (TypeError, ValueError):
-            log.warning("Error syncing Bitbucket admin repositories")
 
         return remote_ids
 
@@ -168,12 +216,28 @@ class BitbucketService(UserService):
         """
         Get a single repository by its remote ID where the user has a specific role.
 
-        Bitbucket doesn't provide an endpoint to get a single repository by its ID (it requires the group ID as well),
-        and it also doesn't return the user's role in the repository, so we filter the repositories by role
-        and then look for the repository with the matching ID.
+        Bitbucket doesn't provide an endpoint to get a single repository by its ID
+        (it requires the workspace as well), and it also doesn't return the user's
+        role in the repository, so we filter the repositories in the workspace by
+        role and then look for the repository with the matching ID.
+
+        The cross-workspace ``/2.0/repositories/?role=<role>`` endpoint was
+        deprecated on 2026-04-14, so we scope the query to the workspace the
+        repository belongs to.
         """
+        # ``full_name`` has the form ``workspace_slug/repo_slug``. Fall back to
+        # the organization slug if ``full_name`` is not available.
+        workspace_slug = None
+        if remote_repository.full_name and "/" in remote_repository.full_name:
+            workspace_slug = remote_repository.full_name.split("/", 1)[0]
+        elif remote_repository.organization:
+            workspace_slug = remote_repository.organization.slug
+
+        if not workspace_slug:
+            return None
+
         repos = self.paginate(
-            f"{self.base_api_url}/2.0/repositories/",
+            f"{self.base_api_url}/2.0/repositories/{workspace_slug}",
             role=role,
             q=f'uuid="{remote_repository.remote_id}"',
         )

--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -212,9 +212,9 @@ class BitbucketService(UserService):
         deprecated on 2026-04-14, so we scope the query to the workspace the
         repository belongs to.
         """
-        for workspace in self._get_workspaces():
+        for workspace_base in self._get_workspaces_base():
             repos = self.paginate(
-                f"{self.base_api_url}/2.0/repositories/{workspace['slug']}",
+                f"{self.base_api_url}/2.0/repositories/{workspace_base['slug']}",
                 role=role,
                 q=f'uuid="{remote_repository.remote_id}"',
             )

--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -38,18 +38,14 @@ class BitbucketService(UserService):
 
         Bitbucket deprecated the cross-workspace ``/2.0/repositories/?role=<role>``
         endpoint on 2026-04-14, so listing repositories now has to be done per
-        workspace. See
-        https://developer.atlassian.com/cloud/bitbucket/changelog/#CHANGE-3022.
+        workspace.
+        See https://developer.atlassian.com/cloud/bitbucket/changelog/#CHANGE-3022.
         """
-        return self.paginate(
-            f"{self.base_api_url}/2.0/workspaces/",
-            role="member",
-        )
+        return self.paginate(f"{self.base_api_url}/2.0/user/workspaces/")
 
     def sync_repositories(self):
         """Sync repositories from Bitbucket API, one workspace at a time."""
         remote_ids = []
-        admin_remote_ids = []
 
         try:
             workspace_slugs = [workspace["slug"] for workspace in self._get_workspaces()]
@@ -89,20 +85,19 @@ class BitbucketService(UserService):
                     f"{self.base_api_url}/2.0/repositories/{workspace_slug}",
                     role="admin",
                 )
-                admin_remote_ids.extend(repo["uuid"] for repo in admin_repos)
+                admin_repos_ids = [repo["uuid"] for repo in admin_repos]
+                if admin_repos_ids:
+                    RemoteRepositoryRelation.objects.filter(
+                        user=self.user,
+                        account=self.account,
+                        remote_repository__vcs_provider=self.vcs_provider_slug,
+                        remote_repository__remote_id__in=admin_repos_ids,
+                    ).update(admin=True)
             except (TypeError, ValueError):
                 log.warning(
                     "Error syncing Bitbucket admin repositories for workspace.",
                     workspace=workspace_slug,
                 )
-
-        if admin_remote_ids:
-            RemoteRepositoryRelation.objects.filter(
-                user=self.user,
-                account=self.account,
-                remote_repository__vcs_provider=self.vcs_provider_slug,
-                remote_repository__remote_id__in=admin_remote_ids,
-            ).update(admin=True)
 
         return remote_ids
 
@@ -205,25 +200,15 @@ class BitbucketService(UserService):
         deprecated on 2026-04-14, so we scope the query to the workspace the
         repository belongs to.
         """
-        # ``full_name`` has the form ``workspace_slug/repo_slug``. Fall back to
-        # the organization slug if ``full_name`` is not available.
-        workspace_slug = None
-        if remote_repository.full_name and "/" in remote_repository.full_name:
-            workspace_slug = remote_repository.full_name.split("/", 1)[0]
-        elif remote_repository.organization:
-            workspace_slug = remote_repository.organization.slug
-
-        if not workspace_slug:
-            return None
-
-        repos = self.paginate(
-            f"{self.base_api_url}/2.0/repositories/{workspace_slug}",
-            role=role,
-            q=f'uuid="{remote_repository.remote_id}"',
-        )
-        for repo in repos:
-            if repo["uuid"] == remote_repository.remote_id:
-                return repo
+        for workspace in self._get_workspaces():
+            repos = self.paginate(
+                f"{self.base_api_url}/2.0/repositories/{workspace['slug']}",
+                role=role,
+                q=f'uuid="{remote_repository.remote_id}"',
+            )
+            for repo in repos:
+                if repo["uuid"] == remote_repository.remote_id:
+                    return repo
         return None
 
     def _update_repository_from_fields(self, repo, fields):

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -2560,8 +2560,14 @@ class BitbucketOAuthTests(TestCase):
         )
         assert not remote_repo.users.filter(id=self.user.id).exists()
 
-        request.get(f"https://api.bitbucket.org/2.0/repositories/?role=admin", json={"values": [self.repo_response_data]})
-        request.get(f"https://api.bitbucket.org/2.0/repositories/?role=member", json={"values": [self.repo_response_data]})
+        request.get(
+            "https://api.bitbucket.org/2.0/repositories/testuser?role=admin",
+            json={"values": [self.repo_response_data]},
+        )
+        request.get(
+            "https://api.bitbucket.org/2.0/repositories/testuser?role=member",
+            json={"values": [self.repo_response_data]},
+        )
         self.service.update_repository(remote_repo)
         remote_repo.refresh_from_db()
 
@@ -2590,8 +2596,14 @@ class BitbucketOAuthTests(TestCase):
         )
         assert remote_repo.users.filter(id=self.user.id).exists()
 
-        request.get(f"https://api.bitbucket.org/2.0/repositories/?role=admin", json={"values": []})
-        request.get(f"https://api.bitbucket.org/2.0/repositories/?role=member", json={"values": []})
+        request.get(
+            "https://api.bitbucket.org/2.0/repositories/testuser?role=admin",
+            json={"values": []},
+        )
+        request.get(
+            "https://api.bitbucket.org/2.0/repositories/testuser?role=member",
+            json={"values": []},
+        )
         self.service.update_repository(remote_repo)
         remote_repo.refresh_from_db()
 

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -2703,27 +2703,6 @@ class BitbucketOAuthTests(TestCase):
             self.service.sync_repositories()
 
     @requests_mock.Mocker(kw="request")
-    def test_sync_repositories_skips_workspaces_without_slug(self, request):
-        """Workspaces missing a slug are ignored instead of crashing the sync."""
-        good_workspace = self._make_workspace_response("workspace-a", "{uuid-a}")
-        bad_workspace = self._make_workspace_response("ignored", "{uuid-bad}")
-        bad_workspace.pop("slug")
-        repo = self._make_repo_response("workspace-a", "repo", "{repo}")
-
-        request.get(
-            "https://api.bitbucket.org/2.0/workspaces/",
-            json={"values": [bad_workspace, good_workspace]},
-        )
-        request.get(
-            "https://api.bitbucket.org/2.0/repositories/workspace-a",
-            json={"values": [repo]},
-        )
-
-        remote_ids = self.service.sync_repositories()
-
-        assert remote_ids == ["{repo}"]
-
-    @requests_mock.Mocker(kw="request")
     def test_update_repository_uses_workspace_scoped_endpoint(self, request):
         """``update_repository`` must hit the per-workspace URL, not the deprecated one."""
         remote_repo = get(

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -2550,6 +2550,204 @@ class BitbucketOAuthTests(TestCase):
         assert relationship.user == self.user
         assert relationship.account == self.service.account
 
+    def _make_workspace_response(self, slug, uuid):
+        """Build a minimal workspace payload returned by the /2.0/workspaces/ endpoint."""
+        return {
+            "slug": slug,
+            "name": slug.title(),
+            "uuid": uuid,
+            "type": "workspace",
+            "is_private": True,
+            "links": {
+                "self": {"href": f"https://api.bitbucket.org/2.0/workspaces/{slug}"},
+                "html": {"href": f"https://bitbucket.org/{slug}"},
+                "avatar": {"href": f"https://bitbucket.org/{slug}/avatar"},
+            },
+        }
+
+    def _make_repo_response(self, workspace_slug, name, uuid):
+        """Build a minimal repository payload returned by the /2.0/repositories/ endpoint."""
+        workspace = self._make_workspace_response(workspace_slug, f"{{ws-{workspace_slug}}}")
+        return {
+            "scm": "git",
+            "uuid": uuid,
+            "name": name,
+            "full_name": f"{workspace_slug}/{name}",
+            "description": f"Repository {name}",
+            "is_private": False,
+            "workspace": workspace,
+            "mainbranch": {"type": "branch", "name": "main"},
+            "links": {
+                "html": {"href": f"https://bitbucket.org/{workspace_slug}/{name}"},
+                "avatar": {"href": ""},
+                "clone": [
+                    {
+                        "href": f"https://bitbucket.org/{workspace_slug}/{name}.git",
+                        "name": "https",
+                    },
+                    {
+                        "href": f"git@bitbucket.org:{workspace_slug}/{name}.git",
+                        "name": "ssh",
+                    },
+                ],
+            },
+        }
+
+    @requests_mock.Mocker(kw="request")
+    def test_sync_repositories_iterates_workspaces(self, request):
+        """
+        sync_repositories must query each workspace individually.
+
+        The cross-workspace ``/2.0/repositories/?role=<role>`` endpoint was
+        deprecated by Bitbucket on 2026-04-14, so the sync must enumerate
+        workspaces first and hit ``/2.0/repositories/{workspace}`` per workspace.
+        """
+        workspace_a = self._make_workspace_response("workspace-a", "{uuid-a}")
+        workspace_b = self._make_workspace_response("workspace-b", "{uuid-b}")
+        repo_a = self._make_repo_response("workspace-a", "repo-a", "{repo-a}")
+        repo_b = self._make_repo_response("workspace-b", "repo-b", "{repo-b}")
+
+        request.get(
+            "https://api.bitbucket.org/2.0/workspaces/",
+            json={"values": [workspace_a, workspace_b]},
+        )
+        request.get(
+            "https://api.bitbucket.org/2.0/repositories/workspace-a",
+            json={"values": [repo_a]},
+        )
+        request.get(
+            "https://api.bitbucket.org/2.0/repositories/workspace-b",
+            json={"values": [repo_b]},
+        )
+
+        remote_ids = self.service.sync_repositories()
+
+        assert sorted(remote_ids) == ["{repo-a}", "{repo-b}"]
+        assert RemoteRepository.objects.filter(
+            vcs_provider=BITBUCKET, remote_id="{repo-a}"
+        ).exists()
+        assert RemoteRepository.objects.filter(
+            vcs_provider=BITBUCKET, remote_id="{repo-b}"
+        ).exists()
+
+        # Ensure the deprecated cross-workspace endpoint is never hit.
+        for req in request.request_history:
+            assert req.path != "/2.0/repositories/", (
+                "sync_repositories must not call the deprecated "
+                "cross-workspace /2.0/repositories/ endpoint"
+            )
+
+    @requests_mock.Mocker(kw="request")
+    def test_sync_repositories_sets_admin_flag_per_workspace(self, request):
+        """Repositories returned by the ``role=admin`` query get admin=True."""
+        workspace = self._make_workspace_response("workspace-a", "{uuid-a}")
+        admin_repo = self._make_repo_response("workspace-a", "admin-repo", "{repo-admin}")
+        member_repo = self._make_repo_response("workspace-a", "member-repo", "{repo-member}")
+
+        request.get(
+            "https://api.bitbucket.org/2.0/workspaces/",
+            json={"values": [workspace]},
+        )
+        # ``?role=admin`` returns the admin-accessible repo, ``?role=member``
+        # returns every repo the user can see.
+        request.get(
+            "https://api.bitbucket.org/2.0/repositories/workspace-a?role=admin",
+            json={"values": [admin_repo]},
+        )
+        request.get(
+            "https://api.bitbucket.org/2.0/repositories/workspace-a?role=member",
+            json={"values": [admin_repo, member_repo]},
+        )
+
+        remote_ids = self.service.sync_repositories()
+
+        assert sorted(remote_ids) == ["{repo-admin}", "{repo-member}"]
+
+        admin_relation = RemoteRepositoryRelation.objects.get(
+            user=self.user,
+            account=self.social_account,
+            remote_repository__remote_id="{repo-admin}",
+        )
+        member_relation = RemoteRepositoryRelation.objects.get(
+            user=self.user,
+            account=self.social_account,
+            remote_repository__remote_id="{repo-member}",
+        )
+        assert admin_relation.admin is True
+        assert member_relation.admin is False
+
+    @requests_mock.Mocker(kw="request")
+    def test_sync_repositories_no_workspaces(self, request):
+        """A user with no workspaces returns an empty list without API errors."""
+        request.get(
+            "https://api.bitbucket.org/2.0/workspaces/",
+            json={"values": []},
+        )
+
+        remote_ids = self.service.sync_repositories()
+
+        assert remote_ids == []
+        # Only the workspaces endpoint should have been called.
+        assert [req.path for req in request.request_history] == ["/2.0/workspaces/"]
+
+    @requests_mock.Mocker(kw="request")
+    def test_sync_repositories_invalid_token_raises(self, request):
+        """A 401 from Bitbucket maps to ``SyncServiceError``."""
+        request.get(
+            "https://api.bitbucket.org/2.0/workspaces/",
+            status_code=401,
+            json={"error": {"message": "Unauthorized"}},
+        )
+
+        with self.assertRaises(SyncServiceError):
+            self.service.sync_repositories()
+
+    @requests_mock.Mocker(kw="request")
+    def test_sync_repositories_skips_workspaces_without_slug(self, request):
+        """Workspaces missing a slug are ignored instead of crashing the sync."""
+        good_workspace = self._make_workspace_response("workspace-a", "{uuid-a}")
+        bad_workspace = self._make_workspace_response("ignored", "{uuid-bad}")
+        bad_workspace.pop("slug")
+        repo = self._make_repo_response("workspace-a", "repo", "{repo}")
+
+        request.get(
+            "https://api.bitbucket.org/2.0/workspaces/",
+            json={"values": [bad_workspace, good_workspace]},
+        )
+        request.get(
+            "https://api.bitbucket.org/2.0/repositories/workspace-a",
+            json={"values": [repo]},
+        )
+
+        remote_ids = self.service.sync_repositories()
+
+        assert remote_ids == ["{repo}"]
+
+    @requests_mock.Mocker(kw="request")
+    def test_update_repository_uses_workspace_scoped_endpoint(self, request):
+        """``update_repository`` must hit the per-workspace URL, not the deprecated one."""
+        remote_repo = get(
+            RemoteRepository,
+            vcs_provider=BITBUCKET,
+            full_name="tutorials/tutorials.bitbucket.org",
+            remote_id=self.repo_response_data["uuid"],
+        )
+        request.get(
+            "https://api.bitbucket.org/2.0/repositories/tutorials?role=admin",
+            json={"values": [self.repo_response_data]},
+        )
+        request.get(
+            "https://api.bitbucket.org/2.0/repositories/tutorials?role=member",
+            json={"values": [self.repo_response_data]},
+        )
+
+        self.service.update_repository(remote_repo)
+
+        called_paths = {req.path for req in request.request_history}
+        assert called_paths == {"/2.0/repositories/tutorials"}
+        # Specifically, the deprecated cross-workspace path must not be called.
+        assert "/2.0/repositories/" not in called_paths
+
     @requests_mock.Mocker(kw="request")
     def test_update_remote_repository(self, request):
         remote_repo = get(

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -2608,7 +2608,7 @@ class BitbucketOAuthTests(TestCase):
         repo_b = self._make_repo_response("workspace-b", "repo-b", "{repo-b}")
 
         request.get(
-            "https://api.bitbucket.org/2.0/workspaces/",
+            "https://api.bitbucket.org/2.0/user/workspaces/",
             json={"values": [workspace_a, workspace_b]},
         )
         request.get(
@@ -2645,7 +2645,7 @@ class BitbucketOAuthTests(TestCase):
         member_repo = self._make_repo_response("workspace-a", "member-repo", "{repo-member}")
 
         request.get(
-            "https://api.bitbucket.org/2.0/workspaces/",
+            "https://api.bitbucket.org/2.0/user/workspaces/",
             json={"values": [workspace]},
         )
         # ``?role=admin`` returns the admin-accessible repo, ``?role=member``
@@ -2680,7 +2680,7 @@ class BitbucketOAuthTests(TestCase):
     def test_sync_repositories_no_workspaces(self, request):
         """A user with no workspaces returns an empty list without API errors."""
         request.get(
-            "https://api.bitbucket.org/2.0/workspaces/",
+            "https://api.bitbucket.org/2.0/user/workspaces/",
             json={"values": []},
         )
 
@@ -2688,44 +2688,19 @@ class BitbucketOAuthTests(TestCase):
 
         assert remote_ids == []
         # Only the workspaces endpoint should have been called.
-        assert [req.path for req in request.request_history] == ["/2.0/workspaces/"]
+        assert [req.path for req in request.request_history] == ["/2.0/user/workspaces/"]
 
     @requests_mock.Mocker(kw="request")
     def test_sync_repositories_invalid_token_raises(self, request):
         """A 401 from Bitbucket maps to ``SyncServiceError``."""
         request.get(
-            "https://api.bitbucket.org/2.0/workspaces/",
+            "https://api.bitbucket.org/2.0/user/workspaces/",
             status_code=401,
             json={"error": {"message": "Unauthorized"}},
         )
 
         with self.assertRaises(SyncServiceError):
             self.service.sync_repositories()
-
-    @requests_mock.Mocker(kw="request")
-    def test_update_repository_uses_workspace_scoped_endpoint(self, request):
-        """``update_repository`` must hit the per-workspace URL, not the deprecated one."""
-        remote_repo = get(
-            RemoteRepository,
-            vcs_provider=BITBUCKET,
-            full_name="tutorials/tutorials.bitbucket.org",
-            remote_id=self.repo_response_data["uuid"],
-        )
-        request.get(
-            "https://api.bitbucket.org/2.0/repositories/tutorials?role=admin",
-            json={"values": [self.repo_response_data]},
-        )
-        request.get(
-            "https://api.bitbucket.org/2.0/repositories/tutorials?role=member",
-            json={"values": [self.repo_response_data]},
-        )
-
-        self.service.update_repository(remote_repo)
-
-        called_paths = {req.path for req in request.request_history}
-        assert called_paths == {"/2.0/repositories/tutorials"}
-        # Specifically, the deprecated cross-workspace path must not be called.
-        assert "/2.0/repositories/" not in called_paths
 
     @requests_mock.Mocker(kw="request")
     def test_update_remote_repository(self, request):
@@ -2736,7 +2711,10 @@ class BitbucketOAuthTests(TestCase):
             remote_id=self.repo_response_data["uuid"],
         )
         assert not remote_repo.users.filter(id=self.user.id).exists()
-
+        request.get(
+            "https://api.bitbucket.org/2.0/user/workspaces/",
+            json={"values": [self._make_workspace_response("testuser", "{uuid-a}")]},
+        )
         request.get(
             "https://api.bitbucket.org/2.0/repositories/testuser?role=admin",
             json={"values": [self.repo_response_data]},
@@ -2773,6 +2751,10 @@ class BitbucketOAuthTests(TestCase):
         )
         assert remote_repo.users.filter(id=self.user.id).exists()
 
+        request.get(
+            "https://api.bitbucket.org/2.0/user/workspaces/",
+            json={"values": [self._make_workspace_response("testuser", "{uuid-a}")]},
+        )
         request.get(
             "https://api.bitbucket.org/2.0/repositories/testuser?role=admin",
             json={"values": []},

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -2550,6 +2550,14 @@ class BitbucketOAuthTests(TestCase):
         assert relationship.user == self.user
         assert relationship.account == self.service.account
 
+    def _make_workspace_access_response(self, slug, uuid):
+        """Build a minimal workspace access payload returned by the /2.0/user/workspaces/ endpoint."""
+        return {
+            "type": "workspace_access",
+            "administrator": True,
+            "workspace": self._make_workspace_response(slug, uuid),
+        }
+
     def _make_workspace_response(self, slug, uuid):
         """Build a minimal workspace payload returned by the /2.0/workspaces/ endpoint."""
         return {
@@ -2602,8 +2610,8 @@ class BitbucketOAuthTests(TestCase):
         deprecated by Bitbucket on 2026-04-14, so the sync must enumerate
         workspaces first and hit ``/2.0/repositories/{workspace}`` per workspace.
         """
-        workspace_a = self._make_workspace_response("workspace-a", "{uuid-a}")
-        workspace_b = self._make_workspace_response("workspace-b", "{uuid-b}")
+        workspace_a = self._make_workspace_access_response("workspace-a", "{uuid-a}")
+        workspace_b = self._make_workspace_access_response("workspace-b", "{uuid-b}")
         repo_a = self._make_repo_response("workspace-a", "repo-a", "{repo-a}")
         repo_b = self._make_repo_response("workspace-b", "repo-b", "{repo-b}")
 
@@ -2640,7 +2648,7 @@ class BitbucketOAuthTests(TestCase):
     @requests_mock.Mocker(kw="request")
     def test_sync_repositories_sets_admin_flag_per_workspace(self, request):
         """Repositories returned by the ``role=admin`` query get admin=True."""
-        workspace = self._make_workspace_response("workspace-a", "{uuid-a}")
+        workspace = self._make_workspace_access_response("workspace-a", "{uuid-a}")
         admin_repo = self._make_repo_response("workspace-a", "admin-repo", "{repo-admin}")
         member_repo = self._make_repo_response("workspace-a", "member-repo", "{repo-member}")
 
@@ -2713,7 +2721,7 @@ class BitbucketOAuthTests(TestCase):
         assert not remote_repo.users.filter(id=self.user.id).exists()
         request.get(
             "https://api.bitbucket.org/2.0/user/workspaces/",
-            json={"values": [self._make_workspace_response("testuser", "{uuid-a}")]},
+            json={"values": [self._make_workspace_access_response("testuser", "{uuid-a}")]},
         )
         request.get(
             "https://api.bitbucket.org/2.0/repositories/testuser?role=admin",
@@ -2753,7 +2761,7 @@ class BitbucketOAuthTests(TestCase):
 
         request.get(
             "https://api.bitbucket.org/2.0/user/workspaces/",
-            json={"values": [self._make_workspace_response("testuser", "{uuid-a}")]},
+            json={"values": [self._make_workspace_access_response("testuser", "{uuid-a}")]},
         )
         request.get(
             "https://api.bitbucket.org/2.0/repositories/testuser?role=admin",

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -2555,7 +2555,15 @@ class BitbucketOAuthTests(TestCase):
         return {
             "type": "workspace_access",
             "administrator": True,
-            "workspace": self._make_workspace_response(slug, uuid),
+            "workspace": {
+                "type": "workspace_base",
+                "slug": slug,
+                "uuid": uuid,
+                "links": {
+                    "self": {"href": f"https://api.bitbucket.org/2.0/workspaces/{slug}"},
+                    "avatar": {"href": f"https://bitbucket.org/{slug}/avatar"},
+                },
+            }
         }
 
     def _make_workspace_response(self, slug, uuid):
@@ -2565,7 +2573,6 @@ class BitbucketOAuthTests(TestCase):
             "name": slug.title(),
             "uuid": uuid,
             "type": "workspace",
-            "is_private": True,
             "links": {
                 "self": {"href": f"https://api.bitbucket.org/2.0/workspaces/{slug}"},
                 "html": {"href": f"https://bitbucket.org/{slug}"},


### PR DESCRIPTION
## Summary

Bitbucket deprecated the cross-workspace `/2.0/repositories/?role=<role>` endpoint on 2026-04-14 ([CHANGE-3022](https://developer.atlassian.com/cloud/bitbucket/changelog/#CHANGE-3022)), which broke `BitbucketService.sync_repositories` and made repositories disappear from the dashboard for commercial users.

The fix enumerates the user's workspaces first (via `/2.0/workspaces/?role=member`) and then queries `/2.0/repositories/{workspace}` per workspace for both `role=member` and `role=admin`. `_get_repository` (used by `update_repository`) is updated in the same way, deriving the workspace slug from `RemoteRepository.full_name` with a fallback to `organization.slug`.

Tests cover:
- iterating multiple workspaces and aggregating results
- admin-flag assignment per workspace
- empty-workspace and invalid-token (401) paths
- workspaces missing a `slug` being skipped
- `update_repository` hitting the workspace-scoped URL and never the deprecated path

---

_This PR was generated by AI (Claude)._