### PR TITLE
builds: add files changed overview to the build detail page

### DIFF
--- a/readthedocs/builds/tests/test_views.py
+++ b/readthedocs/builds/tests/test_views.py
@@ -8,10 +8,12 @@ from django_dynamic_fixture import get
 
 from readthedocs.builds.constants import (
     BUILD_STATE_CANCELLED,
+    BUILD_STATE_FINISHED,
     BUILD_STATE_INSTALLING,
     BUILD_STATE_TRIGGERED,
 )
 from readthedocs.builds.models import Build, Version
+from readthedocs.builds.views import BuildDetail
 from readthedocs.organizations.models import Organization
 from readthedocs.projects.constants import PUBLIC
 from readthedocs.projects.models import Project
@@ -139,3 +141,37 @@ class BuildViewsTests(TestCase):
         url = reverse("builds_detail", args=[self.project.slug, self.build.pk])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 410)
+
+    @mock.patch("readthedocs.builds.views.get_diff_for_build")
+    def test_files_changed_diff_for_successful_build(self, get_diff_for_build):
+        get_diff_for_build.return_value = "diff-sentinel"
+        self.build.state = BUILD_STATE_FINISHED
+        self.build.success = True
+        self.build.save()
+
+        diff = BuildDetail()._get_files_changed_diff(self.build)
+
+        assert diff == "diff-sentinel"
+        get_diff_for_build.assert_called_once_with(self.build)
+
+    @mock.patch("readthedocs.builds.views.get_diff_for_build")
+    def test_files_changed_diff_skipped_for_unsuccessful_build(self, get_diff_for_build):
+        self.build.state = BUILD_STATE_FINISHED
+        self.build.success = False
+        self.build.save()
+
+        diff = BuildDetail()._get_files_changed_diff(self.build)
+
+        assert diff is None
+        get_diff_for_build.assert_not_called()
+
+    @mock.patch("readthedocs.builds.views.get_diff_for_build")
+    def test_files_changed_diff_skipped_for_unfinished_build(self, get_diff_for_build):
+        self.build.state = BUILD_STATE_INSTALLING
+        self.build.success = True
+        self.build.save()
+
+        diff = BuildDetail()._get_files_changed_diff(self.build)
+
+        assert diff is None
+        get_diff_for_build.assert_not_called()

--- a/readthedocs/builds/tests/test_views.py
+++ b/readthedocs/builds/tests/test_views.py
@@ -8,12 +8,10 @@ from django_dynamic_fixture import get
 
 from readthedocs.builds.constants import (
     BUILD_STATE_CANCELLED,
-    BUILD_STATE_FINISHED,
     BUILD_STATE_INSTALLING,
     BUILD_STATE_TRIGGERED,
 )
 from readthedocs.builds.models import Build, Version
-from readthedocs.builds.views import BuildDetail
 from readthedocs.organizations.models import Organization
 from readthedocs.projects.constants import PUBLIC
 from readthedocs.projects.models import Project
@@ -141,37 +139,3 @@ class BuildViewsTests(TestCase):
         url = reverse("builds_detail", args=[self.project.slug, self.build.pk])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 410)
-
-    @mock.patch("readthedocs.builds.views.get_diff_for_build")
-    def test_files_changed_diff_for_successful_build(self, get_diff_for_build):
-        get_diff_for_build.return_value = "diff-sentinel"
-        self.build.state = BUILD_STATE_FINISHED
-        self.build.success = True
-        self.build.save()
-
-        diff = BuildDetail()._get_files_changed_diff(self.build)
-
-        assert diff == "diff-sentinel"
-        get_diff_for_build.assert_called_once_with(self.build)
-
-    @mock.patch("readthedocs.builds.views.get_diff_for_build")
-    def test_files_changed_diff_skipped_for_unsuccessful_build(self, get_diff_for_build):
-        self.build.state = BUILD_STATE_FINISHED
-        self.build.success = False
-        self.build.save()
-
-        diff = BuildDetail()._get_files_changed_diff(self.build)
-
-        assert diff is None
-        get_diff_for_build.assert_not_called()
-
-    @mock.patch("readthedocs.builds.views.get_diff_for_build")
-    def test_files_changed_diff_skipped_for_unfinished_build(self, get_diff_for_build):
-        self.build.state = BUILD_STATE_INSTALLING
-        self.build.success = True
-        self.build.save()
-
-        diff = BuildDetail()._get_files_changed_diff(self.build)
-
-        assert diff is None
-        get_diff_for_build.assert_not_called()

--- a/readthedocs/builds/views.py
+++ b/readthedocs/builds/views.py
@@ -22,6 +22,7 @@ from readthedocs.core.filters import FilterContextMixin
 from readthedocs.core.permissions import AdminPermission
 from readthedocs.core.utils import cancel_build
 from readthedocs.doc_builder.exceptions import BuildAppError
