### PR TITLE
builds: backfill queue_time for builds triggered this year

### DIFF
--- a/readthedocs/builds/migrations/0075_backfill_queue_time.py
+++ b/readthedocs/builds/migrations/0075_backfill_queue_time.py
@@ -1,0 +1,56 @@
+import datetime
+
+from django.db import migrations
+from django_safemigrate import Safe
+
+
+# Builds created this year (2026); ``task_executed_at`` was added on
+# 2025-09-30, so only recent builds have it populated and can be backfilled.
+BACKFILL_SINCE = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+BATCH_SIZE = 5000
+
+
+def forward_backfill_queue_time(apps, schema_editor):
+    """
+    Backfill ``queue_time`` for builds triggered this year.
+
+    The queued time is the number of seconds between when the build was
+    triggered (``date``) and when the task started running on a builder
+    (``task_executed_at``). Computed in Python and written in batches to avoid
+    a single large UPDATE locking the table.
+    """
+    Build = apps.get_model("builds", "Build")
+    queryset = (
+        Build.objects.filter(
+            date__gte=BACKFILL_SINCE,
+            task_executed_at__isnull=False,
+            queue_time__isnull=True,
+        )
+        .only("id", "date", "task_executed_at")
+        .order_by("pk")
+    )
+
+    batch = []
+    for build in queryset.iterator():
+        build.queue_time = int((build.task_executed_at - build.date).total_seconds())
+        batch.append(build)
+        if len(batch) >= BATCH_SIZE:
+            Build.objects.bulk_update(batch, ["queue_time"])
+            batch = []
+    if batch:
+        Build.objects.bulk_update(batch, ["queue_time"])
+
+
+class Migration(migrations.Migration):
+    safe = Safe.after_deploy()
+
+    dependencies = [
+        ("builds", "0074_build_queue_time"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            forward_backfill_queue_time,
+            migrations.RunPython.noop,
+        ),
+    ]


### PR DESCRIPTION
Stacked on top of #13080 (targets that branch, not `main`).

## Why a separate PR

The backfill is a one-time data migration with different risk and review concerns than the schema/feature change in #13080, so it's split out to be reviewed and reverted independently.

## Decisions

**Bounded to this year.** `task_executed_at` only exists from 2025-09-30 onward, so older builds can't be backfilled at all. We further limit the window to builds since 2026-01-01 to keep the at-deploy DML small rather than rewriting every eligible row.

**Runs after deploy, in batches, idempotently.** It only fills rows where the value is still null and never overwrites, so it's safe to re-run; batching avoids holding a long lock on a large table.

**Computed in Python, not SQL.** Extracting epoch seconds from a timestamp delta differs between PostgreSQL (production) and SQLite (tests); computing in Python keeps behavior identical across both.

## Merge order

Merge after #13080, since it depends on the column that PR adds.

---
🤖 Generated by the Claude Code AI agent.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCZXopgi75L1AE4NAjNhbK)_