### PR TITLE
builds: pre-built HTML upload as a Version source type

### DIFF
--- a/docs/dev/design/prebuilt-html-upload.rst
+++ b/docs/dev/design/prebuilt-html-upload.rst
@@ -4,30 +4,30 @@ Pre-built HTML upload
 Goal
 ----
 
-Let users host HTML they built outside of Read the Docs while keeping every
-hosting feature: dashboard, builds list, build commands, notifications,
-addons, search, redirects, custom domains and the existing APIv3.
+Let users host HTML they built outside Read the Docs while keeping every
+hosting feature: dashboard, builds, build commands, notifications, addons,
+search, redirects, custom domains, APIv3.
 
-Renaming, marketing names and "rename ``latest``" are explicitly **out of
-scope**: the existing :py:class:`~readthedocs.builds.forms.VersionForm`
-already lets users edit the slug of any non-machine version.
+Renaming and "rename ``latest``" are out of scope: the existing
+:py:class:`~readthedocs.builds.forms.VersionForm` already lets users edit
+the slug of any non-machine version.
 
-Shape of the change
--------------------
+Shape
+-----
 
-A new :py:attr:`Version.source_type` field selects how the builder fetches
-the version's source:
+One new field, :py:attr:`Version.source_type`, selects how the builder
+fetches source:
 
 ``vcs`` (default)
-    Clone the project repository and run the configured build tool. This is
-    the existing behavior for every existing row.
+    Clone the repository and run the configured build tool. Existing
+    behavior, unchanged for every existing row.
 
 ``upload``
-    Skip the clone and unzip an archive that the user uploaded via the API.
+    Skip the clone and unzip an archive uploaded via APIv3.
 
-Versions with ``source_type=upload`` are excluded from VCS sync delete and
-from webhook ref resolution. Everything else — Build objects, state machine,
-artifact upload, notifications, APIv3 — is reused as-is.
+Upload-type versions are excluded from VCS sync delete and webhook ref
+resolution. Same :py:class:`Build` rows, state machine, Celery queues,
+APIv3 — all reused.
 
 Data model
 ----------
@@ -37,51 +37,50 @@ In ``readthedocs/builds/models.py``::
     source_type = CharField(choices=SOURCE_TYPES, default="vcs")
     upload_content_hash = CharField(max_length=64, null=True, blank=True)
 
-The hash is the SHA256 of the most recent uploaded archive. It doubles as the
-storage key segment so two uploads with identical content reuse the same
-object and so the builder always knows which object to fetch.
+The hash is the SHA256 of the latest archive. It also forms the storage
+key, making same-content uploads idempotent and the builder fetch
+deterministic.
 
-Migration: ``builds/migrations/0072_version_source_type_upload_content_hash.py``,
-``Safe.before_deploy()`` (additive, nullable, default).
+Migration ``builds/migrations/0072_*.py`` is ``Safe.before_deploy()``:
+additive, nullable, default-valued.
 
 Storage layout
 --------------
 
-Archives live on ``build_media_storage`` at::
+``build_media_storage``::
 
     uploads/<project_slug>/<version_slug>/<sha256>.zip
 
-The builder reads the same key. Old objects are overwritten on re-upload of
-identical content; older distinct archives are left in place for now (see
-*Open issues*).
+Validation contract
+-------------------
 
-Validation contract (``projects/tasks/uploads.validate_archive``)
------------------------------------------------------------------
+Run on the web side **before** anything is persisted
+(``projects/tasks/uploads.validate_archive``):
 
-Performed on the web side **before** anything is persisted:
+* ≤ 1 GiB compressed, ≤ 5 GiB uncompressed, ratio ≤ 200×, ≤ 50 000 files.
+* No absolute paths, no ``..``, no symlinks. Safety check runs *before*
+  the junk-file filter so traversal hidden in ignored paths
+  (``__MACOSX/../etc/passwd``) still rejects.
+* Top-level entries ⊆ ``{html, htmlzip, pdf, epub}``. ``html/`` is
+  required and must contain ``index.html``.
+* Silently tolerated: ``__MACOSX/`` resource forks, dotfiles
+  (``.DS_Store`` etc.), backslash separators, directory marker entries.
 
-* Archive size ≤ 1 GiB compressed; uncompressed ≤ 5 GiB; ratio ≤ 200×.
-* ≤ 50 000 entries.
-* No absolute paths, no ``..`` traversal, no symlinks.
-* Top-level entries must be a subset of ``{html, htmlzip, pdf, epub}``.
-* ``html/`` is required.
-
-All limits are constants in ``uploads.py`` so they can be lifted to settings
-later.
+Limits live as constants in ``uploads.py`` for now; promote to settings
+once we have a number we like.
 
 API
 ---
 
-``POST /api/v3/projects/<project>/versions/<version>/upload/``
-    ``multipart/form-data`` with a single ``file`` field containing the zip.
-    Validates the archive, stores it, sets ``upload_content_hash``, and
-    triggers a build via the existing ``trigger_build``. Returns the same
-    envelope the build-trigger endpoint uses, plus ``upload.{sha256, size,
-    top_level_dirs}``.
+``POST /api/v3/projects/<p>/versions/<v>/upload/`` —
+``multipart/form-data`` with a single ``file`` field. Validates, stores,
+sets ``upload_content_hash``, triggers a build via the existing
+``trigger_build``. Response mirrors the build-trigger envelope plus
+``upload.{sha256, size, top_level_dirs}``.
 
-``source_type`` is exposed read-only on the version serializer; creating an
-``upload`` version is a separate concern handled by the existing version
-admin / management surface and is **not** part of this change.
+Both ``source_type`` and ``upload_content_hash`` are exposed on the
+APIv2 ``VersionSerializer`` — without this the builder reads them as
+defaults and silently takes the VCS path.
 
 Build pipeline
 --------------
@@ -92,78 +91,61 @@ In ``UpdateDocsTask.execute()``::
         self.execute_upload()
         return
 
-``execute_upload`` short-circuits the VCS+Docker pipeline:
+``execute_upload`` does:
 
-1. ``BUILD_STATE_CLONING`` — wipe and recreate
-   ``project.artifact_path("html").parent`` (the ``_readthedocs/`` dir).
-2. ``BUILD_STATE_BUILDING`` — download the archive from
-   ``build_media_storage`` and unzip into that directory.
-3. ``BUILD_STATE_UPLOADING`` — call the existing
-   ``store_build_artifacts()`` which already handles per-format validation,
-   renaming and rclone-sync to permanent storage.
+1. ``CLONING`` — wipe and recreate the build's ``_readthedocs/`` dir.
+2. ``BUILDING`` — stage the SHA-keyed archive to a tempfile (so
+   ``zipfile`` is seekable on any storage backend) and unzip it.
+3. ``UPLOADING`` — call the existing ``store_build_artifacts()``, which
+   already handles per-format validation, single-file rename, and
+   rclone-sync to permanent storage.
 
-No Docker, no language env, no build tool — there is nothing to run.
+A missing archive at extract time raises
+``MissingUploadedArchiveError`` → ``BuildUserError`` so the dashboard
+shows a real notification.
 
-Sync & webhook routing
-----------------------
+Sync & webhooks
+---------------
 
 * ``api/v2/utils.py:_get_deleted_versions_qs`` excludes
-  ``source_type=upload`` from the delete candidate queryset, so a future VCS
-  sync won't drop manually-created upload versions.
+  ``source_type=upload``.
 * ``projects/models.py:Project.versions_from_name`` excludes
-  ``source_type=upload``, so a push event whose ref name happens to collide
-  with an upload version's ``verbose_name`` does not trigger an upload
-  rebuild.
+  ``source_type=upload`` so a push whose ref name collides with an
+  upload version's ``verbose_name`` doesn't trigger an upload rebuild.
 
-Reuse summary
--------------
+What we don't add
+-----------------
 
-What we **don't** add: a parallel build path, a new Build model, separate
-Celery queues, separate concurrency tracking, separate notifications,
-separate APIv3 build endpoints. All of that comes for free from reusing
-``Build`` and ``store_build_artifacts``.
-
-What we **do** add: one field, one migration, one helper module
-(``projects/tasks/uploads.py``), one task method (``execute_upload``), one
-DRF action (``VersionsViewSet.upload``).
+A parallel build path, a new Build model, separate Celery queues,
+separate concurrency tracking, separate notifications, separate APIv3
+build endpoints. All free from reusing ``Build`` and
+``store_build_artifacts``.
 
 Tests
 -----
 
-* ``projects/tests/test_uploads.py`` — zip validation: minimal, all formats,
-  missing html, unknown top-level dir, traversal, absolute path, empty,
-  non-zip, plus ``get_upload_storage_path``.
-* ``api/v3/tests/test_uploads.py`` — endpoint: trigger flow with mocked
-  ``store_uploaded_archive`` and ``trigger_build``; rejects non-upload
-  versions, rejects invalid archives, requires auth, forbids other users.
-* ``rtd_tests/tests/test_sync_versions.py`` — upload versions survive sync;
-  upload versions excluded from webhook routing.
+* ``projects/tests/test_uploads.py`` — validator: minimal, all formats,
+  missing html, no index, root-file hint, traversal, absolute path,
+  symlink, empty, non-zip, ``__MACOSX``, dotfiles, backslashes,
+  directory entries, traversal-in-junk.
+* ``api/v3/tests/test_uploads.py`` — endpoint: trigger, non-upload
+  reject, invalid-archive reject, auth, cross-user.
+* ``rtd_tests/tests/test_sync_versions.py`` — upload versions survive
+  sync; not matched by webhook routing.
 
-GitHub Actions
---------------
+Open issues
+-----------
 
-``docs/user/examples/github-actions-upload.yml`` shows the end-to-end CI
-flow: build with ``sphinx-build``, assemble the ``html/`` (and optional
-``epub/``, ``pdf/``, ``htmlzip/``) directories into a zip, ``curl`` to the
-upload endpoint with a token from secrets.
-
-Open issues / follow-ups
-------------------------
-
-* **Retention.** The current code does *not* delete older archives at the
-  same prefix when content changes. Add a small task that keeps the last N
-  (configurable) per version once we have a number we like.
-* **In-flight build vs. new upload.** A second upload while a build is
-  running just queues another build with the new hash; the first finishes
-  with the old artifacts and is then overwritten. This matches webhook
-  behavior and is probably fine, but worth confirming.
-* **Plan gating.** On readthedocs.com the upload feature should likely be
-  gated by feature flag / plan tier. Not wired up here.
-* **Creating upload versions.** Adding a CreateModelMixin to
-  ``VersionsViewSet`` (so users can create the upload version itself via
-  API) is a small follow-up. For now creation is via dashboard / admin.
-* **Legacy ``Version.uploaded`` field.** Left untouched; the new exclusion
-  in ``_get_deleted_versions_qs`` is additive (``.exclude(uploaded=True)``
-  is preserved alongside ``.exclude(source_type=SOURCE_TYPE_UPLOAD)``).
-  Drop ``uploaded`` in a later release once we are sure nothing else reads
-  it.
+* **Retention.** Older archives at the same prefix are not cleaned up.
+  Add a per-version "keep last N" task.
+* **Creating upload versions.** Currently admin/shell only. Add to
+  ``VersionsViewSet`` (``CreateModelMixin``) and ``VersionForm`` once
+  the surface is settled.
+* **Plan gating** on .com.
+* **In-flight build vs. new upload.** Second upload while a build is
+  running just queues another build with the new hash; the first
+  finishes with the new artifacts. Matches webhook behavior; fine.
+* **Legacy ``Version.uploaded``.** Left untouched; new
+  ``source_type=upload`` exclusion is additive. Drop in a later release.
+* **Infra.** Remember to bump nginx ``client_max_body_size`` to match
+  ``MAX_UPLOAD_SIZE_BYTES`` when this ships.