+from readthedocs.filetreediff import get_diff_for_build
 from readthedocs.projects.models import Project
 from readthedocs.projects.views.base import ProjectSpamMixin
 
@@ -96,6 +97,23 @@ class BuildDetail(BuildBase, ProjectSpamMixin, DetailView):
     def get_project(self):
         return self.get_object().project
 
+    def _get_files_changed_diff(self, build):
+        """
+        Get the file tree diff shown in the build's "Files changed" tab.
+
+        This is available for successful builds that have a file manifest,
+        comparing pull request builds against their base version and normal
+        version builds against the version's previous build.
+        """
+        if not build.success or not build.finished:
+            return None
+
+        try:
+            return get_diff_for_build(build)
+        except Exception:
+            log.exception("Error getting the file tree diff for the build.", build_id=build.pk)
+            return None
+
     @method_decorator(login_required)
     def post(self, request, project_slug, build_pk):
         project = get_object_or_404(Project, slug=project_slug)
@@ -116,6 +134,7 @@ class BuildDetail(BuildBase, ProjectSpamMixin, DetailView):
 
         build = self.get_object()
         context["notifications"] = build.notifications.all()
+        context["files_changed_diff"] = self._get_files_changed_diff(build)
         if not build.notifications.filter(message_id=BuildAppError.GENERIC_WITH_BUILD_ID).exists():
             # Do not suggest to open an issue if the error is not generic
             return context

--- a/readthedocs/builds/views.py
+++ b/readthedocs/builds/views.py
@@ -97,18 +97,6 @@ class BuildDetail(BuildBase, ProjectSpamMixin, DetailView):
     def get_project(self):
         return self.get_object().project
 
-    def _get_files_changed_diff(self, build):
-        """
-        Get the file tree diff shown in the build's "Files changed" tab.
-
-        This compares pull request builds against their base version and
-        normal version builds against the version's previous build. It is
-        only available for builds that finished successfully.
-        """
-        if not build.success or not build.finished:
-            return None
-        return get_diff_for_build(build)
-
     @method_decorator(login_required)
     def post(self, request, project_slug, build_pk):
         project = get_object_or_404(Project, slug=project_slug)
@@ -129,7 +117,7 @@ class BuildDetail(BuildBase, ProjectSpamMixin, DetailView):
 
         build = self.get_object()
         context["notifications"] = build.notifications.all()
-        context["files_changed_diff"] = self._get_files_changed_diff(build)
+        context["files_changed_diff"] = get_diff_for_build(build)
         if not build.notifications.filter(message_id=BuildAppError.GENERIC_WITH_BUILD_ID).exists():
             # Do not suggest to open an issue if the error is not generic
             return context

--- a/readthedocs/builds/views.py
+++ b/readthedocs/builds/views.py
@@ -101,18 +101,13 @@ class BuildDetail(BuildBase, ProjectSpamMixin, DetailView):
         """
         Get the file tree diff shown in the build's "Files changed" tab.
 
-        This is available for successful builds that have a file manifest,
-        comparing pull request builds against their base version and normal
-        version builds against the version's previous build.
+        This compares pull request builds against their base version and
+        normal version builds against the version's previous build. It is
+        only available for builds that finished successfully.
         """
         if not build.success or not build.finished:
             return None
-
-        try:
-            return get_diff_for_build(build)
-        except Exception:
-            log.exception("Error getting the file tree diff for the build.", build_id=build.pk)
-            return None
+        return get_diff_for_build(build)
 
     @method_decorator(login_required)
     def post(self, request, project_slug, build_pk):

--- a/readthedocs/filetreediff/__init__.py
+++ b/readthedocs/filetreediff/__init__.py
@@ -36,6 +36,16 @@ BASE_MANIFEST_SNAPSHOT_FILE_NAME = "base_manifest_snapshot.json"
 PREVIOUS_MANIFEST_SNAPSHOT_FILE_NAME = "previous_manifest_snapshot.json"
 
 
+def get_diff_base_version(project):
+    """
+    Resolve the base version a PR's diff should be compared against.
+
+    Falls back to the project's latest version if no explicit base is
+    configured. Returns ``None`` if no base version can be determined.
+    """
+    return project.addons.options_base_version or project.get_latest_version()
+
+
 def get_diff(current_version: Version, base_version: Version) -> FileTreeDiff | None:
     """
     Get the file tree diff between two versions.
@@ -48,10 +58,6 @@ def get_diff(current_version: Version, base_version: Version) -> FileTreeDiff | 
     Set operations are used to calculate the added, deleted, and modified files.
     To get the modified files, we compare the main content hash of each common file.
     If there are no changes between the versions, all lists will be empty.
-
-    When ``current_version`` and ``base_version`` are the same normal version,
-    the comparison is done against the version's own previous build, using the
-    manifest snapshot taken before the latest build overwrote the manifest.
     """
     current_version_manifest = get_manifest(current_version)
     if not current_version_manifest:
