### PR TITLE
Tests: Reduce tests log levels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
     docker:
       - image: 'cimg/python:3.12'
         environment:
-          PYTEST_COVERAGE: --cov-config .coveragerc --cov
+          PYTEST_COVERAGE: --cov-config .coveragerc --cov --no-cov-on-fail
     steps:
       - setup-checkout
       - skip-if-docs-only
@@ -115,7 +115,7 @@ jobs:
     docker:
       - image: 'cimg/python:3.12'
         environment:
-          PYTEST_COVERAGE: --cov-config .coveragerc --cov
+          PYTEST_COVERAGE: --cov-config .coveragerc --cov --no-cov-on-fail
       - image: 'docker.elastic.co/elasticsearch/elasticsearch:9.3.1'
         name: search
         environment:
@@ -151,7 +151,7 @@ jobs:
     docker:
       - image: 'cimg/python:3.12'
         environment:
-          PYTEST_COVERAGE: --cov-config .coveragerc --cov
+          PYTEST_COVERAGE: --cov-config .coveragerc --cov --no-cov-on-fail
     steps:
       - setup-checkout
       - skip-if-docs-only

--- a/docs/dev/tests.rst
+++ b/docs/dev/tests.rst
@@ -79,31 +79,25 @@ docs-dev
 Debug logging
 -------------
 
-By default the test suite only surfaces ``WARNING`` and above log records.
-This keeps test failure reports focused on the actual error instead of a
-wall of ``DEBUG``/``INFO`` output from the ``readthedocs`` logger.
+Test failure reports only include ``WARNING`` and above log records, so the
+error you're looking at isn't buried under ``DEBUG``/``INFO`` output from
+the ``readthedocs`` logger.
 
-When you do need verbose logs (e.g. when diagnosing why a test fails),
-override the level on the command line:
+Full ``DEBUG`` output is always written to ``logs/debug.log`` by the file
+handler in ``readthedocs/settings/test.py``. After a failing run, tail or
+open that file to see everything the failing test logged — no re-running
+with extra flags required:
 
 .. prompt:: bash
 
-   # Capture DEBUG records and include them in failure reports
-   tox -e py312 -- --log-level=DEBUG -k test_something
+   tail -n 200 logs/debug.log
 
-   # Stream logs live to the terminal while tests run
-   tox -e py312 -- --log-cli-level=DEBUG -k test_something
-
-The ``WARNING`` default is set in two places:
+The ``WARNING`` threshold for the test report is set in two places:
 
 - ``pytest.ini`` — ``log_level = WARNING`` controls what pytest captures
   and shows on test failure.
 - ``readthedocs/settings/test.py`` — the Django ``console`` log handler
   is pinned to ``WARNING`` for the test settings module.
-
-Regardless of the console level, ``DEBUG`` records are still written to
-``logs/debug.log`` by the file handler, so you can inspect them after a
-run without re-running with extra flags.
 
 Pytest marks
 ------------

--- a/docs/dev/tests.rst
+++ b/docs/dev/tests.rst
@@ -83,10 +83,10 @@ Test failure reports only include ``WARNING`` and above log records, so the
 error you're looking at isn't buried under ``DEBUG``/``INFO`` output from
 the ``readthedocs`` logger.
 
-Full ``DEBUG`` output is always written to ``logs/debug.log`` by the file
-handler in ``readthedocs/settings/test.py``. After a failing run, tail or
-open that file to see everything the failing test logged — no re-running
-with extra flags required:
+Full ``DEBUG`` output is always written to ``logs/debug.log`` by the
+``debug`` file handler configured in ``readthedocs/settings/base.py``.
+After a failing run, tail or open that file to see everything the failing
+test logged — no re-running with extra flags required:
 
 .. prompt:: bash
 

--- a/docs/dev/tests.rst
+++ b/docs/dev/tests.rst
@@ -76,6 +76,35 @@ docs-dev
 .. _`Tox`: https://tox.readthedocs.io/en/latest/index.html
 
 
