### PR TITLE
Fix observations flagged by Claude in querysets

### DIFF
--- a/readthedocs/core/permissions.py
+++ b/readthedocs/core/permissions.py
@@ -134,6 +134,8 @@ class AdminPermissionBase:
         if isinstance(obj, Organization):
             return obj.owners.all()
 
+        raise ValueError("obj must be an instance of Project or Organization")
+
     @classmethod
     def admins(cls, obj):
         from readthedocs.organizations.models import Organization
@@ -144,6 +146,8 @@ class AdminPermissionBase:
 
         if isinstance(obj, Organization):
             return obj.owners.all()
+
+        raise ValueError("obj must be an instance of Project or Organization")
 
     @classmethod
     def members(cls, obj, user=None):
@@ -175,6 +179,8 @@ class AdminPermissionBase:
             return User.objects.filter(
                 Q(teams__organization=obj) | Q(owner_organizations=obj),
             ).distinct()
+
+        raise ValueError("obj must be an instance of Project or Organization")
 
     @classmethod
     def is_admin(cls, user, obj):

--- a/readthedocs/organizations/signals.py
+++ b/readthedocs/organizations/signals.py
@@ -2,7 +2,6 @@
 
 import structlog
 from allauth.account.signals import user_signed_up
-from django.db.models import Count
 from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 from djstripe.enums import SubscriptionStatus
@@ -14,7 +13,6 @@ from readthedocs.organizations.models import Organization
 from readthedocs.organizations.models import Team
 from readthedocs.organizations.models import TeamMember
 from readthedocs.payments.utils import cancel_subscription
-from readthedocs.projects.models import Project
 
 from .tasks import mark_organization_assets_not_cleaned as mark_organization_assets_not_cleaned_task
 
@@ -36,7 +34,7 @@ def attach_org(sender, request, user, **kwargs):
 @receiver(pre_delete, sender=Organization)
 def remove_organization_completely(sender, instance, using, **kwargs):
     """
-    Remove Organization leaf-overs.
+    Remove Organization leftovers.
 
     This includes:
 
@@ -64,17 +62,9 @@ def remove_organization_completely(sender, instance, using, **kwargs):
             cancel_subscription(subscription.id)
 
     log.info("Removing organization completely", organization_slug=organization.slug)
-
-    # ``Project`` has a ManyToMany relationship with ``Organization``. We need
-    # to be sure that the projects we are deleting here belongs only to the
-    # organization deleted
-    projects = Project.objects.annotate(count_organizations=Count("organizations")).filter(
-        organizations__in=[organization], count_organizations=1
-    )
-
-    # Granular delete that trigger other complex tasks.
-    for project in projects:
-        # Triggers a task to remove artifacts from storage.
+    # Granular delete that trigger other complex tasks,
+    # like remove artifacts from storage.
+    for project in organization.projects.all():
         project.delete()
 
 


### PR DESCRIPTION
- All projects belong to just one organization
- Raise an exception if a wrong object is passed to admins/members/etc.