### PR TITLE
Builds: Update remaining Python 3.12 references to 3.14

### DIFF
--- a/.github/workflows/pip-tools.yaml
+++ b/.github/workflows/pip-tools.yaml
@@ -32,7 +32,7 @@ jobs:
         run: git submodule update --init
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Install "pg_config" requirement
         run: sudo apt-get install libpq-dev

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,9 +13,9 @@ python:
     - requirements: requirements/docs.txt
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.12"
+    python: "3.14"
 
 search:
   ranking:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,10 +73,10 @@ tox -e migrations
 tox -e pre-commit
 
 # Run the main test suite (search, proxito, and embed_api tests are excluded by default)
-tox -e py312 -- --nomigrations
+tox -e py314 -- --nomigrations
 
 # Run tests matching a keyword (faster) — use -k because --pyargs readthedocs is hardcoded
-tox -e py312 -- -k "<keyword>" --reuse-db --nomigrations
+tox -e py314 -- -k "<keyword>" --reuse-db --nomigrations
 
 # Run only search tests (requires Elasticsearch sidecar in CI, skip locally unless available)
 tox -e search

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -140,7 +140,7 @@ bumpver
 # xmlsec is a dependency from python3-saml which is required by django-allauth.
 # We have to pin it because the underlying `libxml2-dev` package installed at
 # system level is incompatible with the Python 3.14 version
-# These newer version comes with wheels, so there is no need to compile them from source.
+# These newer versions come with wheels, so there is no need to compile them from source.
 # https://github.com/xmlsec/python-xmlsec/issues/323
 # https://github.com/xmlsec/python-xmlsec/issues/324
 # https://github.com/xmlsec/python-xmlsec/releases/tag/1.3.17


### PR DESCRIPTION
Follow-up to #13027 — updates the remaining Python 3.12 references that were missed in the initial PR.

**Fixed:**
- `.github/workflows/pip-tools.yaml` — `python-version: "3.12"` → `"3.14"`
- `.readthedocs.yml` — `python: "3.12"` → `"3.14"` and `os: ubuntu-22.04` → `ubuntu-24.04`
- `AGENTS.md` / `.claude/CLAUDE.md` — `tox -e py312` → `tox -e py314`
- `requirements/pip.in` — grammar fix in comment

**Not changed (intentional):**
- `docs/user/` example configs — these show supported Python versions for users, not the project's own version

---
*Generated by AI agent (Claude Code)*

---
_Generated by [Claude Code](https://claude.ai/code/session_01PoSwN1ZgNm3mrboFs9kTDr)_