### PR TITLE
filetreediff: refresh base snapshot when PR merge-base advances

### DIFF
--- a/docs/dev/design/file-tree-diff-base-resolution.rst
+++ b/docs/dev/design/file-tree-diff-base-resolution.rst
@@ -1,0 +1,178 @@
+File tree diff base resolution
+==============================
+
+This document explains how the file tree diff (FTD) for pull request builds
+decides *which* base state to compare against, why the current approach exists,
+and where someone picking this up next should look.
+
+It assumes you've read :doc:`file-tree-diff`, which covers the manifest format
+and the diff API. This document is only about the base version resolution
+problem for external (pull request) versions.
+
+Context
+-------
+
+For a pull request preview, the diff compares the PR's files against a "base"
+version (the project's ``latest`` by default). The naive approach — always
+compare against whatever the base version currently contains — breaks in two
+opposite ways:
+
+**Stale base.**
+A PR opens against base@A and builds. The base branch then moves forward to
+base@B with unrelated new files. Comparing the PR (still at base@A) against
+the live base@B makes base@B's new files look like they were *deleted* by the
+PR. Wrong.
+
+**Merged base.**
+A PR opens against base@A. The base branch moves to base@B. The user merges
+base@B into the PR branch and pushes. The PR now contains ``base@B + the PR's
+own changes``. If we're still comparing against a pinned snapshot of base@A,
+base@B's content looks like it was *added* by the PR. Also wrong.
+
+Neither "always pin" nor "always refresh" is correct. The semantically correct
+base is the commit the PR has actually been brought up to — in git's own sense,
+the merge-base.
+
+The snapshot
+------------
+
+To fix the stale-base problem, the first successful PR build takes a snapshot of
+the base version's manifest and pins it:
+
+.. code-block::
+
+   diff/{project}/{external_version}/base_manifest_snapshot.json
+
+Subsequent PR builds diff against this snapshot instead of the live base
+manifest. This is written from ``FileManifestIndexer.collect`` in
+``readthedocs/projects/tasks/search.py``, and read back in ``get_diff`` in
+``readthedocs/filetreediff/__init__.py``.
+
+The snapshot was originally **write-once**: once the file existed, it was never
+rewritten. That fixed stale-base but *created* the merged-base problem, because
+a PR that merged in newer base kept being compared against the old pinned state.
+
+Smart refresh
+-------------
+
+The snapshot is now refreshed on each PR build, but only when the PR has
+actually pulled the base branch into its own history. The check lives in
+``should_refresh_snapshot`` (``readthedocs/filetreediff/__init__.py``) and runs
+a single git command against the build's live clone:
+
+.. code-block:: bash
+
+   git merge-base --is-ancestor <base_commit> HEAD
+
+- Exit ``0`` — the base commit is reachable from ``HEAD``, i.e. the user merged
+  the base branch in. Refresh the snapshot from the base version's current
+  manifest.
+- Any other exit — not an ancestor, or the commit isn't in the clone. Leave the
+  snapshot pinned (stale-base fix preserved).
+
+Why no extra fetch is needed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Read the Docs does a shallow clone and only fetches the PR ref
+(``pull/{id}/head``); the base branch is never fetched separately. It might seem
+like we'd need to fetch the base branch to reason about it — we don't.
+
+``<base_commit>`` is present in the PR's clone *only if* it's reachable from
+``HEAD``, which is exactly the condition we're testing. If the user merged the
+base branch in, the merge commit has the base tip as a parent, so that history
+is already in the clone. If they didn't, the base commit is on a divergent
+branch that was never fetched, and ``--is-ancestor`` returns non-zero. Either
+way the local clone already contains everything needed to answer the question.
+
+``--is-ancestor`` is a pure history walk: no network, no working-tree change.
+
+Where ``base_commit`` comes from
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Two sources, in priority order:
+
+1. ``Version.base_identifier`` — the base commit the PR targets, captured from
+   the webhook payload (``pull_request.base.sha`` on GitHub) in
+   ``get_or_create_external_version``
+   (``readthedocs/core/views/hooks.py``). This is the precise answer: the base
+   the PR actually points at. (Introduced as a follow-up; see below.)
+2. ``base_version.latest_successful_build.commit`` — the base version's most
+   recent successful build. This is what the initial implementation uses, and
+   the fallback when ``base_identifier`` isn't set (GitLab's merge request
+   payload has no equivalent field; versions created before ``base_identifier``
+   existed).
+
+.. note::
+
+   The initial change resolves ``base_commit`` from
+   ``latest_successful_build.commit`` only. Capturing ``pull_request.base.sha``
+   into ``Version.base_identifier`` and preferring it is a stacked follow-up —
+   it's more precise (the base the PR *targets*, rather than whatever the base
+   version last built), needs no forge API, and is plumbed from a webhook field
+   we already receive.
+
+Where the code runs
+-------------------
+
+The refresh check needs the live git clone, so it runs *during* the build, not
+in the post-build indexing task:
+
+- ``refresh_snapshot_if_stale`` (``readthedocs/filetreediff/__init__.py``) is
+  called from ``UpdateDocsTask.execute`` in
+  ``readthedocs/projects/tasks/builds.py``, inside the VCS environment context
+  (after ``setup_vcs``, before the environment is torn down).
+- Snapshot *creation* on the first PR build still happens in
+  ``FileManifestIndexer.collect``, which runs in the ``index_build`` Celery task
+  after the build — the clone is already gone by then, but creation only needs
+  the base manifest from storage, not git.
+
+So there are two writers for one snapshot file: the indexer creates it, the
+build task refreshes it. This split exists because creation and refresh have
+different data dependencies (storage vs. live git).
+
+The remaining gap
+-----------------
+
+The snapshot is always written from the base version's *latest* manifest, and
+the manifest is **per-version, overwritten on every build** — there is no
+per-build manifest history. So if the base branch has moved *further* than the
+commits the user merged in, we can't reconstruct the exact merge-base manifest;
+we can only snapshot "current base," which may be slightly too new. A few
+base-only files can then still show as changed.
+
+This is a **storage** limitation, not a detection one. Computing a more precise
+merge-base (even via a forge API) would not help, because we still couldn't
+materialize the manifest for that commit. In practice the gap is small for
+active projects, since the base builds frequently and ``latest_successful_build``
+stays close to the merge-base.
+
+Path forward
+------------
+
+The clean fix for the remaining gap is **per-build manifest history**: store a
+manifest per build (e.g. content-addressed by commit) instead of overwriting one
+per version, and pin the diff to the exact merge-base build via a
+``Build.diff_base_build`` foreign key. That removes the "current base is too new"
+approximation entirely and would let the refresh check resolve to the precise
+merge-base manifest.
+
+That redesign is independent of, and supersedes, the smart-refresh approach
+described here. A prototype exists on the ``claude/compassionate-thompson-iEEik``
+branch. Until it lands, the merge-base ``--is-ancestor`` check is the best
+approximation available within the per-version storage model.
+
+Things to know before touching this
+------------------------------------
+
+- **The base branch name is not persisted.** It arrives on the webhook
+  (``ExternalVersionData.base_branch``) and is used to drive the fetch, then
+  discarded. Only ``base_identifier`` (the base *commit*) is stored. Don't assume
+  you can read the base branch name at build time.
+- **Shallow clones.** ``git merge-base --is-ancestor`` can return non-zero
+  simply because a commit is beyond the fetch depth. The check treats that as
+  "don't refresh," which is safe (worst case is current behavior), but it means
+  the refresh silently no-ops on deep histories.
+- **Everything is best-effort.** ``should_refresh_snapshot`` and
+  ``refresh_snapshot_if_stale`` swallow every failure and fall back to the
+  existing write-once snapshot. A bug here degrades the diff; it must never fail
+  a build.

