### PR TITLE
vcs: fix typos in git backend comments/log message

### DIFF
--- a/readthedocs/vcs_support/backends/git.py
+++ b/readthedocs/vcs_support/backends/git.py
@@ -66,7 +66,7 @@ class Backend(BaseVCS):
         This method sits on top of a lot of legacy design.
         It decides how to treat the incoming ``Version.identifier`` from
         knowledge of how the caller (the build process) uses build data.
-        Thi is:
+        This is:
 
         For branches:
 
@@ -180,7 +180,7 @@ class Backend(BaseVCS):
         .. note::
 
            This check is better done just after the clone step,
-           to ensure that no commands controled by the user are run.
+           to ensure that no commands controlled by the user are run.
         """
         remote_name = "rtd-test-ssh-key"
         ssh_url = self.project.repo
@@ -527,7 +527,7 @@ class Backend(BaseVCS):
                 yield value
             else:
                 # This should never happen, but we log a warning just in case the regex is wrong.
-                log.warning("Unexpected key extracted fom .gitmodules.", key=key)
+                log.warning("Unexpected key extracted from .gitmodules.", key=key)
 
     def checkout(self, identifier=None):
         """Checkout to identifier or latest."""


### PR DESCRIPTION

**Repo:** readthedocs/readthedocs.org (⭐ 7900)
**Type:** docs
**Files changed:** 1
**Lines:** +3/-3

## What
Fixes three small typos in `readthedocs/vcs_support/backends/git.py`: "Thi is" → "This is" and "controled" → "controlled" in docstrings, and "fom" → "from" in a `log.warning(...)` message emitted when an unexpected key is parsed from `.gitmodules`.

## Why
The log message typo ("extracted fom .gitmodules") is user/operator-facing — it appears in production logs and search/grep tooling. Fixing it makes log searches reliable and improves the readability of the surrounding docstrings. Found via `codespell` over the `readthedocs/` package.

## Testing
Pure string change in comments/docstrings and a log message format string; no behavior change. Verified the file still parses (no syntax change). The log message is informational only.

## Risk
Low — comment/docstring/log-string only, no logic change.
