### PR TITLE
ci: harden workflows against zizmor findings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,19 +17,23 @@ jobs:
 
     steps:
     - name: Trigger tests in readthedocs-corporate
+      env:
+        CIRCLECI_USER_TOKEN: ${{ secrets.CIRCLECI_USER_TOKEN }}
       run: |
         curl --request POST \
         --silent --output /dev/null \
         --url https://circleci.com/api/v2/project/gh/readthedocs/readthedocs-corporate/pipeline \
-        --user '${{ secrets.CIRCLECI_USER_TOKEN }}:' \
+        --user "${CIRCLECI_USER_TOKEN}:" \
         --header 'content-type: application/json' \
         --data '{"branch": "main", "parameters":{"tests_only": true}}'
 
     - name: Trigger tests in readthedocs-ext
+      env:
+        CIRCLECI_USER_TOKEN: ${{ secrets.CIRCLECI_USER_TOKEN }}
       run: |
         curl --request POST \
         --silent --output /dev/null \
-        --url https:/circleci.com/api/v2/project/gh/readthedocs/readthedocs-ext/pipeline \
-        --user '${{ secrets.CIRCLECI_USER_TOKEN }}:' \
+        --url https://circleci.com/api/v2/project/gh/readthedocs/readthedocs-ext/pipeline \
+        --user "${CIRCLECI_USER_TOKEN}:" \
         --header 'content-type: application/json' \
         --data '{"branch": "main", "parameters":{"tests_only": true}}'

--- a/.github/workflows/pip-tools.yaml
+++ b/.github/workflows/pip-tools.yaml
@@ -25,12 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'readthedocs' # do not run this job on forks
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Update submodules
         run: git submodule update --init
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
@@ -45,7 +45,7 @@ jobs:
         run: invoke requirements.update
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           add-paths: |
             requirements/*.txt


### PR DESCRIPTION
## Summary

Ran [zizmor](https://docs.zizmor.sh) against `.github/workflows/` and addressed every error/high-severity finding. Workflow security is a common cause of open-source compromise, so the remaining items are worth fixing even though our triggers are already conservative (`push: main` and `schedule`).

### Template injection (high) — `main.yml`

`${{ secrets.CIRCLECI_USER_TOKEN }}` was expanded directly into the `run:` shell script. Even for a secret (not user-controllable), zizmor flags this because the value is interpolated into the script source rather than passed as data. Switched to `env:` + `"${CIRCLECI_USER_TOKEN}:"` so the value never lands in the rendered script.

While editing those lines I also corrected a pre-existing typo on the `readthedocs-ext` URL (`https:/circleci.com` → `https://circleci.com`) that would have made that curl fail.

### Unpinned uses (error) — `pip-tools.yaml`

Pinned the three actions to immutable commit SHAs with version comments:

- `actions/checkout` → `de0fac2e…` (v6.0.2)
- `actions/setup-python` → `a309ff8b…` (v6.2.0)
- `peter-evans/create-pull-request` → `5f6978fa…` (v8.1.1)

Dependabot is already watching `github-actions` weekly, so it will keep these current.

### Result

`zizmor .github/workflows/` now reports **no findings**. Pedantic mode still surfaces stylistic items (concurrency limits, job names, permission comments) but no security findings remain.

## Test plan

- [ ] CI passes on this branch
- [ ] Confirm CircleCI still gets triggered on the next push to `main` (i.e. the env-var rewrite works in practice)

---

_Generated by AI._

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzU5MvLYL9Y2ZU8nTsL2qz)_