### PR TITLE
docs: Add Docusaurus tutorial for Read the Docs

### DIFF
--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -166,11 +166,11 @@ We have a few places for you to get started:
 
 .. descriptions here are active
 
-:doc:`/tutorial/docusaurus`
-  Follow the Read the Docs tutorial for Docusaurus.
-
 :doc:`/tutorial/index`
   Follow the Read the Docs tutorial for Sphinx.
+
+:doc:`/tutorial/docusaurus`
+  Follow the Read the Docs tutorial for Docusaurus.
 
 :doc:`/intro/doctools`
   Quick start for MkDocs and other tools.

--- a/docs/user/index.rst
+++ b/docs/user/index.rst
@@ -6,7 +6,8 @@ Read the Docs: documentation simplified
    :hidden:
    :caption: Getting started
 
-   Tutorial </tutorial/index>
+   Sphinx tutorial </tutorial/index>
+   Docusaurus tutorial </tutorial/docusaurus>
    /intro/add-project
    /intro/doctools
    /examples
@@ -165,11 +166,14 @@ We have a few places for you to get started:
 
 .. descriptions here are active
 
+:doc:`/tutorial/docusaurus`
+  Follow the Read the Docs tutorial for Docusaurus.
+
 :doc:`/tutorial/index`
-  Follow the Read the Docs tutorial.
+  Follow the Read the Docs tutorial for Sphinx.
 
 :doc:`/intro/doctools`
-  Quick start for MkDocs and Docusaurus.
+  Quick start for MkDocs and other tools.
 
 :doc:`/examples`
   Start your journey with an example project to learn how to use Read the Docs.

--- a/docs/user/tutorial/docusaurus.rst
+++ b/docs/user/tutorial/docusaurus.rst
@@ -57,11 +57,9 @@ Creating a Read the Docs account
 
 To create a Read the Docs account,
 navigate to the `Sign Up page <https://app.readthedocs.org/accounts/signup/>`_
-and choose the option :guilabel:`Sign up with GitHub`.
+and choose the option :guilabel:`Sign up with GitHub` and then :guilabel:`Sign up using GitHub App`.
 
-Confirm your e-mail and username on Read the Docs, then click the :guilabel:`Sign Up »` button to create your account and open your :term:`dashboard`.
-
-When you click the link in the verification email from Read the Docs, your account will be ready to create your first project.
+.. TODO: we need a way to install the GitHub App upfront before adding a project
 
 Installing the Read the Docs GitHub App
 ---------------------------------------
@@ -74,16 +72,19 @@ install the `Read the Docs Community GitHub App <https://github.com/apps/read-th
 #. Select :guilabel:`Only select repositories` and pick ``docusaurus-tutorial``. You can grant access to additional repositories at any time from your GitHub settings.
 #. Click :guilabel:`Install` to complete the setup.
 
-See :ref:`reference/git-integration:GitHub App` for more details on what the GitHub App can do and the permissions it requests.
+.. seealso::
 
-Importing the project to Read the Docs
---------------------------------------
+   :ref:`reference/git-integration:GitHub App`
+     Details on what the GitHub App can do and the permissions it requests.
 
-To import your GitHub project to Read the Docs:
+Adding the project to Read the Docs
+-----------------------------------
 
-#. Click the :guilabel:`Import a Project` button on your `dashboard <https://app.readthedocs.org/dashboard/>`_.
+To add your GitHub project to Read the Docs:
 
-#. Click the |:heavy_plus_sign:| button to the right of your ``docusaurus-tutorial`` project. If the list of repositories is empty, click the |:arrows_counterclockwise:| button.
+#. Click the :guilabel:`Add project` button on your `dashboard <https://app.readthedocs.org/dashboard/>`_.
+
+#. Search for your ``docusaurus-tutorial`` repository, select it, and click :guilabel:`Continue`.
 
 #. Enter some details about your Read the Docs project:
 
@@ -100,6 +101,8 @@ To import your GitHub project to Read the Docs:
 
    Then click the :guilabel:`Next` button to create the project and open the :term:`project home`.
 
+ #. Click :guilabel:`This file exists` to trigger the first build of your documentation.
+
 You just created your first Docusaurus project on Read the Docs! |:tada:|
 
 Checking the first build
@@ -107,6 +110,9 @@ Checking the first build
 
 Read the Docs will build your project documentation right after you create it.
 
+.. TODO: update this since the UI has changed
+.. 1. click on the version
+.. 2. click on the build that just started
 To see the build logs:
 
 #. Click the :guilabel:`Your documentation is building` link on the :term:`project home`.
@@ -115,18 +121,6 @@ To see the build logs:
    - If the build has finished, you'll see a green "Build completed" indicator, the completion date, the elapsed time, and a link to the generated documentation.
 
 #. Click on :guilabel:`View docs` to see your documentation live!
