### PR TITLE
docs: use anchor for Sign up CTA to match Learn more

### DIFF
--- a/docs/_templates/breadcrumbs.html
+++ b/docs/_templates/breadcrumbs.html
@@ -6,7 +6,7 @@
   <div class="info admonition rst-footer-buttons">
     <div class="wy-btn-group">
       <a class="btn btn-link" href="https://about.readthedocs.com/">Learn more about Read the Docs</a>
-      <button class="btn btn-info btn-mini float-right" onclick="window.location.href='https://about.readthedocs.com/#signup'">Sign up</button>
+      <a class="btn btn-info btn-mini float-right" href="https://about.readthedocs.com/#signup">Sign up</a>
     </div>
   </div>
   <ul class="wy-breadcrumbs">


### PR DESCRIPTION
Follow-up to #12841.

@agjohnson noted in review: _"Seems we somehow ended up with one link and one button? Review should be looked at a bit closer here."_

This makes both CTAs in the docs breadcrumb header use `<a>` tags. The `btn-*` classes apply to anchor elements, so the inline `onclick` JS on the **Sign up** button was unnecessary — same reasoning given for the **Learn more** button earlier in the original review.

---
_Generated by AI (Claude Code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_017BxSawks42dpBkMuctohGA)_