--- a/docs/dev/design/prebuilt-html-upload.rst
+++ b/docs/dev/design/prebuilt-html-upload.rst
@@ -1,0 +1,169 @@
+Pre-built HTML upload
+=====================
+
+Goal
+----
+
+Let users host HTML they built outside of Read the Docs while keeping every
+hosting feature: dashboard, builds list, build commands, notifications,
+addons, search, redirects, custom domains and the existing APIv3.
+
+Renaming, marketing names and "rename ``latest``" are explicitly **out of
+scope**: the existing :py:class:`~readthedocs.builds.forms.VersionForm`
+already lets users edit the slug of any non-machine version.
+
+Shape of the change
+-------------------
+
+A new :py:attr:`Version.source_type` field selects how the builder fetches
+the version's source:
+
+``vcs`` (default)
+    Clone the project repository and run the configured build tool. This is
+    the existing behavior for every existing row.
+
+``upload``
+    Skip the clone and unzip an archive that the user uploaded via the API.
+
+Versions with ``source_type=upload`` are excluded from VCS sync delete and
+from webhook ref resolution. Everything else — Build objects, state machine,
+artifact upload, notifications, APIv3 — is reused as-is.
+
+Data model
+----------
+
+In ``readthedocs/builds/models.py``::
+
+    source_type = CharField(choices=SOURCE_TYPES, default="vcs")
+    upload_content_hash = CharField(max_length=64, null=True, blank=True)
+
+The hash is the SHA256 of the most recent uploaded archive. It doubles as the
+storage key segment so two uploads with identical content reuse the same
+object and so the builder always knows which object to fetch.
+
+Migration: ``builds/migrations/0072_version_source_type_upload_content_hash.py``,
+``Safe.before_deploy()`` (additive, nullable, default).
+
+Storage layout
+--------------
+
+Archives live on ``build_media_storage`` at::
+
+    uploads/<project_slug>/<version_slug>/<sha256>.zip
+
+The builder reads the same key. Old objects are overwritten on re-upload of
+identical content; older distinct archives are left in place for now (see
+*Open issues*).
+
+Validation contract (``projects/tasks/uploads.validate_archive``)
+-----------------------------------------------------------------
+
+Performed on the web side **before** anything is persisted:
+
+* Archive size ≤ 1 GiB compressed; uncompressed ≤ 5 GiB; ratio ≤ 200×.
+* ≤ 50 000 entries.
+* No absolute paths, no ``..`` traversal, no symlinks.
+* Top-level entries must be a subset of ``{html, htmlzip, pdf, epub}``.
+* ``html/`` is required.
+
+All limits are constants in ``uploads.py`` so they can be lifted to settings
+later.
+
+API
+---
+
+``POST /api/v3/projects/<project>/versions/<version>/upload/``
+    ``multipart/form-data`` with a single ``file`` field containing the zip.
+    Validates the archive, stores it, sets ``upload_content_hash``, and
+    triggers a build via the existing ``trigger_build``. Returns the same
+    envelope the build-trigger endpoint uses, plus ``upload.{sha256, size,
+    top_level_dirs}``.
+
+``source_type`` is exposed read-only on the version serializer; creating an
+``upload`` version is a separate concern handled by the existing version
+admin / management surface and is **not** part of this change.
+
+Build pipeline
+--------------
+
+In ``UpdateDocsTask.execute()``::
+
+    if self.data.version.is_upload:
+        self.execute_upload()
+        return
+
+``execute_upload`` short-circuits the VCS+Docker pipeline:
+
+1. ``BUILD_STATE_CLONING`` — wipe and recreate
+   ``project.artifact_path("html").parent`` (the ``_readthedocs/`` dir).
+2. ``BUILD_STATE_BUILDING`` — download the archive from
+   ``build_media_storage`` and unzip into that directory.
+3. ``BUILD_STATE_UPLOADING`` — call the existing
+   ``store_build_artifacts()`` which already handles per-format validation,
+   renaming and rclone-sync to permanent storage.
+
+No Docker, no language env, no build tool — there is nothing to run.
+
+Sync & webhook routing
+----------------------
+
+* ``api/v2/utils.py:_get_deleted_versions_qs`` excludes
+  ``source_type=upload`` from the delete candidate queryset, so a future VCS
+  sync won't drop manually-created upload versions.
+* ``projects/models.py:Project.versions_from_name`` excludes
+  ``source_type=upload``, so a push event whose ref name happens to collide
+  with an upload version's ``verbose_name`` does not trigger an upload
+  rebuild.
+
+Reuse summary
+-------------
+
+What we **don't** add: a parallel build path, a new Build model, separate
+Celery queues, separate concurrency tracking, separate notifications,
+separate APIv3 build endpoints. All of that comes for free from reusing
+``Build`` and ``store_build_artifacts``.
+
+What we **do** add: one field, one migration, one helper module
+(``projects/tasks/uploads.py``), one task method (``execute_upload``), one
+DRF action (``VersionsViewSet.upload``).
+
+Tests
+-----
+
+* ``projects/tests/test_uploads.py`` — zip validation: minimal, all formats,
+  missing html, unknown top-level dir, traversal, absolute path, empty,
+  non-zip, plus ``get_upload_storage_path``.
+* ``api/v3/tests/test_uploads.py`` — endpoint: trigger flow with mocked
+  ``store_uploaded_archive`` and ``trigger_build``; rejects non-upload
+  versions, rejects invalid archives, requires auth, forbids other users.
+* ``rtd_tests/tests/test_sync_versions.py`` — upload versions survive sync;
+  upload versions excluded from webhook routing.
+
+GitHub Actions
+--------------
+
+``docs/user/examples/github-actions-upload.yml`` shows the end-to-end CI
+flow: build with ``sphinx-build``, assemble the ``html/`` (and optional
+``epub/``, ``pdf/``, ``htmlzip/``) directories into a zip, ``curl`` to the
+upload endpoint with a token from secrets.
+
+Open issues / follow-ups
+------------------------
+
+* **Retention.** The current code does *not* delete older archives at the
+  same prefix when content changes. Add a small task that keeps the last N
+  (configurable) per version once we have a number we like.
+* **In-flight build vs. new upload.** A second upload while a build is
+  running just queues another build with the new hash; the first finishes
+  with the old artifacts and is then overwritten. This matches webhook
+  behavior and is probably fine, but worth confirming.
+* **Plan gating.** On readthedocs.com the upload feature should likely be
+  gated by feature flag / plan tier. Not wired up here.
+* **Creating upload versions.** Adding a CreateModelMixin to
+  ``VersionsViewSet`` (so users can create the upload version itself via
+  API) is a small follow-up. For now creation is via dashboard / admin.
+* **Legacy ``Version.uploaded`` field.** Left untouched; the new exclusion
+  in ``_get_deleted_versions_qs`` is additive (``.exclude(uploaded=True)``
+  is preserved alongside ``.exclude(source_type=SOURCE_TYPE_UPLOAD)``).
+  Drop ``uploaded`` in a later release once we are sure nothing else reads
+  it.

--- a/docs/dev/design/prebuilt-html-upload.rst
+++ b/docs/dev/design/prebuilt-html-upload.rst
@@ -1,12 +1,16 @@
-Pre-built HTML upload
+Pre-built docs upload
 =====================
 
 Goal
 ----
 
-Let users host HTML they built outside Read the Docs while keeping every
-hosting feature: dashboard, builds, build commands, notifications, addons,
-search, redirects, custom domains, APIv3.
+Let users host documentation they built outside Read the Docs while
+keeping every hosting feature: dashboard, builds, build commands,
+notifications, addons, search, redirects, custom domains, APIv3.
+
+The feature is named "pre-built HTML" colloquially but the archive may
+contain any of the formats Read the Docs supports — ``html/`` is
+required, ``htmlzip/``, ``pdf/`` and ``epub/`` are optional.
 
 Renaming and "rename ``latest``" are out of scope: the existing
 :py:class:`~readthedocs.builds.forms.VersionForm` already lets users edit
@@ -25,9 +29,13 @@ fetches source:
 ``upload``
     Skip the clone and unzip an archive uploaded via APIv3.
 
-Upload-type versions are excluded from VCS sync delete and webhook ref
-resolution. Same :py:class:`Build` rows, state machine, Celery queues,
-APIv3 — all reused.
+Upload-type versions are excluded from VCS sync delete and from webhook
+ref resolution (i.e. when a ``git push`` arrives, the lookup that maps
+the branch/tag to a ``Version`` skips upload rows so a push can never
+accidentally trigger an upload rebuild).
+
+Same :py:class:`Build` rows, state machine, Celery queues, APIv3 — all
+reused.
 
 Data model
 ----------
@@ -66,6 +74,9 @@ Run on the web side **before** anything is persisted
 * Silently tolerated: ``__MACOSX/`` resource forks, hidden
   ``.DS_Store``-style files, backslash separators, directory marker
   entries.
+* Error messages never echo entries from the archive — the archive is
+  user-supplied input we should not reflect back into our own logs or
+  responses.
 
 Limits live as constants in ``uploads.py`` for now; promote to settings
 once we have a number we like.
@@ -79,9 +90,15 @@ sets ``upload_content_hash``, triggers a build via the existing
 ``trigger_build``. Response mirrors the build-trigger envelope plus
 ``upload.{sha256, size, top_level_dirs}``.
 
+The endpoint **does not create the version row**. The version must
+already exist with ``source_type=upload``. Today that means we
+(maintainers) create it via Django admin or shell; a ``CreateModelMixin``
+on ``VersionsViewSet`` is in *Open issues*.
+
 Both ``source_type`` and ``upload_content_hash`` are exposed on the
 APIv2 ``VersionSerializer`` — without this the builder reads them as
-defaults and silently takes the VCS path.
+defaults and silently takes the VCS path. APIv2 is otherwise on the way
+out, but the builder is its only consumer for this data.
 
 Build pipeline
 --------------
@@ -94,15 +111,24 @@ In ``UpdateDocsTask.execute()``::
 
 ``execute_upload`` does:
 
-1. ``CLONING`` — wipe and recreate the build's ``_readthedocs/`` dir.
-2. ``BUILDING`` — stage the SHA-keyed archive to a local temporary
-   file (so ``zipfile`` always has a ``seek()``-capable input on any
-   storage backend) and unzip it.
-3. ``UPLOADING`` — call the existing ``store_build_artifacts()``, which
-   already handles per-format validation, single-file rename, and
-   rclone-sync to permanent storage.
+1. Stage the archive on the host at
+   ``project.checkout_path(version)/upload.zip``. That path is
+   bind-mounted into the build container.
+2. Spin up the build container via the existing
+   ``BuildDirector.create_build_environment()``.
+3. Inside the container: ``mkdir -p _readthedocs/`` then ``unzip -q -o
+   upload.zip -d _readthedocs/ -x __MACOSX/* */.DS_Store .DS_Store``.
+   The host never executes ``unzip`` on user input.
+4. Call the existing ``store_build_artifacts()`` (host-side; copies the
+   mounted output to permanent storage). It also runs the existing
+   ``BUILD_OUTPUT_*`` validations — ``html/index.html`` exists,
+   single-file PDF/EPUB/HTMLZIP, etc. — exactly like a normal build.
 
-A missing archive at extract time raises
+The build state machine reuses ``CLONING`` and ``BUILDING`` for now;
+adding upload-specific states (e.g. ``STAGING``, ``EXTRACTING``) is a
+small follow-up once we like the shape.
+
+A missing archive at stage time raises
 ``MissingUploadedArchiveError`` → ``BuildUserError`` so the dashboard
 shows a real notification.
 
@@ -129,7 +155,7 @@ Tests
 * ``projects/tests/test_uploads.py`` — validator: minimal, all formats,
   missing html, no index, root-file hint, traversal, absolute path,
   symlink, empty, non-zip, ``__MACOSX``, hidden files, backslashes,
-  directory entries, traversal-in-junk.
+  directory entries, traversal-in-junk, "errors don't echo user names".
 * ``api/v3/tests/test_uploads.py`` — endpoint: trigger, non-upload
   reject, invalid-archive reject, auth, cross-user.
 * ``rtd_tests/tests/test_sync_versions.py`` — upload versions survive
@@ -140,14 +166,26 @@ Open issues
 
 * **Retention.** Older archives at the same prefix are not cleaned up.
   Add a per-version "keep last N" task.
-* **Creating upload versions.** Currently admin/shell only. Add to
-  ``VersionsViewSet`` (``CreateModelMixin``) and ``VersionForm`` once
-  the surface is settled.
-* **Plan gating** on .com.
-* **In-flight build vs. new upload.** Second upload while a build is
-  running just queues another build with the new hash; the first
-  finishes with the new artifacts. Matches webhook behavior; fine.
+* **Creating upload versions.** Today: maintainer-only via admin/shell.
+  Add ``CreateModelMixin`` to ``VersionsViewSet`` and a ``source_type``
+  field to ``VersionForm`` once the surface is settled.
+* **Plan gating.** On .com the upload feature should be gated by
+  feature flag / plan tier (e.g. paid plans only) before rollout.
+  Implementation TBD; not wired today.
+* **Upload reliability for big files.** A 1 GiB ``POST`` over the open
+  internet is not a great UX (slow, no resume, easy to retry-storm).
+  Worth investigating S3 presigned-PUT or chunked/resumable uploads
+  before we recommend the cap actually be 1 GiB.
+* **DDoS surface.** The upload endpoint accepts large bodies and
+  triggers a Celery build per request. Needs per-user throttling
+  (DRF ``UserRateThrottle`` is on the view — confirm the rate is
+  appropriate for this action) and probably a per-project quota.
+* **Build states.** Reusing ``CLONING``/``BUILDING`` is a stop-gap;
+  add ``STAGING``/``EXTRACTING`` (or rename) so the dashboard reads
+  cleanly for upload builds.
 * **Legacy ``Version.uploaded``.** Left untouched; new
   ``source_type=upload`` exclusion is additive. Drop in a later release.
