### PR TITLE
Notifications: user content type model attribute instead of name

### DIFF
--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -263,7 +263,7 @@ class NotificationSerializer(serializers.ModelSerializer):
         read_only_fields = ["dismissable", "news"]
 
     def get_attached_to_content_type(self, obj):
-        return obj.attached_to_content_type.name
+        return obj.attached_to_content_type.model
 
 
 class VersionLinksSerializer(BaseLinksSerializer):

--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -263,6 +263,7 @@ class NotificationSerializer(serializers.ModelSerializer):
         read_only_fields = ["dismissable", "news"]
 
     def get_attached_to_content_type(self, obj):
+        # NOTE: Don't user name, because it can change based on the current language.
         return obj.attached_to_content_type.model
 
 

--- a/readthedocs/notifications/models.py
+++ b/readthedocs/notifications/models.py
@@ -87,11 +87,10 @@ class Notification(TimeStampedModel):
         return message
 
     def get_absolute_url(self):
-        content_type_name = self.attached_to_content_type.name
-        path = ""
+        content_type_name = self.attached_to_content_type.model
         if content_type_name == "user":
             url = "users-notifications-detail"
-            path = reverse(
+            return reverse(
                 url,
                 kwargs={
                     "notification_pk": self.pk,
@@ -99,10 +98,10 @@ class Notification(TimeStampedModel):
                 },
             )
 
-        elif content_type_name == "build":
+        if content_type_name == "build":
             url = "projects-builds-notifications-detail"
             project_slug = self.attached_to.project.slug
-            path = reverse(
+            return reverse(
                 url,
                 kwargs={
                     "notification_pk": self.pk,
@@ -111,10 +110,10 @@ class Notification(TimeStampedModel):
                 },
             )
 
-        elif content_type_name == "project":
+        if content_type_name == "project":
             url = "projects-notifications-detail"
             project_slug = self.attached_to.slug
-            path = reverse(
+            return reverse(
                 url,
                 kwargs={
                     "notification_pk": self.pk,
@@ -122,13 +121,14 @@ class Notification(TimeStampedModel):
                 },
             )
 
-        elif content_type_name == "organization":
+        if content_type_name == "organization":
             url = "organizations-notifications-detail"
-            path = reverse(
+            return reverse(
                 url,
                 kwargs={
                     "notification_pk": self.pk,
                     "parent_lookup_organization__slug": self.attached_to.slug,
                 },
             )
-        return path
+
+        raise ValueError("Unknown content type for notification")

--- a/readthedocs/notifications/models.py
+++ b/readthedocs/notifications/models.py
@@ -87,6 +87,7 @@ class Notification(TimeStampedModel):
         return message
 
     def get_absolute_url(self):
+        # NOTE: Don't user name, because it can change based on the current language.
         content_type_name = self.attached_to_content_type.model
         if content_type_name == "user":
             url = "users-notifications-detail"


### PR DESCRIPTION
name is the verbose name of the model, which is subject to change based on the current language, the model attribute is the actual name of the model, which is not subject to change based on the current language.

Also, error instead of silently returning an empty string.

Fixes https://github.com/readthedocs/readthedocs.org/issues/12994#issuecomment-4343770850