-
-.. note::
-
-   Advertisement is one of our main sources of revenue.
-   If you want to learn more about how do we fund our operations
-   and explore options to go ad-free,
-   check out our `Sustainability page <https://app.readthedocs.org/sustainability/>`_.
-
-   If you don't see the ad, you might be using an ad blocker.
-   Our EthicalAds network respects your privacy, doesn't target you,
-   and tries to be as unobtrusive as possible,
-   so we would like to kindly ask you to :doc:`not block us </advertising/ad-blocking>` |:heart:|
 
 Configuring the project
 -----------------------

--- a/docs/user/tutorial/docusaurus.rst
+++ b/docs/user/tutorial/docusaurus.rst
@@ -40,17 +40,10 @@ Preparing your repository on GitHub
    ``README.md``
       Description of the repository.
 
-   ``package.json``
-      Node.js project metadata, including the Docusaurus dependencies.
-
-   ``docusaurus.config.js``
-      Docusaurus site configuration.
-
-   ``sidebars.js``
-      Defines the sidebar structure for the documentation.
-
    ``docs/``
-      Directory holding the Markdown source files of the documentation.
+      Directory holding the Docusaurus project, including
+      ``package.json``, ``docusaurus.config.js``, ``sidebars.js``,
+      and the Markdown source files under ``docs/pages/``.
 
 Creating a Read the Docs account
 --------------------------------
@@ -147,12 +140,12 @@ To trigger builds from pull requests:
 
 #. Make some changes to your documentation:
 
-   #. Navigate to your GitHub repository, locating the file ``docs/intro.md``, and clicking on the |:pencil2:| icon on the top-right with the tooltip "Edit this file" to open a web editor.
+   #. Navigate to your GitHub repository, locating the file ``docs/pages/intro.mdx``, and clicking on the |:pencil2:| icon on the top-right with the tooltip "Edit this file" to open a web editor.
 
    #. In the editor, add the following sentence to the file:
 
       .. code-block:: markdown
-         :caption: docs/intro.md
+         :caption: docs/pages/intro.mdx
 
          This documentation is hosted on Read the Docs.
 
@@ -213,15 +206,15 @@ Docusaurus is a Node.js application, so Read the Docs builds it by running a seq
    build:
      os: "ubuntu-22.04"
      tools:
-       nodejs: "18"
+       nodejs: "20"
      jobs:
        install:
-         - npm install
+         - cd docs/ && npm install
        build:
          html:
-           - npm run build
+           - cd docs/ && npm run build
            - mkdir --parents $READTHEDOCS_OUTPUT/html/