@@ -77,11 +83,6 @@ def get_diff(current_version: Version, base_version: Version) -> FileTreeDiff | 
     base_version_manifest = None
     if current_version.is_external:
         base_version_manifest = _get_base_manifest_snapshot(current_version)
-    elif current_version.pk == base_version.pk:
-        # Comparing a normal version against itself: use the manifest snapshot
-        # taken before the latest build, so the diff reflects what the latest
-        # build changed relative to the version's previous build.
-        base_version_manifest = _get_previous_manifest_snapshot(current_version)
 
     if not base_version_manifest:
         base_version_manifest = get_manifest(base_version)
@@ -95,11 +96,41 @@ def get_diff(current_version: Version, base_version: Version) -> FileTreeDiff | 
         if base_latest_build.id != base_version_manifest.build.id:
             outdated = True
 
+    return _build_diff(
+        current_version=current_version,
+        current_version_manifest=current_version_manifest,
+        base_version=base_version,
+        base_version_manifest=base_version_manifest,
+        outdated=outdated,
+    )
+
+
+def _build_diff(
+    *,
+    current_version: Version,
+    current_version_manifest: FileTreeDiffManifest,
+    base_version: Version,
+    base_version_manifest: FileTreeDiffManifest,
+    outdated: bool,
+) -> FileTreeDiff | None:
+    """
+    Construct a :class:`FileTreeDiff` from two resolved manifests.
+
+    Returns ``None`` if either manifest's referenced Build row has been
+    deleted (e.g. by ``delete_old_build_objects``). The diff would otherwise
+    crash with ``Build.DoesNotExist``.
+    """
+    current_version_build = Build.objects.filter(
+        id=current_version_manifest.build.id
+    ).first()
+    base_version_build = Build.objects.filter(
+        id=base_version_manifest.build.id
+    ).first()
+    if not current_version_build or not base_version_build:
+        return None
+
     current_version_file_paths = set(current_version_manifest.files.keys())
     base_version_file_paths = set(base_version_manifest.files.keys())
-
-    current_version_build = Build.objects.get(id=current_version_manifest.build.id)
-    base_version_build = Build.objects.get(id=base_version_manifest.build.id)
 
     files: list[tuple[str, FileTreeDiffFileStatus]] = []
     for file_path in current_version_file_paths - base_version_file_paths:
@@ -130,10 +161,12 @@ def get_diff_for_build(build: Build) -> FileTreeDiff | None:
 
     Pull request builds are compared against the project's base version (the
     latest version by default). Normal version builds are compared against the
-    version's own previous build.
+    version's own previous build, using the manifest snapshot taken before the
+    current build overwrote the version's manifest.
 
-    Returns ``None`` if the build didn't finish successfully, has no version,
-    or has no diff available.
+    Returns ``None`` if the build didn't finish successfully, isn't the
+    version's latest successful build (manifests are per-version and represent
+    only the latest build), has no version, or has no diff available.
     """
     if not build.success or not build.finished:
         return None
@@ -142,17 +175,43 @@ def get_diff_for_build(build: Build) -> FileTreeDiff | None:
     if not version:
         return None
 
-    project = build.project
-    if version.is_external:
-        base_version = project.addons.options_base_version or project.get_latest_version()
-    else:
-        # Normal versions are compared against their own previous build.
-        base_version = version
-
-    if not base_version:
+    # Manifests are stored per-version and overwritten by each new build, so
+    # they only represent the latest successful build. Computing a diff for an
+    # older build would silently return the latest build's diff, which is
+    # misleading on a historical build's detail page.
+    latest = version.latest_successful_build
+    if not latest or latest.id != build.id:
         return None
 
-    return get_diff(current_version=version, base_version=base_version)
+    if version.is_external:
+        base_version = get_diff_base_version(build.project)
+        if not base_version:
+            return None
+        return get_diff(current_version=version, base_version=base_version)
+
+    return _get_diff_against_previous_build(version)
+
+
+def _get_diff_against_previous_build(version: Version) -> FileTreeDiff | None:
+    """
+    Diff the version's latest manifest against its own previous-build snapshot.
+
+    Used for non-PR builds. Returns ``None`` when no previous snapshot exists
+    (e.g. the very first build of the version).
+    """
+    current_manifest = get_manifest(version)
+    if not current_manifest:
+        return None
+    previous_manifest = _get_previous_manifest_snapshot(version)
+    if not previous_manifest:
+        return None
+    return _build_diff(
+        current_version=version,
+        current_version_manifest=current_manifest,
+        base_version=version,
+        base_version_manifest=previous_manifest,
+        outdated=False,
+    )
 
 
 def get_manifest(version: Version) -> FileTreeDiffManifest | None:
@@ -260,7 +319,7 @@ def _get_previous_manifest_snapshot(version: Version) -> FileTreeDiffManifest | 
     return FileTreeDiffManifest.from_dict(data)
 
 
-def snapshot_previous_manifest(version: Version):
+def snapshot_previous_manifest(version: Version, new_build_id: int | None = None):
     """
     Snapshot a version's current manifest before it is overwritten.
 
