### PR TITLE
builds: move get_base_version_for_diff to Version model

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -616,6 +616,19 @@ class Version(TimeStampedModel):
         filename = f"{self.project.slug}.{extension}"
         return self.get_storage_path(media_type=media_type, filename=filename)
 
+    def get_base_version_for_diff(self):
+        """
+        Resolve the base version this version is compared against in file tree diffs.
+
+        Uses the project's configured override
+        (``addons.options_base_version``) if set, otherwise the project's
+        "latest" version. Intended for external (PR) versions.
+        """
+        return (
+            self.project.addons.options_base_version
+            or self.project.get_latest_version()
+        )
+
 
 class APIVersion(Version):
     """

--- a/readthedocs/filetreediff/__init__.py
+++ b/readthedocs/filetreediff/__init__.py
@@ -209,19 +209,6 @@ def snapshot_base_manifest(
     )
 
 
-def get_base_version_for_diff(external_version: Version) -> Version | None:
-    """
-    Resolve the base version a PR version is compared against in file tree diffs.
-
-    Uses the project's configured override (``addons.options_base_version``)
-    if set, otherwise the project's "latest" version.
-    """
-    return (
-        external_version.project.addons.options_base_version
-        or external_version.project.get_latest_version()
-    )
-
-
 def should_refresh_snapshot(external_version: Version, vcs_repository) -> bool:
     """
     Return True iff the PR's snapshot has fallen behind its merge-base.
@@ -296,7 +283,7 @@ def refresh_snapshot_if_stale(external_version: Version, vcs_repository) -> None
     if not external_version.is_external:
         return
     try:
-        base_version = get_base_version_for_diff(external_version)
+        base_version = external_version.get_base_version_for_diff()
         if not base_version:
             return
         if should_refresh_snapshot(external_version, vcs_repository):

--- a/readthedocs/projects/tasks/search.py
+++ b/readthedocs/projects/tasks/search.py
@@ -9,7 +9,6 @@ from readthedocs.builds.constants import LATEST
 from readthedocs.builds.models import Build
 from readthedocs.builds.models import Version
 from readthedocs.builds.tasks import post_build_overview
-from readthedocs.filetreediff import get_base_version_for_diff
 from readthedocs.filetreediff import snapshot_base_manifest
 from readthedocs.filetreediff import write_manifest
 from readthedocs.filetreediff.dataclasses import FileTreeDiffManifest
@@ -159,7 +158,7 @@ class FileManifestIndexer(Indexer):
         # problem). Subsequent rebases are handled by ``refresh_snapshot_if_stale``
         # in the build task.
         if self.version.is_external:
-            base_version = get_base_version_for_diff(self.version)
+            base_version = self.version.get_base_version_for_diff()
             if base_version:
                 snapshot_base_manifest(self.version, base_version)
 


### PR DESCRIPTION
## Why

"Which version do we diff this PR against?" is per-version data, not module
data. Putting it on `Version` puts the answer next to `is_external`,
`latest_successful_build`, and the other version-shaped questions, instead of
behind a free function callers have to know to import.

Stacked on top of #13081.

---

🤖 Generated by Claude Code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cp76KDdAUP9vXL4hCNuD3Q)_