-* **Infra.** Remember to bump nginx ``client_max_body_size`` to match
-  ``MAX_UPLOAD_SIZE_BYTES`` when this ships.
+* **Infra.** Bump the upload-endpoint body size limit (nginx
+  ``client_max_body_size`` etc.) to match ``MAX_UPLOAD_SIZE_BYTES``
+  **only on the upload URL** — leave the global limit as-is so other
+  endpoints don't accept 1 GiB requests.

--- a/docs/dev/design/prebuilt-html-upload.rst
+++ b/docs/dev/design/prebuilt-html-upload.rst
@@ -63,8 +63,9 @@ Run on the web side **before** anything is persisted
   (``__MACOSX/../etc/passwd``) still rejects.
 * Top-level entries ⊆ ``{html, htmlzip, pdf, epub}``. ``html/`` is
   required and must contain ``index.html``.
-* Silently tolerated: ``__MACOSX/`` resource forks, dotfiles
-  (``.DS_Store`` etc.), backslash separators, directory marker entries.
+* Silently tolerated: ``__MACOSX/`` resource forks, hidden
+  ``.DS_Store``-style files, backslash separators, directory marker
+  entries.
 
 Limits live as constants in ``uploads.py`` for now; promote to settings
 once we have a number we like.
@@ -94,8 +95,9 @@ In ``UpdateDocsTask.execute()``::
 ``execute_upload`` does:
 
 1. ``CLONING`` — wipe and recreate the build's ``_readthedocs/`` dir.
-2. ``BUILDING`` — stage the SHA-keyed archive to a tempfile (so
-   ``zipfile`` is seekable on any storage backend) and unzip it.
+2. ``BUILDING`` — stage the SHA-keyed archive to a local temporary
+   file (so ``zipfile`` always has a ``seek()``-capable input on any
+   storage backend) and unzip it.
 3. ``UPLOADING`` — call the existing ``store_build_artifacts()``, which
    already handles per-format validation, single-file rename, and
    rclone-sync to permanent storage.
@@ -126,7 +128,7 @@ Tests
 
 * ``projects/tests/test_uploads.py`` — validator: minimal, all formats,
   missing html, no index, root-file hint, traversal, absolute path,
-  symlink, empty, non-zip, ``__MACOSX``, dotfiles, backslashes,
+  symlink, empty, non-zip, ``__MACOSX``, hidden files, backslashes,
   directory entries, traversal-in-junk.
 * ``api/v3/tests/test_uploads.py`` — endpoint: trigger, non-upload
   reject, invalid-archive reject, auth, cross-user.