@@ -270,9 +329,18 @@ def snapshot_previous_manifest(version: Version):
 
     Unlike :func:`snapshot_base_manifest`, this overwrites any existing
     snapshot, so it always reflects the build right before the latest one.
+
+    If ``new_build_id`` is provided and matches the existing manifest's
+    build id (e.g. on a re-index of the same build, or a re-run that reuses
+    the same Build row), the snapshot is *not* refreshed — refreshing would
+    overwrite the previous baseline with the current build's own manifest,
+    making the next diff empty.
     """
     current_manifest = get_manifest(version)
     if not current_manifest:
+        return
+
+    if new_build_id is not None and current_manifest.build.id == new_build_id:
         return
 
     snapshot_path = version.get_storage_path(
@@ -286,5 +354,5 @@ def snapshot_previous_manifest(version: Version):
         "Previous manifest snapshot created.",
         project_slug=version.project.slug,
         version_slug=version.slug,
-        build_id=current_manifest.build.id,
+        previous_build_id=current_manifest.build.id,
     )

--- a/readthedocs/filetreediff/__init__.py
+++ b/readthedocs/filetreediff/__init__.py
@@ -33,6 +33,7 @@ log = structlog.get_logger(__name__)
 
 MANIFEST_FILE_NAME = "manifest.json"
 BASE_MANIFEST_SNAPSHOT_FILE_NAME = "base_manifest_snapshot.json"
+PREVIOUS_MANIFEST_SNAPSHOT_FILE_NAME = "previous_manifest_snapshot.json"
 
 
 def get_diff(current_version: Version, base_version: Version) -> FileTreeDiff | None:
@@ -47,6 +48,10 @@ def get_diff(current_version: Version, base_version: Version) -> FileTreeDiff | 
     Set operations are used to calculate the added, deleted, and modified files.
     To get the modified files, we compare the main content hash of each common file.
     If there are no changes between the versions, all lists will be empty.
+
+    When ``current_version`` and ``base_version`` are the same normal version,
+    the comparison is done against the version's own previous build, using the
+    manifest snapshot taken before the latest build overwrote the manifest.
     """
     current_version_manifest = get_manifest(current_version)
     if not current_version_manifest:
@@ -72,6 +77,11 @@ def get_diff(current_version: Version, base_version: Version) -> FileTreeDiff | 
     base_version_manifest = None
     if current_version.is_external:
         base_version_manifest = _get_base_manifest_snapshot(current_version)
+    elif current_version.pk == base_version.pk:
+        # Comparing a normal version against itself: use the manifest snapshot
+        # taken before the latest build, so the diff reflects what the latest
+        # build changed relative to the version's previous build.
+        base_version_manifest = _get_previous_manifest_snapshot(current_version)
 
     if not base_version_manifest:
         base_version_manifest = get_manifest(base_version)
@@ -112,6 +122,33 @@ def get_diff(current_version: Version, base_version: Version) -> FileTreeDiff | 
         base_version_build=base_version_build,
         outdated=outdated,
     )
+
+
+def get_diff_for_build(build: Build) -> FileTreeDiff | None:
+    """
+    Get the file tree diff for a build, picking the right base to compare against.
+
+    Pull request builds are compared against the project's base version (the
+    latest version by default). Normal version builds are compared against the
+    version's own previous build.
+
+    Returns ``None`` if the build has no version or no diff is available.
+    """
+    version = build.version
+    if not version:
+        return None
+
+    project = build.project
+    if version.is_external:
+        base_version = project.addons.options_base_version or project.get_latest_version()
+    else:
+        # Normal versions are compared against their own previous build.
+        base_version = version
+
+    if not base_version:
+        return None
+
+    return get_diff(current_version=version, base_version=base_version)
 
 
 def get_manifest(version: Version) -> FileTreeDiffManifest | None:
@@ -202,3 +239,48 @@ def snapshot_base_manifest(external_version: Version, base_version: Version):
     # rebase/synchronize webhook events so the snapshot refreshes when the
     # PR is rebased against a newer base.
     # See https://github.com/readthedocs/readthedocs.org/issues/12232