+Debug logging
+-------------
+
+By default the test suite only surfaces ``WARNING`` and above log records.
+This keeps test failure reports focused on the actual error instead of a
+wall of ``DEBUG``/``INFO`` output from the ``readthedocs`` logger.
+
+When you do need verbose logs (e.g. when diagnosing why a test fails),
+override the level on the command line:
+
+.. prompt:: bash
+
+   # Capture DEBUG records and include them in failure reports
+   tox -e py312 -- --log-level=DEBUG -k test_something
+
+   # Stream logs live to the terminal while tests run
+   tox -e py312 -- --log-cli-level=DEBUG -k test_something
+
+The ``WARNING`` default is set in two places:
+
+- ``pytest.ini`` — ``log_level = WARNING`` controls what pytest captures
+  and shows on test failure.
+- ``readthedocs/settings/test.py`` — the Django ``console`` log handler
+  is pinned to ``WARNING`` for the test settings module.
+
+Regardless of the console level, ``DEBUG`` records are still written to
+``logs/debug.log`` by the file handler, so you can inspect them after a
+run without re-running with extra flags.
+
 Pytest marks
 ------------
 

--- a/docs/dev/tests.rst
+++ b/docs/dev/tests.rst
@@ -92,6 +92,13 @@ with extra flags required:
 
    tail -n 200 logs/debug.log
 
+If you'd rather see the debug records inline with the failure report,
+override the level on the command line:
+
+.. prompt:: bash
+
+   tox -e py312 -- --log-level=DEBUG -k test_something
+
 The ``WARNING`` threshold for the test report is set in two places:
 
 - ``pytest.ini`` — ``log_level = WARNING`` controls what pytest captures

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,9 @@
 [pytest]
 addopts = --strict-markers
+# Only capture WARNING+ log records so a failing test's report shows the
+# error instead of a wall of DEBUG/INFO noise from the `readthedocs` logger.
+# Override on the CLI when debugging: `pytest --log-level=DEBUG`.
+log_level = WARNING
 markers =
     search
     serve

--- a/readthedocs/settings/test.py
+++ b/readthedocs/settings/test.py
@@ -126,7 +126,10 @@ class CommunityTestSettings(CommunityBaseSettings):
     def LOGGING(self):  # noqa - avoid pep8 N802
         logging = super().LOGGING
 
-        logging["handlers"]["console"]["level"] = "DEBUG"
+        # Keep test output focused on failures: only warnings/errors reach the
+        # console. DEBUG-level records are still written to the debug.log file
+        # handler for post-mortem inspection.
+        logging["handlers"]["console"]["level"] = "WARNING"
         logging["formatters"]["default"]["format"] = "[%(asctime)s] " + self.LOG_FORMAT
         # Allow Sphinx and other tools to create loggers
         logging["disable_existing_loggers"] = False

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,8 @@ setenv =
     LC_ALL=en_US.UTF-8
     DJANGO_SETTINGS_SKIP_LOCAL=True
 passenv = CI,TRAVIS,TRAVIS_*,HOME
+# Suppress the post-install `freeze>` dump of every pinned dep.
+list_dependencies_command = python -c ""
 deps =
   -r requirements/testing.txt
   readthedocsext-theme@git+https://github.com/readthedocs/ext-theme.git@main

--- a/tox.ini
+++ b/tox.ini
@@ -12,8 +12,6 @@ setenv =
     LC_ALL=en_US.UTF-8
     DJANGO_SETTINGS_SKIP_LOCAL=True
 passenv = CI,TRAVIS,TRAVIS_*,HOME
-# Suppress the post-install `freeze>` dump of every pinned dep.
-list_dependencies_command = python -c ""
 deps =
   -r requirements/testing.txt
   readthedocsext-theme@git+https://github.com/readthedocs/ext-theme.git@main


### PR DESCRIPTION
HS: I kept hitting issues with spammy test logs that are hard to debug, so try and keep the user-facing logging way more simple, but keep the logs in `logs/debug.log`.

Also added `--no-cov-on-fail` in CI so failing test runs skip the coverage table and the failure stays at the top of the log.

---
*Generated by AI agent*

https://claude.ai/code/session_01KzkUNKQs18iWRTgEZpbMUj