### PR TITLE
Automation rules: update migrations to fix issues

### DIFF
--- a/readthedocs/builds/migrations/0071_alter_automationrulematch_rule_and_more.py
+++ b/readthedocs/builds/migrations/0071_alter_automationrulematch_rule_and_more.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("builds", "0070_delete_build_old_config"),
-        ("projects", "0162_add_automationrule_v2"),
+        ("projects", "0163_automationrule_data_migration"),
     ]
 
     operations = [

--- a/readthedocs/projects/migrations/0163_automationrule_data_migration.py
+++ b/readthedocs/projects/migrations/0163_automationrule_data_migration.py
@@ -6,10 +6,11 @@ from django_safemigrate import Safe
 
 def forward_migrate_data(apps, schema_editor):
     RegexAutomationRule = apps.get_model("builds", "RegexAutomationRule")
+    AutomationRuleMatch = apps.get_model("builds", "AutomationRuleMatch")
     AutomationRule = apps.get_model("projects", "AutomationRule")
 
     for rule in RegexAutomationRule.objects.iterator():
-        AutomationRule.objects.create(
+        newrule = AutomationRule.objects.create(
             # Keep the same date for the migrated rules.
             created=rule.created,
             modified=rule.modified,
@@ -28,6 +29,10 @@ def forward_migrate_data(apps, schema_editor):
             action=rule.action,
             enabled=True,
         )
+
+        for match in AutomationRuleMatch.objects.filter(rule_id=rule.id):
+            match.rule_id = newrule.id
+            match.save(update_fields=["rule_id"])
 
 
 class Migration(migrations.Migration):

--- a/readthedocs/projects/migrations/0163_automationrule_data_migration.py
+++ b/readthedocs/projects/migrations/0163_automationrule_data_migration.py
@@ -11,9 +11,6 @@ def forward_migrate_data(apps, schema_editor):
 
     for rule in RegexAutomationRule.objects.iterator():
         newrule = AutomationRule.objects.create(
-            # Keep the same date for the migrated rules.
-            created=rule.created,
-            modified=rule.modified,
             project=rule.project,
             priority=rule.priority,
             description=rule.description,
@@ -28,6 +25,12 @@ def forward_migrate_data(apps, schema_editor):
             else "custom-match",
             action=rule.action,
             enabled=True,
+        )
+        # ``auto_now_add`` and ``auto_now`` fields ignore values passed to create(),
+        # so we use update() to preserve the original timestamps.
+        AutomationRule.objects.filter(pk=newrule.pk).update(
+            created=rule.created,
+            modified=rule.modified,
         )
 
         for match in AutomationRuleMatch.objects.filter(rule_id=rule.id):

--- a/readthedocs/projects/migrations/0163_automationrule_data_migration.py
+++ b/readthedocs/projects/migrations/0163_automationrule_data_migration.py
@@ -33,9 +33,7 @@ def forward_migrate_data(apps, schema_editor):
             modified=rule.modified,
         )
 
-        for match in AutomationRuleMatch.objects.filter(rule_id=rule.id):
-            match.rule_id = newrule.id
-            match.save(update_fields=["rule_id"])
+        AutomationRuleMatch.objects.filter(rule_id=rule.id).update(rule_id=newrule.id)
 
 
 class Migration(migrations.Migration):

--- a/readthedocs/projects/migrations/0163_automationrule_data_migration.py
+++ b/readthedocs/projects/migrations/0163_automationrule_data_migration.py
@@ -6,11 +6,13 @@ from django_safemigrate import Safe
 
 def forward_migrate_data(apps, schema_editor):
     RegexAutomationRule = apps.get_model("builds", "RegexAutomationRule")
-    AutomationRuleMatch = apps.get_model("builds", "AutomationRuleMatch")
     AutomationRule = apps.get_model("projects", "AutomationRule")
 
     for rule in RegexAutomationRule.objects.iterator():
+        # Preserve the legacy PK so that existing ``AutomationRuleMatch.rule_id``
+        # values remain valid without needing to be remapped.
         newrule = AutomationRule.objects.create(
+            id=rule.id,
             project=rule.project,
             priority=rule.priority,
             description=rule.description,
@@ -32,8 +34,6 @@ def forward_migrate_data(apps, schema_editor):
             created=rule.created,
             modified=rule.modified,
         )
-
-        AutomationRuleMatch.objects.filter(rule_id=rule.id).update(rule_id=newrule.id)
 
 
 class Migration(migrations.Migration):

--- a/readthedocs/projects/ordering.py
+++ b/readthedocs/projects/ordering.py
@@ -22,9 +22,20 @@ class ProjectItemPositionManager:
         model = item._meta.model
         total = model.objects.filter(project=item.project).count()
 
+        # We are creating new AutomationRules passing `id=` attribute in the migration,
+        # so we cannot check for `if item.pk` to know if the item is new or not.
+        current_position = None
+        try:
+            current_position = model.objects.values_list(
+                self.position_field_name,
+                flat=True,
+            ).get(pk=item.pk)
+        except model.DoesNotExist:
+            pass
+
         # If the item was just created, we just need to insert it at the given position.
         # We do this by moving the other items down before saving.
-        if not item.pk:
+        if current_position is None:
             # A new item can be created at the end as max.
             position = min(getattr(item, self.position_field_name), total)
             setattr(item, self.position_field_name, position)
@@ -43,11 +54,6 @@ class ProjectItemPositionManager:
             )
             expression = F(self.position_field_name) + 1
         else:
-            current_position = model.objects.values_list(
-                self.position_field_name,
-                flat=True,
-            ).get(pk=item.pk)
-
             # An existing item can't be moved past the end.
             position = min(getattr(item, self.position_field_name), total - 1)
             setattr(item, self.position_field_name, position)


### PR DESCRIPTION
This was missing and created some inconsistencies.

- keep datetimes for objects
- preserve rule ID to avoid db iconsistencies