### PR TITLE
Add form, view for basic dashboard preferences pane in user settings

### DIFF
--- a/readthedocs/core/forms.py
+++ b/readthedocs/core/forms.py
@@ -73,6 +73,14 @@ class UserDeleteForm(forms.ModelForm):
         return data
 
 
+class UserProfileDashboardPreferencesForm(forms.ModelForm):
+    """Form for dashboard preferences."""
+
+    class Meta:
+        model = UserProfile
+        fields = ["theme"]
+
+
 class UserAdvertisingForm(forms.ModelForm):
     class Meta:
         model = UserProfile

--- a/readthedocs/profiles/tests/test_views.py
+++ b/readthedocs/profiles/tests/test_views.py
@@ -10,6 +10,8 @@ from django.urls import reverse
 from django_dynamic_fixture import get
 
 from readthedocs.allauth.providers.githubapp.provider import GitHubAppProvider
+from readthedocs.core.forms import UserProfileDashboardPreferencesForm
+from readthedocs.core.models import UserProfile
 from readthedocs.notifications.models import Notification
 from readthedocs.oauth.constants import GITHUB, GITHUB_APP
 from readthedocs.oauth.migrate import InstallationTargetGroup, MigrationTarget, GitHubAccountTarget
@@ -907,3 +909,70 @@ class TestMigrateToGitHubAppView(TestCase):
         assert context["has_projects_pending_migration"] is True
         assert "installation_target_groups" not in context
         assert "migration_targets" not in context
+
+
+class TestUserProfileDashboardPreferencesEdit(TestCase):
+    def setUp(self):
+        self.user = get(User)
+        self.profile = get(UserProfile, user=self.user)
+        self.url = reverse("profiles_dashboard_preferences_edit")
+        self.client.force_login(self.user)
+
+    def test_theme_post_default(self):
+        data = {"theme": "default"}
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
+
+        self.profile.refresh_from_db()
+        assert self.profile.theme == "default"
+
+        assert not self.profile.use_dark_theme()
+        assert self.profile.use_light_theme()
+
+    def test_theme_post_light(self):
+        data = {"theme": "light"}
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
+
+        self.profile.refresh_from_db()
+        assert self.profile.theme == "light"
+
+        assert not self.profile.use_dark_theme()
+        assert self.profile.use_light_theme()
+
+    def test_theme_post_dark(self):
+        data = {"theme": "dark"}
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
+
+        self.profile.refresh_from_db()
+        assert self.profile.theme == "dark"
+
+        assert self.profile.use_dark_theme()
+        assert not self.profile.use_light_theme()
+
+    def test_theme_post_system(self):
+        data = {"theme": "system"}
+        response = self.client.post(self.url, data)
+        assert response.status_code == 302
+
+        self.profile.refresh_from_db()
+        assert self.profile.theme == "system"
+
+        assert not self.profile.use_dark_theme()
+        assert not self.profile.use_light_theme()
+
+    def test_invalid_data_post(self):
+        invalid_data = {"theme": "invalid_theme"}
+        response = self.client.post(self.url, invalid_data)
+        assert response.status_code == 200
+
+        self.profile.refresh_from_db()
+        # Verify theme remains unchanged
+        assert self.profile.theme == "default"
+
+        form = UserProfileDashboardPreferencesForm(data=invalid_data)
+        assert not form.is_valid()
+        assert len(form.errors) == 1
+        assert "theme" in form.errors
+        assert len(form.errors["theme"]) == 1

--- a/readthedocs/profiles/urls/private.py
+++ b/readthedocs/profiles/urls/private.py
@@ -37,6 +37,11 @@ account_urls = [
         name="profiles_security_log",
     ),
     path(
+        "preferences/",
+        views.UserProfileDashboardPreferencesEdit.as_view(),
+        name="profiles_dashboard_preferences_edit",
+    ),
+    path(
         "advertising/",
         views.AccountAdvertisingEdit.as_view(),
         name="account_advertising",

--- a/readthedocs/profiles/views.py
+++ b/readthedocs/profiles/views.py
@@ -33,6 +33,7 @@ from readthedocs.audit.filters import UserSecurityLogFilter
 from readthedocs.audit.models import AuditLog
 from readthedocs.core.forms import UserAdvertisingForm
 from readthedocs.core.forms import UserDeleteForm
+from readthedocs.core.forms import UserProfileDashboardPreferencesForm
 from readthedocs.core.forms import UserProfileForm
 from readthedocs.core.history import set_change_reason
 from readthedocs.core.mixins import PrivateViewMixin
@@ -179,6 +180,23 @@ class ProfileDetail(DetailView):
         context = super().get_context_data(**kwargs)
         context["profile"] = self.get_object().profile
         return context
+
+
+class UserProfileDashboardPreferencesEdit(PrivateViewMixin, UpdateView):
+    """View for user profile dashboard preferences."""
+
+    model = UserProfile
+    form_class = UserProfileDashboardPreferencesForm
+    template_name = "profiles/private/dashboard_preferences_form.html"
+    context_object_name = "profile"
+
+    def get_object(self):
+        return self.request.user.profile
+
+    def get_success_url(self):
+        return reverse(
+            "profiles_dashboard_preferences_edit",
+        )
 
 
 class AccountAdvertisingEdit(PrivateViewMixin, SuccessMessageMixin, UpdateView):

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -402,7 +402,7 @@ class TestPrivateViews(TestCase):
         # This number is bit higher, but for projects with lots of builds
         # is better to have more queries than optimizing with a prefetch,
         # see comment in annotate_has_successful_build.
-        with self.assertNumQueries(26):
+        with self.assertNumQueries(34):
             r = self.client.get(reverse(("projects_dashboard")))
         assert r.status_code == 200
 


### PR DESCRIPTION
Just the basic scaffolding for a preferences pane. We may build this out into
more specific pages later.

- Requires readthedocs/ext-theme#749
- Refs readthedocs/ext-theme#743

<img width="1164" height="436" alt="image" src="https://github.com/user-attachments/assets/07112e8b-091b-4d5d-9a9a-8581207d393b" />
