### PR TITLE
docs: align skip-build limitations with actual behavior

### DIFF
--- a/docs/user/guides/build/skip-build.rst
+++ b/docs/user/guides/build/skip-build.rst
@@ -205,14 +205,17 @@ Be aware of these limitations when using the skip build feature:
    Cancelled builds appear in your build history as cancelled, not as skipped or successful.
    This is different from builds that never start due to branch/version filters.
 
-**No webhook notifications are sent**
+**No failure notifications are sent**
    When a build is skipped via exit code ``183``, Read the Docs does not send
-   ``build:failed`` webhook notifications or failure emails for it. The build is
-   treated as an intentional skip rather than a failure.
+   ``build:failed`` webhook notifications or failure emails for it. The build
+   is treated as an intentional skip rather than a failure. Note that a
+   ``build:triggered`` webhook may still have been delivered earlier, before
+   the build command had a chance to exit with ``183``.
 
 **Pull request status is reported as successful**
-   For pull request builds, the commit status sent to your Git provider is
-   reported as successful so that the pull request is not blocked from merging.
+   When a commit status is sent to your Git provider (for pull request builds),
+   it is reported as successful so that the pull request is not blocked from
+   merging.
 
 Troubleshooting
 ---------------

--- a/docs/user/guides/build/skip-build.rst
+++ b/docs/user/guides/build/skip-build.rst
@@ -205,9 +205,14 @@ Be aware of these limitations when using the skip build feature:
    Cancelled builds appear in your build history as cancelled, not as skipped or successful.
    This is different from builds that never start due to branch/version filters.
 
-**Webhook notifications still trigger**
-   Even though the build is cancelled, webhook notifications (if configured) may still be sent
-   with a cancelled status.
+**No webhook notifications are sent**
+   When a build is skipped via exit code ``183``, Read the Docs does not send
+   ``build:failed`` webhook notifications or failure emails for it. The build is
+   treated as an intentional skip rather than a failure.
+
+**Pull request status is reported as successful**
+   For pull request builds, the commit status sent to your Git provider is
+   reported as successful so that the pull request is not blocked from merging.
 
 Troubleshooting
 ---------------


### PR DESCRIPTION
## Summary

The skip-build guide (`docs/user/guides/build/skip-build.rst`) contained a "Limitations" entry claiming that webhook notifications still trigger for builds cancelled via exit code 183. The implementation actually excludes `BuildCancelled.SKIPPED_EXIT_CODE_183` from `exceptions_without_notifications` in `readthedocs/projects/tasks/builds.py`, so no `build:failed` webhook or failure email is sent.

This PR updates the docs to reflect actual behavior and adds a small note about the pull-request commit status being reported as successful (so PRs aren't blocked from merging), since that behavior surprises some users.

## Test plan

- [ ] Docs render without syntax errors (RST changes only, no code paths touched)
- [ ] Content reads accurately against `readthedocs/projects/tasks/builds.py:304-309` and `:569-582`

---

*Generated by AI.*