### PR TITLE
Docs: Conditionally map intersphinx references between docsets

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -113,8 +113,9 @@ intersphinx_mapping = {
     "jupyter": ("https://docs.jupyter.org/en/latest/", None),
 }
 
-# Cross-reference the other docset only:
-# the dev docs link to the user docs (rtd), and the user docs link to the dev docs (rtd-dev).
+# Cross-reference the required docset only
+# to avoid Sphinx falling back to old references that won't exist after a PR is merged.
+# The dev docs link to the user docs (rtd), and the user docs link to the dev docs (rtd-dev).
 if docset == "dev":
     intersphinx_mapping["rtd"] = ("https://docs.readthedocs.io/en/stable/", None)
 else:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,11 +109,16 @@ intersphinx_mapping = {
     "jupyterbook": ("https://jupyterbook.org/en/stable/", None),
     "executablebook": ("https://executablebooks.org/en/latest/", None),
     "rst-to-myst": ("https://rst-to-myst.readthedocs.io/en/stable/", None),
-    "rtd": ("https://docs.readthedocs.io/en/stable/", None),
-    "rtd-dev": ("https://dev.readthedocs.io/en/latest/", None),
     "rtd-blog": ("https://blog.readthedocs.com/", None),
     "jupyter": ("https://docs.jupyter.org/en/latest/", None),
 }
+
+# Cross-reference the other docset only:
+# the dev docs link to the user docs (rtd), and the user docs link to the dev docs (rtd-dev).
+if docset == "dev":
+    intersphinx_mapping["rtd"] = ("https://docs.readthedocs.io/en/stable/", None)
+else:
+    intersphinx_mapping["rtd-dev"] = ("https://dev.readthedocs.io/en/latest/", None)
 
 # Intersphinx: Do not try to resolve unresolved labels that aren't explicitly prefixed.
 # The default setting for intersphinx_disabled_reftypes can cause some pretty bad

--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -28,7 +28,7 @@ Install external dependencies (Docker, Docker Compose, gVisor)
 
 #. Install Docker by following `the official guide <https://docs.docker.com/get-docker/>`_.
 #. Install Docker Compose with `the official instructions <https://docs.docker.com/compose/install/>`_.
-#. Install and set up gVisor following :doc:`rtd-dev:guides/gvisor`.
+#. Install and set up gVisor following :doc:`/guides/gvisor`.
 
 
 Set up your environment


### PR DESCRIPTION
We have the two targets since the dev docs reference the user docs, and the other way around. When a PR changes the references, Sphinx will fallback to intersphinx, and since they exist there, the PR will pass, but after the PR is merged, the references will stop existing. So, only add the intersphinx targets when the doc project needs it.

**Key changes**

- Moved `rtd` and `rtd-dev` mappings from the static `intersphinx_mapping` dictionary into conditional logic based on the `docset` variable
- Updated the gVisor installation reference in `docs/dev/install.rst` to use a relative path (`:doc:/guides/gvisor`) instead of the explicit `rtd-dev:` prefix, which now works correctly with the conditional mapping

**Implementation details**

The conditional logic checks the `docset` variable at build time and adds the appropriate cross-reference mapping. This approach is cleaner than maintaining both mappings simultaneously and allows each docset to only reference the other when needed.

---
*Generated by AI agent*

https://claude.ai/code/session_0142tFaUgigeW9t8SWUUoFTJ