+
+
+def _get_previous_manifest_snapshot(version: Version) -> FileTreeDiffManifest | None:
+    """Get the manifest snapshot from before the version's latest build, or None."""
+    snapshot_path = version.get_storage_path(
+        media_type=MEDIA_TYPE_DIFF,
+        filename=PREVIOUS_MANIFEST_SNAPSHOT_FILE_NAME,
+    )
+    try:
+        with build_media_storage.open(snapshot_path) as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        return None
+
+    return FileTreeDiffManifest.from_dict(data)
+
+
+def snapshot_previous_manifest(version: Version):
+    """
+    Snapshot a version's current manifest before it is overwritten.
+
+    This is called before writing the manifest for a new build of a normal
+    version, so the file tree diff can compare the new build against the
+    version's previous build.
+
+    Unlike :func:`snapshot_base_manifest`, this overwrites any existing
+    snapshot, so it always reflects the build right before the latest one.
+    """
+    current_manifest = get_manifest(version)
+    if not current_manifest:
+        return
+
+    snapshot_path = version.get_storage_path(
+        media_type=MEDIA_TYPE_DIFF,
+        filename=PREVIOUS_MANIFEST_SNAPSHOT_FILE_NAME,
+    )
+    with build_media_storage.open(snapshot_path, "w") as f:
+        json.dump(current_manifest.as_dict(), f)
+
+    log.info(
+        "Previous manifest snapshot created.",
+        project_slug=version.project.slug,
+        version_slug=version.slug,
+        build_id=current_manifest.build.id,
+    )

--- a/readthedocs/filetreediff/__init__.py
+++ b/readthedocs/filetreediff/__init__.py
@@ -132,8 +132,12 @@ def get_diff_for_build(build: Build) -> FileTreeDiff | None:
     latest version by default). Normal version builds are compared against the
     version's own previous build.
 
-    Returns ``None`` if the build has no version or no diff is available.
+    Returns ``None`` if the build didn't finish successfully, has no version,
+    or has no diff available.
     """
+    if not build.success or not build.finished:
+        return None
+
     version = build.version
     if not version:
         return None

--- a/readthedocs/filetreediff/tests/test_filetreediff.py
+++ b/readthedocs/filetreediff/tests/test_filetreediff.py
@@ -5,7 +5,12 @@ from unittest import mock
 from django.test import TestCase
 from django_dynamic_fixture import get
 
-from readthedocs.builds.constants import BUILD_STATE_FINISHED, EXTERNAL, LATEST
+from readthedocs.builds.constants import (
+    BUILD_STATE_FINISHED,
+    BUILD_STATE_TRIGGERED,
+    EXTERNAL,
+    LATEST,
+)
 from readthedocs.builds.models import Build, Version
 from readthedocs.filetreediff import (
     get_diff,
@@ -363,3 +368,29 @@ class TestsPreviousManifestSnapshot(TestCase):
         assert [f.path for f in diff.added] == ["new.html"]
         assert diff.modified == []
         assert diff.deleted == []
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_get_diff_for_build_skipped_for_failed_build(self, storage_open):
+        """A build that didn't succeed has no diff."""
+        failed_build = get(
+            Build,
+            project=self.project,
+            version=self.version,
+            state=BUILD_STATE_FINISHED,
+            success=False,
+        )
+        assert get_diff_for_build(failed_build) is None
+        storage_open.assert_not_called()
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_get_diff_for_build_skipped_for_unfinished_build(self, storage_open):
+        """A build that hasn't finished has no diff."""
+        running_build = get(
+            Build,
+            project=self.project,
+            version=self.version,
+            state=BUILD_STATE_TRIGGERED,
+            success=True,
+        )
+        assert get_diff_for_build(running_build) is None
+        storage_open.assert_not_called()

--- a/readthedocs/filetreediff/tests/test_filetreediff.py
+++ b/readthedocs/filetreediff/tests/test_filetreediff.py
@@ -7,7 +7,12 @@ from django_dynamic_fixture import get
 
 from readthedocs.builds.constants import BUILD_STATE_FINISHED, EXTERNAL, LATEST
 from readthedocs.builds.models import Build, Version
-from readthedocs.filetreediff import get_diff, snapshot_base_manifest
+from readthedocs.filetreediff import (
+    get_diff,
+    get_diff_for_build,
+    snapshot_base_manifest,
+    snapshot_previous_manifest,
+)
 from readthedocs.projects.models import Project
 from readthedocs.rtd_tests.storage import BuildMediaFileSystemStorageTest
 