--- a/docs/user/visual-diff.rst
+++ b/docs/user/visual-diff.rst
@@ -91,6 +91,10 @@ moment.
 This prevents unrelated files from appearing as changed when the base branch
 moves forward while the pull request is open.
 
+If you later merge the base branch into your pull request, the snapshot is
+refreshed automatically so the diff reflects the new baseline. You don't need
+to take any action.
+
 How main content is detected
 ----------------------------
 
@@ -110,8 +114,7 @@ Limitations and known issues
 
 - The diff considers HTML files only.
 - The diff is done between the files from the latest successful build of the pull request and the default base version (latest by default).
-  A snapshot of the base version's manifest is saved on the first successful build of the pull request, so the diff stays stable as the base branch moves forward.
-  If the pull request is later updated against a newer base, the snapshot is not currently refreshed automatically, and the diff may show stale differences until this is addressed in a future update.
+- If the base branch has moved further than the commits you've merged into your pull request, a few base-only files can still appear in the diff. The gap is small for active projects and closes when the base branch is built again.
 - Invisible changes. Some sections may be highlighted as changed, even when they haven't actually visually changed.
   This can happen when the underlying HTML changes without a corresponding visual change, for example, if a link's URL is updated
 - Tables may be shown to have changes when they have not actually changed.

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -616,6 +616,19 @@ class Version(TimeStampedModel):
         filename = f"{self.project.slug}.{extension}"
         return self.get_storage_path(media_type=media_type, filename=filename)
 
+    def get_base_version_for_diff(self):
+        """
+        Resolve the base version this version is compared against in file tree diffs.
+
+        Uses the project's configured override
+        (``addons.options_base_version``) if set, otherwise the project's
+        "latest" version. Intended for external (PR) versions.
+        """
+        return (
+            self.project.addons.options_base_version
+            or self.project.get_latest_version()
+        )
+
 
 class APIVersion(Version):
     """

--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -114,6 +114,44 @@ class BuildDirector:
         if commit:
             self.data.build["commit"] = commit
 
+    def maybe_refresh_filetreediff_snapshot(self):
+        """
+        Refresh the file tree diff base manifest snapshot if it has fallen behind.
+
+        On each PR build, check whether the existing snapshot's commit is still
+        an ancestor of the PR's current merge-base against the default branch.
+        If it isn't (the user merged the base branch into the PR), rewrite the
+        snapshot from the base version's current manifest so the diff stays
+        clean. Must run while the VCS clone is live.
+
+        Best-effort: any failure is swallowed; the existing write-once snapshot
+        from ``FileManifestIndexer.collect`` continues to act as the fallback.
+        """
+        # Imported lazily to avoid a circular import at module load time
+        # (filetreediff imports from projects, which loads this module).
+        from readthedocs.filetreediff import should_refresh_snapshot
+        from readthedocs.filetreediff import snapshot_base_manifest
+
+        version = self.data.version
+        if not version.is_external:
+            return
+
+        try:
+            base_version = (
+                version.project.addons.options_base_version
+                or version.project.get_latest_version()
+            )
+            if not base_version:
+                return
+            if should_refresh_snapshot(version, self.vcs_repository):
+                snapshot_base_manifest(version, base_version, force_refresh=True)
+        except Exception:
+            log.exception(
+                "Filetreediff snapshot refresh check failed.",
+                project_slug=version.project.slug,
+                version_slug=version.slug,
+            )
+
     def create_vcs_environment(self):
         self.vcs_environment = self.data.environment_class(
             project=self.data.project,

--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -114,44 +114,6 @@ class BuildDirector:
         if commit:
             self.data.build["commit"] = commit
 
-    def maybe_refresh_filetreediff_snapshot(self):
-        """
-        Refresh the file tree diff base manifest snapshot if it has fallen behind.
-
-        On each PR build, check whether the existing snapshot's commit is still
-        an ancestor of the PR's current merge-base against the default branch.
-        If it isn't (the user merged the base branch into the PR), rewrite the
-        snapshot from the base version's current manifest so the diff stays
-        clean. Must run while the VCS clone is live.
-
-        Best-effort: any failure is swallowed; the existing write-once snapshot
-        from ``FileManifestIndexer.collect`` continues to act as the fallback.
-        """
-        # Imported lazily to avoid a circular import at module load time
-        # (filetreediff imports from projects, which loads this module).
-        from readthedocs.filetreediff import should_refresh_snapshot
-        from readthedocs.filetreediff import snapshot_base_manifest
-
-        version = self.data.version
-        if not version.is_external:
-            return
-
-        try:
-            base_version = (
-                version.project.addons.options_base_version
-                or version.project.get_latest_version()
-            )
-            if not base_version:
-                return
-            if should_refresh_snapshot(version, self.vcs_repository):
-                snapshot_base_manifest(version, base_version, force_refresh=True)
-        except Exception:
-            log.exception(
-                "Filetreediff snapshot refresh check failed.",
-                project_slug=version.project.slug,
-                version_slug=version.slug,
-            )
-
     def create_vcs_environment(self):
         self.vcs_environment = self.data.environment_class(
             project=self.data.project,

--- a/readthedocs/filetreediff/__init__.py
+++ b/readthedocs/filetreediff/__init__.py
@@ -26,6 +26,7 @@ from readthedocs.filetreediff.dataclasses import FileTreeDiff
 from readthedocs.filetreediff.dataclasses import FileTreeDiffFileStatus
 from readthedocs.filetreediff.dataclasses import FileTreeDiffManifest
 from readthedocs.projects.constants import MEDIA_TYPE_DIFF
+from readthedocs.projects.exceptions import RepositoryError
 from readthedocs.storage import build_media_storage
 
 
@@ -59,11 +60,10 @@ def get_diff(current_version: Version, base_version: Version) -> FileTreeDiff | 
     outdated = current_latest_build.id != current_version_manifest.build.id
 
     # For external versions (PRs), prefer the snapshotted base manifest
-    # (pinned at first PR build) over the live base manifest. This prevents
-    # false positives when the base branch has moved forward since the PR was
-    # created. Falls back to the live manifest if no snapshot exists.
-    # TODO: call clear_base_manifest_snapshot() on PR rebase/synchronize
-    # events so the snapshot is refreshed against the new base.
+    # (pinned at first PR build, refreshed when the PR's merge-base advances)
+    # over the live base manifest. This prevents false positives when the
+    # base branch has moved forward since the PR was created. Falls back to
+    # the live manifest if no snapshot exists.
     #
     # When a snapshot is used, we intentionally skip the base-side `outdated`
     # check. The snapshot's build will be older than the base version's latest
@@ -159,11 +159,18 @@ def _get_base_manifest_snapshot(
     return FileTreeDiffManifest.from_dict(data)
 
 
-def snapshot_base_manifest(external_version: Version, base_version: Version):
+def snapshot_base_manifest(
+    external_version: Version,
+    base_version: Version,
+    force_refresh: bool = False,
+):
     """
     Snapshot the base version's current manifest for a PR version.
 
