### PR TITLE
settings: fix CSP warnings in local dev

### DIFF
--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -468,6 +468,9 @@ class CommunityBaseSettings(Settings):
             "https://plausible.io/api/event",
         ]
         CSP_CONNECT_SRC.append(f"ws://{self.PRODUCTION_DOMAIN}:10001/ws")
+        if self.RTD_EXT_THEME_DEV_SERVER:
+            # webpack-dev-server fetches source maps over XHR.
+            CSP_CONNECT_SRC.append(self.RTD_EXT_THEME_DEV_SERVER)
         return CSP_CONNECT_SRC
 
     @property
@@ -481,7 +484,10 @@ class CommunityBaseSettings(Settings):
             # Stripe (used for Gold subscriptions)
             "https://js.stripe.com/",
         ]
-        CSP_SCRIPT_SRC.append(self.STATIC_URL)
+        # Skip STATIC_URL when relative (e.g. "/static/" in dev) — relative
+        # paths are invalid CSP sources and 'self' already covers them.
+        if self.STATIC_URL.startswith(("http://", "https://")):
+            CSP_SCRIPT_SRC.append(self.STATIC_URL)
         if self.RTD_EXT_THEME_DEV_SERVER:
             CSP_SCRIPT_SRC.append(self.RTD_EXT_THEME_DEV_SERVER)
         return CSP_SCRIPT_SRC
@@ -494,7 +500,8 @@ class CommunityBaseSettings(Settings):
             "data:",
             "https://ka-p.fontawesome.com",
         ]
-        CSP_FONT_SRC.append(self.STATIC_URL)
+        if self.STATIC_URL.startswith(("http://", "https://")):
+            CSP_FONT_SRC.append(self.STATIC_URL)
         if self.RTD_EXT_THEME_DEV_SERVER:
             CSP_FONT_SRC.append(self.RTD_EXT_THEME_DEV_SERVER)
         return CSP_FONT_SRC
@@ -507,7 +514,8 @@ class CommunityBaseSettings(Settings):
             # TODO: we should remove this.
             "'unsafe-inline'",
         ]
-        CSP_STYLE_SRC.append(self.STATIC_URL)
+        if self.STATIC_URL.startswith(("http://", "https://")):
+            CSP_STYLE_SRC.append(self.STATIC_URL)
         if self.RTD_EXT_THEME_DEV_SERVER:
             CSP_STYLE_SRC.append(self.RTD_EXT_THEME_DEV_SERVER)
         return CSP_STYLE_SRC

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -33,6 +33,11 @@ class DockerBaseSettings(CommunityBaseSettings):
     # Reference: https://docs.djangoproject.com/en/4.2/ref/settings/#secure-proxy-ssl-header
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
+    # Dev runs over plain HTTP on devthedocs.org, so browsers ignore COOP and
+    # log a warning. Disable it in dev to keep the console clean; production
+    # still uses Django's default ("same-origin").
+    SECURE_CROSS_ORIGIN_OPENER_POLICY = None
+
     STATIC_URL = "/static/"
 
     # In the local docker environment, nginx should be trusted to set the host correctly


### PR DESCRIPTION
## Summary

Three small fixes for CSP-related warnings/errors in the local dev console:

- **Invalid `/static/` source.** `base.py` appends `STATIC_URL` to `CSP_SCRIPT_SRC` / `CSP_STYLE_SRC` / `CSP_FONT_SRC`. In dev `STATIC_URL` is `/static/` — a relative path, which is not a valid CSP source and gets ignored by browsers with a console warning. Now only emitted when absolute (i.e. a CDN); `'self'` already covers same-origin assets, so this is also just generally more correct, not dev-only.
- **Source-map fetches blocked.** `RTD_EXT_THEME_DEV_SERVER` was wired into `script-src` / `style-src` / `font-src` but not `connect-src`, so webpack-dev-server's XHR source-map fetches against `http://assets.devthedocs.org:10001` were getting blocked. Added under the same `if RTD_EXT_THEME_DEV_SERVER` gate already used elsewhere in `base.py`, so prod is unaffected.
- **COOP warning.** Django defaults `SECURE_CROSS_ORIGIN_OPENER_POLICY = "same-origin"` since 4.1, but browsers ignore COOP on insecure (non-HTTPS, non-localhost) origins like `http://devthedocs.org` and emit a warning. Set to `None` in `docker_compose.py` to keep the dev console clean. Production is unaffected.

## Test plan

- [ ] Restart the dev web container and reload the dashboard
- [ ] Confirm `/static/` warnings are gone from script/style/font-src
- [ ] Confirm `assets.devthedocs.org:10001/...map` requests succeed (no `connect-src` block)
- [ ] Confirm the COOP warning is no longer logged
- [ ] Sanity-check a prod-like environment (CDN `STATIC_URL`) still emits the absolute URL in CSP

---

🤖 Generated with [Claude Code](https://claude.com/claude-code).