@@ -240,3 +245,121 @@ class TestsBaseManifestSnapshot(TestCase):
         """snapshot_base_manifest is a no-op if a snapshot already exists."""
         snapshot_base_manifest(self.pr_version, self.base_version)
         storage_open.assert_not_called()
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_get_diff_for_build_uses_base_snapshot(self, storage_open):
+        """For PR builds, get_diff_for_build compares against the base version."""
+        pr_files = {"index.html": "pr-hash", "new-page.html": "new-hash"}
+        snapshot_files = {"index.html": "original-hash"}
+
+        # get_diff reads: 1) PR manifest, 2) base snapshot
+        storage_open.side_effect = [
+            _mock_manifest(self.pr_build.id, pr_files)(),
+            _mock_manifest(self.base_build.id, snapshot_files)(),
+        ]
+        diff = get_diff_for_build(self.pr_build)
+        assert [f.path for f in diff.added] == ["new-page.html"]
+        assert [f.path for f in diff.modified] == ["index.html"]
+        assert diff.deleted == []
+
+
+@mock.patch(
+    "readthedocs.filetreediff.build_media_storage",
+    new=BuildMediaFileSystemStorageTest(),
+)
+class TestsPreviousManifestSnapshot(TestCase):
+    """Tests for comparing a normal version against its own previous build."""
+
+    def setUp(self):
+        self.project = get(Project)
+        self.version = self.project.versions.get(slug=LATEST)
+        self.previous_build = get(
+            Build,
+            project=self.project,
+            version=self.version,
+            state=BUILD_STATE_FINISHED,
+            success=True,
+        )
+        self.latest_build = get(
+            Build,
+            project=self.project,
+            version=self.version,
+            state=BUILD_STATE_FINISHED,
+            success=True,
+        )
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_diff_uses_previous_manifest_snapshot(self, storage_open):
+        """A normal version is compared against its previous build's manifest."""
+        current_files = {"index.html": "hash1", "new.html": "hash-new"}
+        previous_files = {"index.html": "hash0"}
+
+        # get_diff reads: 1) current manifest, 2) previous manifest snapshot
+        storage_open.side_effect = [
+            _mock_manifest(self.latest_build.id, current_files)(),
+            _mock_manifest(self.previous_build.id, previous_files)(),
+        ]
+        diff = get_diff(self.version, self.version)
+        assert [f.path for f in diff.added] == ["new.html"]
+        assert [f.path for f in diff.modified] == ["index.html"]
+        assert diff.deleted == []
+        assert not diff.outdated
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_diff_falls_back_to_live_manifest_when_no_snapshot(self, storage_open):
+        """Without a snapshot, the diff against the same version has no changes."""
+        files = {"index.html": "hash1"}
+
+        # get_diff reads: 1) current manifest, 2) snapshot miss, 3) live manifest
+        storage_open.side_effect = [
+            _mock_manifest(self.latest_build.id, files)(),
+            FileNotFoundError,
+            _mock_manifest(self.latest_build.id, files)(),
+        ]
+        diff = get_diff(self.version, self.version)
+        assert diff.files == []
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_snapshot_previous_manifest_copies_current_manifest(self, storage_open):
+        """snapshot_previous_manifest writes a copy of the current manifest."""
+        current_files = {"index.html": "hash1", "guide.html": "hash2"}
+        writes = []
+
+        @contextmanager
+        def write_capture(*args, **kwargs):
+            write_mock = mock.MagicMock()
+            write_mock.write.side_effect = writes.append
+            yield write_mock
+
+        storage_open.side_effect = [
+            _mock_manifest(self.latest_build.id, current_files)(),
+            write_capture(),
+        ]
+        snapshot_previous_manifest(self.version)
+
+        assert storage_open.call_count == 2
+        written = json.loads("".join(writes))
+        assert written["build"]["id"] == self.latest_build.id
+        assert set(written["files"].keys()) == {"index.html", "guide.html"}
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_snapshot_previous_manifest_noop_without_manifest(self, storage_open):
+        """snapshot_previous_manifest does nothing if there is no manifest yet."""
+        storage_open.side_effect = FileNotFoundError
+        snapshot_previous_manifest(self.version)
+        storage_open.assert_called_once()
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_get_diff_for_build_uses_previous_manifest_snapshot(self, storage_open):
+        """For normal version builds, get_diff_for_build compares previous builds."""
+        current_files = {"index.html": "hash1", "new.html": "hash-new"}
+        previous_files = {"index.html": "hash1"}
+
+        storage_open.side_effect = [
+            _mock_manifest(self.latest_build.id, current_files)(),
+            _mock_manifest(self.previous_build.id, previous_files)(),
+        ]
+        diff = get_diff_for_build(self.latest_build)
+        assert [f.path for f in diff.added] == ["new.html"]
+        assert diff.modified == []
+        assert diff.deleted == []

--- a/readthedocs/filetreediff/tests/test_filetreediff.py
+++ b/readthedocs/filetreediff/tests/test_filetreediff.py
@@ -295,34 +295,31 @@ class TestsPreviousManifestSnapshot(TestCase):
 
     @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
     def test_diff_uses_previous_manifest_snapshot(self, storage_open):
-        """A normal version is compared against its previous build's manifest."""
+        """A normal version's latest build is compared against the previous build's snapshot."""
         current_files = {"index.html": "hash1", "new.html": "hash-new"}
         previous_files = {"index.html": "hash0"}
 
-        # get_diff reads: 1) current manifest, 2) previous manifest snapshot
+        # get_diff_for_build reads: 1) current manifest, 2) previous manifest snapshot
         storage_open.side_effect = [
             _mock_manifest(self.latest_build.id, current_files)(),
             _mock_manifest(self.previous_build.id, previous_files)(),
         ]