-    Only writes if no snapshot exists yet (first build of the PR).
+    By default (``force_refresh=False``), only writes if no snapshot exists
+    yet (first build of the PR). When called with ``force_refresh=True`` from
+    the build task after detecting that the PR's merge-base has advanced,
+    rewrites the snapshot with the base version's current manifest.
 
     This stores a full copy of the base manifest per PR. If many PRs branch
     from the same base commit, the same content is duplicated. This is a
@@ -181,7 +188,7 @@ def snapshot_base_manifest(external_version: Version, base_version: Version):
         media_type=MEDIA_TYPE_DIFF,
         filename=BASE_MANIFEST_SNAPSHOT_FILE_NAME,
     )
-    if build_media_storage.exists(snapshot_path):
+    if not force_refresh and build_media_storage.exists(snapshot_path):
         return
 
     base_manifest = get_manifest(base_version)
@@ -197,8 +204,81 @@ def snapshot_base_manifest(external_version: Version, base_version: Version):
         external_version_slug=external_version.slug,
         base_version_slug=base_version.slug,
         base_build_id=base_manifest.build.id,
+        force_refresh=force_refresh,
     )
-    # TODO: add a clear_base_manifest_snapshot() helper and call it on PR
-    # rebase/synchronize webhook events so the snapshot refreshes when the
-    # PR is rebased against a newer base.
-    # See https://github.com/readthedocs/readthedocs.org/issues/12232
+
+
+def should_refresh_snapshot(external_version: Version, vcs_repository) -> bool:
+    """
+    Decide whether the base manifest snapshot for a PR should be refreshed.
+
+    Returns True only when an existing snapshot's captured commit has fallen
+    behind the PR's current merge-base against the project's default branch
+    (i.e. the user merged the base branch into the PR, so the snapshot is now
+    older than what the PR has actually been brought up to).
+
+    All ambiguity, missing data, or git failures map to False — the snapshot
+    is left as-is (preserving the stale-base fix). The caller must invoke
+    this while the build clone is live (``vcs_repository.working_dir``
+    exists).
+    """
+    snapshot = _get_base_manifest_snapshot(external_version)
+    if snapshot is None:
+        # First PR build; the indexer will create the snapshot on success.
+        return False
+
+    snap_commit = (
+        Build.objects.filter(id=snapshot.build.id)
+        .values_list("commit", flat=True)
+        .first()
+    )
+    if not snap_commit:
+        return False
+
+    base_branch = external_version.project.get_default_branch()
+    if not base_branch:
+        return False
+
+    base_ref = f"refs/remotes/origin/{base_branch}"
+    try:
+        code, _, _ = vcs_repository.run(
+            "git",
+            "fetch",
+            "--depth",
+            "50",
+            "origin",
+            f"refs/heads/{base_branch}:{base_ref}",
+            record=False,
+        )
+        if code != 0:
+            return False
+
+        code, mb_stdout, _ = vcs_repository.run(
+            "git",
+            "merge-base",
+            "HEAD",
+            base_ref,
+            record=False,
+        )
+        if code != 0:
+            return False
+        mb_commit = mb_stdout.strip()
+        if not mb_commit:
+            return False
+
+        code, _, _ = vcs_repository.run(
+            "git",
+            "merge-base",
+            "--is-ancestor",
+            snap_commit,
+            mb_commit,
+            record=False,
+        )
+    except RepositoryError:
+        return False
+
+    # Exit 0: snap is still an ancestor of mb → snapshot is in sync, no refresh.
+    # Exit 1: snap is NOT an ancestor → merge-base advanced past it → refresh.
+    # Any other code (commit unknown to clone, shallow history, git error) →
+    # be conservative and keep the existing snapshot.
+    return code == 1

