### PR TITLE
Build: do not update `asdf` before compiling the build tools

### DIFF
--- a/scripts/compile_version_upload_s3.sh
+++ b/scripts/compile_version_upload_s3.sh
@@ -80,8 +80,11 @@ echo "Running all the commands in Docker container: $CONTAINER_ID"
 # echo -n 'asdf version: '
 # docker exec --user root $CONTAINER_ID asdf version
 
+# NOTE: we can't update asdf anymore since the new stable version is the Go version
+# and it breaks the building of build tools
 # Update asdf to the latest stable release
-docker exec $CONTAINER_ID asdf update
+# docker exec $CONTAINER_ID asdf update
+
 # Update all asdf plugins to the latest commit
 # (we require this to be able to compile newer versions)
 docker exec $CONTAINER_ID asdf plugin update --all


### PR DESCRIPTION
```
+ docker exec 3496be7735c6269d37b4116fe8f5f6d72612daebde435a7e9c9cf1a291b52933 asdf plugin update --all
OCI runtime exec failed: exec failed: unable to start container process: exec: "asdf": executable file not found in $PATH: unknown
```

https://app.circleci.com/pipelines/github/readthedocs/readthedocs-docker-images/320/workflows/0ac15f16-8c78-4501-a838-3adf8b510964/jobs/554