### PR TITLE
Projects: Move AddonsConfig creation to model save method

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -700,6 +700,8 @@ class Project(models.Model):
         return self.name
 
     def save(self, *args, **kwargs):
+        new_project = self.pk is None
+
         if not self.slug:
             # Subdomains can't have underscores in them.
             self.slug = slugify(self.name)
@@ -727,6 +729,10 @@ class Project(models.Model):
 
         super().save(*args, **kwargs)
         self.update_latest_version()
+
+        # Create the ``AddonsConfig`` on new projects.
+        if new_project:
+            AddonsConfig.objects.get_or_create(project=self)
 
     def delete(self, *args, **kwargs):
         from readthedocs.builds.tasks import remove_build_commands_storage_paths

--- a/readthedocs/projects/signals.py
+++ b/readthedocs/projects/signals.py
@@ -9,7 +9,6 @@ from django.dispatch import receiver
 
 from readthedocs.integrations.models import GitHubAppIntegrationProviderData
 from readthedocs.integrations.models import Integration
-from readthedocs.projects.models import AddonsConfig
 from readthedocs.projects.models import Project
 
 
@@ -25,12 +24,6 @@ project_import = django.dispatch.Signal()
 
 # Used to purge files from the CDN
 files_changed = django.dispatch.Signal()
-
-
-@receiver(post_save, sender=Project)
-def create_addons_on_new_projects(instance, *args, **kwargs):
-    """Create ``AddonsConfig`` on new projects."""
-    AddonsConfig.objects.get_or_create(project=instance)
 
 
 @receiver(post_save, sender=Project)


### PR DESCRIPTION
Signals should be used for code we don't have access to. All projects have an addons config already.

---
*Generated by AI agent*

https://claude.ai/code/session_01Dxarv92vP2qW8aRNDFqSoU