### PR TITLE
Fix allauth Bitbucket authentication bug

### DIFF
--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -130,7 +130,7 @@ django==5.2.13
     #   djangorestframework
     #   drf-extensions
     #   jsonfield
-django-allauth[mfa,saml,socialaccount] @ git+https://github.com/readthedocs/django-allauth.git@ddb58116
+django-allauth[mfa,saml,socialaccount] @ git+https://github.com/readthedocs/django-allauth.git@ddb581168628432afa1b18b038b33341a73a366b
     # via -r requirements/pip.txt
 django-annoying==0.10.8
     # via -r requirements/pip.txt

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -130,7 +130,7 @@ django==5.2.13
     #   djangorestframework
     #   drf-extensions
     #   jsonfield
-django-allauth[mfa,saml,socialaccount]==65.12.1
+django-allauth[mfa,saml,socialaccount] @ git+https://github.com/readthedocs/django-allauth.git@ddb58116
     # via -r requirements/pip.txt
 django-annoying==0.10.8
     # via -r requirements/pip.txt

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -136,7 +136,7 @@ django==5.2.13
     #   djangorestframework
     #   drf-extensions
     #   jsonfield
-django-allauth[mfa,saml,socialaccount] @ git+https://github.com/readthedocs/django-allauth.git@ddb58116
+django-allauth[mfa,saml,socialaccount] @ git+https://github.com/readthedocs/django-allauth.git@ddb581168628432afa1b18b038b33341a73a366b
     # via -r requirements/pip.txt
 django-annoying==0.10.8
     # via -r requirements/pip.txt

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -136,7 +136,7 @@ django==5.2.13
     #   djangorestframework
     #   drf-extensions
     #   jsonfield
-django-allauth[mfa,saml,socialaccount]==65.12.1
+django-allauth[mfa,saml,socialaccount] @ git+https://github.com/readthedocs/django-allauth.git@ddb58116
     # via -r requirements/pip.txt
 django-annoying==0.10.8
     # via -r requirements/pip.txt

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -58,7 +58,9 @@ django-celery-beat
 
 # 65.13.0 performs some breaking changes to Okta that we need to review before upgrading.
 # https://docs.allauth.org/en/latest/release-notes/recent.html#id1
-django-allauth[socialaccount,saml,mfa]==65.12.1
+# django-allauth[socialaccount,saml,mfa]==65.12.1
+# For now, we need a fix for Bitbucket:
+django-allauth[socialaccount,saml,mfa] @ git+https://github.com/readthedocs/django-allauth.git@ddb58116
 
 requests-oauthlib
 

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -60,7 +60,7 @@ django-celery-beat
 # https://docs.allauth.org/en/latest/release-notes/recent.html#id1
 # django-allauth[socialaccount,saml,mfa]==65.12.1
 # For now, we need a fix for Bitbucket:
-django-allauth[socialaccount,saml,mfa] @ git+https://github.com/readthedocs/django-allauth.git@ddb58116
+django-allauth[socialaccount,saml,mfa] @ git+https://github.com/readthedocs/django-allauth.git@ddb581168628432afa1b18b038b33341a73a366b
 
 requests-oauthlib
 

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -93,7 +93,7 @@ django==5.2.13
     #   djangorestframework
     #   drf-extensions
     #   jsonfield
-django-allauth[mfa,saml,socialaccount]==65.12.1
+django-allauth[mfa,saml,socialaccount] @ git+https://github.com/readthedocs/django-allauth.git@ddb58116
     # via -r requirements/pip.in
 django-annoying==0.10.8
     # via -r requirements/pip.in

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -93,7 +93,7 @@ django==5.2.13
     #   djangorestframework
     #   drf-extensions
     #   jsonfield
-django-allauth[mfa,saml,socialaccount] @ git+https://github.com/readthedocs/django-allauth.git@ddb58116
+django-allauth[mfa,saml,socialaccount] @ git+https://github.com/readthedocs/django-allauth.git@ddb581168628432afa1b18b038b33341a73a366b
     # via -r requirements/pip.in
 django-annoying==0.10.8
     # via -r requirements/pip.in

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -131,7 +131,7 @@ django==5.2.13
     #   djangorestframework
     #   drf-extensions
     #   jsonfield
-django-allauth[mfa,saml,socialaccount]==65.12.1
+django-allauth[mfa,saml,socialaccount] @ git+https://github.com/readthedocs/django-allauth.git@ddb58116
     # via -r requirements/pip.txt
 django-annoying==0.10.8
     # via -r requirements/pip.txt

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -131,7 +131,7 @@ django==5.2.13
     #   djangorestframework
     #   drf-extensions
     #   jsonfield
-django-allauth[mfa,saml,socialaccount] @ git+https://github.com/readthedocs/django-allauth.git@ddb58116
+django-allauth[mfa,saml,socialaccount] @ git+https://github.com/readthedocs/django-allauth.git@ddb581168628432afa1b18b038b33341a73a366b
     # via -r requirements/pip.txt
 django-annoying==0.10.8
     # via -r requirements/pip.txt


### PR DESCRIPTION
The fix for this isn't merged yet and will only be live on the latest
release. We'll need to test the full release more before being able to
use it. For now, a temporary fork uses the patch applied to the last
known good release version we can use.

- Refs https://codeberg.org/allauth/django-allauth/pulls/4733
- https://github.com/readthedocs/django-allauth/tree/hotfix-65.12.1