--- a/readthedocs/filetreediff/__init__.py
+++ b/readthedocs/filetreediff/__init__.py
@@ -168,9 +168,10 @@ def snapshot_base_manifest(
     Snapshot the base version's current manifest for a PR version.
 
     By default (``force_refresh=False``), only writes if no snapshot exists
-    yet (first build of the PR). When called with ``force_refresh=True`` from
-    the build task after detecting that the PR's merge-base has advanced,
-    rewrites the snapshot with the base version's current manifest.
+    yet (first build of the PR). When called with ``force_refresh=True``,
+    rewrites the snapshot with the base version's current manifest — used by
+    ``refresh_snapshot_if_stale`` after detecting that the PR's merge-base
+    has advanced.
 
     This stores a full copy of the base manifest per PR. If many PRs branch
     from the same base commit, the same content is duplicated. This is a
@@ -208,19 +209,26 @@ def snapshot_base_manifest(
     )
 
 
+def get_base_version_for_diff(external_version: Version) -> Version | None:
+    """
+    Resolve the base version a PR version is compared against in file tree diffs.
+
+    Uses the project's configured override (``addons.options_base_version``)
+    if set, otherwise the project's "latest" version.
+    """
+    return (
+        external_version.project.addons.options_base_version
+        or external_version.project.get_latest_version()
+    )
+
+
 def should_refresh_snapshot(external_version: Version, vcs_repository) -> bool:
     """
-    Decide whether the base manifest snapshot for a PR should be refreshed.
+    Return True iff the PR's snapshot has fallen behind its merge-base.
 
-    Returns True only when an existing snapshot's captured commit has fallen
-    behind the PR's current merge-base against the project's default branch
-    (i.e. the user merged the base branch into the PR, so the snapshot is now
-    older than what the PR has actually been brought up to).
-
-    All ambiguity, missing data, or git failures map to False — the snapshot
-    is left as-is (preserving the stale-base fix). The caller must invoke
-    this while the build clone is live (``vcs_repository.working_dir``
-    exists).
+    The merge-base is computed against the project's default branch using the
+    live VCS clone. Any missing data or git failure returns False so the
+    existing snapshot is preserved.
     """
     snapshot = _get_base_manifest_snapshot(external_version)
     if snapshot is None:
@@ -254,16 +262,9 @@ def should_refresh_snapshot(external_version: Version, vcs_repository) -> bool:
             return False
 
         code, mb_stdout, _ = vcs_repository.run(
-            "git",
-            "merge-base",
-            "HEAD",
-            base_ref,
-            record=False,
+            "git", "merge-base", "HEAD", base_ref, record=False
         )
         if code != 0:
-            return False
-        mb_commit = mb_stdout.strip()
-        if not mb_commit:
             return False
 
         code, _, _ = vcs_repository.run(
@@ -271,14 +272,40 @@ def should_refresh_snapshot(external_version: Version, vcs_repository) -> bool:
             "merge-base",
             "--is-ancestor",
             snap_commit,
-            mb_commit,
+            mb_stdout.strip(),
             record=False,
         )
     except RepositoryError:
         return False
 
-    # Exit 0: snap is still an ancestor of mb → snapshot is in sync, no refresh.
-    # Exit 1: snap is NOT an ancestor → merge-base advanced past it → refresh.
-    # Any other code (commit unknown to clone, shallow history, git error) →
-    # be conservative and keep the existing snapshot.
+    # 0 = snap still in sync; 1 = needs refresh; anything else = stay conservative.
     return code == 1
+
+
+def refresh_snapshot_if_stale(external_version: Version, vcs_repository) -> None:
+    """
+    Rewrite the PR's base manifest snapshot if the merge-base has advanced.
+
+    Best-effort: any failure is swallowed and the existing snapshot (if any)
+    is left in place. No-op when no snapshot exists yet — the indexer
+    creates it on first PR build.
+
+    Must be called while the VCS clone is live (i.e. inside the build
+    task's VCS environment context).
+    """
+    if not external_version.is_external:
+        return
+    try:
+        base_version = get_base_version_for_diff(external_version)
+        if not base_version:
+            return
+        if should_refresh_snapshot(external_version, vcs_repository):
+            snapshot_base_manifest(
+                external_version, base_version, force_refresh=True
+            )
+    except Exception:
+        log.exception(
+            "Filetreediff snapshot refresh check failed.",
+            project_slug=external_version.project.slug,
+            version_slug=external_version.slug,
+        )

--- a/readthedocs/filetreediff/__init__.py
+++ b/readthedocs/filetreediff/__init__.py
@@ -209,19 +209,6 @@ def snapshot_base_manifest(
     )
 
 
-def get_base_version_for_diff(external_version: Version) -> Version | None:
-    """
-    Resolve the base version a PR version is compared against in file tree diffs.
-
-    Uses the project's configured override (``addons.options_base_version``)
-    if set, otherwise the project's "latest" version.
-    """
-    return (
-        external_version.project.addons.options_base_version
-        or external_version.project.get_latest_version()
-    )
-
-
 def should_refresh_snapshot(external_version: Version, vcs_repository) -> bool:
     """
     Return True iff the PR's snapshot has fallen behind its merge-base.
@@ -296,7 +283,7 @@ def refresh_snapshot_if_stale(external_version: Version, vcs_repository) -> None
     if not external_version.is_external:
         return
     try:
-        base_version = get_base_version_for_diff(external_version)
+        base_version = external_version.get_base_version_for_diff()
         if not base_version:
             return
         if should_refresh_snapshot(external_version, vcs_repository):

--- a/readthedocs/filetreediff/__init__.py
+++ b/readthedocs/filetreediff/__init__.py
@@ -60,7 +60,7 @@ def get_diff(current_version: Version, base_version: Version) -> FileTreeDiff | 
     outdated = current_latest_build.id != current_version_manifest.build.id
 
     # For external versions (PRs), prefer the snapshotted base manifest
-    # (pinned at first PR build, refreshed when the PR's merge-base advances)
+    # (pinned at first PR build, refreshed once the PR merges in newer base)
     # over the live base manifest. This prevents false positives when the
     # base branch has moved forward since the PR was created. Falls back to
     # the live manifest if no snapshot exists.
@@ -170,8 +170,7 @@ def snapshot_base_manifest(
     By default (``force_refresh=False``), only writes if no snapshot exists
     yet (first build of the PR). When called with ``force_refresh=True``,
     rewrites the snapshot with the base version's current manifest — used by
-    ``refresh_snapshot_if_stale`` after detecting that the PR's merge-base
-    has advanced.
+    ``refresh_snapshot_if_stale`` once the PR has merged in newer base.
 
     This stores a full copy of the base manifest per PR. If many PRs branch
     from the same base commit, the same content is duplicated. This is a
@@ -209,69 +208,58 @@ def snapshot_base_manifest(
     )
 
 
-def should_refresh_snapshot(external_version: Version, vcs_repository) -> bool:
+def should_refresh_snapshot(
+    external_version: Version,
+    base_version: Version,
+    vcs_repository,
+) -> bool:
     """
-    Return True iff the PR's snapshot has fallen behind its merge-base.
+    Return True iff the PR has merged in the base version's current state.
 
-    The merge-base is computed against the project's default branch using the
-    live VCS clone. Any missing data or git failure returns False so the
-    existing snapshot is preserved.
+    The snapshot is always written from ``base_version``'s latest build, so
+    adopting it is correct exactly when the PR has pulled that base commit
+    into its own history. We check this with a single ``merge-base
+    --is-ancestor`` against the existing clone — no extra fetch. The base
+    commit is present in the clone only if it's reachable from ``HEAD`` (i.e.
+    the user merged the base branch in), so an unmerged base simply isn't an
+    ancestor and we leave the snapshot pinned.
+
+    Any missing data or git failure returns False so the existing snapshot is
+    preserved.
     """
     snapshot = _get_base_manifest_snapshot(external_version)
     if snapshot is None:
         # First PR build; the indexer will create the snapshot on success.
         return False
 
-    snap_commit = (
-        Build.objects.filter(id=snapshot.build.id)
-        .values_list("commit", flat=True)
-        .first()
-    )
-    if not snap_commit:
+    base_latest_build = base_version.latest_successful_build
+    if not base_latest_build or not base_latest_build.commit:
         return False
 
-    base_branch = external_version.project.get_default_branch()
-    if not base_branch:
+    # Snapshot already reflects the base version's latest build; nothing to do.
+    if snapshot.build.id == base_latest_build.id:
         return False
 
-    base_ref = f"refs/remotes/origin/{base_branch}"
     try:
-        code, _, _ = vcs_repository.run(
-            "git",
-            "fetch",
-            "--depth",
-            "50",
-            "origin",
-            f"refs/heads/{base_branch}:{base_ref}",
-            record=False,
-        )
-        if code != 0:
-            return False
-
-        code, mb_stdout, _ = vcs_repository.run(
-            "git", "merge-base", "HEAD", base_ref, record=False
-        )
-        if code != 0:
-            return False
-
         code, _, _ = vcs_repository.run(
             "git",
             "merge-base",
             "--is-ancestor",
-            snap_commit,
-            mb_stdout.strip(),
+            base_latest_build.commit,
+            "HEAD",
             record=False,
         )
     except RepositoryError:
         return False
 
-    # 0 = snap still in sync; 1 = needs refresh; anything else = stay conservative.
-    return code == 1
+    # 0 = base commit is in the PR's history (merged in) → refresh.
+    # Anything else (not an ancestor, or not in the clone) → stay pinned.
+    return code == 0
 
 
 def refresh_snapshot_if_stale(external_version: Version, vcs_repository) -> None:
     """
