### PR TITLE
builds: use `uv run mkdocs` when building under UvEnv

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -11,6 +11,7 @@ import yaml
 from django.conf import settings
 
 from readthedocs.doc_builder.base import BaseBuilder
+from readthedocs.doc_builder.python_environments import UvEnv
 from readthedocs.projects.exceptions import UserFileNotFound
 
 
@@ -66,9 +67,7 @@ class BaseMkdocs(BaseBuilder):
 
     def build(self):
         build_command = [
-            self.python_env.venv_bin(filename="python"),
-            "-m",
-            "mkdocs",
+            *self.get_mkdocs_cmd(),
             self.builder,
             "--clean",
             "--site-dir",
@@ -85,6 +84,20 @@ class BaseMkdocs(BaseBuilder):
             bin_path=self.python_env.venv_bin(),
         )
         return cmd_ret.successful
+
+    def get_mkdocs_cmd(self):
+        if isinstance(self.python_env, UvEnv):
+            return (
+                "uv",
+                "run",
+                "mkdocs",
+            )
+
+        return (
+            self.python_env.venv_bin(filename="python"),
+            "-m",
+            "mkdocs",
+        )
 
 
 class MkdocsHTML(BaseMkdocs):

--- a/readthedocs/rtd_tests/tests/test_doc_builder.py
+++ b/readthedocs/rtd_tests/tests/test_doc_builder.py
@@ -9,7 +9,9 @@ from django.test.utils import override_settings
 
 from readthedocs.config.tests.test_config import get_build_config
 from readthedocs.doc_builder.backends.mkdocs import BaseMkdocs
+from readthedocs.doc_builder.backends.mkdocs import MkdocsHTML
 from readthedocs.doc_builder.backends.sphinx import BaseSphinx
+from readthedocs.doc_builder.python_environments import UvEnv
 from readthedocs.doc_builder.python_environments import Virtualenv
 from readthedocs.projects.exceptions import ProjectConfigurationError
 from readthedocs.projects.exceptions import UserFileNotFound
@@ -173,3 +175,71 @@ class MkDocsBuilderTest(TestCase):
             e.exception.format_values.get("filename"),
             "mkdocs.yml",
         )
+
+    @patch("readthedocs.doc_builder.backends.mkdocs.BaseMkdocs.run")
+    @patch("readthedocs.projects.models.Project.checkout_path")
+    @patch("readthedocs.doc_builder.python_environments.load_yaml_config")
+    def test_get_mkdocs_cmd_uses_uv_run_for_uv_env(
+        self,
+        load_yaml_config,
+        checkout_path,
+        _,
+    ):
+        """
+        When the python env is uv-managed, the mkdocs builder
+        should invoke ``uv run mkdocs`` instead of ``python -m mkdocs``.
+        """
+        tmp_dir = tempfile.mkdtemp()
+        checkout_path.return_value = tmp_dir
+        config = get_build_config(
+            {
+                "mkdocs": {"configuration": "mkdocs.yml"},
+                "python": {
+                    "install": [{"method": "uv", "command": "sync"}],
+                },
+            },
+            validate=True,
+            source_file=f"{tmp_dir}/readthedocs.yml",
+        )
+        python_env = UvEnv(
+            version=self.version,
+            build_env=self.build_env,
+            config=config,
+        )
+        builder = MkdocsHTML(
+            build_env=self.build_env,
+            python_env=python_env,
+        )
+
+        assert builder.get_mkdocs_cmd() == ("uv", "run", "mkdocs")
+
+    @patch("readthedocs.doc_builder.backends.mkdocs.BaseMkdocs.run")
+    @patch("readthedocs.projects.models.Project.checkout_path")
+    @patch("readthedocs.doc_builder.python_environments.load_yaml_config")
+    def test_get_mkdocs_cmd_uses_python_module_for_virtualenv(
+        self,
+        load_yaml_config,
+        checkout_path,
+        _,
+    ):
+        """A non-uv environment should keep using ``python -m mkdocs``."""
+        tmp_dir = tempfile.mkdtemp()
+        checkout_path.return_value = tmp_dir
+        config = get_build_config(
+            {"mkdocs": {"configuration": "mkdocs.yml"}},
+            validate=True,
+            source_file=f"{tmp_dir}/readthedocs.yml",
+        )
+        python_env = Virtualenv(
+            version=self.version,
+            build_env=self.build_env,
+            config=config,
+        )
+        builder = MkdocsHTML(
+            build_env=self.build_env,
+            python_env=python_env,
+        )
+
+        cmd = builder.get_mkdocs_cmd()
+        assert cmd[-2:] == ("-m", "mkdocs")
+        assert cmd[0] == python_env.venv_bin(filename="python")


### PR DESCRIPTION
## Summary

When a project uses the new native `uv` install method (`method: uv`, `command: sync`), the MkDocs build fails with `/bin/sh: 1: /bin/python: not found`. The Sphinx backend already handles this via `get_sphinx_cmd()` (see `readthedocs/doc_builder/backends/sphinx.py:179-191`), but the MkDocs backend was still hard-coding `python -m mkdocs`.

This change extracts an analogous `get_mkdocs_cmd()` on `BaseMkdocs` that returns `("uv", "run", "mkdocs")` when `self.python_env` is a `UvEnv`, and otherwise keeps the existing `python -m mkdocs` invocation.

Fixes #12996

## Test plan

- [x] `tox -e py312 -- -k MkDocsBuilderTest --reuse-db --nomigrations`
- [x] `tox -e py312 -- -k test_doc_builder --reuse-db --nomigrations`
- [x] `pre-commit run --files readthedocs/doc_builder/backends/mkdocs.py readthedocs/rtd_tests/tests/test_doc_builder.py` (vale hook skipped due to local Go toolchain network error)

---
_This PR was generated by AI (Claude Code)._

---
_Generated by [Claude Code](https://claude.ai/code/session_018WF95xtcCeG6Ahyp5nfivE)_