### PR TITLE
Tests: use `tox-uv` for faster virtualenv creation

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,8 @@
 [tox]
-minversion=2.9.0
+minversion=4.0.0
+requires =
+    tox-uv>=1.35
+runner = uv-venv-runner
 envlist = py312,lint,docs
 skipsdist = True
 


### PR DESCRIPTION
Another attempt to use tox-uv for our tests.

Closes #11851