-    Rewrite the PR's base manifest snapshot if the merge-base has advanced.
+    Rewrite the PR's base manifest snapshot if the PR has merged in newer base.
 
     Best-effort: any failure is swallowed and the existing snapshot (if any)
     is left in place. No-op when no snapshot exists yet — the indexer
@@ -286,7 +274,7 @@ def refresh_snapshot_if_stale(external_version: Version, vcs_repository) -> None
         base_version = external_version.get_base_version_for_diff()
         if not base_version:
             return
-        if should_refresh_snapshot(external_version, vcs_repository):
+        if should_refresh_snapshot(external_version, base_version, vcs_repository):
             snapshot_base_manifest(
                 external_version, base_version, force_refresh=True
             )

--- a/readthedocs/filetreediff/tests/test_filetreediff.py
+++ b/readthedocs/filetreediff/tests/test_filetreediff.py
@@ -251,14 +251,9 @@ class TestsBaseManifestSnapshot(TestCase):
     def test_force_refresh_overwrites_existing_snapshot(self, storage_open, storage_exists):
         """``force_refresh=True`` bypasses the write-once early-return."""
         base_files = {"index.html": "fresh-hash"}
-
-        @contextmanager
-        def _write_cm(*args, **kwargs):
-            yield mock.MagicMock()
-
         storage_open.side_effect = [
             _mock_manifest(self.base_build.id, base_files)(),
-            _write_cm(),
+            mock.MagicMock(),
         ]
         snapshot_base_manifest(
             self.pr_version, self.base_version, force_refresh=True
@@ -336,16 +331,11 @@ class TestsShouldRefreshSnapshot(TestCase):
         assert should_refresh_snapshot(self.pr_version, self.vcs_repository) is False
         self.vcs_repository.run.assert_not_called()
 
+    @mock.patch.object(Project, "get_default_branch", return_value=None)
     @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
-    def test_default_branch_missing_returns_false(self, storage_open):
-        self.project.default_branch = None
-        self.project.save()
-        # Ensure the VCS-fallback path also yields None.
-        with mock.patch.object(Project, "get_default_branch", return_value=None):
-            storage_open.side_effect = [self._snapshot_mock(self.snap_build.id)]
-            assert (
-                should_refresh_snapshot(self.pr_version, self.vcs_repository) is False
-            )
+    def test_default_branch_missing_returns_false(self, storage_open, get_default_branch):
+        storage_open.side_effect = [self._snapshot_mock(self.snap_build.id)]
+        assert should_refresh_snapshot(self.pr_version, self.vcs_repository) is False
         self.vcs_repository.run.assert_not_called()
 
     @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
@@ -400,13 +390,4 @@ class TestsShouldRefreshSnapshot(TestCase):
         self.vcs_repository.run.side_effect = RepositoryError(
             message_id=RepositoryError.GENERIC
         )
-        assert should_refresh_snapshot(self.pr_version, self.vcs_repository) is False
-
-    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
-    def test_empty_merge_base_output_returns_false(self, storage_open):
-        storage_open.side_effect = [self._snapshot_mock(self.snap_build.id)]
-        self.vcs_repository.run.side_effect = [
-            (0, "", ""),
-            (0, "   \n", ""),
-        ]
         assert should_refresh_snapshot(self.pr_version, self.vcs_repository) is False

--- a/readthedocs/filetreediff/tests/test_filetreediff.py
+++ b/readthedocs/filetreediff/tests/test_filetreediff.py
@@ -278,11 +278,12 @@ class TestsBaseManifestSnapshot(TestCase):
     new=BuildMediaFileSystemStorageTest(),
 )
 class TestsShouldRefreshSnapshot(TestCase):
-    """Tests for the merge-base-aware snapshot refresh decision."""
+    """Tests for the snapshot refresh decision (no extra git fetch)."""
 
     def setUp(self):
         self.project = get(Project, default_branch="main")
         self.base_version = self.project.versions.get(slug=LATEST)
