### PR TITLE
Tests: allow running with `--nomigrations` option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
       - run: sudo apt install -y rclone
       # tox-uv makes tox use uv for virtualenv creation and dep resolution.
       - run: pip install --user tox tox-uv
-      - run: tox -e py312 -- --nomigrations
+      - run: tox -e py312
       - run: cp .coverage .coverage.tests
       - save_cache:
           key: pip-tests-v2-{{ checksum "requirements-cache-key.txt" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
       - run: sudo apt install -y rclone
       # tox-uv makes tox use uv for virtualenv creation and dep resolution.
       - run: pip install --user tox tox-uv
-      - run: tox -e py312
+      - run: tox -e py312 -- --nomigrations
       - run: cp .coverage .coverage.tests
       - save_cache:
           key: pip-tests-v2-{{ checksum "requirements-cache-key.txt" }}

--- a/readthedocs/rtd_tests/tests/test_build_notifications.py
+++ b/readthedocs/rtd_tests/tests/test_build_notifications.py
@@ -26,6 +26,8 @@ class BuildNotificationsTests(TestCase):
         self.project = get(Project, slug="test", language="en")
         self.version = get(Version, project=self.project, slug="1.0")
         self.build = get(Build, version=self.version, commit="abc1234567890")
+        for name, _ in WebHookEvent.EVENTS:
+            WebHookEvent.objects.get_or_create(name=name)
 
     @mock.patch("readthedocs.builds.managers.log")
     def test_send_notification_none_if_wrong_version_pk(self, mock_logger):
@@ -327,6 +329,8 @@ class TestForms(TestCase):
         self.project = get(Project)
         self.version = get(Version, project=self.project)
         self.build = get(Build, version=self.version)
+        for name, _ in WebHookEvent.EVENTS:
+            WebHookEvent.objects.get_or_create(name=name)
 
     def test_webhook_form_url_length(self):
         form = WebHookForm(

--- a/readthedocs/rtd_tests/tests/test_project_forms.py
+++ b/readthedocs/rtd_tests/tests/test_project_forms.py
@@ -1027,6 +1027,8 @@ class TestTranslationForms(TestCase):
 class TestWebhookForm(TestCase):
     def setUp(self):
         self.project = get(Project)
+        for name, _ in WebHookEvent.EVENTS:
+            WebHookEvent.objects.get_or_create(name=name)
 
     def test_webhookform(self):
         self.assertEqual(self.project.webhook_notifications.all().count(), 0)

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -749,6 +749,8 @@ class TestWebhooksViews(TestCase):
         self.version = get(Version, slug="1.0", project=self.project)
         self.webhook = get(WebHook, project=self.project)
         self.client.force_login(self.user)
+        for name, _ in WebHookEvent.EVENTS:
+            WebHookEvent.objects.get_or_create(name=name)
 
     def test_list(self):
         resp = self.client.get(


### PR DESCRIPTION
We were depending on running a specific migration that creates WebHookEvent objects,
but that is not possible when running with `--nomigrations`.

If a test class needs specific WebHookEvent objects,
that class should create the objects in the `setUp` method.
That is what this PR does.

Now we can run the tests with `--nomigrations` option, which is faster.