### PR TITLE
Fix YAML in uv examples

### DIFF
--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -271,9 +271,9 @@ For example, to run ``uv sync --group docs``:
     python:
        install:
           - method: uv
-             command: sync
-             groups:
-                - docs
+            command: sync
+            groups:
+               - docs
 
 For example, to run ``uv pip install -r docs/requirements.txt``:
 
@@ -284,8 +284,8 @@ For example, to run ``uv pip install -r docs/requirements.txt``:
     python:
        install:
           - method: uv
-             command: pip
-             requirements: docs/requirements.txt
+            command: pip
+            requirements: docs/requirements.txt
 
 For example, to run ``uv pip install .[docs]``:
 
@@ -296,10 +296,10 @@ For example, to run ``uv pip install .[docs]``:
     python:
        install:
           - method: uv
-             command: pip
-             path: .
-             extras:
-                - docs
+            command: pip
+            path: .
+            extras:
+               - docs
 
 conda
 ~~~~~


### PR DESCRIPTION
Currently the YAML syntax highlighting in https://docs.readthedocs.com/platform/stable/config-file/v2.html#uv is broken because of an indentation mismatch within the block.