+        # The build the snapshot was captured from (older base state).
         self.snap_build = get(
             Build,
             project=self.project,
@@ -290,6 +291,15 @@ class TestsShouldRefreshSnapshot(TestCase):
             state=BUILD_STATE_FINISHED,
             success=True,
             commit="snap-sha",
+        )
+        # The base version's current latest build (newer base state).
+        self.base_latest_build = get(
+            Build,
+            project=self.project,
+            version=self.base_version,
+            state=BUILD_STATE_FINISHED,
+            success=True,
+            commit="base-latest-sha",
         )
         self.pr_version = get(
             Version,
@@ -301,88 +311,59 @@ class TestsShouldRefreshSnapshot(TestCase):
             built=True,
         )
         self.vcs_repository = mock.MagicMock()
-        # Default script: fetch ok, merge-base ok with sha, is-ancestor ok.
-        self.vcs_repository.run.side_effect = [
-            (0, "", ""),
-            (0, "mb-sha\n", ""),
-            (0, "", ""),
-        ]
+        # Default: the base commit is an ancestor of HEAD (merged in).
+        self.vcs_repository.run.return_value = (0, "", "")
 
     def _snapshot_mock(self, build_id):
         return _mock_manifest(build_id, {"index.html": "h"})()
 
+    def _refresh(self):
+        return should_refresh_snapshot(
+            self.pr_version, self.base_version, self.vcs_repository
+        )
+
     @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
     def test_no_existing_snapshot_returns_false(self, storage_open):
         storage_open.side_effect = FileNotFoundError
-        assert should_refresh_snapshot(self.pr_version, self.vcs_repository) is False
+        assert self._refresh() is False
         self.vcs_repository.run.assert_not_called()
 
     @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
-    def test_snap_build_missing_returns_false(self, storage_open):
-        storage_open.side_effect = [self._snapshot_mock(999999)]
-        assert should_refresh_snapshot(self.pr_version, self.vcs_repository) is False
-        self.vcs_repository.run.assert_not_called()
-
-    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
-    def test_snap_build_commit_null_returns_false(self, storage_open):
-        self.snap_build.commit = None
-        self.snap_build.save()
+    def test_base_commit_null_returns_false(self, storage_open):
+        self.base_latest_build.commit = None
+        self.base_latest_build.save()
         storage_open.side_effect = [self._snapshot_mock(self.snap_build.id)]
-        assert should_refresh_snapshot(self.pr_version, self.vcs_repository) is False
-        self.vcs_repository.run.assert_not_called()
-
-    @mock.patch.object(Project, "get_default_branch", return_value=None)
-    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
-    def test_default_branch_missing_returns_false(self, storage_open, get_default_branch):
-        storage_open.side_effect = [self._snapshot_mock(self.snap_build.id)]
-        assert should_refresh_snapshot(self.pr_version, self.vcs_repository) is False
+        assert self._refresh() is False
         self.vcs_repository.run.assert_not_called()
 
     @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
-    def test_fetch_failure_returns_false(self, storage_open):
+    def test_snapshot_already_at_latest_returns_false(self, storage_open):
+        """Snapshot already points at the base's latest build; no git needed."""
+        storage_open.side_effect = [self._snapshot_mock(self.base_latest_build.id)]
+        assert self._refresh() is False
+        self.vcs_repository.run.assert_not_called()
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_base_merged_in_returns_true(self, storage_open):
+        """is-ancestor exit 0: base's latest commit is in the PR history."""
         storage_open.side_effect = [self._snapshot_mock(self.snap_build.id)]
-        self.vcs_repository.run.side_effect = [(1, "", "boom")]
-        assert should_refresh_snapshot(self.pr_version, self.vcs_repository) is False
+        self.vcs_repository.run.return_value = (0, "", "")
+        assert self._refresh() is True
         assert self.vcs_repository.run.call_count == 1
 
     @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
-    def test_merge_base_failure_returns_false(self, storage_open):
+    def test_base_not_merged_in_returns_false(self, storage_open):
+        """is-ancestor exit 1: PR hasn't pulled in the base; stay pinned."""
         storage_open.side_effect = [self._snapshot_mock(self.snap_build.id)]
-        self.vcs_repository.run.side_effect = [
-            (0, "", ""),
-            (128, "", "fatal"),
-        ]
-        assert should_refresh_snapshot(self.pr_version, self.vcs_repository) is False
-        assert self.vcs_repository.run.call_count == 2
+        self.vcs_repository.run.return_value = (1, "", "")
+        assert self._refresh() is False
 
     @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
-    def test_snap_is_ancestor_returns_false(self, storage_open):
-        """is-ancestor exit 0 means snap is still in sync; no refresh."""
+    def test_base_commit_unknown_to_clone_returns_false(self, storage_open):
+        """is-ancestor exit 128 (commit not in shallow clone); stay pinned."""
         storage_open.side_effect = [self._snapshot_mock(self.snap_build.id)]
-        assert should_refresh_snapshot(self.pr_version, self.vcs_repository) is False
-        assert self.vcs_repository.run.call_count == 3
-
-    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
-    def test_snap_not_ancestor_returns_true(self, storage_open):
-        """is-ancestor exit 1 means merge-base advanced past snap; refresh."""
-        storage_open.side_effect = [self._snapshot_mock(self.snap_build.id)]
-        self.vcs_repository.run.side_effect = [
-            (0, "", ""),
-            (0, "mb-sha\n", ""),
-            (1, "", ""),
-        ]
-        assert should_refresh_snapshot(self.pr_version, self.vcs_repository) is True
-
-    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
-    def test_snap_unknown_to_clone_returns_false(self, storage_open):
-        """is-ancestor exit 128 (commit unknown) is conservative — no refresh."""
-        storage_open.side_effect = [self._snapshot_mock(self.snap_build.id)]
-        self.vcs_repository.run.side_effect = [
-            (0, "", ""),
-            (0, "mb-sha\n", ""),
-            (128, "", "fatal: Not a valid commit"),
-        ]
-        assert should_refresh_snapshot(self.pr_version, self.vcs_repository) is False
+        self.vcs_repository.run.return_value = (128, "", "fatal: Not a valid commit")
+        assert self._refresh() is False
 
     @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
     def test_repository_error_returns_false(self, storage_open):
@@ -390,4 +371,4 @@ class TestsShouldRefreshSnapshot(TestCase):
         self.vcs_repository.run.side_effect = RepositoryError(
             message_id=RepositoryError.GENERIC
         )
-        assert should_refresh_snapshot(self.pr_version, self.vcs_repository) is False
+        assert self._refresh() is False

