### PR TITLE
docs: Update "Read the Docs for Business" to "Read the Docs Business"

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -179,7 +179,7 @@ html_context = {
 # See dev/style_guide.rst for documentation
 rst_epilog = """
 .. |org_brand| replace:: Read the Docs Community
-.. |com_brand| replace:: Read the Docs for Business
+.. |com_brand| replace:: Read the Docs Business
 .. |git_providers_and| replace:: GitHub, Bitbucket, and GitLab
 .. |git_providers_or| replace:: GitHub, Bitbucket, or GitLab
 """

--- a/docs/dev/design/new-search-api.rst
+++ b/docs/dev/design/new-search-api.rst
@@ -182,7 +182,7 @@ But also, re-using the current serializers shouldn't be a problem either.
              "type": "section",
              "id": "full-text-search",
              "title": "Full-Text Search",
-             "content": "We provide search across all the projects that we host. This actually comes in two different search experiences: dashboard search on the Read the Docs dashboard and in-doc search on documentation sites, using your own theme and our search results. We offer a number of search features: Search across subprojects Search results land on the exact content you were looking for Search across projects you have access to (available on Read the Docs for Business) A full range of search operators including exact matching and excluding phrases. Learn more about Server Side Search.",
+             "content": "We provide search across all the projects that we host. This actually comes in two different search experiences: dashboard search on the Read the Docs dashboard and in-doc search on documentation sites, using your own theme and our search results. We offer a number of search features: Search across subprojects Search results land on the exact content you were looking for Search across projects you have access to (available on Read the Docs Business) A full range of search operators including exact matching and excluding phrases. Learn more about Server Side Search.",
              "highlights": {
                "title": [
                  "Full-<span>Text</span> Search"
@@ -195,7 +195,7 @@ But also, re-using the current serializers shouldn't be a problem either.
              "role": "http:post",
              "name": "/api/v3/projects/",
              "id": "post--api-v3-projects-",
-             "content": "Import a project under authenticated user. Example request: BashPython$ curl \\ -X POST \\ -H \"Authorization: Token <token>\" https://app.readthedocs.org/api/v3/projects/ \\ -H \"Content-Type: application/json\" \\ -d @body.json import requests import json URL = 'https://app.readthedocs.org/api/v3/projects/' TOKEN = '<token>' HEADERS = {'Authorization': f'token {TOKEN}'} data = json.load(open('body.json', 'rb')) response = requests.post( URL, json=data, headers=HEADERS, ) print(response.json()) The content of body.json is like, { \"name\": \"Test Project\", \"repository\": { \"url\": \"https://github.com/readthedocs/template\", \"type\": \"git\" }, \"homepage\": \"http://template.readthedocs.io/\", \"programming_language\": \"py\", \"language\": \"es\" } Example response: See Project details Note Read the Docs for Business, also accepts",
+             "content": "Import a project under authenticated user. Example request: BashPython$ curl \\ -X POST \\ -H \"Authorization: Token <token>\" https://app.readthedocs.org/api/v3/projects/ \\ -H \"Content-Type: application/json\" \\ -d @body.json import requests import json URL = 'https://app.readthedocs.org/api/v3/projects/' TOKEN = '<token>' HEADERS = {'Authorization': f'token {TOKEN}'} data = json.load(open('body.json', 'rb')) response = requests.post( URL, json=data, headers=HEADERS, ) print(response.json()) The content of body.json is like, { \"name\": \"Test Project\", \"repository\": { \"url\": \"https://github.com/readthedocs/template\", \"type\": \"git\" }, \"homepage\": \"http://template.readthedocs.io/\", \"programming_language\": \"py\", \"language\": \"es\" } Example response: See Project details Note Read the Docs Business, also accepts",
              "highlights": {
                "name": [],
                "content": [

--- a/docs/user/advertising/ethical-advertising.rst
+++ b/docs/user/advertising/ethical-advertising.rst
@@ -177,7 +177,7 @@ We have added multiple ways to opt out of the advertising on Read the Docs.
    * Change your advertising settings
 
 4. If you are part of a company that uses Read the Docs to host documentation for a commercial product,
-   we offer :doc:`Read the Docs for Business </commercial/index>` that offers a completely ad-free experience,
+   we offer :doc:`Read the Docs Business </commercial/index>` that offers a completely ad-free experience,
    additional build resources, and other great features like CDN support and private documentation.
 
 5. If you would like to completely remove advertising from your open source project,

--- a/docs/user/advertising/index.rst
+++ b/docs/user/advertising/index.rst
@@ -26,7 +26,7 @@ although you will still see :ref:`community ads <advertising/ethical-advertising
 `Gold members`_ may also remove advertising from their projects for all visitors.
 
 For businesses looking to remove advertising,
-please consider :doc:`Read the Docs for Business </commercial/index>`.
+please consider :doc:`Read the Docs Business </commercial/index>`.
 
 .. _Gold members: https://app.readthedocs.org/accounts/gold/
 

--- a/docs/user/api/v3.rst
+++ b/docs/user/api/v3.rst
@@ -102,7 +102,7 @@ There are some URL attributes that applies to all of these resources:
 
 .. note::
 
-   If you are using :doc:`Read the Docs for Business </commercial/index>` take into account that you will need to replace
+   If you are using :doc:`Read the Docs Business </commercial/index>` take into account that you will need to replace
    https://app.readthedocs.org/ by https://app.readthedocs.com/ in all the URLs used in the following examples.
 
 
@@ -208,7 +208,7 @@ Projects list
 
        .. FIXME: we can't use :query string: here because it doesn't render properly
 
-      :doc:`Read the Docs for Business </commercial/index>`, also accepts
+      :doc:`Read the Docs Business </commercial/index>`, also accepts
 
       :Query Parameters:
 
@@ -322,7 +322,7 @@ Project details
 
        .. FIXME: we can't use :query string: here because it doesn't render properly
 
-      :doc:`Read the Docs for Business </commercial/index>`, also accepts
+      :doc:`Read the Docs Business </commercial/index>`, also accepts
 
       :Query Parameters:
 
@@ -407,7 +407,7 @@ Project create
 
        .. FIXME: we can't use :query string: here because it doesn't render properly
 
-      :doc:`Read the Docs for Business </commercial/index>`, also accepts
+      :doc:`Read the Docs Business </commercial/index>`, also accepts
 
       :Request JSON Object:
 
@@ -416,7 +416,7 @@ Project create
 
       .. note::
 
-         Privacy levels are only available in :doc:`Read the Docs for Business </commercial/index>`.
+         Privacy levels are only available in :doc:`Read the Docs Business </commercial/index>`.
 
 Project update
 ++++++++++++++
@@ -487,7 +487,7 @@ Project update
 
     .. note::
 
-       Privacy levels are only available in :doc:`Read the Docs for Business </commercial/index>`.
+       Privacy levels are only available in :doc:`Read the Docs Business </commercial/index>`.
 
     :statuscode 204: Updated successfully
 
@@ -696,7 +696,7 @@ Version update
 
     .. note::
 
-       Privacy levels are only available in :doc:`Read the Docs for Business </commercial/index>`.
+       Privacy levels are only available in :doc:`Read the Docs Business </commercial/index>`.
 
 Builds
 ~~~~~~
@@ -1578,7 +1578,7 @@ See :doc:`/commercial/sharing` for more information.
 
 .. note::
 
-   The ``/api/v3/projects/<project_slug>/sharing/`` endpoint is only available in :doc:`Read the Docs for Business </commercial/index>`.
+   The ``/api/v3/projects/<project_slug>/sharing/`` endpoint is only available in :doc:`Read the Docs Business </commercial/index>`.
 
 
 Sharing method details
@@ -1804,7 +1804,7 @@ Organizations
 
 .. note::
 
-   The ``/api/v3/organizations/`` endpoint is only available in :doc:`Read the Docs for Business </commercial/index>` currently.
+   The ``/api/v3/organizations/`` endpoint is only available in :doc:`Read the Docs Business </commercial/index>` currently.
    We plan to have organizations on |org_brand| in a near future and we will add support for this endpoint at the same time.
 
 

--- a/docs/user/builds.rst
+++ b/docs/user/builds.rst
@@ -159,5 +159,5 @@ Our build limits are:
       Send an email to support@readthedocs.org providing a good reason why your documentation needs more resources.
 
       If your business is hitting build limits hosting documentation on Read the Docs,
-      please consider :doc:`Read the Docs for Business </commercial/index>`
+      please consider :doc:`Read the Docs Business </commercial/index>`
       which has options for additional build resources.

--- a/docs/user/commercial/index.rst
+++ b/docs/user/commercial/index.rst
@@ -1,7 +1,7 @@
 Business hosting
 ================
 
-.. this page is currently moving towards becoming "About Read the Docs for Business"
+.. this page is currently moving towards becoming "About Read the Docs Business"
 .. rather than an index of features.
 
 We offer |com_brand| for building and hosting documentation for private repositories.

--- a/docs/user/guides/build-troubleshooting.rst
+++ b/docs/user/guides/build-troubleshooting.rst
@@ -24,7 +24,7 @@ This error also occurs if you have changed a ``public`` repository to ``private`
 
 .. note::
 
-   To use private repositories, you need a plan on `Read the Docs for Business <https://app.readthedocs.com>`__.
+   To use private repositories, you need a plan on `Read the Docs Business <https://app.readthedocs.com>`__.
 
 
 error: pathspec

--- a/docs/user/guides/management/index.rst
+++ b/docs/user/guides/management/index.rst
@@ -1,7 +1,7 @@
 How-to guides: account management
 =================================
 
-⏩️ :doc:`Managing your Read the Docs for Business subscription </commercial/subscriptions>`
+⏩️ :doc:`Managing your Read the Docs Business subscription </commercial/subscriptions>`
     Solving the most common tasks for managing Read the Docs subscriptions.
 
 🔒 :doc:`/guides/management/2fa`
@@ -12,5 +12,5 @@ How-to guides: account management
    :hidden:
    :glob:
 
-   Managing your Read the Docs for Business subscription </commercial/subscriptions>
+   Managing your Read the Docs Business subscription </commercial/subscriptions>
    *

--- a/docs/user/legal/dpa/subprocessors.rst
+++ b/docs/user/legal/dpa/subprocessors.rst
@@ -4,7 +4,7 @@ Sub-processor list
 :Effective: April 16, 2021
 :Last updated: August 9, 2024
 
-Read the Docs for Business uses services from the following sub-processors to
+Read the Docs Business uses services from the following sub-processors to
 provide documentation hosting services. This document supplements :doc:`our Data
 Processing Addendum <index>` and may be separately updated on a periodic basis.
 A sub-processor is a third party data processor who has or potentially will have

--- a/docs/user/privacy-policy.rst
+++ b/docs/user/privacy-policy.rst
@@ -34,7 +34,7 @@ readthedocs.org ("Read the Docs Community")
     writing and distributing technical documentation.
     This Privacy Policy applies to this site in full without reservation.
 
-readthedocs.com ("Read the Docs for Business")
+readthedocs.com ("Read the Docs Business")
     This website is a commercial hosted offering for hosting private
     documentation for corporate clients.
     This Privacy Policy applies to this site in full without reservation.
@@ -117,7 +117,7 @@ anyone (including us) may view their contents.
 If you have included private or sensitive information in your Documentation Site,
 such as email addresses, that information may be indexed by search engines or used by third parties.
 
-Read the Docs for Business may host `private projects <https://about.readthedocs.com/terms-of-service/#private-projects>`_ which we treat as confidential
+Read the Docs Business may host `private projects <https://about.readthedocs.com/terms-of-service/#private-projects>`_ which we treat as confidential
 and we only access them for support reasons, with your consent, or if required to for security reasons
 
 If you're a **child under the age of 13**, you may not have an account on Read the Docs.
@@ -241,7 +241,7 @@ For Read the Docs, this means:
 * Our full DNT policy is `available here`_.
 
 Our DNT policy applies without reservation
-to Read the Docs Community and Read the Docs for Business.
+to Read the Docs Community and Read the Docs Business.
 A best effort is made to apply this to Documentation Sites,
 but we do not have complete control over the contents of these sites.
 
@@ -384,7 +384,7 @@ our legal obligations, resolve disputes, and enforce our agreements,
 but barring legal requirements, we will delete your full profile.
 
 Our web server logs for Read the Docs Community,
-Read the Docs for Business, and Documentation Sites
+Read the Docs Business, and Documentation Sites
 are deleted after 10 days barring legal obligations.
 
 

--- a/docs/user/reference/features.rst
+++ b/docs/user/reference/features.rst
@@ -42,7 +42,7 @@ Feature reference
   with advanced functionality like folder redirects.
 
 ⏩️ :doc:`/commercial/sharing`
-  It is possible to host private and password-protected documentation on Read the Docs for Business.
+  It is possible to host private and password-protected documentation on Read the Docs Business.
 
 ⏩️ :doc:`/reference/cdn`
   Documentation projects are primarily static HTML pages along with media files.

--- a/docs/user/reference/git-integration.rst
+++ b/docs/user/reference/git-integration.rst
@@ -169,7 +169,7 @@ so that you can log in to Read the Docs with your connected account credentials.
 
       .. note::
 
-          :doc:`Read the Docs for Business </commercial/index>`
+          :doc:`Read the Docs Business </commercial/index>`
           asks for one additional permission (``repo``) to allow access to private repositories
           and to allow us to set up SSH keys to clone your private repositories.
           Unfortunately, this is the permission for read/write control of the repository

--- a/docs/user/shared/admonition-rtd-business.rst
+++ b/docs/user/shared/admonition-rtd-business.rst
@@ -1,2 +1,2 @@
 .. note::
-    This feature is only available on `Read the Docs for Business <https://app.readthedocs.com/>`_.
+    This feature is only available on `Read the Docs Business <https://app.readthedocs.com/>`_.

--- a/docs/user/support.rst
+++ b/docs/user/support.rst
@@ -1,7 +1,7 @@
 Site support
 ============
 
-Read the Docs offers support for projects on our :doc:`Read the Docs for Business </commercial/index>` and |org_brand| platforms.
+Read the Docs offers support for projects on our :doc:`Read the Docs Business </commercial/index>` and |org_brand| platforms.
 We're happy to assist with any questions or problems you have using either of our platforms.
 
 .. note::

--- a/docs/user/tutorial/index.rst
+++ b/docs/user/tutorial/index.rst
@@ -5,7 +5,7 @@ In this tutorial you will learn how to host a public documentation project on Re
 
 .. note::
 
-   Find out the `differences between Read the Docs Community and Read the Docs for Business <https://about.readthedocs.com/pricing/#/community>`_.
+   Find out the `differences between Read the Docs Community and Read the Docs Business <https://about.readthedocs.com/pricing/#/community>`_.
 
 In the tutorial we will:
 

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -681,7 +681,7 @@ class OrganizationsViewSetBase(
     # /api/v3/organizations/<slug>/notifications/
     # However, accessing to /api/v3/organizations/ or /api/v3/organizations/<slug>/ will return 404.
     # We can implement these endpoints when we need them, tho.
-    # Also note that Read the Docs Business expose this endpoint already.
+    # Also note that Read the Docs Business exposes this endpoint already.
 
     model = Organization
     serializer_class = OrganizationSerializer

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -681,7 +681,7 @@ class OrganizationsViewSetBase(
     # /api/v3/organizations/<slug>/notifications/
     # However, accessing to /api/v3/organizations/ or /api/v3/organizations/<slug>/ will return 404.
     # We can implement these endpoints when we need them, tho.
-    # Also note that Read the Docs for Business expose this endpoint already.
+    # Also note that Read the Docs Business expose this endpoint already.
 
     model = Organization
     serializer_class = OrganizationSerializer

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -900,7 +900,7 @@ class AddonsConfigForm(forms.ModelForm):
         kwargs["instance"] = self.project.addons
         super().__init__(*args, **kwargs)
 
-        # Keep the ability to disable addons completely on Read the Docs for Business
+        # Keep the ability to disable addons completely on Read the Docs Business
         if not settings.RTD_ALLOW_ORGANIZATIONS:
             self.fields["enabled"].disabled = True
 

--- a/readthedocs/subscriptions/templates/subscriptions/notifications/organization_disabled_email.html
+++ b/readthedocs/subscriptions/templates/subscriptions/notifications/organization_disabled_email.html
@@ -11,7 +11,7 @@ documentation, please renew the subscription for your organization now.</p>
 <p><b>Your builds will soon be disabled and access to your documentation will be removed.</b></p>
 
 <p>
-    If you need more help with Read the Docs for Business, we'd love to help you!
+    If you need more help with Read the Docs Business, we'd love to help you!
     <a href="{{ production_uri }}{% url 'support' %}">Get in touch with us</a>
     and let us know what problems you're having.
 </p>

--- a/readthedocs/subscriptions/templates/subscriptions/notifications/organization_disabled_email.txt
+++ b/readthedocs/subscriptions/templates/subscriptions/notifications/organization_disabled_email.txt
@@ -10,7 +10,7 @@ You can renew it here:
 
 Your builds will soon be disabled and access to your documentation will be removed.
 
-If you need more help with Read the Docs for Business, we'd love to help you!
+If you need more help with Read the Docs Business, we'd love to help you!
 Get in touch with us at {{ production_uri }}{% url 'support' %}
 and let us know what problems you're having.
 {% endblock %}

--- a/readthedocs/templates/projects/project_advertising.html
+++ b/readthedocs/templates/projects/project_advertising.html
@@ -70,7 +70,7 @@
     <li class="module-item">
       {% blocktrans trimmed %}
         If you are part of a company that uses Read the Docs to host documentation for a commercial product,
-        please consider <a href="https://readthedocs.com/">Read the Docs for Business</a>
+        please consider <a href="https://readthedocs.com/">Read the Docs Business</a>
         which offers a completely ad-free experience,
         private repositories, private documentation, additional build resources, and dedicated support.
       {% endblocktrans %}
@@ -95,7 +95,7 @@
     <li class="module-item">
       {% blocktrans trimmed %}
         If you would like to completely remove advertising from your open source project,
-        but both Read the Docs for Business and our Gold memberships don't seem like the right fit,
+        but both Read the Docs Business and our Gold memberships don't seem like the right fit,
         please <a href="mailto:ads@readthedocs.org?subject=Alternatives%20to%20advertising">get in touch</a>
         to discuss alternatives to advertising.
       {% endblocktrans %}
@@ -113,7 +113,7 @@
       {% blocktrans trimmed %}
         If you are a company hosting commercial documentation on our community site,
         we do not allow removing paid advertisements on your documentation.
-        Please consider Read the Docs for Business or a Gold membership.
+        Please consider Read the Docs Business or a Gold membership.
       {% endblocktrans %}
       </small>
     </p>

--- a/readthedocs/templates/projects/project_import.html
+++ b/readthedocs/templates/projects/project_import.html
@@ -78,7 +78,7 @@
             <p>
             {% blocktrans trimmed %}
                 We're only showing public repositories. For private projects and other features,
-                please use <a href="https://readthedocs.com/">Read the Docs for Business</a>.
+                please use <a href="https://readthedocs.com/">Read the Docs Business</a>.
             {% endblocktrans %}
             </p>
           </div>


### PR DESCRIPTION
Renames the commercial product from "Read the Docs for Business" to "Read the Docs Business" across documentation, templates, and code comments to match the current marketing terminology.

Intentionally excluded:
- `CHANGELOG.rst` — historical PR titles, kept as a faithful record.
- `readthedocs/search/tests/data/sphinx/{in,out}/httpdomain.{html,json}` — search test fixtures.
- `readthedocs/locale/*/LC_MESSAGES/django.po` — auto-generated by `makemessages`; refreshed on the next translation run.

---
*Generated by AI agent*

https://claude.ai/code/session_01EFVQyHrHnZ2tR3HJEnE6rQ