### PR TITLE
ci: refresh CircleCI orbs (codecov v3 → v5, drop unused node orb)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,7 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@3.2.2
-  node: circleci/node@5.1.0
+  codecov: codecov/codecov@5.4.3
 
 commands:
   setup-checkout:


### PR DESCRIPTION
Companion to the GitHub Actions hardening in #13000. Zizmor doesn't cover CircleCI, so this is a manual sweep of `.circleci/config.yml`.

## Changes

- **`codecov/codecov@3.2.2` → `@5.4.3`.** v3 is end-of-life and stale; codecov has a history of supply-chain incidents (the 2021 bash-uploader compromise), so running on a maintained line is worth doing. The `upload` command still works without arguments in v5, so our `- codecov/upload` step is unchanged.
- **Drop `circleci/node@5.1.0`.** The orb was declared but never referenced — no `node/...` step appears anywhere in the file. Removing dead orbs reduces the third-party surface area we trust.

## Things deliberately not changed

- Docker images (`cimg/python:3.12`, Elasticsearch `9.3.1`) are pinned by tag, not by digest. Pinning by digest would be stricter, but the maintenance cost (manually bumping SHAs every patch) is high and the failure mode is low for these well-known images. Happy to add this in a follow-up if you'd like.
- `ELASTIC_PASSWORD: password` in the search sidecar — the sidecar has no real data and isn't reachable from outside the job, so this isn't a real secret.

## Test plan

- [ ] CircleCI parses the new orb (`circleci config validate` passes in CI)
- [ ] `coverage-report` job uploads successfully to Codecov on a real run

---

_Generated by AI._

---
_Generated by [Claude Code](https://claude.ai/code/session_01MzU5MvLYL9Y2ZU8nTsL2qz)_