### PR TITLE
emails: use instance production_uri for account settings link

### DIFF
--- a/readthedocs/templates/projects/notifications/deprecated_build_image_used_email.html
+++ b/readthedocs/templates/projects/notifications/deprecated_build_image_used_email.html
@@ -25,7 +25,7 @@ We have identified that the following projects which you maintain, and were buil
 </ul>
 
 Please use <code>build.os</code> on your configuration file to ensure that they continue building successfully and to stop receiving these notifications.
-If you want to opt-out from these emails, you can <a href="https://readthedocs.org/accounts/edit/"> edit your preferences in your account settings</a>.
+If you want to opt-out from these emails, you can <a href="{{ production_uri }}/accounts/edit/"> edit your preferences in your account settings</a>.
 
 For more information on how to use <code>build.os</code>,
 <a href="https://blog.readthedocs.com/use-build-os-config/">read our blog post</a>

--- a/readthedocs/templates/projects/notifications/deprecated_build_image_used_email.txt
+++ b/readthedocs/templates/projects/notifications/deprecated_build_image_used_email.txt
@@ -21,7 +21,7 @@ We have identified that the following projects which you maintain, and were buil
 {% endif %}
 
 Please use "build.os" on your configuration file to ensure that they continue building successfully and to stop receiving these notifications.
-If you want to opt-out from these emails, you can edit your preferences in your account settings, at https://readthedocs.org/accounts/edit/.
+If you want to opt-out from these emails, you can edit your preferences in your account settings, at {{ production_uri }}/accounts/edit/.
 
 For more information on how to use "build.os",
 read our blog post at https://blog.readthedocs.com/use-build-os-config/

--- a/readthedocs/templates/projects/notifications/deprecated_config_file_used_email.html
+++ b/readthedocs/templates/projects/notifications/deprecated_config_file_used_email.html
@@ -25,7 +25,7 @@ We have identified that the following projects which you maintain, and were buil
 </ul>
 
 Please add a configuration file to your projects to ensure that they continue building successfully and to stop receiving these notifications.
-If you want to opt-out from these emails, you can <a href="https://readthedocs.org/accounts/edit/"> edit your preferences in your account settings</a>.
+If you want to opt-out from these emails, you can <a href="{{ production_uri }}/accounts/edit/"> edit your preferences in your account settings</a>.
 
 For more information on how to create a required configuration file,
 <a href="https://blog.readthedocs.com/migrate-configuration-v2/">read our blog post</a>

--- a/readthedocs/templates/projects/notifications/deprecated_config_file_used_email.txt
+++ b/readthedocs/templates/projects/notifications/deprecated_config_file_used_email.txt
@@ -21,7 +21,7 @@ We have identified that the following projects which you maintain, and were buil
 {% endif %}
 
 Please add a configuration file to your projects to ensure that they continue building successfully and to stop receiving these notifications.
-If you want to opt-out from these emails, you can edit your preferences in your account settings, at https://readthedocs.org/accounts/edit/.
+If you want to opt-out from these emails, you can edit your preferences in your account settings, at {{ production_uri }}/accounts/edit/.
 
 For more information on how to create a required configuration file,
 read our blog post at https://blog.readthedocs.com/migrate-configuration-v2/


### PR DESCRIPTION
## Summary

The deprecation emails (`deprecated_build_image_used_email` and `deprecated_config_file_used_email`, both `.html` and `.txt` variants) hardcoded `https://readthedocs.org/accounts/edit/` for the opt-out link. For business recipients this points at the wrong instance. `production_uri` is already in the email context (the same templates already use it for project links and the support URL), so this is a one-for-one substitution.

## Test plan

- [ ] Render each changed template with `PRODUCTION_DOMAIN=readthedocs.org` — link resolves to `https://readthedocs.org/accounts/edit/`.
- [ ] Render each changed template with `PRODUCTION_DOMAIN=app.readthedocs.com` — link resolves to `https://app.readthedocs.com/accounts/edit/`.

---

Part of a broader effort to unify community/business URL links, mirroring the pattern from readthedocs/website#381.

Generated by AI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XG1RFYMTJ9u653qbZ1LSwr)_