-        diff = get_diff(self.version, self.version)
+        diff = get_diff_for_build(self.latest_build)
         assert [f.path for f in diff.added] == ["new.html"]
         assert [f.path for f in diff.modified] == ["index.html"]
         assert diff.deleted == []
         assert not diff.outdated
 
     @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
-    def test_diff_falls_back_to_live_manifest_when_no_snapshot(self, storage_open):
-        """Without a snapshot, the diff against the same version has no changes."""
+    def test_diff_returns_none_when_no_previous_snapshot(self, storage_open):
+        """Without a previous snapshot, a normal version has no diff to show."""
         files = {"index.html": "hash1"}
-
-        # get_diff reads: 1) current manifest, 2) snapshot miss, 3) live manifest
+        # 1) current manifest, 2) previous snapshot miss
         storage_open.side_effect = [
             _mock_manifest(self.latest_build.id, files)(),
             FileNotFoundError,
-            _mock_manifest(self.latest_build.id, files)(),
         ]
-        diff = get_diff(self.version, self.version)
-        assert diff.files == []
+        assert get_diff_for_build(self.latest_build) is None
 
     @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
     def test_snapshot_previous_manifest_copies_current_manifest(self, storage_open):
@@ -394,3 +391,36 @@ class TestsPreviousManifestSnapshot(TestCase):
         )
         assert get_diff_for_build(running_build) is None
         storage_open.assert_not_called()
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_get_diff_for_build_skipped_for_non_latest_build(self, storage_open):
+        """Manifests are per-version: only the latest build can produce a diff."""
+        # `self.previous_build` is older than `self.latest_build` for the same version.
+        assert get_diff_for_build(self.previous_build) is None
+        storage_open.assert_not_called()
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_get_diff_returns_none_when_manifest_build_row_missing(self, storage_open):
+        """If a Build row referenced by a manifest was pruned, get_diff returns None."""
+        files = {"index.html": "hash1"}
+        previous_files = {"index.html": "hash0"}
+        # Manifest references a build that no longer exists in the DB.
+        storage_open.side_effect = [
+            _mock_manifest(self.latest_build.id, files)(),
+            _mock_manifest(99999, previous_files)(),
+        ]
+        assert get_diff_for_build(self.latest_build) is None
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_snapshot_previous_manifest_skips_when_existing_belongs_to_same_build(
+        self, storage_open
+    ):
+        """Re-indexing the same build (e.g. reindex_version) must not refresh
+        the previous-build snapshot, or the next diff would be empty."""
+        files = {"index.html": "hash1"}
+        # Only the read of the existing manifest happens; no write.
+        storage_open.side_effect = [
+            _mock_manifest(self.latest_build.id, files)(),
+        ]
+        snapshot_previous_manifest(self.version, new_build_id=self.latest_build.id)
+        assert storage_open.call_count == 1

--- a/readthedocs/projects/tasks/search.py
+++ b/readthedocs/projects/tasks/search.py
@@ -10,6 +10,7 @@ from readthedocs.builds.models import Build
 from readthedocs.builds.models import Version
 from readthedocs.builds.tasks import post_build_overview
 from readthedocs.filetreediff import snapshot_base_manifest
+from readthedocs.filetreediff import snapshot_previous_manifest
 from readthedocs.filetreediff import write_manifest
 from readthedocs.filetreediff.dataclasses import FileTreeDiffManifest
 from readthedocs.filetreediff.dataclasses import FileTreeDiffManifestFile
@@ -148,6 +149,13 @@ class FileManifestIndexer(Indexer):
                 for path, content_hash in self._hashes.items()
             ],
         )
+
+        # For normal versions, snapshot the existing manifest before it gets
+        # overwritten, so the file tree diff can compare this build against the
+        # version's previous build.
+        if not self.version.is_external:
+            snapshot_previous_manifest(self.version)
+
         write_manifest(self.version, manifest)
 
         # For PR previews, snapshot the base version's manifest on the first

--- a/readthedocs/projects/tasks/search.py
+++ b/readthedocs/projects/tasks/search.py
@@ -9,6 +9,7 @@ from readthedocs.builds.constants import LATEST
 from readthedocs.builds.models import Build
 from readthedocs.builds.models import Version
 from readthedocs.builds.tasks import post_build_overview
+from readthedocs.filetreediff import get_diff_base_version
 from readthedocs.filetreediff import snapshot_base_manifest
 from readthedocs.filetreediff import snapshot_previous_manifest
 from readthedocs.filetreediff import write_manifest
@@ -151,10 +152,17 @@ class FileManifestIndexer(Indexer):
         )
 
         # For normal versions, snapshot the existing manifest before it gets
-        # overwritten, so the file tree diff can compare this build against the
-        # version's previous build.
+        # overwritten by write_manifest below — the file tree diff for this
+        # build compares the new manifest against this snapshot. The call
+        # MUST come before write_manifest; reversing the order would snapshot
+        # the new build's own manifest and produce an empty diff.
+        #
+        # We pass self.build.id so the snapshot is skipped when this is a
+        # reindex/rerun of the same build (e.g. via reindex_version), where
+        # the existing manifest already belongs to self.build and refreshing
+        # the snapshot would clobber the real previous baseline.
         if not self.version.is_external:
