### PR TITLE
builds: add visual diff link to build overview PR comment

### DIFF
--- a/readthedocs/builds/tests/test_tasks.py
+++ b/readthedocs/builds/tests/test_tasks.py
@@ -356,7 +356,7 @@ class TestPostBuildOverview(TestCase):
             <summary>3 files changed</summary>
             <br>
             <code>+</code> <a href="http://my-project--1.readthedocs.build/en/1/changes.html"><code>changes.html</code></a><br>
-            <code>±</code> <a href="http://my-project--1.readthedocs.build/en/1/index.html"><code>index.html</code></a><br>
+            <code>±</code> <a href="http://my-project--1.readthedocs.build/en/1/index.html"><code>index.html</code></a> · <a href="http://my-project--1.readthedocs.build/en/1/index.html?readthedocs-diff=true">visual diff</a><br>
             <code>-</code> <a href="http://my-project--1.readthedocs.build/en/1/deleteme.html"><code>deleteme.html</code></a><br>
             </details>
 
@@ -404,10 +404,10 @@ class TestPostBuildOverview(TestCase):
             - [`changes.html`](http://my-project--1.readthedocs.build/en/1/changes.html)
 
             `±` **Modified**
-            - [`index.html`](http://my-project--1.readthedocs.build/en/1/index.html)
-            - [`one.html`](http://my-project--1.readthedocs.build/en/1/one.html)
-            - [`three.html`](http://my-project--1.readthedocs.build/en/1/three.html)
-            - [`two.html`](http://my-project--1.readthedocs.build/en/1/two.html)
+            - [`index.html`](http://my-project--1.readthedocs.build/en/1/index.html) · [visual diff](http://my-project--1.readthedocs.build/en/1/index.html?readthedocs-diff=true)
+            - [`one.html`](http://my-project--1.readthedocs.build/en/1/one.html) · [visual diff](http://my-project--1.readthedocs.build/en/1/one.html?readthedocs-diff=true)
+            - [`three.html`](http://my-project--1.readthedocs.build/en/1/three.html) · [visual diff](http://my-project--1.readthedocs.build/en/1/three.html?readthedocs-diff=true)
+            - [`two.html`](http://my-project--1.readthedocs.build/en/1/two.html) · [visual diff](http://my-project--1.readthedocs.build/en/1/two.html?readthedocs-diff=true)
 
             `-` **Deleted**
             - [`deleteme.html`](http://my-project--1.readthedocs.build/en/1/deleteme.html)

--- a/readthedocs/filetreediff/dataclasses.py
+++ b/readthedocs/filetreediff/dataclasses.py
@@ -101,6 +101,16 @@ class FileTreeDiffFile:
         )
 
     @property
+    def diff_url(self):
+        """URL to the file in the current version with visual diff enabled."""
+        url = self._resolver.resolve_version(
+            project=self.current_version.project,
+            version=self.current_version,
+            filename=self.path,
+        )
+        return f"{url}?readthedocs-diff=true"
+
+    @property
     def base_url(self):
         """URL to the file in the base version."""
         return self._resolver.resolve_version(

--- a/readthedocs/templates/core/build-overview.md
+++ b/readthedocs/templates/core/build-overview.md
@@ -17,7 +17,7 @@ Markdown inside <details> requires a blank line after </summary>.
 <summary>{{ diff.files|length }} file{{ diff.files|length|pluralize }} changed</summary>
 <br>
 {% for file in diff.added %}<code>+</code> <a href="{{ file.url }}"><code>{{ file.path }}</code></a><br>
-{% endfor %}{% for file in diff.modified %}<code>±</code> <a href="{{ file.url }}"><code>{{ file.path }}</code></a><br>
+{% endfor %}{% for file in diff.modified %}<code>±</code> <a href="{{ file.url }}"><code>{{ file.path }}</code></a> · <a href="{{ file.diff_url }}">visual diff</a><br>
 {% endfor %}{% for file in diff.deleted %}<code>-</code> <a href="{{ file.url }}"><code>{{ file.path }}</code></a><br>
 {% endfor %}</details>
 {% else %}
@@ -30,7 +30,7 @@ Markdown inside <details> requires a blank line after </summary>.
 {% endfor %}{% if diff.added|length > 10 %}- *and {{ diff.added|length|add:"-10" }} more...*
 {% endif %}{% endif %}{% if diff.modified %}
 `±` **Modified**
-{% for file in diff.modified|slice:":10" %}- [`{{ file.path }}`]({{ file.url }})
+{% for file in diff.modified|slice:":10" %}- [`{{ file.path }}`]({{ file.url }}) · [visual diff]({{ file.diff_url }})
 {% endfor %}{% if diff.modified|length > 10 %}- *and {{ diff.modified|length|add:"-10" }} more...*
 {% endif %}{% endif %}{% if diff.deleted %}
 `-` **Deleted**


### PR DESCRIPTION
## Summary

- Adds a ` · visual diff` link next to each modified file in the build-overview PR comment.
- The link appends `?readthedocs-diff=true` to the file's preview URL. The addons JS ([`docdiff.js`](https://github.com/readthedocs/addons/blob/main/src/docdiff.js) line 118) reads that parameter on page load and auto-enables the visual diff overlay.
- Added only on modified files — added/deleted files don't have a meaningful visual diff.

## Example

### Documentation build overview

> 📚 [My project](https://example.com) | 🛠️ Build [#123](https://example.com) | 📁 Comparing `5678abcd` against [latest](https://example.com) (`1234abcd`)

[<kbd> &nbsp; 🔍 Preview build &nbsp; </kbd>](https://example.com)

<details open>
<summary>3 files changed</summary>
<br>
<code>+</code> <a href="https://example.com"><code>changes.html</code></a><br>
<code>±</code> <a href="https://example.com"><code>index.html</code></a> · <a href="https://example.com?readthedocs-diff=true">visual diff</a><br>
<code>-</code> <a href="https://example.com"><code>deleteme.html</code></a><br>
</details>

## Test plan

- [ ] `pytest readthedocs/builds/tests/test_tasks.py -k build_overview --reuse-db` passes
- [ ] Manually verify a PR comment renders the \`visual diff\` link and clicking it activates the diff overlay on the preview page

Made by AI.