### PR TITLE
Tests: force creation of the user profile

### DIFF
--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -375,6 +375,8 @@ class TestPrivateViews(TestCase):
         self.user = new(User, username="eric")
         self.user.set_password("test")
         self.user.save()
+        # Force the creation of the user profile to avoid extra queries in the tests.
+        self.user.profile
         self.client.login(username="eric", password="test")
         self.project = get(Project, slug="pip", users=[self.user])
 
@@ -402,7 +404,7 @@ class TestPrivateViews(TestCase):
         # This number is bit higher, but for projects with lots of builds
         # is better to have more queries than optimizing with a prefetch,
         # see comment in annotate_has_successful_build.
-        with self.assertNumQueries(26):
+        with self.assertNumQueries(27):
             r = self.client.get(reverse(("projects_dashboard")))
         assert r.status_code == 200
 

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -6,7 +6,7 @@ from django.http.response import HttpResponseRedirect
 from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.views.generic.base import ContextMixin
-from django_dynamic_fixture import get, new
+from django_dynamic_fixture import get
 
 from readthedocs.builds.constants import BUILD_STATE_FINISHED, EXTERNAL
 from readthedocs.builds.models import Build, Version
@@ -372,7 +372,7 @@ class TestPublicViews(TestCase):
 @mock.patch("readthedocs.core.utils.trigger_build", mock.MagicMock())
 class TestPrivateViews(TestCase):
     def setUp(self):
-        self.user = new(User, username="eric")
+        self.user = get(User, username="eric")
         self.user.set_password("test")
         self.user.save()
         # Force the creation of the user profile to avoid extra queries in the tests.


### PR DESCRIPTION
https://github.com/readthedocs/ext-theme/pull/727 introduced one extra query in all templates. Since we are using an autoonefield, the UserProfile model is created when the attribute is first accessed, and somehow is creating a bunch of queries from inside the template...

We may want to ditch autoonefield, and just use a signal, it's the only thing we are using from django-annoying. 

https://github.com/readthedocs/readthedocs.org/blob/009b1114f663a7dd126730eff622041413327cd7/readthedocs/core/models.py#L28-L33