### PR TITLE
Bitbucket: migrate OAuth sync off removed cross-workspace APIs

### DIFF
--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -35,19 +35,27 @@ class BitbucketService(UserService):
     def sync_repositories(self):
         """Sync repositories from Bitbucket API."""
         remote_ids = []
+        workspace_slugs = []
 
-        # Get user repos
+        # The cross-workspace repositories endpoint was removed.
+        # List workspaces available to the user and fetch repositories per workspace.
         try:
-            repos = self.paginate(
-                "https://bitbucket.org/api/2.0/repositories/",
-                role="member",
+            workspaces = self.paginate(
+                f"{self.base_api_url}/2.0/user/workspaces",
             )
-            for repo in repos:
-                remote_repository = self.create_repository(repo)
-                if remote_repository:
-                    remote_ids.append(remote_repository.remote_id)
+            workspace_slugs = [w["workspace"]["slug"] for w in workspaces]
 
-        except (TypeError, ValueError):
+            for workspace_slug in workspace_slugs:
+                repos = self.paginate(
+                    f"{self.base_api_url}/2.0/repositories/{workspace_slug}",
+                    role="member",
+                )
+                for repo in repos:
+                    remote_repository = self.create_repository(repo)
+                    if remote_repository:
+                        remote_ids.append(remote_repository.remote_id)
+
+        except (KeyError, TypeError, ValueError):
             log.warning("Error syncing Bitbucket repositories")
             raise SyncServiceError(
                 SyncServiceError.INVALID_OR_REVOKED_ACCESS_TOKEN.format(
@@ -59,17 +67,21 @@ class BitbucketService(UserService):
         # again for repositories that user has admin role for, and update
         # existing repositories.
         try:
-            resp = self.paginate(
-                "https://bitbucket.org/api/2.0/repositories/",
-                role="admin",
-            )
+            admin_repository_ids = []
+            for workspace_slug in workspace_slugs:
+                repos = self.paginate(
+                    f"{self.base_api_url}/2.0/repositories/{workspace_slug}",
+                    role="admin",
+                )
+                admin_repository_ids.extend([repo["uuid"] for repo in repos])
+
             RemoteRepositoryRelation.objects.filter(
                 user=self.user,
                 account=self.account,
                 remote_repository__vcs_provider=self.vcs_provider_slug,
-                remote_repository__remote_id__in=[r["uuid"] for r in resp],
+                remote_repository__remote_id__in=admin_repository_ids,
             ).update(admin=True)
-        except (TypeError, ValueError):
+        except (KeyError, TypeError, ValueError):
             log.warning("Error syncing Bitbucket admin repositories")
 
         return remote_ids
@@ -85,15 +97,22 @@ class BitbucketService(UserService):
         organization_remote_ids = []
 
         try:
-            workspaces = self.paginate(
-                f"{self.base_api_url}/2.0/workspaces/",
-                role="member",
+            workspace_accesses = self.paginate(
+                f"{self.base_api_url}/2.0/user/workspaces",
             )
-            for workspace in workspaces:
+            for workspace_access in workspace_accesses:
+                workspace_slug = workspace_access["workspace"]["slug"]
+                workspace_response = self.session.get(
+                    f"{self.base_api_url}/2.0/workspaces/{workspace_slug}",
+                )
+                if workspace_response.status_code != 200:
+                    continue
+
+                workspace = workspace_response.json()
                 remote_organization = self.create_organization(workspace)
                 remote_organization.get_remote_organization_relation(self.user, self.account)
                 organization_remote_ids.append(remote_organization.remote_id)
-        except ValueError:
+        except (KeyError, TypeError, ValueError):
             log.warning("Error syncing Bitbucket organizations")
             raise SyncServiceError(
                 SyncServiceError.INVALID_OR_REVOKED_ACCESS_TOKEN.format(
@@ -172,8 +191,18 @@ class BitbucketService(UserService):
         and it also doesn't return the user's role in the repository, so we filter the repositories by role
         and then look for the repository with the matching ID.
         """
+        workspace_slug = None
+        if remote_repository.organization:
+            workspace_slug = remote_repository.organization.slug
+
+        if not workspace_slug and remote_repository.full_name:
+            workspace_slug = remote_repository.full_name.split("/", 1)[0]
+
+        if not workspace_slug:
+            return None
+
         repos = self.paginate(
-            f"{self.base_api_url}/2.0/repositories/",
+            f"{self.base_api_url}/2.0/repositories/{workspace_slug}",
             role=role,
             q=f'uuid="{remote_repository.remote_id}"',
         )

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -2560,8 +2560,10 @@ class BitbucketOAuthTests(TestCase):
         )
         assert not remote_repo.users.filter(id=self.user.id).exists()
 
-        request.get(f"https://api.bitbucket.org/2.0/repositories/?role=admin", json={"values": [self.repo_response_data]})
-        request.get(f"https://api.bitbucket.org/2.0/repositories/?role=member", json={"values": [self.repo_response_data]})
+        request.get(
+            "https://api.bitbucket.org/2.0/repositories/testuser",
+            json={"values": [self.repo_response_data]},
+        )
         self.service.update_repository(remote_repo)
         remote_repo.refresh_from_db()
 
@@ -2590,8 +2592,10 @@ class BitbucketOAuthTests(TestCase):
         )
         assert remote_repo.users.filter(id=self.user.id).exists()
 
-        request.get(f"https://api.bitbucket.org/2.0/repositories/?role=admin", json={"values": []})
-        request.get(f"https://api.bitbucket.org/2.0/repositories/?role=member", json={"values": []})
+        request.get(
+            "https://api.bitbucket.org/2.0/repositories/testuser",
+            json={"values": []},
+        )
         self.service.update_repository(remote_repo)
         remote_repo.refresh_from_db()
 


### PR DESCRIPTION
## Summary
Bitbucket removed cross-workspace listing APIs on Apr 14, 2026 (CHANGE-2770), which breaks Bitbucket repository/org syncing.

This updates `BitbucketService` to use workspace-scoped endpoints:
- `GET /2.0/user/workspaces`
- `GET /2.0/repositories/{workspace}` (member/admin passes)
- `GET /2.0/workspaces/{workspace}` for full org metadata

## Changes
- `sync_repositories` now:
  - lists accessible workspaces via `/2.0/user/workspaces`
  - iterates repositories per workspace for `role=member`
  - iterates repositories per workspace for `role=admin` to update relation admin flag
- `sync_organizations` now:
  - reads from `/2.0/user/workspaces`
  - fetches full workspace payload from `/2.0/workspaces/{slug}` before calling `create_organization`
- `_get_repository` now:
  - queries `/2.0/repositories/{workspace}` instead of removed global endpoint
  - falls back to `full_name` owner when organization relation is missing

## Tests
- Updated Bitbucket OAuth tests that mocked the removed global endpoint to workspace-scoped repository URLs.

## Validation
- `python -m compileall readthedocs/oauth/services/bitbucket.py readthedocs/rtd_tests/tests/test_oauth.py`

`pytest` is not available in this environment, so I couldn't run the full test suite locally.
