### PR TITLE
templates: unify Business upsell CTAs on about.readthedocs.com

### DIFF
--- a/readthedocs/templates/projects/notifications/new_dashboard_email.html
+++ b/readthedocs/templates/projects/notifications/new_dashboard_email.html
@@ -5,7 +5,7 @@
     original user interface and replace it with a completely new dashboard.
   </p>
   <p>
-    Documentation hosted on <a href="https://readthedocs.com">Read the Docs Business</a>
+    Documentation hosted on <a href="https://about.readthedocs.com/">Read the Docs Business</a>
     will display this new dashboard in several places where documentation
     readers interact with our application: documentation authentication and our
     default documentation error pages.
@@ -24,7 +24,7 @@
 
   <p>
     On <strong>Dec 10th</strong> we will make our new dashboard the default
-    dashboard for users logging into <a href="https://readthedocs.com">Read the Docs Business</a>
+    dashboard for users logging into <a href="https://about.readthedocs.com/">Read the Docs Business</a>
     from our website. This change will mainly affect project maintainers,
     especially maintainers that have not yet switched to the new dashboard.
   </p>
@@ -42,6 +42,6 @@
   <p>
     Projects can update to use these new pages in their documentation at
     any point. If you would like to update your project to use these pages
-    before then, <a href="https://app.readthedocs.com/support">contact us</a>.
+    before then, <a href="{{ production_uri }}{% url 'support' %}">contact us</a>.
   </p>
 {% endblock content %}

--- a/readthedocs/templates/projects/notifications/new_dashboard_email.txt
+++ b/readthedocs/templates/projects/notifications/new_dashboard_email.txt
@@ -32,6 +32,6 @@ Projects can update to use these new pages in their documentation at any
 point. If you would like to update your project to use these pages
 before then, contact us:
 
-https://app.readthedocs.com/support
+{{ production_uri }}{% url 'support' %}
 
 {% endblock content %}

--- a/readthedocs/templates/projects/project_advertising.html
+++ b/readthedocs/templates/projects/project_advertising.html
@@ -70,7 +70,7 @@
     <li class="module-item">
       {% blocktrans trimmed %}
         If you are part of a company that uses Read the Docs to host documentation for a commercial product,
-        please consider <a href="https://readthedocs.com/">Read the Docs for Business</a>
+        please consider <a href="https://about.readthedocs.com/">Read the Docs for Business</a>
         which offers a completely ad-free experience,
         private repositories, private documentation, additional build resources, and dedicated support.
       {% endblocktrans %}

--- a/readthedocs/templates/projects/project_import.html
+++ b/readthedocs/templates/projects/project_import.html
@@ -78,7 +78,7 @@
             <p>
             {% blocktrans trimmed %}
                 We're only showing public repositories. For private projects and other features,
-                please use <a href="https://readthedocs.com/">Read the Docs for Business</a>.
+                please use <a href="https://about.readthedocs.com/">Read the Docs for Business</a>.
             {% endblocktrans %}
             </p>
           </div>


### PR DESCRIPTION
## Summary

Points the "Read the Docs for Business" marketing CTAs at `about.readthedocs.com` (the canonical marketing host) instead of `readthedocs.com`, consistent with the unified-link pattern established in readthedocs/website#381 (where sign-up/login CTAs go through `about.readthedocs.com/#signup` / `#login` and the marketing site's modal handles community/business routing).

Also routes the new-dashboard email's "contact us" link through the sending instance via `{{ production_uri }}{% url 'support' %}` — the existing hardcoded `https://app.readthedocs.com/support` only works for business recipients.

Changes:
- `project_advertising.html:73`, `project_import.html:81`, `new_dashboard_email.html:8,27`: `https://readthedocs.com/` → `https://about.readthedocs.com/`
- `new_dashboard_email.html:45` and `new_dashboard_email.txt:35`: `https://app.readthedocs.com/support` → `{{ production_uri }}{% url 'support' %}`

The `.po` translation files will regenerate on the next `makemessages` run and are intentionally left out of this PR.

## Test plan

- [ ] Load `/dashboard/<project>/advertising/` and `/dashboard/import/`; confirm the "Read the Docs for Business" links point to `about.readthedocs.com`.
- [ ] Render `new_dashboard_email.html/.txt` from a community instance (`PRODUCTION_DOMAIN=readthedocs.org`) and a business instance (`PRODUCTION_DOMAIN=app.readthedocs.com`); confirm the support link goes to the sending instance and the Business marketing links go to `about.readthedocs.com`.

---

Part of a broader effort to unify community/business URL links, mirroring the pattern from readthedocs/website#381.

Generated by AI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XG1RFYMTJ9u653qbZ1LSwr)_