### PR TITLE
celery: Reduce revoked task set to mitigate pidbox reply bloat

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -666,6 +666,14 @@ class CommunityBaseSettings(Settings):
     CELERY_WORKER_PREFETCH_MULTIPLIER = 1
     CELERY_TASK_CREATE_MISSING_QUEUES = True
 
+    # Reduce the max number of revoked task IDs kept in memory from the
+    # default of 50,000 to 2,000. Each worker syncs its full revoked set via
+    # pidbox "hello" replies during mingle (worker startup), and with
+    # aggressive build cancellation the default limit produces ~6 MB reply
+    # messages that leak in Redis with TTL=-1.
+    # See https://github.com/celery/celery/issues/6089
+    CELERY_WORKER_REVOKES_MAX = 2000
+
     # https://github.com/readthedocs/readthedocs.org/issues/12317#issuecomment-3070950434
     # https://docs.celeryq.dev/en/stable/getting-started/backends-and-brokers/redis.html#visibility-timeout
     CELERY_BROKER_TRANSPORT_OPTIONS = {


### PR DESCRIPTION
## Summary

Lower `CELERY_WORKER_REVOKES_MAX` from the default 50,000 to 2,000 to reduce the size of pidbox reply messages that leak in Redis with `TTL=-1`.

## Investigation context

We are seeing `reply.celery.pidbox` keys in Redis at ~6 MB each. Tracing through the Celery/Kombu source reveals the most likely cause:

1. **RTD aggressively revokes builds** -- `cancel_build()` calls `app.control.revoke()` every time a new push arrives for a version with running builds. Each revoke adds a UUID to the worker in-memory `revoked` LimitedSet.
2. **The default limit is 50,000 entries** (`CELERY_WORKER_REVOKES_MAX`), expiring after 3 hours.
3. **Every new worker startup triggers mingle** -- the `Mingle` bootstep broadcasts a `hello` command to all existing workers, and each replies with its **entire `revoked._data` dict** (up to 50k UUIDs).
4. **50,000 UUIDs x ~36 bytes + serialization overhead = 3-6 MB per reply.**
5. These reply keys are written to Redis with `TTL=-1` (upstream bug: [celery/celery#6089](https://github.com/celery/celery/issues/6089)), so they accumulate until our `cleanup_pidbox_keys` task cleans them up every 15 minutes.

With autoscaling or frequent deploys, new workers are created often, each triggering a round of multi-MB hello replies from every existing worker.

### Why task arguments are not the issue

The other potential source of large pidbox replies would be `inspect().active()` / `inspect().reserved()`, which serialize full task `args`/`kwargs` via `Request.info()`. However, RTD task arguments are small (integer PKs, short strings, API keys), so this is not the bloat source here.

### What this PR changes

Reduces `CELERY_WORKER_REVOKES_MAX` to 2,000. RTD revocations are short-lived build cancellations -- there is no need to retain 50k revoked IDs. This should bring hello replies down from ~6 MB to ~250 KB.

### Alternative/additional options to consider

- **Disable mingle** (`--without-mingle` worker flag) if revoke sync across workers is not needed
- **Set `CELERY_WORKER_REVOKE_EXPIRES`** to a shorter window (default is 3 hours)

---

*Made by AI*