### PR TITLE
Builds: Add get_result_display property to Build model

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -1065,7 +1065,6 @@ class Build(models.Model):
 
         return None
 
-    @property
     def get_result_display(self):
         """Human-readable build result combining state and success."""
         if self.state == BUILD_STATE_FINISHED:

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -23,6 +23,7 @@ import readthedocs.builds.automation_actions as actions
 from readthedocs.builds.constants import BRANCH
 from readthedocs.builds.constants import BUILD_FINAL_STATES
 from readthedocs.builds.constants import BUILD_STATE
+from readthedocs.builds.constants import BUILD_STATE_CANCELLED
 from readthedocs.builds.constants import BUILD_STATE_FINISHED
 from readthedocs.builds.constants import BUILD_STATE_TRIGGERED
 from readthedocs.builds.constants import BUILD_STATUS_CHOICES
@@ -1063,6 +1064,17 @@ class Build(models.Model):
                 return BITBUCKET_COMMIT_URL.format(user=user, repo=repo, commit=self.commit)
 
         return None
+
+    @property
+    def get_result_display(self):
+        """Human-readable build result combining state and success."""
+        if self.state == BUILD_STATE_FINISHED:
+            if self.success:
+                return _("Build passed")
+            return _("Build failed")
+        if self.state == BUILD_STATE_CANCELLED:
+            return _("Build cancelled")
+        return _("Building")
 
     @property
     def finished(self):


### PR DESCRIPTION
Adds a `get_result_display` property to the Build model that returns a human-readable build result string: "Build passed", "Build failed", "Build cancelled", or "Building". This centralizes logic that was previously duplicated in templates and JavaScript.

Companion to [ext-theme#758](https://github.com/readthedocs/ext-theme/pull/758), which uses this property for OpenGraph meta tags on build detail pages.

---
*Generated by Claude Code*

---
_Generated by [Claude Code](https://claude.ai/code/session_012fjaaMr8qJHLJsqmJqE78e)_