-            snapshot_previous_manifest(self.version)
+            snapshot_previous_manifest(self.version, new_build_id=self.build.id)
 
         write_manifest(self.version, manifest)
 
@@ -165,10 +173,7 @@ class FileManifestIndexer(Indexer):
         # current state. This prevents false file changes when the base branch
         # moves forward (the "stale branch" problem).
         if self.version.is_external:
-            base_version = (
-                self.version.project.addons.options_base_version
-                or self.version.project.get_latest_version()
-            )
+            base_version = get_diff_base_version(self.version.project)
             if base_version:
                 snapshot_base_manifest(self.version, base_version)
 

--- a/readthedocs/projects/tests/test_indexers.py
+++ b/readthedocs/projects/tests/test_indexers.py
@@ -1,10 +1,16 @@
+from unittest import mock
+
 from django.test import TestCase
 from django_dynamic_fixture import get
 
-from readthedocs.builds.constants import BUILD_STATE_FINISHED, EXTERNAL
+from readthedocs.builds.constants import BUILD_STATE_FINISHED, EXTERNAL, LATEST
 from readthedocs.builds.models import Build, Version
 from readthedocs.projects.models import Project
-from readthedocs.projects.tasks.search import SearchIndexer, _get_indexers
+from readthedocs.projects.tasks.search import (
+    FileManifestIndexer,
+    SearchIndexer,
+    _get_indexers,
+)
 
 
 class TestSearchIndexing(TestCase):
@@ -70,3 +76,51 @@ class TestSearchIndexing(TestCase):
             indexer for indexer in indexers if isinstance(indexer, SearchIndexer)
         ]
         assert len(search_indexers) == 0
+
+
+class TestFileManifestIndexerCollect(TestCase):
+    """Pinning down behavior of FileManifestIndexer.collect() for the diff feature."""
+
+    def setUp(self):
+        self.project = get(Project)
+        self.version = self.project.versions.get(slug=LATEST)
+        self.build = get(
+            Build,
+            project=self.project,
+            version=self.version,
+            state=BUILD_STATE_FINISHED,
+            success=True,
+        )
+
+    @mock.patch("readthedocs.projects.tasks.search.write_manifest")
+    @mock.patch("readthedocs.projects.tasks.search.snapshot_previous_manifest")
+    def test_snapshot_runs_before_write_manifest(
+        self, snapshot_previous, write_manifest
+    ):
+        """The previous-manifest snapshot MUST be taken before the new manifest
+        overwrites it; reversing the order would snapshot the new manifest and
+        produce an empty diff."""
+        calls = []
+        snapshot_previous.side_effect = lambda *a, **kw: calls.append("snapshot")
+        write_manifest.side_effect = lambda *a, **kw: calls.append("write")
+
+        indexer = FileManifestIndexer(
+            version=self.version, build=self.build, post_build_overview=False
+        )
+        indexer.collect(sync_id=1)
+        assert calls == ["snapshot", "write"]
+
+    @mock.patch("readthedocs.projects.tasks.search.write_manifest")
+    @mock.patch("readthedocs.projects.tasks.search.snapshot_previous_manifest")
+    def test_snapshot_passes_new_build_id_for_reindex_guard(
+        self, snapshot_previous, write_manifest
+    ):
+        """The collect call must hand the new build id to snapshot_previous_manifest
+        so re-indexing the same build doesn't refresh the snapshot."""
+        indexer = FileManifestIndexer(
+            version=self.version, build=self.build, post_build_overview=False
+        )
+        indexer.collect(sync_id=1)
+        snapshot_previous.assert_called_once_with(
+            self.version, new_build_id=self.build.id
+        )


### PR DESCRIPTION
## Summary

Exposes a file tree diff on the build detail page so it can be shown in a new "Files changed" tab. It works for both pull request builds and normal version builds, with the correct base to compare against:

- **Pull request builds** are compared against the project's base version (the latest version by default), reusing the existing diff logic.
- **Normal version builds** are compared against the version's *own previous build*. A manifest snapshot is taken before each build overwrites the manifest, so the diff reflects what the latest build changed — reusing the snapshot mechanism already used to pin pull request base manifests.

`BuildDetail` passes a `files_changed_diff` (`FileTreeDiff`) to the template for successful, finished builds.

The frontend that renders this tab lives in the companion PR: readthedocs/ext-theme#744.

## Test plan

- [x] `tox -e py312 -- -k "filetreediff or PreviousManifestSnapshot or files_changed or post_build_overview"` — new and existing tests pass
- [ ] Verify on a PR build and a normal version build in a full environment

---
*This pull request was generated by an AI agent (Claude Code).*