### PR TITLE
Tests: use `master` as the default branch for git repositories

### DIFF
--- a/readthedocs/rtd_tests/utils.py
+++ b/readthedocs/rtd_tests/utils.py
@@ -142,7 +142,7 @@ def make_git_repo(directory, name="sample_repo"):
     chdir(directory)
 
     # Initialize and configure
-    check_output(["git", "init"] + [directory], env=env)
+    check_output(["git", "init", "--initial-branch=master"] + [directory], env=env)
     check_output(
         ["git", "config", "user.email", "dev@readthedocs.org"],
         env=env,


### PR DESCRIPTION
We have hardcoded `master` as the default branch in some tests. When running with newer version of Git the default branch is `main` and the tests fail.

I'm creating repositories using `master` as the default branch to make all these tests to pass.