### PR TITLE
Account: block deletion for spam accounts

### DIFF
--- a/readthedocs/core/utils/spam.py
+++ b/readthedocs/core/utils/spam.py
@@ -25,6 +25,9 @@ def is_spammer(user):
     A user is considered a spammer if they are banned or if any of the projects
     they have access to have reached the dashboard denied threshold.
     """
+    if user.is_anonymous:
+        return False
+
     if user.profile.banned:
         return True
 

--- a/readthedocs/core/utils/spam.py
+++ b/readthedocs/core/utils/spam.py
@@ -1,0 +1,35 @@
+"""
+Spam fighting utilities.
+
+This is a proxy for the spam fighting utilities that are in
+the readthedocsext.spamfighting private module.
+"""
+
+from django.conf import settings
+
+from readthedocs.core.permissions import AdminPermission
+
+
+def get_spam_score(project):
+    if "readthedocsext.spamfighting" in settings.INSTALLED_APPS:
+        from readthedocsext.spamfighting.utils import spam_score
+
+        return spam_score(project)
+    return 0
+
+
+def is_spammer(user):
+    """
+    Determine if the user is a spammer.
+
+    A user is considered a spammer if they are banned or if any of the projects
+    they have access to have reached the dashboard denied threshold.
+    """
+    if user.profile.banned:
+        return True
+
+    for project in AdminPermission.projects(user=user, admin=True, member=True):
+        if get_spam_score(project) >= settings.RTD_SPAM_THRESHOLD_DONT_SHOW_DASHBOARD:
+            return True
+
+    return False

--- a/readthedocs/profiles/views.py
+++ b/readthedocs/profiles/views.py
@@ -39,6 +39,7 @@ from readthedocs.core.mixins import PrivateViewMixin
 from readthedocs.core.models import UserProfile
 from readthedocs.core.permissions import AdminPermission
 from readthedocs.core.utils.extend import SettingsOverrideObject
+from readthedocs.core.utils.spam import is_spammer
 from readthedocs.notifications.models import Notification
 from readthedocs.oauth.migrate import get_installation_target_groups_for_user
 from readthedocs.oauth.migrate import get_migrated_projects
@@ -124,6 +125,14 @@ class AccountDelete(PrivateViewMixin, SuccessMessageMixin, FormView):
         set_change_reason(user, self.get_change_reason())
         user.delete()
         return super().form_valid(form)
+
+    def post(self, request, *args, **kwargs):
+        if is_spammer(request.user):
+            messages.error(
+                request, _("Your account has been flagged as spam. Please contact support.")
+            )
+            return HttpResponseRedirect(reverse("homepage"))
+        return super().post(request, *args, **kwargs)
 
     def get_form(self, data=None, files=None, **kwargs):
         kwargs["instance"] = self.get_object()

--- a/readthedocs/rtd_tests/tests/test_profile_views.py
+++ b/readthedocs/rtd_tests/tests/test_profile_views.py
@@ -402,3 +402,20 @@ class ProfileViewsWithOrganizationsTest(ProfileViewsTest):
         url = reverse("profiles_profile_detail", kwargs={"username": new_user.username})
         resp = self.client.get(url)
         self.assertEqual(resp.status_code, 200)
+
+    @mock.patch("readthedocs.core.utils.spam.get_spam_score")
+    def test_delete_account_spam_score(self, mock_get_spam_score):
+        self.client.force_login(self.owner)
+        project = get(Project)
+        self.org.projects.add(project)
+        mock_get_spam_score.return_value = settings.RTD_SPAM_THRESHOLD_DONT_SHOW_DASHBOARD
+
+        response = self.client.post(
+            reverse("delete_account"),
+            data={"username": self.owner.username},
+        )
+
+        assert response.status_code == 302
+        assert response["Location"] == reverse("homepage")
+        assert User.objects.filter(username=self.owner.username).exists()
+        mock_get_spam_score.assert_called_once_with(project)

--- a/readthedocs/rtd_tests/tests/test_profile_views.py
+++ b/readthedocs/rtd_tests/tests/test_profile_views.py
@@ -1,5 +1,7 @@
 import itertools
+from unittest import mock
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -93,6 +95,34 @@ class ProfileViewsTest(TestCase):
         self.assertFalse(
             User.objects.filter(username=self.user.username).exists(),
         )
+
+    def test_delete_account_banned_profile(self):
+        self.user.profile.banned = True
+        self.user.profile.save()
+
+        response = self.client.post(
+            reverse("delete_account"),
+            data={"username": self.user.username},
+        )
+
+        assert response.status_code == 302
+        assert response["Location"] == reverse("homepage")
+        assert User.objects.filter(username=self.user.username).exists()
+
+    @mock.patch("readthedocs.core.utils.spam.get_spam_score")
+    def test_delete_account_spam_score(self, mock_get_spam_score):
+        project = get(Project, users=[self.user])
+        mock_get_spam_score.return_value = settings.RTD_SPAM_THRESHOLD_DONT_SHOW_DASHBOARD
+
+        response = self.client.post(
+            reverse("delete_account"),
+            data={"username": self.user.username},
+        )
+
+        assert response.status_code == 302
+        assert response["Location"] == reverse("homepage")
+        assert User.objects.filter(username=self.user.username).exists()
+        mock_get_spam_score.assert_called_once_with(project)
 
     def test_profile_detail(self):
         resp = self.client.get(


### PR DESCRIPTION
We are blocking project deletion, but spammers are getting around that by deleting the whole account.