### PR TITLE
builds: distinct commit status for skipped (exit code 183) builds

### DIFF
--- a/readthedocs/builds/constants.py
+++ b/readthedocs/builds/constants.py
@@ -88,6 +88,10 @@ NON_REPOSITORY_VERSIONS = (
 BUILD_STATUS_FAILURE = "failed"
 BUILD_STATUS_PENDING = "pending"
 BUILD_STATUS_SUCCESS = "success"
+# Reported as success to the Git provider (so the pull request can merge),
+# but communicates in the description that the build was intentionally
+# skipped via exit code 183.
+BUILD_STATUS_SKIPPED = "skipped"
 
 # GitHub Build Statuses
 GITHUB_BUILD_STATUS_FAILURE = "failure"
@@ -115,6 +119,11 @@ SELECT_BUILD_STATUS = {
         "github": GITHUB_BUILD_STATUS_SUCCESS,
         "gitlab": GITLAB_BUILD_STATUS_SUCCESS,
         "description": "Read the Docs build succeeded!",
+    },
+    BUILD_STATUS_SKIPPED: {
+        "github": GITHUB_BUILD_STATUS_SUCCESS,
+        "gitlab": GITLAB_BUILD_STATUS_SUCCESS,
+        "description": "Read the Docs build skipped.",
     },
 }
 

--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -219,7 +219,7 @@ def send_build_status(build_pk, commit, status):
 
     :param build_pk: Build primary key
     :param commit: commit sha of the pull/merge request
-    :param status: build status failed, pending, or success to be sent.
+    :param status: build status failed, pending, success, or skipped to be sent.
     """
     build = Build.objects.filter(pk=build_pk).select_related("version").first()
     # Bulds without a verion shouldn't send status, it can happen when

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -37,6 +37,7 @@ from readthedocs.builds.constants import BUILD_STATE_INSTALLING
 from readthedocs.builds.constants import BUILD_STATE_TRIGGERED
 from readthedocs.builds.constants import BUILD_STATE_UPLOADING
 from readthedocs.builds.constants import BUILD_STATUS_FAILURE
+from readthedocs.builds.constants import BUILD_STATUS_SKIPPED
 from readthedocs.builds.constants import BUILD_STATUS_SUCCESS
 from readthedocs.builds.constants import EXTERNAL
 from readthedocs.builds.constants import UNDELETABLE_ARTIFACT_TYPES
@@ -569,10 +570,12 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
             status = BUILD_STATUS_FAILURE
             if message_id == BuildCancelled.SKIPPED_EXIT_CODE_183:
                 # The build was skipped by returning the magic exit code,
-                # marked as CANCELLED, but communicated to GitHub as successful.
-                # This is because the PR has to be available for merging when the build
-                # was skipped on purpose.
-                status = BUILD_STATUS_SUCCESS
+                # marked as CANCELLED, and communicated to the Git provider as
+                # a success so that the pull request is not blocked from merging.
+                # The SKIPPED status keeps the underlying provider state as
+                # "success" but uses a distinct description so reviewers can tell
+                # the build was intentionally skipped rather than actually built.
+                status = BUILD_STATUS_SKIPPED
 
             send_external_build_status(
                 version_type=version_type,

--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -172,7 +172,7 @@ def send_external_build_status(version_type, build_pk, commit, status):
      :param version_type: Version type e.g EXTERNAL, BRANCH, TAG
      :param build_pk: Build pk
      :param commit: commit sha of the pull/merge request
-     :param status: build status failed, pending, or success to be sent.
+     :param status: build status failed, pending, success, or skipped to be sent.
     """
 
     # Send status reports for only External (pull/merge request) Versions.

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -1,4 +1,5 @@
 import copy
+import json
 from unittest import mock
 
 from allauth.socialaccount.providers.bitbucket_oauth2.provider import BitbucketOAuth2Provider
@@ -17,6 +18,7 @@ from readthedocs.allauth.providers.githubapp.provider import GitHubAppProvider
 from readthedocs.builds.constants import (
     BUILD_STATUS_FAILURE,
     BUILD_STATUS_PENDING,
+    BUILD_STATUS_SKIPPED,
     BUILD_STATUS_SUCCESS,
     EXTERNAL,
     LATEST,
@@ -1669,6 +1671,29 @@ class GitHubOAuthTests(TestCase):
         # Should link to build detail page, not version URL
         self.assertIn(f'/projects/{self.project.slug}/builds/{self.external_build.pk}/', target_url)
         self.assertNotIn('.readthedocs.io', target_url)
+
+    @mock.patch("readthedocs.oauth.services.github.structlog")
+    @mock.patch("readthedocs.oauth.services.github.log")
+    @mock.patch("readthedocs.oauth.services.github.GitHubService.session")
+    def test_send_build_status_skipped(self, session, mock_logger, mock_structlog):
+        """Skipped builds report as success to GitHub with a distinct description."""
+        session.post.return_value.status_code = 201
+        success = self.service.send_build_status(
+            build=self.external_build,
+            commit=self.external_build.commit,
+            status=BUILD_STATUS_SKIPPED,
+        )
+
+        self.assertTrue(success)
+        posted = json.loads(session.post.call_args.kwargs["data"])
+        assert posted["state"] == "success"
+        assert posted["description"] == "Read the Docs build skipped."
+        # Skipped builds link to the build detail page, not the version docs,
+        # since no new documentation was produced for this commit.
+        assert (
+            f"/projects/{self.project.slug}/builds/{self.external_build.pk}/"
+            in posted["target_url"]
+        )
 
     @mock.patch("readthedocs.oauth.services.github.structlog")
     @mock.patch("readthedocs.oauth.services.github.log")

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -1062,6 +1062,43 @@ class GitHubAppTests(TestCase):
         }
 
     @requests_mock.Mocker(kw="request")