--- a/readthedocs/filetreediff/tests/test_filetreediff.py
+++ b/readthedocs/filetreediff/tests/test_filetreediff.py
@@ -7,7 +7,12 @@ from django_dynamic_fixture import get
 
 from readthedocs.builds.constants import BUILD_STATE_FINISHED, EXTERNAL, LATEST
 from readthedocs.builds.models import Build, Version
-from readthedocs.filetreediff import get_diff, snapshot_base_manifest
+from readthedocs.filetreediff import (
+    get_diff,
+    should_refresh_snapshot,
+    snapshot_base_manifest,
+)
+from readthedocs.projects.exceptions import RepositoryError
 from readthedocs.projects.models import Project
 from readthedocs.rtd_tests.storage import BuildMediaFileSystemStorageTest
 
@@ -240,3 +245,168 @@ class TestsBaseManifestSnapshot(TestCase):
         """snapshot_base_manifest is a no-op if a snapshot already exists."""
         snapshot_base_manifest(self.pr_version, self.base_version)
         storage_open.assert_not_called()
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "exists", return_value=True)
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_force_refresh_overwrites_existing_snapshot(self, storage_open, storage_exists):
+        """``force_refresh=True`` bypasses the write-once early-return."""
+        base_files = {"index.html": "fresh-hash"}
+
+        @contextmanager
+        def _write_cm(*args, **kwargs):
+            yield mock.MagicMock()
+
+        storage_open.side_effect = [
+            _mock_manifest(self.base_build.id, base_files)(),
+            _write_cm(),
+        ]
+        snapshot_base_manifest(
+            self.pr_version, self.base_version, force_refresh=True
+        )
+        # Two calls: read live base manifest, then write snapshot.
+        assert storage_open.call_count == 2
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "exists", return_value=True)
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_force_refresh_noop_when_base_manifest_missing(self, storage_open, storage_exists):
+        """If the live base manifest is missing, no write happens."""
+        storage_open.side_effect = FileNotFoundError
+        snapshot_base_manifest(
+            self.pr_version, self.base_version, force_refresh=True
+        )
+        # Only the read attempt; no second open() for the write.
+        assert storage_open.call_count == 1
+
+
+@mock.patch(
+    "readthedocs.filetreediff.build_media_storage",
+    new=BuildMediaFileSystemStorageTest(),
+)
+class TestsShouldRefreshSnapshot(TestCase):
+    """Tests for the merge-base-aware snapshot refresh decision."""
+
+    def setUp(self):
+        self.project = get(Project, default_branch="main")
+        self.base_version = self.project.versions.get(slug=LATEST)
+        self.snap_build = get(
+            Build,
+            project=self.project,
+            version=self.base_version,
+            state=BUILD_STATE_FINISHED,
+            success=True,
+            commit="snap-sha",
+        )
+        self.pr_version = get(
+            Version,
+            project=self.project,
+            slug="pr-42",
+            verbose_name="42",
+            type=EXTERNAL,
+            active=True,
+            built=True,
+        )
+        self.vcs_repository = mock.MagicMock()
+        # Default script: fetch ok, merge-base ok with sha, is-ancestor ok.
+        self.vcs_repository.run.side_effect = [
+            (0, "", ""),
+            (0, "mb-sha\n", ""),
+            (0, "", ""),
+        ]
+
+    def _snapshot_mock(self, build_id):
+        return _mock_manifest(build_id, {"index.html": "h"})()
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_no_existing_snapshot_returns_false(self, storage_open):
+        storage_open.side_effect = FileNotFoundError
+        assert should_refresh_snapshot(self.pr_version, self.vcs_repository) is False
+        self.vcs_repository.run.assert_not_called()
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_snap_build_missing_returns_false(self, storage_open):
+        storage_open.side_effect = [self._snapshot_mock(999999)]
+        assert should_refresh_snapshot(self.pr_version, self.vcs_repository) is False
+        self.vcs_repository.run.assert_not_called()
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_snap_build_commit_null_returns_false(self, storage_open):
+        self.snap_build.commit = None
+        self.snap_build.save()
+        storage_open.side_effect = [self._snapshot_mock(self.snap_build.id)]
+        assert should_refresh_snapshot(self.pr_version, self.vcs_repository) is False
+        self.vcs_repository.run.assert_not_called()
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_default_branch_missing_returns_false(self, storage_open):
+        self.project.default_branch = None
+        self.project.save()
+        # Ensure the VCS-fallback path also yields None.
+        with mock.patch.object(Project, "get_default_branch", return_value=None):
+            storage_open.side_effect = [self._snapshot_mock(self.snap_build.id)]
+            assert (
+                should_refresh_snapshot(self.pr_version, self.vcs_repository) is False
+            )
+        self.vcs_repository.run.assert_not_called()
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_fetch_failure_returns_false(self, storage_open):
+        storage_open.side_effect = [self._snapshot_mock(self.snap_build.id)]
+        self.vcs_repository.run.side_effect = [(1, "", "boom")]
+        assert should_refresh_snapshot(self.pr_version, self.vcs_repository) is False
+        assert self.vcs_repository.run.call_count == 1
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_merge_base_failure_returns_false(self, storage_open):
+        storage_open.side_effect = [self._snapshot_mock(self.snap_build.id)]
+        self.vcs_repository.run.side_effect = [
+            (0, "", ""),
+            (128, "", "fatal"),
+        ]
+        assert should_refresh_snapshot(self.pr_version, self.vcs_repository) is False
+        assert self.vcs_repository.run.call_count == 2
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_snap_is_ancestor_returns_false(self, storage_open):
+        """is-ancestor exit 0 means snap is still in sync; no refresh."""
+        storage_open.side_effect = [self._snapshot_mock(self.snap_build.id)]
+        assert should_refresh_snapshot(self.pr_version, self.vcs_repository) is False
+        assert self.vcs_repository.run.call_count == 3
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_snap_not_ancestor_returns_true(self, storage_open):
+        """is-ancestor exit 1 means merge-base advanced past snap; refresh."""
+        storage_open.side_effect = [self._snapshot_mock(self.snap_build.id)]
+        self.vcs_repository.run.side_effect = [
+            (0, "", ""),
+            (0, "mb-sha\n", ""),
+            (1, "", ""),
+        ]
+        assert should_refresh_snapshot(self.pr_version, self.vcs_repository) is True
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_snap_unknown_to_clone_returns_false(self, storage_open):
+        """is-ancestor exit 128 (commit unknown) is conservative — no refresh."""
+        storage_open.side_effect = [self._snapshot_mock(self.snap_build.id)]
+        self.vcs_repository.run.side_effect = [
+            (0, "", ""),
+            (0, "mb-sha\n", ""),
+            (128, "", "fatal: Not a valid commit"),
+        ]
+        assert should_refresh_snapshot(self.pr_version, self.vcs_repository) is False
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_repository_error_returns_false(self, storage_open):
+        storage_open.side_effect = [self._snapshot_mock(self.snap_build.id)]
+        self.vcs_repository.run.side_effect = RepositoryError(
+            message_id=RepositoryError.GENERIC
+        )
+        assert should_refresh_snapshot(self.pr_version, self.vcs_repository) is False
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_empty_merge_base_output_returns_false(self, storage_open):
+        storage_open.side_effect = [self._snapshot_mock(self.snap_build.id)]
+        self.vcs_repository.run.side_effect = [
+            (0, "", ""),
+            (0, "   \n", ""),
+        ]
+        assert should_refresh_snapshot(self.pr_version, self.vcs_repository) is False

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -848,6 +848,12 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         with self.data.build_director.vcs_environment:
             self.data.build_director.setup_vcs()
 