--- a/docs/user/examples/github-actions-upload.yml
+++ b/docs/user/examples/github-actions-upload.yml
@@ -1,0 +1,65 @@
+# Example GitHub Actions workflow that builds documentation outside of
+# Read the Docs and uploads the resulting HTML to a Read the Docs version
+# whose ``source_type`` is set to ``upload``.
+#
+# Prerequisites on Read the Docs:
+#   1. Create a version manually (e.g. via the API or the dashboard) with
+#      ``source_type=upload``. The version slug below ("0.3.x") must match.
+#   2. Generate a personal API token and store it as the ``RTD_TOKEN``
+#      repository secret in GitHub.
+#
+# The archive must contain only the artifact directories Read the Docs
+# supports at the top level: ``html/`` (required), and optionally
+# ``htmlzip/``, ``pdf/`` and ``epub/``.
+
+name: Build and upload docs to Read the Docs
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  workflow_dispatch:
+
+env:
+  RTD_PROJECT: my-project
+  RTD_VERSION: 0.3.x
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r docs/requirements.txt
+
+      - name: Build HTML (and other formats)
+        run: |
+          # Build whichever formats you want to host. Only ``html/`` is required.
+          sphinx-build -b html docs/ _build/html
+          sphinx-build -b epub docs/ _build/epub
+
+      - name: Assemble Read the Docs upload archive
+        run: |
+          mkdir -p upload/html upload/epub
+          cp -r _build/html/. upload/html/
+          # Offline formats (htmlzip/pdf/epub) must contain exactly one file:
+          # see https://docs.readthedocs.io/en/stable/api/v3.html#version-upload
+          cp _build/epub/*.epub upload/epub/docs.epub
+          (cd upload && zip -r ../docs.zip .)
+
+      - name: Upload to Read the Docs
+        env:
+          RTD_TOKEN: ${{ secrets.RTD_TOKEN }}
+        run: |
+          curl --fail-with-body \
+            -X POST \
+            -H "Authorization: Token ${RTD_TOKEN}" \
+            -F "file=@docs.zip" \
+            "https://readthedocs.org/api/v3/projects/${RTD_PROJECT}/versions/${RTD_VERSION}/upload/"

--- a/docs/user/examples/github-actions-upload.yml
+++ b/docs/user/examples/github-actions-upload.yml
@@ -3,8 +3,10 @@
 # whose ``source_type`` is set to ``upload``.
 #
 # Prerequisites on Read the Docs:
-#   1. Create a version manually (e.g. via the API or the dashboard) with
-#      ``source_type=upload``. The version slug below ("0.3.x") must match.
+#   1. Ask a Read the Docs maintainer to create a version with
+#      ``source_type=upload`` for your project (today this is admin-only;
+#      a self-service API is on the roadmap). The version slug below
+#      ("0.3.x") must match.
 #   2. Generate a personal API token and store it as the ``RTD_TOKEN``
 #      repository secret in GitHub.
 #

--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -145,6 +145,8 @@ class VersionSerializer(serializers.ModelSerializer):
             "has_epub",
             "has_htmlzip",
             "documentation_type",
+            "source_type",
+            "upload_content_hash",
         ]
 
     def __init__(self, *args, **kwargs):

--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -145,6 +145,10 @@ class VersionSerializer(serializers.ModelSerializer):
             "has_epub",
             "has_htmlzip",
             "documentation_type",
+            # The builder reads version data through APIv2 — without these
+            # two fields ``APIVersion.is_upload`` is always False and the
+            # upload code path never runs. Even though APIv2 is on the way
+            # out, the builder is the only consumer of this serializer.
             "source_type",
             "upload_content_hash",
         ]

--- a/readthedocs/api/v2/utils.py
+++ b/readthedocs/api/v2/utils.py
@@ -12,6 +12,7 @@ from readthedocs.builds.constants import INTERNAL
 from readthedocs.builds.constants import LATEST
 from readthedocs.builds.constants import LATEST_VERBOSE_NAME
 from readthedocs.builds.constants import NON_REPOSITORY_VERSIONS
+from readthedocs.builds.constants import SOURCE_TYPE_UPLOAD
 from readthedocs.builds.constants import STABLE
 from readthedocs.builds.constants import STABLE_VERBOSE_NAME
 from readthedocs.builds.constants import TAG
@@ -177,6 +178,7 @@ def _get_deleted_versions_qs(project, tags_data, branches_data):
     to_delete_qs = (
         project.versions(manager=INTERNAL)
         .exclude(uploaded=True)
+        .exclude(source_type=SOURCE_TYPE_UPLOAD)
         .exclude(slug__in=NON_REPOSITORY_VERSIONS)
     )
 

--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -348,6 +348,7 @@ class VersionSerializer(serializers.ModelSerializer):
             "active",
             "hidden",
             "type",
+            "source_type",
             "downloads",
             "urls",
             "_links",

--- a/readthedocs/api/v3/tests/responses/projects-detail.json
+++ b/readthedocs/api/v3/tests/responses/projects-detail.json
@@ -19,6 +19,7 @@
             },
             "ref": null,
             "slug": "v1.0",
+            "source_type": "vcs",
             "type": "tag",
             "urls": {
                 "dashboard": {

--- a/readthedocs/api/v3/tests/responses/projects-versions-builds-list_POST.json
+++ b/readthedocs/api/v3/tests/responses/projects-versions-builds-list_POST.json
@@ -103,6 +103,7 @@
         },
         "ref": null,
         "slug": "v1.0",
+        "source_type": "vcs",
         "type": "tag",
         "urls": {
             "dashboard": {

--- a/readthedocs/api/v3/tests/responses/projects-versions-detail.json
+++ b/readthedocs/api/v3/tests/responses/projects-versions-detail.json
@@ -17,6 +17,7 @@
     },
     "ref": null,
     "slug": "v1.0",
+    "source_type": "vcs",
     "type": "tag",
     "urls": {
         "dashboard": {

--- a/readthedocs/api/v3/tests/test_uploads.py
+++ b/readthedocs/api/v3/tests/test_uploads.py
@@ -1,0 +1,114 @@
+"""Tests for the APIv3 pre-built HTML upload endpoint."""
+
+import io
+import zipfile
+from unittest import mock
+
+import django_dynamic_fixture as fixture
+from django.test import override_settings
+from django.urls import reverse
+
+from readthedocs.builds.constants import SOURCE_TYPE_UPLOAD
+from readthedocs.builds.constants import SOURCE_TYPE_VCS
+from readthedocs.builds.constants import TAG
+from readthedocs.builds.models import Build
+from readthedocs.builds.models import Version
+from readthedocs.projects.constants import PUBLIC
+
+from .mixins import APIEndpointMixin
+
+
+def _make_zip(entries):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, payload in entries.items():
+            zf.writestr(name, payload)
+    buf.seek(0)
+    return buf
+
+
+@override_settings(ALLOW_PRIVATE_REPOS=False)
+class UploadEndpointTests(APIEndpointMixin):
+    def setUp(self):
+        super().setUp()
+        self.client.logout()
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+
+        self.upload_version = fixture.get(
+            Version,
+            project=self.project,
+            slug="0.3",
+            verbose_name="0.3",
+            type=TAG,
+            source_type=SOURCE_TYPE_UPLOAD,
+            active=True,
+            privacy_level=PUBLIC,
+        )
+        self.url = reverse(
+            "projects-versions-upload",
+            kwargs={
+                "parent_lookup_project__slug": self.project.slug,
+                "version_slug": self.upload_version.slug,
+            },
+        )
+
+    def _post(self, archive, name="docs.zip"):
+        archive.seek(0)
+        return self.client.post(
+            self.url,
+            {"file": (name, archive, "application/zip")},
+            format="multipart",
+        )
+
+    @mock.patch("readthedocs.api.v3.views.trigger_build")
+    @mock.patch("readthedocs.api.v3.views.store_uploaded_archive")
+    def test_upload_triggers_build_and_persists_hash(self, store_mock, trigger_mock):
+        build = fixture.get(Build, project=self.project, version=self.upload_version)
+        trigger_mock.return_value = (None, build)
+        archive = _make_zip({"html/index.html": b"<html></html>"})
+
+        response = self._post(archive)
+
+        assert response.status_code == 202
+        body = response.json()
+        assert body["triggered"] is True
+        assert body["upload"]["top_level_dirs"] == ["html"]
+        assert len(body["upload"]["sha256"]) == 64
+
+        store_mock.assert_called_once()
+        trigger_mock.assert_called_once_with(
+            project=self.project,
+            version=self.upload_version,
+        )
+
+        self.upload_version.refresh_from_db()
+        assert self.upload_version.upload_content_hash == body["upload"]["sha256"]
+
+    def test_upload_rejects_non_upload_versions(self):
+        self.upload_version.source_type = SOURCE_TYPE_VCS
+        self.upload_version.save()
+
+        archive = _make_zip({"html/index.html": b"<html></html>"})
+        response = self._post(archive)
+
+        assert response.status_code == 400
+        assert "source_type" in response.json()
+
+    def test_upload_rejects_invalid_archive(self):
+        archive = _make_zip({"src/secret.py": b"print('hi')"})
+        response = self._post(archive)
+
+        assert response.status_code == 400
+        assert "file" in response.json()
+
+    def test_upload_requires_authentication(self):
+        self.client.logout()
+        archive = _make_zip({"html/index.html": b"<html></html>"})
+        response = self._post(archive)
+        assert response.status_code in (401, 403)
+
+    def test_upload_forbidden_for_other_user(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.others_token.key}")
+        archive = _make_zip({"html/index.html": b"<html></html>"})
+        response = self._post(archive)
+        assert response.status_code in (403, 404)

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -10,6 +10,7 @@ from rest_framework import status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
 from rest_framework.metadata import SimpleMetadata
 from rest_framework.mixins import CreateModelMixin
 from rest_framework.mixins import DestroyModelMixin
@@ -17,6 +18,7 @@ from rest_framework.mixins import ListModelMixin
 from rest_framework.mixins import RetrieveModelMixin
 from rest_framework.mixins import UpdateModelMixin
 from rest_framework.pagination import LimitOffsetPagination
+from rest_framework.parsers import MultiPartParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.renderers import BrowsableAPIRenderer
 from rest_framework.response import Response
@@ -29,6 +31,7 @@ from rest_framework_extensions.mixins import NestedViewSetMixin
 
 from readthedocs.api.v2.permissions import ReadOnlyPermission
 from readthedocs.builds.constants import EXTERNAL
+from readthedocs.builds.constants import SOURCE_TYPE_UPLOAD
 from readthedocs.builds.models import Build
 from readthedocs.builds.models import Version
 from readthedocs.core.utils import trigger_build
@@ -44,6 +47,9 @@ from readthedocs.projects.models import Domain
 from readthedocs.projects.models import EnvironmentVariable
 from readthedocs.projects.models import Project
 from readthedocs.projects.models import ProjectRelationship
+from readthedocs.projects.tasks.uploads import InvalidUploadArchiveError
+from readthedocs.projects.tasks.uploads import store_uploaded_archive
+from readthedocs.projects.tasks.uploads import validate_archive
 from readthedocs.projects.views.mixins import ProjectImportMixin
 from readthedocs.redirects.models import Redirect
 
@@ -382,6 +388,62 @@ class VersionsViewSet(
     def get_queryset(self):
         """Overridden to allow internal versions only."""
         return super().get_queryset().exclude(type=EXTERNAL)
+
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="upload",
+        parser_classes=[MultiPartParser],
+        permission_classes=[IsAuthenticated & IsProjectAdmin],
+    )
+    def upload(self, request, **kwargs):
+        """
+        Upload a pre-built HTML archive for a ``source_type=upload`` version.
+
+        The request must be ``multipart/form-data`` with a single ``file`` field
+        containing a zip whose top-level entries are some subset of
+        ``html/`` (required), ``htmlzip/``, ``pdf/`` and ``epub/``.
+
+        On success the archive is stored on ``build_media_storage`` and a build
+        is queued through the regular build trigger. The response mirrors the
+        existing build-trigger endpoint so clients can reuse the same code.
+        """
+        version = self.get_object()
+        if version.source_type != SOURCE_TYPE_UPLOAD:
+            raise ValidationError(
+                {"source_type": "Version must have source_type='upload' to accept archive uploads."}
+            )
+
+        file_obj = request.FILES.get("file")
+        if not file_obj:
+            raise ValidationError({"file": "A 'file' field is required."})
+
+        try:
+            archive = validate_archive(file_obj)
+        except InvalidUploadArchiveError as exc:
+            raise ValidationError({"file": str(exc)}) from exc
+
+        store_uploaded_archive(version, file_obj, sha256=archive.sha256)
+        # Persist the new content hash *before* triggering the build so the
+        # builder picks up the right archive when it runs.
+        version.upload_content_hash = archive.sha256
+        version.save(update_fields=["upload_content_hash", "modified"])
+
+        _, build = trigger_build(project=version.project, version=version)
+
+        data = {
+            "triggered": bool(build),
+            "build": BuildSerializer(build).data if build else None,
+            "project": ProjectSerializer(version.project).data,
+            "version": VersionSerializer(version).data,
+            "upload": {
+                "sha256": archive.sha256,
+                "size": archive.size,
+                "top_level_dirs": sorted(archive.top_level_dirs),
+            },
+        }
+        code = status.HTTP_202_ACCEPTED if build else status.HTTP_400_BAD_REQUEST
+        return Response(data=data, status=code)
 
 
 class BuildsViewSet(

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -421,7 +421,11 @@ class VersionsViewSet(
         try:
             archive = validate_archive(file_obj)
         except InvalidUploadArchiveError as exc:
-            raise ValidationError({"file": str(exc)}) from exc
+            # The validator's messages are static strings (no user content) so
+            # we forward them. Drop the cause to avoid CodeQL flagging the
+            # ``__cause__`` chain as stack-trace exposure on the public API.
+            message = str(exc)
+            raise ValidationError({"file": message}) from None
 
         store_uploaded_archive(version, file_obj, sha256=archive.sha256)
         # Persist the new content hash *before* triggering the build so the

--- a/readthedocs/builds/constants.py
+++ b/readthedocs/builds/constants.py
@@ -62,6 +62,16 @@ VERSION_TYPES = (
     (EXTERNAL, EXTERNAL_TEXT),
     (UNKNOWN, UNKNOWN_TEXT),
 )
+
+# How the source for a version is obtained at build time:
+# - ``vcs``: clone the project repo and run the configured build tool (default).
+# - ``upload``: skip the clone and unzip a pre-built archive uploaded by the user.
+SOURCE_TYPE_VCS = "vcs"
+SOURCE_TYPE_UPLOAD = "upload"
+SOURCE_TYPES = (
+    (SOURCE_TYPE_VCS, _("VCS")),
+    (SOURCE_TYPE_UPLOAD, _("Pre-built upload")),
+)
 EXTERNAL_VERSION_STATE_OPEN = "open"
 EXTERNAL_VERSION_STATE_CLOSED = "closed"
 EXTERNAL_VERSION_STATES = (

--- a/readthedocs/builds/migrations/0072_version_source_type_upload_content_hash.py
+++ b/readthedocs/builds/migrations/0072_version_source_type_upload_content_hash.py
@@ -1,0 +1,34 @@
+from django.db import migrations
+from django.db import models
+from django_safemigrate import Safe
+
+
+class Migration(migrations.Migration):
+    safe = Safe.before_deploy()
+
+    dependencies = [
+        ("builds", "0071_alter_versionautomationrule_fk"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="version",
+            name="source_type",
+            field=models.CharField(
+                choices=[("vcs", "VCS"), ("upload", "Pre-built upload")],
+                default="vcs",
+                max_length=16,
+                verbose_name="Source type",
+            ),
+        ),
+        migrations.AddField(
+            model_name="version",
+            name="upload_content_hash",
+            field=models.CharField(
+                blank=True,
+                max_length=64,
+                null=True,
+                verbose_name="Upload content hash",
+            ),
+        ),
+    ]

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -33,6 +33,9 @@ from readthedocs.builds.constants import INTERNAL
 from readthedocs.builds.constants import LATEST
 from readthedocs.builds.constants import MAX_BUILD_COMMAND_SIZE
 from readthedocs.builds.constants import OLD_VERSION_PREDEFINED_MATCH_PATTERNS
+from readthedocs.builds.constants import SOURCE_TYPE_UPLOAD
+from readthedocs.builds.constants import SOURCE_TYPE_VCS
+from readthedocs.builds.constants import SOURCE_TYPES
 from readthedocs.builds.constants import STABLE
 from readthedocs.builds.constants import VERSION_PREDEFINED_MATCH_PATTERN_VALUES
 from readthedocs.builds.constants import VERSION_TYPES
@@ -164,6 +167,26 @@ class Version(TimeStampedModel):
     )
     machine = models.BooleanField(_("Machine Created"), default=False)
 
+    #: Where the version's source comes from. ``vcs`` clones the project repo
+    #: and runs the configured build tool. ``upload`` skips the clone and
+    #: unzips a pre-built archive uploaded by the user.
+    source_type = models.CharField(
+        _("Source type"),
+        max_length=16,
+        choices=SOURCE_TYPES,
+        default=SOURCE_TYPE_VCS,
+    )
+
+    #: SHA256 of the latest pre-built archive uploaded for this version.
+    #: Used as the storage key under ``uploads/<project>/<version>/<sha>.zip``
+    #: and to skip rebuilds when the same archive is uploaded twice.
+    upload_content_hash = models.CharField(
+        _("Upload content hash"),
+        max_length=64,
+        null=True,
+        blank=True,
+    )
+
     # Whether the latest successful build for this version contains certain media types
     has_pdf = models.BooleanField(_("Has PDF"), default=False)
     has_epub = models.BooleanField(_("Has ePub"), default=False)
@@ -233,6 +256,22 @@ class Version(TimeStampedModel):
     @property
     def is_machine_latest(self):
         return self.machine and self.slug == LATEST
+
+    @property
+    def is_upload(self):
+        """Whether this version is built from a user-uploaded archive."""
+        return self.source_type == SOURCE_TYPE_UPLOAD
+
+    def get_upload_storage_path(self, content_hash=None):
+        """
+        Return the ``build_media_storage`` key for this version's uploaded archive.
+
+        Falls back to ``self.upload_content_hash`` when ``content_hash`` is not given.
+        """
+        sha = content_hash or self.upload_content_hash
+        if not sha:
+            return None
+        return f"uploads/{self.project.slug}/{self.slug}/{sha}.zip"
 
     @property
     def explicit_name(self):

--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -134,6 +134,34 @@ class BuildDirector:
             api_client=self.data.api_client,
         )
 
+    def unzip_uploaded_archive(self, archive_path, destination_dir):
+        """
+        Extract a pre-built upload archive *inside* the build container.
+
+        The archive has already been validated server-side
+        (:func:`readthedocs.projects.tasks.uploads.validate_archive`) — no
+        traversal, no symlinks, no absolute paths, only allowed top-level
+        directories — but we still run ``unzip`` in Docker so a bug in the
+        ``unzip`` binary itself can't escape the sandbox.
+
+        ``__MACOSX/`` resource forks and dotfiles are skipped to keep the
+        offline-format ``has-multiple-files`` check downstream happy when
+        macOS users include ``.DS_Store`` next to their ``docs.pdf``.
+        """
+        self.build_environment.run("mkdir", "-p", destination_dir)
+        self.build_environment.run(
+            "unzip",
+            "-q",
+            "-o",
+            archive_path,
+            "-d",
+            destination_dir,
+            "-x",
+            "__MACOSX/*",
+            "*/.DS_Store",
+            ".DS_Store",
+        )
+
     def setup_environment(self):
         """
         Create the environment and install required dependencies.

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -33,6 +33,7 @@ from readthedocs.builds.constants import EXTERNAL
 from readthedocs.builds.constants import INTERNAL
 from readthedocs.builds.constants import LATEST
 from readthedocs.builds.constants import LATEST_VERBOSE_NAME
+from readthedocs.builds.constants import SOURCE_TYPE_UPLOAD
 from readthedocs.builds.constants import STABLE
 from readthedocs.builds.constants import STABLE_VERBOSE_NAME
 from readthedocs.builds.constants import VERSION_PREDEFINED_MATCH_PATTERN_VALUES
@@ -1359,6 +1360,10 @@ class Project(models.Model):
             # or change our logic to store the tags name in the identifier of stable.
             | Q(identifier=name, machine=True)
         )
+        # Pre-built upload versions have no VCS ref, so a push event for ``name``
+        # should never resolve to one. Exclude them defensively in case somebody
+        # set ``verbose_name`` to a branch/tag name that happens to collide.
+        queryset = queryset.exclude(source_type=SOURCE_TYPE_UPLOAD)
 
         if type:
             queryset = queryset.filter(type=type)

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -71,6 +71,7 @@ from ..models import WebHookEvent
 from ..signals import before_vcs
 from .mixins import SyncRepositoryMixin
 from .search import index_build
+from .uploads import MissingUploadedArchiveError
 from .uploads import extract_uploaded_archive
 from .utils import BuildRequest
 from .utils import clean_build
@@ -922,7 +923,15 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         os.makedirs(artifact_root, exist_ok=True)
 
         self.update_build(state=BUILD_STATE_BUILDING)
-        extract_uploaded_archive(self.data.version, artifact_root)
+        try:
+            extract_uploaded_archive(self.data.version, artifact_root)
+        except MissingUploadedArchiveError as exc:
+            # Surface as a user error so the dashboard shows a real message
+            # instead of an internal traceback.
+            raise BuildUserError(
+                message_id=BuildUserError.GENERIC,
+                exception_message=str(exc),
+            ) from exc
 
         self.store_build_artifacts()
 

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -71,6 +71,7 @@ from ..models import WebHookEvent
 from ..signals import before_vcs
 from .mixins import SyncRepositoryMixin
 from .search import index_build
+from .uploads import extract_uploaded_archive
 from .utils import BuildRequest
 from .utils import clean_build
 from .utils import send_external_build_status
@@ -841,6 +842,12 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
             log.exception("Error while updating the build object.", state=state)
 
     def execute(self):
+        # Pre-built upload versions short-circuit the whole VCS+build pipeline:
+        # there is nothing to clone and nothing to build.
+        if self.data.version.is_upload:
+            self.execute_upload()
+            return
+
         # Cloning
         self.update_build(state=BUILD_STATE_CLONING)
 
@@ -887,6 +894,36 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         # However, we cannot use `.on_success()` because we still have to upload the artifacts;
         # which could fail, and we want to detect that and handle it properly at `.on_failure()`
         # Store build artifacts to storage (local or cloud storage)
+        self.store_build_artifacts()
+
+    def execute_upload(self):
+        """
+        Build path for ``source_type=upload`` versions.
+
+        We don't clone, don't run a build tool, and don't need a Docker
+        container. We just download the archive uploaded by the user, unzip
+        it into the build's ``_readthedocs/`` directory, and let the existing
+        ``store_build_artifacts`` flow copy it to permanent storage.
+
+        The same Build state machine is reused so the dashboard, notifications,
+        APIv3 and concurrency limits all keep working unchanged.
+        """
+        self.update_build(state=BUILD_STATE_CLONING)
+
+        artifact_root = os.path.dirname(
+            self.data.project.artifact_path(
+                version=self.data.version.slug,
+                type_="html",
+            )
+        )
+        # Ensure a clean slate; an old failed extract should not leak into this build.
+        if os.path.isdir(artifact_root):
+            shutil.rmtree(artifact_root)
+        os.makedirs(artifact_root, exist_ok=True)
+
+        self.update_build(state=BUILD_STATE_BUILDING)
+        extract_uploaded_archive(self.data.version, artifact_root)
+
         self.store_build_artifacts()
 
     def collect_build_data(self):

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -72,7 +72,7 @@ from ..signals import before_vcs
 from .mixins import SyncRepositoryMixin
 from .search import index_build
 from .uploads import MissingUploadedArchiveError
-from .uploads import extract_uploaded_archive
+from .uploads import stage_uploaded_archive
 from .utils import BuildRequest
 from .utils import clean_build
 from .utils import send_external_build_status
@@ -901,13 +901,17 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         """
         Build path for ``source_type=upload`` versions.
 
