### PR TITLE
tests: cover stable version selection by verbose_name

### DIFF
--- a/docs/user/versions.rst
+++ b/docs/user/versions.rst
@@ -29,6 +29,8 @@ create either a tag or branch in your project with that name.
 .. note::
    If you have at least one tag,
    tags will take preference over branches when selecting the stable version.
+   The comparison uses the tag or branch name from your Git repository,
+   not the version slug shown in URLs.
 
 When you have :doc:`/reference/git-integration` configured for your repository,
 we will automatically build each version when you push a commit.

--- a/readthedocs/projects/tests/test_version_handling.py
+++ b/readthedocs/projects/tests/test_version_handling.py
@@ -1,9 +1,11 @@
 import django_dynamic_fixture as fixture
 import pytest
 
+from readthedocs.builds.constants import BRANCH, TAG
 from readthedocs.builds.models import Build, Version
 from readthedocs.projects.models import Project
 from readthedocs.projects.version_handling import (
+    determine_stable_version,
     sort_versions_calver,
     sort_versions_custom_pattern,
     sort_versions_python_packaging,
@@ -150,6 +152,46 @@ class TestVersionHandling:
         )
 
         assert expected == [version.slug for version in sorted_versions]
+
+    def test_determine_stable_version_uses_verbose_name_not_slug(self):
+        # slug values are intentionally reversed vs. verbose_name so that
+        # selecting by slug would pick a different winner than verbose_name.
+        fixture.get(
+            Version,
+            project=self.project,
+            type=TAG,
+            slug="9-9",
+            verbose_name="0.1",
+        )
+        winner = fixture.get(
+            Version,
+            project=self.project,
+            type=TAG,
+            slug="0-5",
+            verbose_name="2.0",
+        )
+
+        stable = determine_stable_version(self.project.versions.all())
+        assert stable == winner
+
+    def test_determine_stable_version_prefers_tags_over_branches(self):
+        fixture.get(
+            Version,
+            project=self.project,
+            type=BRANCH,
+            slug="3-0",
+            verbose_name="3.0",
+        )
+        winner = fixture.get(
+            Version,
+            project=self.project,
+            type=TAG,
+            slug="1-0",
+            verbose_name="1.0",
+        )
+
+        stable = determine_stable_version(self.project.versions.all())
+        assert stable == winner
 
     def test_sort_versions_custom_pattern(self):
         slugs = [


### PR DESCRIPTION
A user asked via support how this works -- validate it with a test and document it. 

## Summary

- Add a direct unit test for `determine_stable_version` proving it compares versions by `verbose_name` (the Git ref name) rather than `slug`. The test creates two tags where slug and verbose_name are intentionally inverted, so the result distinguishes which field drives the comparison.
- Add a companion test guarding the tag-over-branch preference.
- Add a one-sentence note in `docs/user/versions.rst` clarifying that the comparison uses the Git ref name, not the URL slug.

## Test plan

- [x] `tox -e py312 -- -k determine_stable_version --reuse-db --nomigrations`
- [x] `pre-commit run --files <changed>`

---

_Generated by an AI agent (Claude Code)._