+            # For PR builds, check whether the file tree diff base manifest
+            # snapshot has fallen behind the PR's merge-base and refresh it
+            # if so. Must run inside the VCS environment while the clone is
+            # live.
+            self.data.build_director.maybe_refresh_filetreediff_snapshot()
+
             # Sync tags/branches from VCS repository into Read the Docs'
             # `Version` objects in the database. This method runs commands
             # (e.g. "hg tags") inside the VCS environment, so it requires to be

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -55,6 +55,7 @@ from readthedocs.doc_builder.exceptions import BuildCancelled
 from readthedocs.doc_builder.exceptions import BuildMaxConcurrencyError
 from readthedocs.doc_builder.exceptions import BuildUserError
 from readthedocs.doc_builder.exceptions import MkDocsYAMLParseError
+from readthedocs.filetreediff import refresh_snapshot_if_stale
 from readthedocs.projects.models import Feature
 from readthedocs.projects.tasks.storage import StorageType
 from readthedocs.projects.tasks.storage import get_storage
@@ -848,11 +849,10 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         with self.data.build_director.vcs_environment:
             self.data.build_director.setup_vcs()
 
-            # For PR builds, check whether the file tree diff base manifest
-            # snapshot has fallen behind the PR's merge-base and refresh it
-            # if so. Must run inside the VCS environment while the clone is
-            # live.
-            self.data.build_director.maybe_refresh_filetreediff_snapshot()
+            refresh_snapshot_if_stale(
+                self.data.version,
+                self.data.build_director.vcs_repository,
+            )
 
             # Sync tags/branches from VCS repository into Read the Docs'
             # `Version` objects in the database. This method runs commands

--- a/readthedocs/projects/tasks/search.py
+++ b/readthedocs/projects/tasks/search.py
@@ -9,7 +9,6 @@ from readthedocs.builds.constants import LATEST
 from readthedocs.builds.models import Build
 from readthedocs.builds.models import Version
 from readthedocs.builds.tasks import post_build_overview
-from readthedocs.filetreediff import get_base_version_for_diff
 from readthedocs.filetreediff import snapshot_base_manifest
 from readthedocs.filetreediff import write_manifest
 from readthedocs.filetreediff.dataclasses import FileTreeDiffManifest
@@ -159,7 +158,7 @@ class FileManifestIndexer(Indexer):
         # problem). Subsequent rebases are handled by ``refresh_snapshot_if_stale``
         # in the build task.
         if self.version.is_external:
-            base_version = get_base_version_for_diff(self.version)
+            base_version = self.version.get_base_version_for_diff()
             if base_version:
                 snapshot_base_manifest(self.version, base_version)
 

--- a/readthedocs/projects/tasks/search.py
+++ b/readthedocs/projects/tasks/search.py
@@ -9,6 +9,7 @@ from readthedocs.builds.constants import LATEST
 from readthedocs.builds.models import Build
 from readthedocs.builds.models import Version
 from readthedocs.builds.tasks import post_build_overview
+from readthedocs.filetreediff import get_base_version_for_diff
 from readthedocs.filetreediff import snapshot_base_manifest
 from readthedocs.filetreediff import write_manifest
 from readthedocs.filetreediff.dataclasses import FileTreeDiffManifest
@@ -151,16 +152,14 @@ class FileManifestIndexer(Indexer):
         write_manifest(self.version, manifest)
 
         # For PR previews, snapshot the base version's manifest on the first
-        # PR build where the snapshot can be created.
-        # This pins the diff baseline so that subsequent builds compare against
-        # that snapshotted base-version state instead of the base version's
-        # current state. This prevents false file changes when the base branch
-        # moves forward (the "stale branch" problem).
+        # PR build where the snapshot can be created. This pins the diff
+        # baseline so subsequent builds compare against that snapshotted base
+        # state instead of the base version's current state, preventing false
+        # file changes when the base branch moves forward (the "stale branch"
+        # problem). Subsequent rebases are handled by ``refresh_snapshot_if_stale``
+        # in the build task.
         if self.version.is_external:
-            base_version = (
-                self.version.project.addons.options_base_version
-                or self.version.project.get_latest_version()
-            )
+            base_version = get_base_version_for_diff(self.version)
             if base_version:
                 snapshot_base_manifest(self.version, base_version)
 


### PR DESCRIPTION
## Why

The base manifest snapshot is write-once today. That fixes the stale-base case
(base moves forward → unrelated files look "deleted by PR") but breaks the
inverse: merge base into the PR and base's files start showing as "added by
this PR" — the most common diff confusion we hear about.

Fix: refresh the snapshot only when its commit is no longer an ancestor of the
PR's live merge-base. Dormant PRs stay pinned (stale-base fix kept); PRs that
pulled in main get a fresh snapshot.

## Reviewer notes

- **Best-effort.** Any failure (no snapshot yet, pruned `Build`, null commit,
  unknown default branch, shallow clone, git error) falls back to write-once —
  worst case is today's behavior.
- **Base ref = project default branch**, since the PR's real base branch isn't
  persisted. Correct for nearly all PRs; non-default targets degrade to
  write-once.
- **Known gap:** if base moved *further* than the user pulled in, the snapshot
  can be a few commits too new, so some base-only files still show as deleted.
  Closes fully under a future per-build-manifest model.

---

🤖 Generated by Claude Code.