+    def test_send_build_status_skipped(self, request):
+        """Skipped builds report as success to GitHub App with a distinct description."""
+        commit = "1234abc"
+        version = get(Version, project=self.project, type=EXTERNAL, built=False)
+        build = get(
+            Build,
+            project=self.project,
+            version=version,
+        )
+        request.post(
+            f"{self.api_url}/app/installations/1111/access_tokens",
+            json=self._get_access_token_json(),
+        )
+        request.get(
+            f"{self.api_url}/repositories/{self.remote_repository.remote_id}/commits/{commit}",
+            json=self._get_commit_json(commit=commit),
+        )
+        status_api_request = request.post(
+            f"{self.api_url}/repos/user/repo/statuses/{commit}",
+            json={},
+        )
+
+        service = self.installation.service
+        assert service.send_build_status(
+            build=build, commit=commit, status=BUILD_STATUS_SKIPPED
+        )
+        assert status_api_request.called
+        assert status_api_request.last_request.json() == {
+            "context": f"docs/readthedocs:{self.project.slug}",
+            "description": "Read the Docs build skipped.",
+            "state": "success",
+            # Skipped builds link to the build detail page, not the version
+            # docs, since no new documentation was produced for this commit.
+            "target_url": f"https://readthedocs.org/projects/{self.project.slug}/builds/{build.pk}/",
+        }
+
+    @requests_mock.Mocker(kw="request")
     def test_get_clone_token(self, request):
         token = "ghs_16C7e42F292c6912E7710c838347Ae178B4a"
         request.post(
@@ -1686,13 +1723,13 @@ class GitHubOAuthTests(TestCase):
 
         self.assertTrue(success)
         posted = json.loads(session.post.call_args.kwargs["data"])
-        assert posted["state"] == "success"
-        assert posted["description"] == "Read the Docs build skipped."
+        self.assertEqual(posted["state"], "success")
+        self.assertEqual(posted["description"], "Read the Docs build skipped.")
         # Skipped builds link to the build detail page, not the version docs,
         # since no new documentation was produced for this commit.
-        assert (
-            f"/projects/{self.project.slug}/builds/{self.external_build.pk}/"
-            in posted["target_url"]
+        self.assertIn(
+            f"/projects/{self.project.slug}/builds/{self.external_build.pk}/",
+            posted["target_url"],
         )
 
     @mock.patch("readthedocs.oauth.services.github.structlog")
@@ -3085,6 +3122,32 @@ class GitLabOAuthTests(TestCase):
         mock_structlog.contextvars.bind_contextvars.assert_called_with(http_status_code=201)
         mock_logger.debug.assert_called_with(
             "GitLab commit status created for project.",
+        )
+
+    @mock.patch("readthedocs.oauth.services.gitlab.structlog")
+    @mock.patch("readthedocs.oauth.services.gitlab.log")
+    @mock.patch("readthedocs.oauth.services.gitlab.GitLabService.session")
+    @mock.patch("readthedocs.oauth.services.gitlab.GitLabService._get_repo_id")
+    def test_send_build_status_skipped(self, repo_id, session, mock_logger, mock_structlog):
+        """Skipped builds report as success to GitLab with a distinct description."""
+        session.post.return_value.status_code = 201
+        repo_id().return_value = "9999"
+
+        success = self.service.send_build_status(
+            build=self.external_build,
+            commit=self.external_build.commit,
+            status=BUILD_STATUS_SKIPPED,
+        )
+
+        self.assertTrue(success)
+        posted = json.loads(session.post.call_args.kwargs["data"])
+        self.assertEqual(posted["state"], "success")
+        self.assertEqual(posted["description"], "Read the Docs build skipped.")
+        # Skipped builds link to the build detail page, not the version docs,
+        # since no new documentation was produced for this commit.
+        self.assertIn(
+            f"/projects/{self.project.slug}/builds/{self.external_build.pk}/",
+            posted["target_url"],
         )
 
     @mock.patch("readthedocs.oauth.services.gitlab.structlog")


### PR DESCRIPTION
## Summary

Today, a pull request build that is intentionally skipped via exit code `183` sends the same `"Read the Docs build succeeded!"` commit status description to GitHub/GitLab as a build that actually ran to completion. For PR reviewers this is misleading — the build status check looks identical whether docs were rebuilt or not.

This PR adds a new `BUILD_STATUS_SKIPPED` value to the abstract status enum. It still maps to the provider's `success` state (so the PR isn't blocked from merging, preserving existing behavior), but the description becomes `"Read the Docs build skipped."`. The existing target-URL logic already routes non-`SUCCESS` statuses to the build detail page, so a reviewer clicking the status check lands on a page that explains the skip rather than stale version docs.

No database changes, no template changes — the only surface area is the commit status API call to the Git provider.

## Test plan

- [x] New unit test `test_send_build_status_skipped` asserts state=`success`, description=`Read the Docs build skipped.`, and that `target_url` points to the build detail page
- [x] Existing `send_build_status` tests still pass (`pytest readthedocs/rtd_tests/tests/test_oauth.py -k send_build_status` — 12 passed)
- [x] `test_celery.py` and skip-related build tests pass

---

*Generated by AI.*