### PR TITLE
Add null check for project before accessing has_feature method

### DIFF
--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -803,7 +803,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
             log.exception("Failed to revoke build api key.", exc_info=True)
 
         # Disable scale-in protection on this instance
-        if self.data.project.has_feature(Feature.SCALE_IN_PROTECTION):
+        if self.data.project and self.data.project.has_feature(Feature.SCALE_IN_PROTECTION):
             set_builder_scale_in_protection.delay(
                 build_id=self.data.build_pk,
                 builder=socket.gethostname(),


### PR DESCRIPTION
## Summary
Added a null safety check to prevent potential AttributeError when accessing the `has_feature` method on a project object that may be None.

Fixes https://read-the-docs.sentry.io/issues/4309953823

https://claude.ai/code/session_013Suh3dDPPfR9yB9AiLQ9SV