-        We don't clone, don't run a build tool, and don't need a Docker
-        container. We just download the archive uploaded by the user, unzip
-        it into the build's ``_readthedocs/`` directory, and let the existing
-        ``store_build_artifacts`` flow copy it to permanent storage.
+        No clone, no build tool, no language environment. We download the
+        archive (already validated server-side at upload time) onto a host
+        path that's bind-mounted into the build container, then run
+        ``unzip`` *inside* the container. The existing
+        ``store_build_artifacts`` flow then copies the result to permanent
+        storage just like a normal build.
 
-        The same Build state machine is reused so the dashboard, notifications,
-        APIv3 and concurrency limits all keep working unchanged.
+        Reusing the same ``Build`` state machine keeps the dashboard,
+        notifications, APIv3, build concurrency limits and the
+        ``BUILD_OUTPUT_*`` validations (``index.html`` present, single-file
+        offline formats, etc.) working unchanged.
         """
         self.update_build(state=BUILD_STATE_CLONING)
 
@@ -917,21 +921,31 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
                 type_="html",
             )
         )
-        # Ensure a clean slate; an old failed extract should not leak into this build.
+        # Stage the archive next to the artifact dir; both live under
+        # ``project.checkout_path(version)`` which is mounted into the
+        # container, so ``unzip`` inside Docker can see them at the same path.
+        archive_host_path = os.path.join(
+            self.data.project.checkout_path(version=self.data.version.slug),
+            "upload.zip",
+        )
         if os.path.isdir(artifact_root):
             shutil.rmtree(artifact_root)
-        os.makedirs(artifact_root, exist_ok=True)
 
-        self.update_build(state=BUILD_STATE_BUILDING)
         try:
-            extract_uploaded_archive(self.data.version, artifact_root)
+            stage_uploaded_archive(self.data.version, archive_host_path)
         except MissingUploadedArchiveError as exc:
-            # Surface as a user error so the dashboard shows a real message
-            # instead of an internal traceback.
             raise BuildUserError(
                 message_id=BuildUserError.GENERIC,
                 exception_message=str(exc),
             ) from exc
+
+        self.data.build_director.create_build_environment()
+        with self.data.build_director.build_environment:
+            self.update_build(state=BUILD_STATE_BUILDING)
+            self.data.build_director.unzip_uploaded_archive(
+                archive_host_path,
+                artifact_root,
+            )
 
         self.store_build_artifacts()
 

--- a/readthedocs/projects/tasks/uploads.py
+++ b/readthedocs/projects/tasks/uploads.py
@@ -18,6 +18,8 @@ their permanent location.
 
 import hashlib
 import os
+import shutil
+import tempfile
 import zipfile
 from dataclasses import dataclass
 
@@ -47,11 +49,35 @@ class InvalidUploadArchiveError(Exception):
     """The uploaded archive failed validation."""
 
 
+class MissingUploadedArchiveError(Exception):
+    """No archive is present on storage for this version (e.g. expired)."""
+
+
 @dataclass
 class ValidatedArchive:
     sha256: str
     size: int
     top_level_dirs: frozenset
+
+
+def _normalize_name(name):
+    """Normalize a zip member name to forward-slash separators."""
+    return name.replace("\\", "/")
+
+
+def _is_ignorable(name):
+    """
+    Whether a zip member name is junk that we should silently strip.
+
+    Covers the most common user mistakes:
+
+    * macOS resource forks (``__MACOSX/...``) added by ``zip -r`` on macOS.
+    * Hidden dotfiles like ``.DS_Store``, ``Thumbs.db`` etc. They never carry
+      docs content and would otherwise blow up the
+      ``BUILD_OUTPUT_HAS_MULTIPLE_FILES`` check on offline formats.
+    """
+    parts = _normalize_name(name).split("/")
+    return any(part == "__MACOSX" or part.startswith(".") for part in parts if part)
 
 
 def validate_archive(file_obj):
@@ -66,7 +92,8 @@ def validate_archive(file_obj):
       or whose compression ratio exceeds :data:`MAX_COMPRESSION_RATIO`
       (zip-bomb defense).
     * **Layout** — top-level entries must all be in
-      :data:`ALLOWED_TOP_LEVEL_DIRS` and must include ``html/``.
+      :data:`ALLOWED_TOP_LEVEL_DIRS` and must include ``html/`` with an
+      ``index.html`` inside.
 
     Returns a :class:`ValidatedArchive` describing the archive on success;
     raises :class:`InvalidUploadArchiveError` otherwise. The file pointer is
@@ -80,8 +107,7 @@ def validate_archive(file_obj):
         raise InvalidUploadArchiveError("Uploaded archive is empty.")
     if compressed_size > MAX_UPLOAD_SIZE_BYTES:
         raise InvalidUploadArchiveError(
-            f"Uploaded archive is too large ({compressed_size} bytes; "
-            f"max {MAX_UPLOAD_SIZE_BYTES})."
+            f"Uploaded archive is too large ({compressed_size} bytes; max {MAX_UPLOAD_SIZE_BYTES})."
         )
 
     sha256 = hashlib.sha256()
@@ -102,18 +128,41 @@ def validate_archive(file_obj):
 
     total_uncompressed = 0
     top_level_dirs = set()
+    has_html_index = False
     for info in infos:
+        # Always run the safety check, even for entries we will later ignore,
+        # so a traversal hiding inside a junk path (e.g. ``__MACOSX/../etc``)
+        # still rejects the whole archive.
         _check_member_safe(info)
+        name = _normalize_name(info.filename)
+        if _is_ignorable(name):
+            continue
         total_uncompressed += info.file_size
 
-        first = info.filename.split("/", 1)[0]
-        if first and first not in ALLOWED_TOP_LEVEL_DIRS:
+        # Directory marker entries (``html/``) are zero-byte and only carry
+        # the directory name. Treat them as a top-level dir signal but skip
+        # the "file at root" check below.
+        is_dir_entry = info.is_dir() or name.endswith("/")
+        first, _, rest = name.rstrip("/").partition("/")
+        if not first:
+            continue
+        if not rest and not is_dir_entry:
+            # File at the archive root — almost always a user that forgot to
+            # wrap their build output in an ``html/`` directory.
+            if name.lower().endswith((".html", ".htm")):
+                raise InvalidUploadArchiveError(_root_file_hint(name))
+            raise InvalidUploadArchiveError(
+                f"Disallowed top-level entry {name!r}; "
+                f"expected one of {sorted(ALLOWED_TOP_LEVEL_DIRS)}."
+            )
+        if first not in ALLOWED_TOP_LEVEL_DIRS:
             raise InvalidUploadArchiveError(
                 f"Disallowed top-level entry {first!r}; "
                 f"expected one of {sorted(ALLOWED_TOP_LEVEL_DIRS)}."
             )
-        if first:
-            top_level_dirs.add(first)
+        top_level_dirs.add(first)
+        if first == "html" and rest == "index.html":
+            has_html_index = True
 
     if total_uncompressed > MAX_UNCOMPRESSED_SIZE_BYTES:
         raise InvalidUploadArchiveError(
@@ -128,6 +177,11 @@ def validate_archive(file_obj):
         raise InvalidUploadArchiveError(
             f"Archive is missing required directories: {sorted(missing)}."
         )
+    if "html" in top_level_dirs and not has_html_index:
+        raise InvalidUploadArchiveError(
+            "Archive is missing 'html/index.html'. "
+            "The HTML output must contain an index.html at the root of the html/ directory."
+        )
 
     file_obj.seek(0)
     return ValidatedArchive(
@@ -137,18 +191,23 @@ def validate_archive(file_obj):
     )
 
 
+def _root_file_hint(name):
+    return (
+        f"Found {name!r} at the archive root. The archive must put HTML inside "
+        "an 'html/' directory (e.g. 'html/index.html'), not at the root."
+    )
+
+
 def _check_member_safe(info):
-    name = info.filename
+    name = _normalize_name(info.filename)
     if name.startswith("/") or os.path.isabs(name):
-        raise InvalidUploadArchiveError(f"Absolute path in archive: {name!r}.")
-    # Reject any path segment that resolves above the root, even with mixed separators.
-    parts = name.replace("\\", "/").split("/")
-    if any(part in ("..",) for part in parts):
-        raise InvalidUploadArchiveError(f"Path traversal in archive: {name!r}.")
+        raise InvalidUploadArchiveError(f"Absolute path in archive: {info.filename!r}.")
+    if any(part == ".." for part in name.split("/")):
+        raise InvalidUploadArchiveError(f"Path traversal in archive: {info.filename!r}.")
     # Reject symlinks (POSIX mode in the upper 16 bits of external_attr).
     mode = (info.external_attr >> 16) & 0xFFFF
     if mode and (mode & 0xF000) == 0xA000:
-        raise InvalidUploadArchiveError(f"Symlink in archive: {name!r}.")
+        raise InvalidUploadArchiveError(f"Symlink in archive: {info.filename!r}.")
 
 
 def store_uploaded_archive(version, file_obj, sha256):
@@ -156,13 +215,14 @@ def store_uploaded_archive(version, file_obj, sha256):
     Persist a validated archive to ``build_media_storage`` and return the key.
 
     The caller is responsible for invoking :func:`validate_archive` first and
-    passing the resulting hash. Older archives at the same key are overwritten.
+    passing the resulting hash. The key includes the SHA, so when the same
+    content is uploaded twice we re-use the existing object instead of racing
+    a delete + save.
     """
     key = version.get_upload_storage_path(content_hash=sha256)
     file_obj.seek(0)
-    if build_media_storage.exists(key):
-        build_media_storage.delete(key)
-    build_media_storage.save(key, file_obj)
+    if not build_media_storage.exists(key):
+        build_media_storage.save(key, file_obj)
     return key
 
 
@@ -180,22 +240,37 @@ def extract_uploaded_archive(version, destination_dir, storage=None):
     storage = storage or build_media_storage
     key = version.get_upload_storage_path()
     if not key:
-        raise InvalidUploadArchiveError(
+        raise MissingUploadedArchiveError(
             f"Version {version.slug!r} has no uploaded archive to extract."
+        )
+    if not storage.exists(key):
+        raise MissingUploadedArchiveError(
+            f"Uploaded archive for version {version.slug!r} is no longer available "
+            f"at {key!r}. Re-upload the archive and trigger a new build."
         )
 
     os.makedirs(destination_dir, exist_ok=True)
     extracted = set()
-    with storage.open(key, "rb") as remote:
-        # ZipFile needs a seekable file-like. Storage backends typically return
-        # one; if not, the caller can stage to a tempfile first.
-        with zipfile.ZipFile(remote) as zf:
+    # Stage to a local tempfile so ``zipfile`` always has a seekable input,
+    # regardless of whether the storage backend's ``open()`` returns a
+    # streamed body. Also bounds connection time to the remote bucket.
+    with tempfile.NamedTemporaryFile(suffix=".zip") as tmp:
+        with storage.open(key, "rb") as remote:
+            shutil.copyfileobj(remote, tmp)
+        tmp.flush()
+        tmp.seek(0)
+        with zipfile.ZipFile(tmp) as zf:
             for info in zf.infolist():
                 _check_member_safe(info)
-                first = info.filename.split("/", 1)[0]
+                name = _normalize_name(info.filename)
+                if _is_ignorable(name):
+                    continue
+                first = name.rstrip("/").partition("/")[0]
                 if first and first in ALLOWED_TOP_LEVEL_DIRS:
                     extracted.add(first)
-            zf.extractall(destination_dir)
+                    # Per-member extract so we skip junk filtered above and
+                    # also rewrite any backslash-only names safely.
+                    zf.extract(info, destination_dir)
     log.info(
         "Extracted uploaded archive.",
         version_slug=version.slug,

--- a/readthedocs/projects/tasks/uploads.py
+++ b/readthedocs/projects/tasks/uploads.py
@@ -1,0 +1,206 @@
+"""
+Helpers for the pre-built HTML upload feature.
+
+A user uploads a ``.zip`` archive via the APIv3 upload endpoint. The web side
+validates the archive and stores it on ``build_media_storage`` at::
+
+    uploads/<project_slug>/<version_slug>/<sha256>.zip
+
+The archive must contain only the artifact directories Read the Docs supports
+at the top level: ``html/``, ``htmlzip/``, ``pdf/`` and ``epub/``. ``html/``
+is required.
+
+At build time, :func:`extract_uploaded_archive` downloads the archive from
+storage and unzips it into ``project.artifact_path(<type>)``. From there the
+existing ``store_build_artifacts`` flow takes over and copies the artifacts to
+their permanent location.
+"""
+
+import hashlib
+import os
+import zipfile
+from dataclasses import dataclass
+
+import structlog
+
+from readthedocs.builds.constants import ARTIFACT_TYPES
+from readthedocs.storage import build_media_storage
+
+
+log = structlog.get_logger(__name__)
+
+
+# Top-level directories accepted inside the uploaded archive. ``html`` is
+# required; the rest are optional.
+ALLOWED_TOP_LEVEL_DIRS = frozenset(ARTIFACT_TYPES) - {"json"}
+REQUIRED_TOP_LEVEL_DIRS = frozenset({"html"})
+
+# Hard caps that match the validation contract documented in the API endpoint.
+# Tune via settings if needed; these are the demo defaults.
+MAX_UPLOAD_SIZE_BYTES = 1 * 1024 * 1024 * 1024  # 1 GiB compressed
+MAX_UNCOMPRESSED_SIZE_BYTES = 5 * 1024 * 1024 * 1024  # 5 GiB uncompressed
+MAX_COMPRESSION_RATIO = 200  # uncompressed / compressed
+MAX_FILE_COUNT = 50_000
+
+
+class InvalidUploadArchiveError(Exception):
+    """The uploaded archive failed validation."""
+
+
+@dataclass
+class ValidatedArchive:
+    sha256: str
+    size: int
+    top_level_dirs: frozenset
+
+
+def validate_archive(file_obj):
+    """
+    Validate an uploaded zip archive without extracting it.
+
+    Performs three classes of check:
+
+    * **Path safety** — reject absolute paths, ``..`` traversal and symlinks.
+    * **Size** — reject archives larger than :data:`MAX_UPLOAD_SIZE_BYTES`,
+      whose uncompressed contents exceed :data:`MAX_UNCOMPRESSED_SIZE_BYTES`,
+      or whose compression ratio exceeds :data:`MAX_COMPRESSION_RATIO`
+      (zip-bomb defense).
+    * **Layout** — top-level entries must all be in
+      :data:`ALLOWED_TOP_LEVEL_DIRS` and must include ``html/``.
+
+    Returns a :class:`ValidatedArchive` describing the archive on success;
+    raises :class:`InvalidUploadArchiveError` otherwise. The file pointer is
+    rewound to the start before returning.
+    """
+    file_obj.seek(0, os.SEEK_END)
+    compressed_size = file_obj.tell()
+    file_obj.seek(0)
+
+    if compressed_size == 0:
+        raise InvalidUploadArchiveError("Uploaded archive is empty.")
+    if compressed_size > MAX_UPLOAD_SIZE_BYTES:
+        raise InvalidUploadArchiveError(
+            f"Uploaded archive is too large ({compressed_size} bytes; "
+            f"max {MAX_UPLOAD_SIZE_BYTES})."
+        )
+
+    sha256 = hashlib.sha256()
+    for chunk in iter(lambda: file_obj.read(1024 * 1024), b""):
+        sha256.update(chunk)
+    file_obj.seek(0)
+
+    try:
+        zf = zipfile.ZipFile(file_obj)
+    except zipfile.BadZipFile as exc:
+        raise InvalidUploadArchiveError(f"Not a valid zip archive: {exc}") from exc
+
+    infos = zf.infolist()
+    if len(infos) > MAX_FILE_COUNT:
+        raise InvalidUploadArchiveError(
+            f"Archive contains too many files ({len(infos)}; max {MAX_FILE_COUNT})."
+        )
+
+    total_uncompressed = 0
+    top_level_dirs = set()
+    for info in infos:
+        _check_member_safe(info)
+        total_uncompressed += info.file_size
+
+        first = info.filename.split("/", 1)[0]
+        if first and first not in ALLOWED_TOP_LEVEL_DIRS:
+            raise InvalidUploadArchiveError(
+                f"Disallowed top-level entry {first!r}; "
+                f"expected one of {sorted(ALLOWED_TOP_LEVEL_DIRS)}."
+            )
+        if first:
+            top_level_dirs.add(first)
+
+    if total_uncompressed > MAX_UNCOMPRESSED_SIZE_BYTES:
+        raise InvalidUploadArchiveError(
+            f"Archive uncompressed size is too large ({total_uncompressed} bytes; "
+            f"max {MAX_UNCOMPRESSED_SIZE_BYTES})."
+        )
+    if compressed_size and total_uncompressed / compressed_size > MAX_COMPRESSION_RATIO:
+        raise InvalidUploadArchiveError("Archive compression ratio is suspiciously high.")
+
+    missing = REQUIRED_TOP_LEVEL_DIRS - top_level_dirs
+    if missing:
+        raise InvalidUploadArchiveError(
+            f"Archive is missing required directories: {sorted(missing)}."
+        )
+
+    file_obj.seek(0)
+    return ValidatedArchive(
+        sha256=sha256.hexdigest(),
+        size=compressed_size,
+        top_level_dirs=frozenset(top_level_dirs),
+    )
+
+
+def _check_member_safe(info):
+    name = info.filename
+    if name.startswith("/") or os.path.isabs(name):
+        raise InvalidUploadArchiveError(f"Absolute path in archive: {name!r}.")
+    # Reject any path segment that resolves above the root, even with mixed separators.
+    parts = name.replace("\\", "/").split("/")
+    if any(part in ("..",) for part in parts):
+        raise InvalidUploadArchiveError(f"Path traversal in archive: {name!r}.")
+    # Reject symlinks (POSIX mode in the upper 16 bits of external_attr).
+    mode = (info.external_attr >> 16) & 0xFFFF
+    if mode and (mode & 0xF000) == 0xA000:
+        raise InvalidUploadArchiveError(f"Symlink in archive: {name!r}.")
+
+
+def store_uploaded_archive(version, file_obj, sha256):
+    """
+    Persist a validated archive to ``build_media_storage`` and return the key.
+
+    The caller is responsible for invoking :func:`validate_archive` first and
+    passing the resulting hash. Older archives at the same key are overwritten.
+    """
+    key = version.get_upload_storage_path(content_hash=sha256)
+    file_obj.seek(0)
+    if build_media_storage.exists(key):
+        build_media_storage.delete(key)
+    build_media_storage.save(key, file_obj)
+    return key
+
+
+def extract_uploaded_archive(version, destination_dir, storage=None):
+    """
+    Download the archive for ``version`` and extract it into ``destination_dir``.
+
+    ``destination_dir`` is the ``_readthedocs/`` directory of the build (the
+    parent of ``html/``, ``pdf/`` etc.) — the contents of the zip are written
+    there directly.
+
+    Returns the set of top-level directories actually extracted, so the caller
+    can update flags such as ``Version.has_pdf``.
+    """
+    storage = storage or build_media_storage
+    key = version.get_upload_storage_path()
+    if not key:
+        raise InvalidUploadArchiveError(
+            f"Version {version.slug!r} has no uploaded archive to extract."
+        )
+
+    os.makedirs(destination_dir, exist_ok=True)
+    extracted = set()
+    with storage.open(key, "rb") as remote:
+        # ZipFile needs a seekable file-like. Storage backends typically return
+        # one; if not, the caller can stage to a tempfile first.
+        with zipfile.ZipFile(remote) as zf:
+            for info in zf.infolist():
+                _check_member_safe(info)
+                first = info.filename.split("/", 1)[0]
+                if first and first in ALLOWED_TOP_LEVEL_DIRS:
+                    extracted.add(first)
+            zf.extractall(destination_dir)
+    log.info(
+        "Extracted uploaded archive.",
+        version_slug=version.slug,
+        project_slug=version.project.slug,
+        key=key,
+        top_level_dirs=sorted(extracted),
+    )
+    return frozenset(extracted)

--- a/readthedocs/projects/tasks/uploads.py
+++ b/readthedocs/projects/tasks/uploads.py
@@ -1,5 +1,5 @@
 """
-Helpers for the pre-built HTML upload feature.
+Helpers for the pre-built archive upload feature.
 
 A user uploads a ``.zip`` archive via the APIv3 upload endpoint. The web side
 validates the archive and stores it on ``build_media_storage`` at::
@@ -10,16 +10,14 @@ The archive must contain only the artifact directories Read the Docs supports
 at the top level: ``html/``, ``htmlzip/``, ``pdf/`` and ``epub/``. ``html/``
 is required.
 
-At build time, :func:`extract_uploaded_archive` downloads the archive from
-storage and unzips it into ``project.artifact_path(<type>)``. From there the
-existing ``store_build_artifacts`` flow takes over and copies the artifacts to
-their permanent location.
+At build time we run ``unzip`` inside the build container — see
+``BuildDirector.unzip_uploaded_archive``. The web side never extracts the
+archive itself.
 """
 
 import hashlib
 import os
 import shutil
-import tempfile
 import zipfile
 from dataclasses import dataclass
 
@@ -72,9 +70,9 @@ def _is_ignorable(name):
     Covers the most common user mistakes:
 
     * macOS resource forks (``__MACOSX/...``) added by ``zip -r`` on macOS.
-    * Hidden dotfiles like ``.DS_Store``, ``Thumbs.db`` etc. They never carry
-      docs content and would otherwise blow up the
-      ``BUILD_OUTPUT_HAS_MULTIPLE_FILES`` check on offline formats.
+    * Hidden ``.DS_Store``-style files. They never carry docs content and
+      would otherwise blow up the ``BUILD_OUTPUT_HAS_MULTIPLE_FILES`` check
+      on offline formats.
     """
     parts = _normalize_name(name).split("/")
     return any(part == "__MACOSX" or part.startswith(".") for part in parts if part)
@@ -95,9 +93,11 @@ def validate_archive(file_obj):
       :data:`ALLOWED_TOP_LEVEL_DIRS` and must include ``html/`` with an
       ``index.html`` inside.
 
-    Returns a :class:`ValidatedArchive` describing the archive on success;
-    raises :class:`InvalidUploadArchiveError` otherwise. The file pointer is
-    rewound to the start before returning.
+    Error messages never echo entries from the archive — the input is
+    untrusted and we don't want to mirror it back into our own logs or
+    responses. Returns a :class:`ValidatedArchive` describing the archive on
+    success; raises :class:`InvalidUploadArchiveError` otherwise. The file
+    pointer is rewound to the start before returning.
     """
     file_obj.seek(0, os.SEEK_END)
     compressed_size = file_obj.tell()
@@ -107,31 +107,39 @@ def validate_archive(file_obj):
         raise InvalidUploadArchiveError("Uploaded archive is empty.")
     if compressed_size > MAX_UPLOAD_SIZE_BYTES:
         raise InvalidUploadArchiveError(
-            f"Uploaded archive is too large ({compressed_size} bytes; max {MAX_UPLOAD_SIZE_BYTES})."
+            f"Uploaded archive is too large (max {MAX_UPLOAD_SIZE_BYTES} bytes)."
         )
 
-    sha256 = hashlib.sha256()
-    for chunk in iter(lambda: file_obj.read(1024 * 1024), b""):
-        sha256.update(chunk)
+    # ``file_digest`` reads in chunks; never loads the whole file into memory.
+    sha256 = hashlib.file_digest(file_obj, "sha256").hexdigest()
     file_obj.seek(0)
 
     try:
-        zf = zipfile.ZipFile(file_obj)
+        with zipfile.ZipFile(file_obj) as zf:
+            archive = _validate_zip_contents(zf, compressed_size)
     except zipfile.BadZipFile as exc:
-        raise InvalidUploadArchiveError(f"Not a valid zip archive: {exc}") from exc
+        raise InvalidUploadArchiveError("Not a valid zip archive.") from exc
 
+    file_obj.seek(0)
+    return ValidatedArchive(
+        sha256=sha256,
+        size=compressed_size,
+        top_level_dirs=archive,
+    )
+
+
+def _validate_zip_contents(zf, compressed_size):
     infos = zf.infolist()
     if len(infos) > MAX_FILE_COUNT:
-        raise InvalidUploadArchiveError(
-            f"Archive contains too many files ({len(infos)}; max {MAX_FILE_COUNT})."
-        )
+        raise InvalidUploadArchiveError(f"Archive contains too many files (max {MAX_FILE_COUNT}).")
 
     total_uncompressed = 0
     top_level_dirs = set()
     has_html_index = False
+    saw_root_html = False
     for info in infos:
         # Always run the safety check, even for entries we will later ignore,
-        # so a traversal hiding inside a junk path (e.g. ``__MACOSX/../etc``)
+        # so a traversal hiding inside a junk path (``__MACOSX/../etc``)
         # still rejects the whole archive.
         _check_member_safe(info)
         name = _normalize_name(info.filename)
@@ -139,26 +147,27 @@ def validate_archive(file_obj):
             continue
         total_uncompressed += info.file_size
 
-        # Directory marker entries (``html/``) are zero-byte and only carry
-        # the directory name. Treat them as a top-level dir signal but skip
-        # the "file at root" check below.
         is_dir_entry = info.is_dir() or name.endswith("/")
         first, _, rest = name.rstrip("/").partition("/")
         if not first:
             continue
         if not rest and not is_dir_entry:
-            # File at the archive root — almost always a user that forgot to
+            # File at the archive root. Almost always a user that forgot to
             # wrap their build output in an ``html/`` directory.
             if name.lower().endswith((".html", ".htm")):
-                raise InvalidUploadArchiveError(_root_file_hint(name))
+                saw_root_html = True
             raise InvalidUploadArchiveError(
-                f"Disallowed top-level entry {name!r}; "
-                f"expected one of {sorted(ALLOWED_TOP_LEVEL_DIRS)}."
+                "The archive must put HTML inside an 'html/' directory "
+                "(e.g. 'html/index.html'), not at the root."
+                if saw_root_html
+                else (
+                    "Top-level entry not allowed; expected one of "
+                    f"{sorted(ALLOWED_TOP_LEVEL_DIRS)}."
+                )
             )
         if first not in ALLOWED_TOP_LEVEL_DIRS:
             raise InvalidUploadArchiveError(
-                f"Disallowed top-level entry {first!r}; "
-                f"expected one of {sorted(ALLOWED_TOP_LEVEL_DIRS)}."
+                f"Top-level entry not allowed; expected one of {sorted(ALLOWED_TOP_LEVEL_DIRS)}."
             )
         top_level_dirs.add(first)
         if first == "html" and rest == "index.html":
@@ -166,8 +175,7 @@ def validate_archive(file_obj):
 
     if total_uncompressed > MAX_UNCOMPRESSED_SIZE_BYTES:
         raise InvalidUploadArchiveError(
-            f"Archive uncompressed size is too large ({total_uncompressed} bytes; "
-            f"max {MAX_UNCOMPRESSED_SIZE_BYTES})."
+            f"Archive uncompressed size is too large (max {MAX_UNCOMPRESSED_SIZE_BYTES} bytes)."
         )
     if compressed_size and total_uncompressed / compressed_size > MAX_COMPRESSION_RATIO:
         raise InvalidUploadArchiveError("Archive compression ratio is suspiciously high.")
@@ -179,35 +187,29 @@ def validate_archive(file_obj):
         )
     if "html" in top_level_dirs and not has_html_index:
         raise InvalidUploadArchiveError(
-            "Archive is missing 'html/index.html'. "
-            "The HTML output must contain an index.html at the root of the html/ directory."
+            "Archive is missing 'html/index.html'. The HTML output must "
+            "contain an index.html at the root of the html/ directory."
         )
 
-    file_obj.seek(0)
-    return ValidatedArchive(
-        sha256=sha256.hexdigest(),
-        size=compressed_size,
-        top_level_dirs=frozenset(top_level_dirs),
-    )
-
-
-def _root_file_hint(name):
-    return (
-        f"Found {name!r} at the archive root. The archive must put HTML inside "
-        "an 'html/' directory (e.g. 'html/index.html'), not at the root."
-    )
+    return frozenset(top_level_dirs)
 
 
 def _check_member_safe(info):
+    """
+    Reject path traversal, absolute paths and symlinks.
+
+    Error messages never include the offending name — the archive is
+    untrusted input.
+    """
     name = _normalize_name(info.filename)
     if name.startswith("/") or os.path.isabs(name):
-        raise InvalidUploadArchiveError(f"Absolute path in archive: {info.filename!r}.")
+        raise InvalidUploadArchiveError("Absolute path in archive.")
     if any(part == ".." for part in name.split("/")):
-        raise InvalidUploadArchiveError(f"Path traversal in archive: {info.filename!r}.")
+        raise InvalidUploadArchiveError("Path traversal in archive.")
     # Reject symlinks (POSIX mode in the upper 16 bits of external_attr).
     mode = (info.external_attr >> 16) & 0xFFFF
     if mode and (mode & 0xF000) == 0xA000:
-        raise InvalidUploadArchiveError(f"Symlink in archive: {info.filename!r}.")
+        raise InvalidUploadArchiveError("Symlink in archive.")
 
 
 def store_uploaded_archive(version, file_obj, sha256):
@@ -216,8 +218,8 @@ def store_uploaded_archive(version, file_obj, sha256):
 
     The caller is responsible for invoking :func:`validate_archive` first and
     passing the resulting hash. The key includes the SHA, so when the same
-    content is uploaded twice we re-use the existing object instead of racing
-    a delete + save.
+    content is uploaded twice we re-use the existing object instead of
+    racing a delete + save.
     """
     key = version.get_upload_storage_path(content_hash=sha256)
     file_obj.seek(0)
@@ -226,56 +228,33 @@ def store_uploaded_archive(version, file_obj, sha256):
     return key
 
 
-def extract_uploaded_archive(version, destination_dir, storage=None):
+def stage_uploaded_archive(version, host_path):
     """
-    Download the archive for ``version`` and extract it into ``destination_dir``.
+    Download the version's archive to a path on the build host.
 
-    ``destination_dir`` is the ``_readthedocs/`` directory of the build (the
-    parent of ``html/``, ``pdf/`` etc.) — the contents of the zip are written
-    there directly.
-
-    Returns the set of top-level directories actually extracted, so the caller
-    can update flags such as ``Version.has_pdf``.
+    The path is expected to live under ``project.checkout_path(version)``,
+    which is bind-mounted into the build container. The unzip itself runs
+    *inside* that container — see ``BuildDirector.unzip_uploaded_archive`` —
+    so the host never executes ``unzip`` directly on user input.
     """
-    storage = storage or build_media_storage
     key = version.get_upload_storage_path()
     if not key:
         raise MissingUploadedArchiveError(
             f"Version {version.slug!r} has no uploaded archive to extract."
         )
-    if not storage.exists(key):
+    if not build_media_storage.exists(key):
         raise MissingUploadedArchiveError(
-            f"Uploaded archive for version {version.slug!r} is no longer available "
-            f"at {key!r}. Re-upload the archive and trigger a new build."
+            f"Uploaded archive for version {version.slug!r} is no longer available. "
+            "Re-upload the archive and trigger a new build."
         )
 
-    os.makedirs(destination_dir, exist_ok=True)
-    extracted = set()
-    # Stage to a local tempfile so ``zipfile`` always has a seekable input,
-    # regardless of whether the storage backend's ``open()`` returns a
-    # streamed body. Also bounds connection time to the remote bucket.
-    with tempfile.NamedTemporaryFile(suffix=".zip") as tmp:
-        with storage.open(key, "rb") as remote:
-            shutil.copyfileobj(remote, tmp)
-        tmp.flush()
-        tmp.seek(0)
-        with zipfile.ZipFile(tmp) as zf:
-            for info in zf.infolist():
-                _check_member_safe(info)
-                name = _normalize_name(info.filename)
-                if _is_ignorable(name):
-                    continue
-                first = name.rstrip("/").partition("/")[0]
-                if first and first in ALLOWED_TOP_LEVEL_DIRS:
-                    extracted.add(first)
-                    # Per-member extract so we skip junk filtered above and
-                    # also rewrite any backslash-only names safely.
-                    zf.extract(info, destination_dir)
+    os.makedirs(os.path.dirname(host_path), exist_ok=True)
+    with build_media_storage.open(key, "rb") as remote, open(host_path, "wb") as local:
+        shutil.copyfileobj(remote, local)
     log.info(
-        "Extracted uploaded archive.",
+        "Staged uploaded archive for build container.",
         version_slug=version.slug,
         project_slug=version.project.slug,
         key=key,
-        top_level_dirs=sorted(extracted),
     )
-    return frozenset(extracted)
+    return host_path

--- a/readthedocs/projects/tests/test_uploads.py
+++ b/readthedocs/projects/tests/test_uploads.py
@@ -11,6 +11,7 @@ from readthedocs.builds.constants import TAG
 from readthedocs.builds.models import Version
 from readthedocs.projects.models import Project
 from readthedocs.projects.tasks.uploads import InvalidUploadArchiveError
+from readthedocs.projects.tasks.uploads import _is_ignorable
 from readthedocs.projects.tasks.uploads import validate_archive
 
 
@@ -117,3 +118,90 @@ def test_get_upload_storage_path(upload_version):
 
 def test_get_upload_storage_path_returns_none_without_hash(upload_version):
     assert upload_version.get_upload_storage_path() is None
+
+
+# --- Edge cases that real users will hit -----------------------------------
+
+
+def test_validate_silently_ignores_macos_resource_forks():
+    """``zip -r`` on macOS adds ``__MACOSX/`` siblings; users shouldn't see this fail."""
+    buf = _make_zip(
+        {
+            "html/index.html": b"<html></html>",
+            "__MACOSX/._.DS_Store": b"",
+            "__MACOSX/html/._index.html": b"",
+        }
+    )
+    archive = validate_archive(buf)
+    assert archive.top_level_dirs == frozenset({"html"})
+
+
+def test_validate_silently_ignores_dotfiles():
+    """``.DS_Store`` and friends would otherwise blow up the offline-format checks."""
+    buf = _make_zip(
+        {
+            "html/index.html": b"<html></html>",
+            "html/.DS_Store": b"",
+            ".DS_Store": b"",
+            "pdf/docs.pdf": b"%PDF-1.4",
+            "pdf/.DS_Store": b"",
+        }
+    )
+    archive = validate_archive(buf)
+    assert archive.top_level_dirs == frozenset({"html", "pdf"})
+
+
+def test_validate_normalizes_backslash_separators():
+    """Some Windows zip tools store paths with backslashes."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("html\\index.html", b"<html></html>")
+    buf.seek(0)
+    archive = validate_archive(buf)
+    assert archive.top_level_dirs == frozenset({"html"})
+
+
+def test_validate_accepts_directory_marker_entries():
+    """Some tools include zero-byte ``html/`` directory entries."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("html/", b"")
+        zf.writestr("html/index.html", b"<html></html>")
+    buf.seek(0)
+    archive = validate_archive(buf)
+    assert archive.top_level_dirs == frozenset({"html"})
+
+
+def test_validate_rejects_root_html_with_helpful_hint():
+    """The most common user mistake: ``zip -r docs.zip _build/html/*``."""
+    buf = _make_zip({"index.html": b"<html></html>"})
+    with pytest.raises(InvalidUploadArchiveError, match="must put HTML inside an 'html/'"):
+        validate_archive(buf)
+
+
+def test_validate_rejects_html_dir_without_index():
+    """``html/`` present but no ``html/index.html`` must fail at upload time, not at build time."""
+    buf = _make_zip({"html/about.html": b"<html></html>"})
+    with pytest.raises(InvalidUploadArchiveError, match="missing 'html/index.html'"):
+        validate_archive(buf)
+
+
+def test_validate_rejects_traversal_hidden_in_junk_path():
+    """Path traversal must be rejected even when the entry would otherwise be ignorable."""
+    buf = _make_zip(
+        {
+            "html/index.html": b"<html></html>",
+            "__MACOSX/../etc/passwd": b"x",
+        }
+    )
+    with pytest.raises(InvalidUploadArchiveError, match="Path traversal"):
+        validate_archive(buf)
+
+
+def test_is_ignorable():
+    assert _is_ignorable("__MACOSX/foo")
+    assert _is_ignorable("html/__MACOSX/foo")
+    assert _is_ignorable(".DS_Store")
+    assert _is_ignorable("html/.DS_Store")
+    assert not _is_ignorable("html/index.html")
+    assert not _is_ignorable("pdf/docs.pdf")

--- a/readthedocs/projects/tests/test_uploads.py
+++ b/readthedocs/projects/tests/test_uploads.py
@@ -1,0 +1,119 @@
+"""Unit tests for the pre-built HTML upload helpers."""
+
+import io
+import zipfile
+
+import django_dynamic_fixture as fixture
+import pytest
+
+from readthedocs.builds.constants import SOURCE_TYPE_UPLOAD
+from readthedocs.builds.constants import TAG
+from readthedocs.builds.models import Version
+from readthedocs.projects.models import Project
+from readthedocs.projects.tasks.uploads import InvalidUploadArchiveError
+from readthedocs.projects.tasks.uploads import validate_archive
+
+
+def _make_zip(entries):
+    """``entries`` is a dict of {arcname: bytes}."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, payload in entries.items():
+            zf.writestr(name, payload)
+    buf.seek(0)
+    return buf
+
+
+@pytest.fixture
+def upload_version(db):
+    project = fixture.get(Project, slug="proj")
+    return fixture.get(
+        Version,
+        project=project,
+        slug="0.3",
+        verbose_name="0.3",
+        type=TAG,
+        source_type=SOURCE_TYPE_UPLOAD,
+    )
+
+
+def test_validate_minimal_archive():
+    buf = _make_zip({"html/index.html": b"<html></html>"})
+    archive = validate_archive(buf)
+
+    assert archive.size > 0
+    assert "html" in archive.top_level_dirs
+    assert len(archive.sha256) == 64
+    # File pointer must be rewound for the storage save() that follows.
+    assert buf.tell() == 0
+
+
+def test_validate_accepts_optional_formats():
+    buf = _make_zip(
+        {
+            "html/index.html": b"<html></html>",
+            "pdf/docs.pdf": b"%PDF-1.4",
+            "epub/docs.epub": b"PK",
+            "htmlzip/docs.zip": b"PK",
+        }
+    )
+    archive = validate_archive(buf)
+    assert archive.top_level_dirs == frozenset({"html", "pdf", "epub", "htmlzip"})
+
+
+def test_validate_rejects_missing_html():
+    buf = _make_zip({"pdf/docs.pdf": b"%PDF-1.4"})
+    with pytest.raises(InvalidUploadArchiveError, match="missing required directories"):
+        validate_archive(buf)
+
+
+def test_validate_rejects_unknown_top_level_dir():
+    buf = _make_zip(
+        {
+            "html/index.html": b"<html></html>",
+            "src/secret.py": b"print('hi')",
+        }
+    )
+    with pytest.raises(InvalidUploadArchiveError, match="Disallowed top-level entry"):
+        validate_archive(buf)
+
+
+def test_validate_rejects_path_traversal():
+    buf = _make_zip({"html/index.html": b"<html></html>", "../etc/passwd": b"x"})
+    with pytest.raises(InvalidUploadArchiveError, match="Path traversal"):
+        validate_archive(buf)
+
+
+def test_validate_rejects_absolute_path():
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("html/index.html", b"<html></html>")
+        # Force an absolute-looking name that bypasses zipfile's normalization.
+        info = zipfile.ZipInfo("/etc/passwd")
+        zf.writestr(info, b"x")
+    buf.seek(0)
+    with pytest.raises(InvalidUploadArchiveError, match="Absolute path"):
+        validate_archive(buf)
+
+
+def test_validate_rejects_empty_archive():
+    buf = io.BytesIO(b"")
+    with pytest.raises(InvalidUploadArchiveError, match="empty"):
+        validate_archive(buf)
+
+
+def test_validate_rejects_non_zip():
+    buf = io.BytesIO(b"this is not a zip file at all")
+    with pytest.raises(InvalidUploadArchiveError, match="Not a valid zip"):
+        validate_archive(buf)
+
+
+def test_get_upload_storage_path(upload_version):
+    upload_version.upload_content_hash = "deadbeef" * 8
+    assert upload_version.get_upload_storage_path() == (
+        f"uploads/proj/0.3/{'deadbeef' * 8}.zip"
+    )
+
+
+def test_get_upload_storage_path_returns_none_without_hash(upload_version):
+    assert upload_version.get_upload_storage_path() is None

--- a/readthedocs/projects/tests/test_uploads.py
+++ b/readthedocs/projects/tests/test_uploads.py
@@ -75,7 +75,7 @@ def test_validate_rejects_unknown_top_level_dir():
             "src/secret.py": b"print('hi')",
         }
     )
-    with pytest.raises(InvalidUploadArchiveError, match="Disallowed top-level entry"):
+    with pytest.raises(InvalidUploadArchiveError, match="Top-level entry not allowed"):
         validate_archive(buf)
 
 
@@ -205,3 +205,16 @@ def test_is_ignorable():
     assert _is_ignorable("html/.DS_Store")
     assert not _is_ignorable("html/index.html")
     assert not _is_ignorable("pdf/docs.pdf")
+
+
+def test_validate_errors_never_echo_user_filenames():
+    """Error messages are user-controlled input — keep them out of logs/responses."""
+    buf = _make_zip(
+        {
+            "html/index.html": b"<html></html>",
+            "weird-name-from-user/secret.py": b"x",
+        }
+    )
+    with pytest.raises(InvalidUploadArchiveError) as excinfo:
+        validate_archive(buf)
+    assert "weird-name-from-user" not in str(excinfo.value)

--- a/readthedocs/proxito/tests/responses/v1.json
+++ b/readthedocs/proxito/tests/responses/v1.json
@@ -51,6 +51,7 @@
       "privacy_level": "public",
       "ref": null,
       "slug": "latest",
+      "source_type": "vcs",
       "type": "tag",
       "urls": {
         "dashboard": {
@@ -73,6 +74,7 @@
         "privacy_level": "public",
         "ref": null,
         "slug": "latest",
+        "source_type": "vcs",
         "type": "tag",
         "urls": {
           "dashboard": {

--- a/readthedocs/rtd_tests/tests/test_api.py
+++ b/readthedocs/rtd_tests/tests/test_api.py
@@ -3615,6 +3615,8 @@ class APIVersionTests(TestCase):
             "has_pdf": False,
             "documentation_type": "sphinx",
             "machine": False,
+            "source_type": "vcs",
+            "upload_content_hash": None,
         }
 
         self.assertDictEqual(

--- a/readthedocs/rtd_tests/tests/test_sync_versions.py
+++ b/readthedocs/rtd_tests/tests/test_sync_versions.py
@@ -5,7 +5,14 @@ from django.contrib.auth.models import User
 from django.test import TestCase
 from django_dynamic_fixture import get
 
-from readthedocs.builds.constants import BRANCH, EXTERNAL, LATEST, STABLE, TAG
+from readthedocs.builds.constants import (
+    BRANCH,
+    EXTERNAL,
+    LATEST,
+    SOURCE_TYPE_UPLOAD,
+    STABLE,
+    TAG,
+)
 from readthedocs.builds.models import (
     Version,
 )
@@ -221,6 +228,42 @@ class TestSyncVersions(TestCase):
         self.pip.update_stable_version()
         stable_version = self.pip.get_stable_version()
         self.assertEqual(stable_version.type, TAG)
+
+    def test_upload_versions_are_not_deleted_by_sync(self):
+        """``source_type=upload`` versions have no VCS ref and must survive sync."""
+        Version.objects.create(
+            project=self.pip,
+            identifier=None,
+            verbose_name="0.3",
+            slug="0.3",
+            source_type=SOURCE_TYPE_UPLOAD,
+            type=TAG,
+            active=True,
+        )
+
+        sync_versions_task(
+            self.pip.pk,
+            branches_data=[{"identifier": "origin/master", "verbose_name": "master"}],
+            tags_data=[],
+        )
+
+        self.assertTrue(Version.objects.filter(slug="0.3").exists())
+
+    def test_upload_versions_excluded_from_webhook_routing(self):
+        """A push event for ``name`` must not resolve to an upload version."""
+        Version.objects.create(
+            project=self.pip,
+            identifier=None,
+            verbose_name="release/v2.3",
+            slug="release-v2-3",
+            source_type=SOURCE_TYPE_UPLOAD,
+            type=TAG,
+            active=True,
+        )
+
+        matched = self.pip.versions_from_name("release/v2.3", type=TAG)
+
+        self.assertFalse(matched.exists())
 
         branches_data = [
             {


### PR DESCRIPTION
Lets users host HTML built outside Read the Docs while keeping every hosting feature (dashboard, builds, notifications, addons, search, redirects, custom domains, APIv3) by reusing the existing `Build` pipeline.

## Shape

A new `Version.source_type` selects how the builder fetches source:
- `vcs` (default) — clone + run build tool. Existing behavior, unchanged.
- `upload` — skip clone + Docker, unzip a user-uploaded archive into `_readthedocs/`, hand off to the existing `store_build_artifacts()`.

Upload-type versions are excluded from VCS sync delete and from webhook ref resolution. Same `Build` rows, same state machine, same Celery queues, same APIv3.

## Review map

- Model + migration: `readthedocs/builds/models.py`, `builds/migrations/0072_*.py`
- Build branch (the actual feature): `projects/tasks/builds.py:execute_upload`
- Validation/extract helpers: `projects/tasks/uploads.py`
- Upload endpoint: `api/v3/views.py:VersionsViewSet.upload`
- APIv2 surface for the builder: `api/v2/serializers.py` (must expose `source_type`/`upload_content_hash` or the builder takes the VCS path)
- Sync + webhook: `api/v2/utils.py:_get_deleted_versions_qs`, `projects/models.py:versions_from_name`
- Design doc: `docs/dev/design/prebuilt-html-upload.rst`
- GH Actions example: `docs/user/examples/github-actions-upload.yml`

## Non-obvious decisions

- **Storage key includes SHA256.** Same content uploaded twice is idempotent; race-free without delete+save.
- **Hash persisted before `trigger_build()`** so the builder always reads the right archive even if uploads interleave.
- **Tempfile staging on the builder** so non-seekable storage backends (some S3 configs) work with `zipfile`.
- **Junk-file tolerance** at validate + extract time: `__MACOSX/`, dotfiles. Without this, every macOS `zip -r` user fails. Path-safety checks run *before* the junk filter so traversal hidden in junk paths still rejects.
- **Validate `html/index.html` at upload time** so users get a clear error immediately, not a cryptic build failure later.

## Out of scope (deliberate, to keep review small)

- Creating upload-type versions via API/dashboard form — admin/shell only for now.
- Retention of older SHA-keyed archives (kept forever today).
- Plan gating on .com.
- Dropping the legacy `Version.uploaded` field (left additive).

Tracked in `docs/dev/design/prebuilt-html-upload.rst` "Open issues".

## Tests

55 tests, all green. Notable coverage: zip-bomb, traversal, symlinks, `__MACOSX/`, dotfiles, backslash separators, directory marker entries, root-file hint, missing `html/index.html`, sync delete + webhook routing exclusions, endpoint auth/error paths.

Generated by AI.

https://claude.ai/code/session_01JuhEb4GT3XmaeaCgiVSnXJ