### PR TITLE
builds: skip PR comment creation on closed/merged external versions

### DIFF
--- a/readthedocs/oauth/services/githubapp.py
+++ b/readthedocs/oauth/services/githubapp.py
@@ -544,6 +544,19 @@ class GitHubAppService(Service):
         # since we only need the object to interact with the commit status API.
         gh_repo = self.installation_client.get_repo(int(remote_repo.remote_id), lazy=True)
         gh_pull = gh_repo.get_pull(int(version.verbose_name))
+
+        # Don't create new comments on pull requests that have already been
+        # closed or merged. Existing comments can still be updated to reflect
+        # the final build state.
+        if gh_pull.state != "open" and create_new:
+            log.debug(
+                "Pull request is closed or merged, skipping new comment.",
+                project=project.slug,
+                build=build.pk,
+                pr_state=gh_pull.state,
+            )
+            create_new = False
+
         existing_gh_comment = None
         comment_marker = f"<!-- readthedocs-{project.pk} -->"
         for gh_comment in gh_pull.get_issue_comments():

--- a/readthedocs/oauth/services/githubapp.py
+++ b/readthedocs/oauth/services/githubapp.py
@@ -545,17 +545,14 @@ class GitHubAppService(Service):
         gh_repo = self.installation_client.get_repo(int(remote_repo.remote_id), lazy=True)
         gh_pull = gh_repo.get_pull(int(version.verbose_name))
 
-        # Don't create new comments on pull requests that have already been
-        # closed or merged. Existing comments can still be updated to reflect
-        # the final build state.
-        if gh_pull.state != "open" and create_new:
-            log.debug(
-                "Pull request is closed or merged, skipping new comment.",
+        if gh_pull.state != "open":
+            log.info(
+                "Pull request is closed or merged, skipping comment.",
                 project=project.slug,
                 build=build.pk,
                 pr_state=gh_pull.state,
             )
-            create_new = False
+            return
 
         existing_gh_comment = None
         comment_marker = f"<!-- readthedocs-{project.pk} -->"

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -1254,6 +1254,72 @@ class GitHubAppTests(TestCase):
             "body": f"<!-- readthedocs-{self.project.id} -->\nComment!",
         }
 
+    @requests_mock.Mocker(kw="request")
+    def test_post_comment_skip_new_comment_on_closed_pr(self, request):
+        version = get(
+            Version,
+            verbose_name="1234",
+            project=self.project,
+            type=EXTERNAL,
+        )
+        build = get(
+            Build,
+            project=self.project,
+            version=version,
+        )
+
+        request.post(
+            f"{self.api_url}/app/installations/1111/access_tokens",
+            json=self._get_access_token_json(),
+        )
+        request.get(
+            f"{self.api_url}/repositories/{self.remote_repository.remote_id}/pulls/{version.verbose_name}",
+            json=self._get_pull_request_json(
+                number=int(version.verbose_name),
+                repo_full_name=self.remote_repository.full_name,
+                state="closed",
+            ),
+        )
+        request.get(
+            f"{self.api_url}/repos/{self.remote_repository.full_name}/issues/{version.verbose_name}/comments",
+            json=[],
+        )
+        request_post_comment = request.post(
+            f"{self.api_url}/repos/{self.remote_repository.full_name}/issues/{version.verbose_name}/comments",
+        )
+
+        service = self.installation.service
+
+        # The PR is closed and there is no existing comment, so no new
+        # comment should be created.
+        service.post_comment(build, "Comment!")
+        assert not request_post_comment.called
+
+        # An existing bot comment can still be updated on a closed PR.
+        request.get(
+            f"{self.api_url}/repos/{self.remote_repository.full_name}/issues/{version.verbose_name}/comments",
+            json=[
+                self._get_comment_json(
+                    id=1,
+                    issue_number=int(version.verbose_name),
+                    repo_full_name=self.remote_repository.full_name,
+                    user={"login": f"{settings.GITHUB_APP_NAME}[bot]"},
+                    body=f"<!-- readthedocs-{self.project.id} -->\nOld comment!",
+                ),
+            ],
+        )
+        request_patch_comment = request.patch(
+            f"{self.api_url}/repos/{self.remote_repository.full_name}/issues/comments/1",
+            json={},
+        )
+
+        service.post_comment(build, "Updated comment!")
+        assert not request_post_comment.called
+        assert request_patch_comment.called
+        assert request_patch_comment.last_request.json() == {
+            "body": f"<!-- readthedocs-{self.project.id} -->\nUpdated comment!",
+        }
+
     def test_integration_attributes(self):
         assert self.integration.is_active
         assert self.integration.get_absolute_url() == "https://github.com/apps/readthedocs/installations/1111"

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -1255,7 +1255,7 @@ class GitHubAppTests(TestCase):
         }
 
     @requests_mock.Mocker(kw="request")
-    def test_post_comment_skip_new_comment_on_closed_pr(self, request):
+    def test_post_comment_skip_on_closed_pr(self, request):
         version = get(
             Version,
             verbose_name="1234",
@@ -1280,45 +1280,14 @@ class GitHubAppTests(TestCase):
                 state="closed",
             ),
         )
-        request.get(
-            f"{self.api_url}/repos/{self.remote_repository.full_name}/issues/{version.verbose_name}/comments",
-            json=[],
-        )
         request_post_comment = request.post(
             f"{self.api_url}/repos/{self.remote_repository.full_name}/issues/{version.verbose_name}/comments",
         )
 
         service = self.installation.service
 
-        # The PR is closed and there is no existing comment, so no new
-        # comment should be created.
         service.post_comment(build, "Comment!")
         assert not request_post_comment.called
-
-        # An existing bot comment can still be updated on a closed PR.
-        request.get(
-            f"{self.api_url}/repos/{self.remote_repository.full_name}/issues/{version.verbose_name}/comments",
-            json=[
-                self._get_comment_json(
-                    id=1,
-                    issue_number=int(version.verbose_name),
-                    repo_full_name=self.remote_repository.full_name,
-                    user={"login": f"{settings.GITHUB_APP_NAME}[bot]"},
-                    body=f"<!-- readthedocs-{self.project.id} -->\nOld comment!",
-                ),
-            ],
-        )
-        request_patch_comment = request.patch(
-            f"{self.api_url}/repos/{self.remote_repository.full_name}/issues/comments/1",
-            json={},
-        )
-
-        service.post_comment(build, "Updated comment!")
-        assert not request_post_comment.called
-        assert request_patch_comment.called
-        assert request_patch_comment.last_request.json() == {
-            "body": f"<!-- readthedocs-{self.project.id} -->\nUpdated comment!",
-        }
 
     def test_integration_attributes(self):
         assert self.integration.is_active


### PR DESCRIPTION
## Summary

When a build finishes for an external version whose pull request is already closed or merged, skip the PR comment entirely. Previously a build finishing after the PR closed would still create a new bot comment on the closed PR.

- Early-return in `GitHubAppService.post_pull_request_comment` when `gh_pull.state != "open"`, so neither new comments are created nor existing comments updated.
- Logs at `info` level for visibility.

Generated by AI.