### PR TITLE
Bumpver: fix version pattern

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,8 +29,8 @@ github_owner = readthedocs
 github_repo = readthedocs.org
 
 [bumpver]
-current_version = "2026.6.2"
-version_pattern = "MAJOR.MINOR.PATCH[TAGNUM]"
+current_version = "2026.06.02"
+version_pattern = "YYYY.0M.0D[.PATCH]"
 commit_message = "Bump version {old_version} -> {new_version}"
 commit = False
 tag = False


### PR DESCRIPTION
Allow for a patch release on the same day. It would no longer normalize the version to remove the padding 0.