-           - cp --recursive build/* $READTHEDOCS_OUTPUT/html/
+           - cp --recursive docs/build/* $READTHEDOCS_OUTPUT/html/
 
 The :doc:`purpose of each key </config-file/v2>` is:
 
@@ -235,10 +228,13 @@ The :doc:`purpose of each key </config-file/v2>` is:
   Specifies the :ref:`Node.js version <config-file/v2:build.tools.nodejs>` used during the build.
 
 ``build.jobs.install``
-  Commands run during the install step. Here we install Docusaurus and its dependencies with ``npm install``.
+  Commands run during the install step. The Docusaurus project lives under ``docs/``,
+  so we ``cd`` into it and run ``npm install`` to install Docusaurus and its dependencies.
 
 ``build.jobs.build.html``
-  Commands run to produce the HTML output. We run ``npm run build`` to invoke Docusaurus, then copy the generated ``build/`` directory into ``$READTHEDOCS_OUTPUT/html/``, where Read the Docs picks it up.
+  Commands run to produce the HTML output. We ``cd docs/`` and run ``npm run build``
+  to invoke Docusaurus, then copy the generated ``docs/build/`` directory into
+  ``$READTHEDOCS_OUTPUT/html/``, where Read the Docs picks it up.
 
 .. tip::
 
@@ -249,7 +245,7 @@ The :doc:`purpose of each key </config-file/v2>` is:
 Using a different Node.js version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To build your project with Node.js 20 instead of 18, edit the ``.readthedocs.yaml`` file and change the Node.js version like this:
+To build your project with Node.js 22 instead of 20, edit the ``.readthedocs.yaml`` file and change the Node.js version like this:
 
 .. code-block:: yaml
    :caption: .readthedocs.yaml
@@ -260,15 +256,15 @@ To build your project with Node.js 20 instead of 18, edit the ``.readthedocs.yam
    build:
      os: "ubuntu-22.04"
      tools:
-       nodejs: "20"
+       nodejs: "22"
      jobs:
        install:
-         - npm install
+         - cd docs/ && npm install
        build:
          html:
-           - npm run build
+           - cd docs/ && npm run build
            - mkdir --parents $READTHEDOCS_OUTPUT/html/
-           - cp --recursive build/* $READTHEDOCS_OUTPUT/html/
+           - cp --recursive docs/build/* $READTHEDOCS_OUTPUT/html/
 
 After you commit these changes, go back to your project home, navigate to the "Builds" page, and open the new build that just started. You will see in the build logs that the new toolchain version was used to install the dependencies and build the site.
 

--- a/docs/user/tutorial/docusaurus.rst
+++ b/docs/user/tutorial/docusaurus.rst
@@ -106,6 +106,7 @@ Read the Docs will build your project documentation right after you create it.
 .. TODO: update this since the UI has changed
 .. 1. click on the version
 .. 2. click on the build that just started
+
 To see the build logs:
 
 #. Click the :guilabel:`Your documentation is building` link on the :term:`project home`.

--- a/docs/user/tutorial/docusaurus.rst
+++ b/docs/user/tutorial/docusaurus.rst
@@ -55,30 +55,26 @@ Preparing your repository on GitHub
 Creating a Read the Docs account
 --------------------------------
 
-To create a Read the Docs account:
+To create a Read the Docs account,
 navigate to the `Sign Up page <https://app.readthedocs.org/accounts/signup/>`_
 and choose the option :guilabel:`Sign up with GitHub`.
-On the authorization page, click the green :guilabel:`Authorize readthedocs` button.
 
-.. figure:: /_static/images/tutorial/github-authorization.png
-   :width: 60%
-   :align: center
-   :alt: GitHub authorization page
+Confirm your e-mail and username on Read the Docs, then click the :guilabel:`Sign Up »` button to create your account and open your :term:`dashboard`.
 
-   GitHub authorization page
+When you click the link in the verification email from Read the Docs, your account will be ready to create your first project.
 
-.. note::
+Installing the Read the Docs GitHub App
+---------------------------------------
 
-   Read the Docs needs elevated permissions to perform certain operations
-   that ensure that the workflow is as smooth as possible,
-   like installing :term:`webhooks <webhook>`.
-   If you want to learn more,
-   check out :ref:`reference/git-integration:permissions for connected accounts`.
+For Read the Docs to access your ``docusaurus-tutorial`` repository,
+install the `Read the Docs Community GitHub App <https://github.com/apps/read-the-docs-community>`_:
 
-After that, you will be redirected to Read the Docs to confirm your e-mail and username. Click the :guilabel:`Sign Up »` button to create your account and
-open your :term:`dashboard`.
+#. Open the GitHub App page and click :guilabel:`Install`.
+#. Choose the GitHub account or organization that owns your ``docusaurus-tutorial`` repository.
+#. Select :guilabel:`Only select repositories` and pick ``docusaurus-tutorial``. You can grant access to additional repositories at any time from your GitHub settings.
+#. Click :guilabel:`Install` to complete the setup.
 
-When you have clicked the link in your email from Read the Docs to "verify your email address" and finalize the process, your Read the Docs account will be ready to create your first project.
+See :ref:`reference/git-integration:GitHub App` for more details on what the GitHub App can do and the permissions it requests.
 
 Importing the project to Read the Docs
 --------------------------------------

--- a/docs/user/tutorial/docusaurus.rst
+++ b/docs/user/tutorial/docusaurus.rst
@@ -52,8 +52,6 @@ To create a Read the Docs account,
 navigate to the `Sign Up page <https://app.readthedocs.org/accounts/signup/>`_
 and choose the option :guilabel:`Sign up with GitHub` and then :guilabel:`Sign up using GitHub App`.
 
-.. TODO: we need a way to install the GitHub App upfront before adding a project
-
 Installing the Read the Docs GitHub App
 ---------------------------------------
 
@@ -82,8 +80,8 @@ To add your GitHub project to Read the Docs:
 #. Enter some details about your Read the Docs project:
 
    Name
-      The name of the project, used to create a unique subdomain for each project.
-      so it is better if you prepend your username,
+      The name of the project is used to create a unique subdomain,
+      so prepend your username to keep it unique,
       for example ``{username}-docusaurus-tutorial``.
 
    Repository URL
@@ -94,7 +92,7 @@ To add your GitHub project to Read the Docs:
 
    Then click the :guilabel:`Next` button to create the project and open the :term:`project home`.
 
- #. Click :guilabel:`This file exists` to trigger the first build of your documentation.
+#. Click :guilabel:`This file exists` to trigger the first build of your documentation.
 
 You just created your first Docusaurus project on Read the Docs! |:tada:|
 
@@ -102,10 +100,6 @@ Checking the first build
 ------------------------
 
 Read the Docs will build your project documentation right after you create it.
-
-.. TODO: update this since the UI has changed
-.. 1. click on the version
-.. 2. click on the build that just started
 
 To see the build logs:
 
@@ -279,6 +273,14 @@ that points to the default branch of your version control system
 (``main`` in the case of this tutorial),
 and that's why the URLs of your HTML documentation contain the string ``/latest/``.
 
+.. note::
+
+   Docusaurus also has its own `built-in versioning <https://docusaurus.io/docs/versioning>`_
+   that lives inside the repository under ``versioned_docs/``.
+   This tutorial uses Read the Docs branch-based versioning instead, which builds
+   each version from a separate Git branch. The two mechanisms can be combined,
+   but doing so is outside the scope of this tutorial.
+
 Creating a new version of your documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -422,7 +424,7 @@ and Read the Docs:
 - Learn how to do specific tasks in the :doc:`/guides/index`.
 - Learn about private project support and other enterprise features
   in :doc:`our commercial service guide </commercial/index>`.
-- Join a global community of fellow `documentarians <writethedocs:documentarians>` in `Write the Docs <https://www.writethedocs.org/>`_ and
+- Join a global community of fellow :doc:`documentarians <writethedocs:documentarians>` in `Write the Docs <https://www.writethedocs.org/>`_ and
   :doc:`its Slack workspace <writethedocs:slack>`.
 - Contribute to Read the Docs in :doc:`rtd-dev:contribute`, we appreciate it!
 

--- a/docs/user/tutorial/docusaurus.rst
+++ b/docs/user/tutorial/docusaurus.rst
@@ -334,49 +334,68 @@ To enable link previews:
 
 Open your published documentation and hover over any internal link. A small popup appears with the target page's content. Link previews only render for internal links inside the main documentation content, so navigation bars and external links are unaffected.
 
-Getting project insights
-------------------------
+Building only when documentation changes
+----------------------------------------
 
-Once your project is up and running, you will probably want to understand
-how readers are using your documentation, addressing some common questions like:
+If your repository hosts both your application code and its documentation,
+Read the Docs rebuilds your docs on every push by default — even when the
+change doesn't touch any documentation files.
+:doc:`Automation rules </automation-rules>` can gate builds on the contents
+of the webhook event from GitHub, so you only spend build time on commits and
+pull requests that actually affect the documentation.
 
-- What are the most visited pages?
-- What are the most frequently used search terms?
-- Are readers finding what they are looking for?
+To create a rule that builds your project only when documentation files change:
 
-Read the Docs has traffic and search analytics tools to help you find answers to these questions.
+#. From the :term:`project home`, open the :guilabel:`⚙ Admin` menu and select
+   :guilabel:`Automation Rules`, then click :guilabel:`Add Rule`.
 
-Understanding traffic analytics
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#. Configure the rule:
 
-The Traffic Analytics view gives you a simple overview of how your readers browse your documentation.
-It respects visitors' privacy by not storing identifying information about them.
+   Description
+      Something memorable, for example ``Build only on documentation changes``.
 
-This page shows the most viewed documentation pages of the past 30 days,
-plus a visualization of the daily views during that period.
+   Match
+      ``Any version``.
 
-To see the Traffic Analytics view, go back to the :term:`project page`,
-click the :guilabel:`⚙ Admin` button, and then click the :guilabel:`Traffic Analytics` section.
-You will see the list of pages in descending order of visits, alongside a daily-views chart.
+   Version types
+      Check :guilabel:`Tag`, :guilabel:`Branch`, and :guilabel:`Pull request`
+      so the rule applies to every kind of build.
 
-You can also download this data in :abbr:`CSV (Comma-Separated Values)` format for closer inspection
-by scrolling to the bottom of the page and clicking the :guilabel:`Download all data` button.
+   Changed files
+      One pattern per line:
 
-Understanding search analytics
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      .. code-block:: text
 
-Read the Docs also shows :doc:`what terms your readers are searching for </search-analytics>`.
-This can inform decisions about what areas to focus on,
-or what parts of your project are less understood or harder to find.
+         docs/*
+         .readthedocs.yaml
 
-To view search analytics, go to the :guilabel:`⚙ Admin` section of your project page
-and click the :guilabel:`Search Analytics` section.
-You will see a table with the most searched queries,
-how many results each query returned, and how many times it was searched,
-plus a visualization of the daily number of search queries during the past 30 days.
+   Action
+      ``Trigger build for version``.
 
-Like Traffic Analytics, you can download the whole dataset in CSV format
-by clicking the :guilabel:`Download all data` button.
+#. Click :guilabel:`Save` to create the rule.
+
+From now on, Read the Docs only triggers a build when the push or pull request
+modifies a file under ``docs/`` or the ``.readthedocs.yaml`` configuration.
+Pushes that only touch application code, tests, or unrelated files no longer
+trigger a documentation build.
+
+.. important::
+
+   Once a rule with the :guilabel:`Trigger build for version` action exists,
+   builds are **gated** by automation rules: if no rule matches the incoming
+   webhook event, no build runs. Make sure your patterns cover every path
+   that should rebuild the docs before relying on this in production.
+
+.. note::
+
+   Webhook-filter automation rules are only available for projects connected
+   through the :ref:`reference/git-integration:GitHub App`.
+
+.. seealso::
+
+   :doc:`/automation-rules`
+     Full reference for automation rules, including filters by commit message
+     and pull request label.
 
 Where to go from here
 ---------------------
@@ -390,7 +409,7 @@ This is the end of the tutorial. You have accomplished a lot:
 #. Reviewed pull requests with the build summary comment and visual diff.
 #. Enabled link previews for your readers.
 #. Added new documentation versions.
-#. Browsed the project analytics.
+#. Configured an automation rule to build only when documentation changes.
 
 Nice work!
 

--- a/docs/user/tutorial/docusaurus.rst
+++ b/docs/user/tutorial/docusaurus.rst
@@ -1,0 +1,423 @@
+Read the Docs tutorial for Docusaurus
+=====================================
+
+In this tutorial you will learn how to host a public `Docusaurus`_ documentation project on Read the Docs Community.
+No prior experience with Docusaurus is required.
+
+.. _Docusaurus: https://docusaurus.io/
+
+.. note::
+
+   Find out the `differences between Read the Docs Community and Read the Docs for Business <https://about.readthedocs.com/pricing/#/community>`_.
+
+In the tutorial we will:
+
+1. Import a Docusaurus project from a GitHub repository.
+2. Tailor the project's configuration.
+3. Explore pull request previews, the build summary comment, visual diff, and link previews.
+
+If you don't have a GitHub account, you'll need to `register for a free account <https://github.com/signup>`_ before you start.
+
+Preparing your repository on GitHub
+-----------------------------------
+
+#. `Sign in to GitHub <https://github.com/login>`_ and navigate to the `Docusaurus tutorial GitHub template <https://github.com/readthedocs/tutorial-docusaurus-template/>`_.
+
+#. Click the green :guilabel:`Use this template` button, then click :guilabel:`Create a new Repository`. On the new page:
+
+   Owner
+      Leave the default, or change it to something suitable for a tutorial project.
+   Repository name
+      Something memorable and appropriate, for example ``docusaurus-tutorial``.
+   Visibility
+      Make sure the project is "Public", rather than "Private".
+
+#. Click the green :guilabel:`Create repository` button to create a public repository that you will use in this Read the Docs tutorial, containing the following files:
+
+   ``.readthedocs.yaml``
+      Read the Docs configuration file. Required.
+
+   ``README.md``
+      Description of the repository.
+
+   ``package.json``
+      Node.js project metadata, including the Docusaurus dependencies.
+
+   ``docusaurus.config.js``
+      Docusaurus site configuration.
+
+   ``sidebars.js``
+      Defines the sidebar structure for the documentation.
+
+   ``docs/``
+      Directory holding the Markdown source files of the documentation.
+
+Creating a Read the Docs account
+--------------------------------
+
+To create a Read the Docs account:
+navigate to the `Sign Up page <https://app.readthedocs.org/accounts/signup/>`_
+and choose the option :guilabel:`Sign up with GitHub`.
+On the authorization page, click the green :guilabel:`Authorize readthedocs` button.
+
+.. figure:: /_static/images/tutorial/github-authorization.png
+   :width: 60%
+   :align: center
+   :alt: GitHub authorization page
+
+   GitHub authorization page
+
+.. note::
+
+   Read the Docs needs elevated permissions to perform certain operations
+   that ensure that the workflow is as smooth as possible,
+   like installing :term:`webhooks <webhook>`.
+   If you want to learn more,
+   check out :ref:`reference/git-integration:permissions for connected accounts`.
+
+After that, you will be redirected to Read the Docs to confirm your e-mail and username. Click the :guilabel:`Sign Up »` button to create your account and
+open your :term:`dashboard`.
+
+When you have clicked the link in your email from Read the Docs to "verify your email address" and finalize the process, your Read the Docs account will be ready to create your first project.
+
+Importing the project to Read the Docs
+--------------------------------------
+
+To import your GitHub project to Read the Docs:
+
+#. Click the :guilabel:`Import a Project` button on your `dashboard <https://app.readthedocs.org/dashboard/>`_.
+
+#. Click the |:heavy_plus_sign:| button to the right of your ``docusaurus-tutorial`` project. If the list of repositories is empty, click the |:arrows_counterclockwise:| button.
+
+#. Enter some details about your Read the Docs project:
+
+   Name
+      The name of the project, used to create a unique subdomain for each project.
+      so it is better if you prepend your username,
+      for example ``{username}-docusaurus-tutorial``.
+
+   Repository URL
+      The URL that contains the documentation source. Leave the automatically filled value.
+
+   Default branch
+      Name of the default branch of the project, leave it as ``main``.
+
+   Then click the :guilabel:`Next` button to create the project and open the :term:`project home`.
+
+You just created your first Docusaurus project on Read the Docs! |:tada:|
+
+Checking the first build
+------------------------
+
+Read the Docs will build your project documentation right after you create it.
+
+To see the build logs:
+
+#. Click the :guilabel:`Your documentation is building` link on the :term:`project home`.
+
+   - If the build has not finished by the time you open it, you will see a spinner next to a "Installing" or "Building" indicator, meaning that it is still in progress.
+   - If the build has finished, you'll see a green "Build completed" indicator, the completion date, the elapsed time, and a link to the generated documentation.
+
+#. Click on :guilabel:`View docs` to see your documentation live!
+
+.. note::
+
+   Advertisement is one of our main sources of revenue.
+   If you want to learn more about how do we fund our operations
+   and explore options to go ad-free,
+   check out our `Sustainability page <https://app.readthedocs.org/sustainability/>`_.
+
+   If you don't see the ad, you might be using an ad blocker.
+   Our EthicalAds network respects your privacy, doesn't target you,
+   and tries to be as unobtrusive as possible,
+   so we would like to kindly ask you to :doc:`not block us </advertising/ad-blocking>` |:heart:|
+
+Configuring the project
+-----------------------
+
+To update the project description and configure the notification settings:
+
+#. Navigate back to the :term:`project page` and click the :guilabel:`⚙ Admin` button, to open the Settings page.
+
+#. Update the project description with a short summary of what the documentation is about.
+
+#. Set a project homepage and add a couple of public project tags such as ``docusaurus, documentation``.
+
+#. To get a notification if the build fails, click the :guilabel:`Email Notifications` link on the left, add your email address, and click the :guilabel:`Add` button.
+
+Triggering builds from pull requests
+------------------------------------
+
+Read the Docs can :doc:`trigger builds from GitHub pull requests </pull-requests>`
+and show you a preview of the documentation with those changes.
+
+To trigger builds from pull requests:
+
+#. Click the :guilabel:`Settings` link on the left under the :guilabel:`⚙ Admin` menu, check the "Build pull requests for this project" checkbox, and click the :guilabel:`Save` button at the bottom of the page.
+
+#. Make some changes to your documentation:
+
+   #. Navigate to your GitHub repository, locating the file ``docs/intro.md``, and clicking on the |:pencil2:| icon on the top-right with the tooltip "Edit this file" to open a web editor.
+
+   #. In the editor, add the following sentence to the file:
+
+      .. code-block:: markdown
+         :caption: docs/intro.md
+
+         This documentation is hosted on Read the Docs.
+
+   #. Write an appropriate commit message, choose the "Create a **new branch** for this commit and start a pull request" option.
+
+   #. Click the green :guilabel:`Propose changes` button to open the new pull request page, then click the :guilabel:`Create pull request` button below the description.
+
+After opening the pull request, a Read the Docs check will appear
+indicating that it is building the documentation for that pull request.
+If you click the :guilabel:`Details` link while your project is building
+the build log will be opened. After building, this link opens the documentation directly.
+
+Reviewing the pull request preview
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Once the pull request build finishes, Read the Docs adds a comment to the pull request with a build overview that includes:
+
+- A link to the documentation preview.
+- The list of files that changed between the pull request and the latest version of the documentation.
+
+This summary saves you from clicking through the build log to find the preview, and helps you confirm at a glance that the changes you expected are the ones being deployed.
+
+.. note::
+
+   The build overview comment is only available for projects connected to a :ref:`reference/git-integration:GitHub App`.
+   See :doc:`/pull-requests` for details on each of the pull request features.
+
+Comparing changes with visual diff
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Reading a Markdown diff is fine for prose,
+but it doesn't always tell you what the page will *look* like once rendered.
+:doc:`Visual diff </visual-diff>` highlights the changes directly on the rendered documentation pages,
+so you can review pull requests the same way readers will see them.
+
+To enable visual diff:
+
+#. Go to the :guilabel:`Settings` tab of your project.
+#. Click :guilabel:`Addons`, then :guilabel:`Visual diff`.
+#. Check :guilabel:`Enable visual diff` and click :guilabel:`Save`.
+
+Open the pull request preview again. A new dropdown appears at the top right of the page listing every file that changed in the pull request. Pick a file to jump to it, then click :guilabel:`Show diff` (or press the ``d`` hotkey) to highlight the additions and deletions inline. Use the up/down arrows to step through each chunk.
+
+Adding a configuration file
+---------------------------
+
+The Admin tab of the :term:`project home` has some *global* configuration settings for your project.
+
+Build process configuration settings live in the ``.readthedocs.yaml`` :doc:`configuration file </config-file/v2>`, in your Git repository, which means it can be different for every version or branch of your project.
+
+Docusaurus is a Node.js application, so Read the Docs builds it by running a sequence of commands defined under :ref:`build.jobs <config-file/v2:build.jobs>`. The template repository ships with this file:
+
+.. code-block:: yaml
+   :caption: .readthedocs.yaml
+
+   version: 2
+
+   build:
+     os: "ubuntu-22.04"
+     tools:
+       nodejs: "18"
+     jobs:
+       install:
+         - npm install
+       build:
+         html:
+           - npm run build
+           - mkdir --parents $READTHEDOCS_OUTPUT/html/
+           - cp --recursive build/* $READTHEDOCS_OUTPUT/html/
+
+The :doc:`purpose of each key </config-file/v2>` is:
+
+``version``
+  Required, specifies :doc:`version 2 of the configuration file </config-file/v2>`.
+
+``build.os``
+  Required, specifies the Docker image used to build the documentation.
+
+``build.tools.nodejs``
+  Specifies the :ref:`Node.js version <config-file/v2:build.tools.nodejs>` used during the build.
+
+``build.jobs.install``
+  Commands run during the install step. Here we install Docusaurus and its dependencies with ``npm install``.
+
+``build.jobs.build.html``
+  Commands run to produce the HTML output. We run ``npm run build`` to invoke Docusaurus, then copy the generated ``build/`` directory into ``$READTHEDOCS_OUTPUT/html/``, where Read the Docs picks it up.
+
+.. tip::
+
+   ``build.jobs`` is the recommended way to override the build process for tools that do not have first-class Read the Docs support.
+   Each step (``install``, ``build.html``, ``post_build``, etc.) can be overridden independently,
+   which keeps the rest of Read the Docs' build pipeline intact.
+
+Using a different Node.js version
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To build your project with Node.js 20 instead of 18, edit the ``.readthedocs.yaml`` file and change the Node.js version like this:
+
+.. code-block:: yaml
+   :caption: .readthedocs.yaml
+   :emphasize-lines: 6
+
+   version: 2
+
+   build:
+     os: "ubuntu-22.04"
+     tools:
+       nodejs: "20"
+     jobs:
+       install:
+         - npm install
+       build:
+         html:
+           - npm run build
+           - mkdir --parents $READTHEDOCS_OUTPUT/html/
+           - cp --recursive build/* $READTHEDOCS_OUTPUT/html/
+
+After you commit these changes, go back to your project home, navigate to the "Builds" page, and open the new build that just started. You will see in the build logs that the new toolchain version was used to install the dependencies and build the site.
+
+Versioning documentation
+------------------------
+
+Read the Docs supports having :doc:`several versions of your documentation </versions>`,
+in the same way that you have several versions of your code.
+By default, it creates a ``latest`` version
+that points to the default branch of your version control system
+(``main`` in the case of this tutorial),
+and that's why the URLs of your HTML documentation contain the string ``/latest/``.
+
+Creating a new version of your documentation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Read the Docs automatically creates documentation versions from GitHub branches and tags that :ref:`follow some rules <versions:Versioning workflows>` about looking like version numbers, such as ``1.0``, ``2.0.3`` or ``4.x``.
+
+To create version ``1.0`` of your code, and consequently of your documentation:
+
+#. Navigate to your GitHub repository, click the branch selector, type ``1.0.x``, and click "Create branch: 1.0.x from 'main'".
+
+#. Check that you now have version ``1.0.x`` in your :term:`project home`, click on the :guilabel:`Versions` button, and under "Active Versions" you will see two entries:
+
+  - The ``latest`` version, pointing to the ``main`` branch.
+  - A new ``stable`` version, pointing to the ``origin/1.0.x`` branch.
+
+When you created your branch, Read the Docs created a new special version called ``stable`` pointing to it. Once it builds, it appears in the :term:`flyout menu`.
+
+Setting stable as the default
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To set ``stable`` as the *default version*, rather than ``latest``, so that users see the ``stable`` documentation when they visit the :term:`root URL` of your documentation:
+
+#. In the :guilabel:`⚙ Admin` menu of your project home, go to the :guilabel:`Settings` link, choose ``stable`` in the "Default version" dropdown, and hit :guilabel:`Save` at the bottom.
+
+Modifying versions
+~~~~~~~~~~~~~~~~~~
+
+Both ``latest`` and ``stable`` are now *active*, which means that they are visible to readers and new builds can be triggered for them.
+In addition to these, Read the Docs also created an *inactive* ``1.0.x`` version, which always points to the ``1.0.x`` branch of your repository.
+
+To activate the ``1.0.x`` version:
+
+#. On your :term:`project home`, go to "Versions", locate ``1.0.x`` under "Activate a version", and click the :guilabel:`Activate` button.
+
+#. On the "Activate" page with "Active" and "Hidden" checkboxes, check only "Active" and click :guilabel:`Save`.
+
+.. note::
+
+   Read more about :ref:`hidden versions <versions:Version states>`
+   in our documentation.
+
+Enabling link previews for your readers
+---------------------------------------
+
+:doc:`Link previews </link-previews>` show readers the content of an internal link when they hover over it,
+so they can decide whether to follow the link without losing their place.
+
+To enable link previews:
+
+#. Go to your project's :term:`dashboard` and click the project name.
+#. Go to :guilabel:`Settings`, then in the left bar, go to :guilabel:`Addons`.
+#. Open :guilabel:`Link previews` and check :guilabel:`Enabled`.
+#. Save your settings -- a rebuild of your project isn't required.
+
+Open your published documentation and hover over any internal link. A small popup appears with the target page's content. Link previews only render for internal links inside the main documentation content, so navigation bars and external links are unaffected.
+
+Getting project insights
+------------------------
+
+Once your project is up and running, you will probably want to understand
+how readers are using your documentation, addressing some common questions like:
+
+- What are the most visited pages?
+- What are the most frequently used search terms?
+- Are readers finding what they are looking for?
+
+Read the Docs has traffic and search analytics tools to help you find answers to these questions.
+
+Understanding traffic analytics
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Traffic Analytics view gives you a simple overview of how your readers browse your documentation.
+It respects visitors' privacy by not storing identifying information about them.
+
+This page shows the most viewed documentation pages of the past 30 days,
+plus a visualization of the daily views during that period.
+
+To see the Traffic Analytics view, go back to the :term:`project page`,
+click the :guilabel:`⚙ Admin` button, and then click the :guilabel:`Traffic Analytics` section.
+You will see the list of pages in descending order of visits, alongside a daily-views chart.
+
+You can also download this data in :abbr:`CSV (Comma-Separated Values)` format for closer inspection
+by scrolling to the bottom of the page and clicking the :guilabel:`Download all data` button.
+
+Understanding search analytics
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Read the Docs also shows :doc:`what terms your readers are searching for </search-analytics>`.
+This can inform decisions about what areas to focus on,
+or what parts of your project are less understood or harder to find.
+
+To view search analytics, go to the :guilabel:`⚙ Admin` section of your project page
+and click the :guilabel:`Search Analytics` section.
+You will see a table with the most searched queries,
+how many results each query returned, and how many times it was searched,
+plus a visualization of the daily number of search queries during the past 30 days.
+
+Like Traffic Analytics, you can download the whole dataset in CSV format
+by clicking the :guilabel:`Download all data` button.
+
+Where to go from here
+---------------------
+
+This is the end of the tutorial. You have accomplished a lot:
+
+#. Created a Docusaurus project from a GitHub template.
+#. Connected it to Read the Docs.
+#. Built its HTML documentation.
+#. Customized the build process with ``build.jobs``.
+#. Reviewed pull requests with the build summary comment and visual diff.
+#. Enabled link previews for your readers.
+#. Added new documentation versions.
+#. Browsed the project analytics.
+
+Nice work!
+
+Here are some resources to help you continue learning about documentation
+and Read the Docs:
+
+- Learn more about the platform :doc:`features </reference/features>`.
+- Read the :doc:`Docusaurus deployment guide </intro/docusaurus>` for more advanced configuration tips.
+- See a list of Read the Docs :doc:`/examples`.
+- Learn how to do specific tasks in the :doc:`/guides/index`.
+- Learn about private project support and other enterprise features
+  in :doc:`our commercial service guide </commercial/index>`.
+- Join a global community of fellow `documentarians <writethedocs:documentarians>` in `Write the Docs <https://www.writethedocs.org/>`_ and
+  :doc:`its Slack workspace <writethedocs:slack>`.
+- Contribute to Read the Docs in :doc:`rtd-dev:contribute`, we appreciate it!
+
+Happy documenting!

--- a/docs/user/tutorial/index.rst
+++ b/docs/user/tutorial/index.rst
@@ -600,7 +600,7 @@ and Read the Docs:
 - Learn how to do specific tasks in the :doc:`/guides/index`.
 - Learn about private project support and other enterprise features
   in :doc:`our commercial service guide </commercial/index>`.
-- Join a global community of fellow `documentarians <writethedocs:documentarians>` in `Write the Docs <https://www.writethedocs.org/>`_ and
+- Join a global community of fellow :doc:`documentarians <writethedocs:documentarians>` in `Write the Docs <https://www.writethedocs.org/>`_ and
   :doc:`its Slack workspace <writethedocs:slack>`.
 - Contribute to Read the Docs in :doc:`rtd-dev:contribute`, we appreciate it!
 

--- a/docs/user/tutorial/index.rst
+++ b/docs/user/tutorial/index.rst
@@ -1,5 +1,5 @@
-Read the Docs tutorial
-======================
+Read the Docs tutorial for Sphinx
+=================================
 
 In this tutorial you will learn how to host a public documentation project on Read the Docs Community.
 


### PR DESCRIPTION
Add a comprehensive tutorial for hosting Docusaurus documentation projects on Read the Docs Community, complementing the existing Sphinx tutorial.

## Summary

This adds a new user-facing tutorial that guides users through the complete process of setting up a Docusaurus project on Read the Docs, from initial repository setup through advanced features like versioning and automation rules.

## Key changes

- **New tutorial document** (`docs/user/tutorial/docusaurus.rst`): Complete 431-line tutorial covering:
  - Repository preparation using a GitHub template
  - Read the Docs account and GitHub App setup
  - Project creation and initial build
  - Configuration via `.readthedocs.yaml` with Node.js toolchain
  - Pull request previews and visual diff
  - Documentation versioning with branch-based workflows
  - Link previews and automation rules for selective builds

- **Updated navigation** (`docs/user/index.rst`):
  - Renamed "Tutorial" to "Sphinx tutorial" for clarity
  - Added new "Docusaurus tutorial" entry in getting started section
  - Updated descriptions to distinguish between Sphinx and Docusaurus tutorials
  - Clarified that `/intro/doctools` covers MkDocs and other tools

- **Updated Sphinx tutorial title** (`docs/user/tutorial/index.rst`):
  - Changed title from "Read the Docs tutorial" to "Read the Docs tutorial for Sphinx" for consistency

The tutorial follows the same structure and depth as the existing Sphinx tutorial, with Docusaurus-specific configuration examples and build process details.

---
*Generated by AI agent*

https://claude.ai/code/session_01PM8AKrUAY6mGdvCbHydk2d