### PR TITLE
Projects: Extract language validation logic to validators module

### DIFF
--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -32,6 +32,7 @@ from readthedocs.projects.models import EnvironmentVariable
 from readthedocs.projects.models import Project
 from readthedocs.projects.models import ProjectRelationship
 from readthedocs.projects.validators import validate_environment_variable_size
+from readthedocs.projects.validators import validate_project_language
 from readthedocs.redirects.constants import TYPE_CHOICES as REDIRECT_TYPE_CHOICES
 from readthedocs.redirects.models import Redirect
 from readthedocs.redirects.validators import validate_redirect
@@ -731,6 +732,11 @@ class ProjectUpdateSerializerBase(TaggitSerializer, serializers.ModelSerializer)
         if not settings.ALLOW_PRIVATE_REPOS:
             self.fields.pop("privacy_level")
             self.fields.pop("external_builds_privacy_level")
+
+    def validate_language(self, value):
+        """Ensure the language isn't already used by a translation of the project."""
+        validate_project_language(value, self.instance)
+        return value
 
 
 class ProjectUpdateSerializer(SettingsOverrideObject):

--- a/readthedocs/api/v3/tests/test_projects.py
+++ b/readthedocs/api/v3/tests/test_projects.py
@@ -715,6 +715,49 @@ class ProjectsEndpointTests(APIEndpointMixin):
         self.assertEqual(list(self.project.tags.names()), ["partial tags", "updated"])
         self.assertNotEqual(self.project.default_version, "updated-default-branch")
 
+    def test_partial_update_project_language_already_in_translation(self):
+        """The project language can't collide with one of its translations."""
+        translation = get(
+            Project,
+            users=[self.me],
+            main_language_project=self.project,
+            language="es",
+        )
+
+        url = reverse(
+            "projects-detail",
+            kwargs={
+                "project_slug": self.project.slug,
+            },
+        )
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+
+        # Changing the main project language to the translation's one fails.
+        response = self.client.patch(url, {"language": "es"})
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("language", response.json())
+
+        # The project keeps its original language.
+        self.project.refresh_from_db()
+        self.assertNotEqual(self.project.language, "es")
+
+        # A language not used by any translation is accepted.
+        response = self.client.patch(url, {"language": "br"})
+        self.assertEqual(response.status_code, 204)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.language, "br")
+
+        # The translation can't take its main project's language either.
+        translation_url = reverse(
+            "projects-detail",
+            kwargs={
+                "project_slug": translation.slug,
+            },
+        )
+        response = self.client.patch(translation_url, {"language": "br"})
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("language", response.json())
+
     def test_partial_update_project_readthedocs_yaml_path(self):
         """Test that readthedocs_yaml_path can be set via PATCH and is returned in GET."""
         url = reverse(

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -52,6 +52,7 @@ from readthedocs.projects.models import WebHook
 from readthedocs.projects.notifications import MESSAGE_PROJECT_SEARCH_INDEXING_DISABLED
 from readthedocs.projects.tasks.search import index_project
 from readthedocs.projects.templatetags.projects_tags import sort_version_aware
+from readthedocs.projects.validators import validate_language
 from readthedocs.redirects.models import Redirect
 
 
@@ -650,28 +651,7 @@ class UpdateProjectForm(
         language = self.cleaned_data["language"]
         project = self.instance
         if project:
-            msg = _(
-                'There is already a "{lang}" translation for the {proj} project.',
-            )
-            if project.translations.filter(language=language).exists():
-                raise forms.ValidationError(
-                    msg.format(lang=language, proj=project.slug),
-                )
-            main_project = project.main_language_project
-            if main_project:
-                if main_project.language == language:
-                    raise forms.ValidationError(
-                        msg.format(lang=language, proj=main_project.slug),
-                    )
-                siblings = (
-                    main_project.translations.filter(language=language)
-                    .exclude(pk=project.pk)
-                    .exists()
-                )
-                if siblings:
-                    raise forms.ValidationError(
-                        msg.format(lang=language, proj=main_project.slug),
-                    )
+            validate_language(language, project)
         return language
 
     def clean_tags(self):

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -52,7 +52,7 @@ from readthedocs.projects.models import WebHook
 from readthedocs.projects.notifications import MESSAGE_PROJECT_SEARCH_INDEXING_DISABLED
 from readthedocs.projects.tasks.search import index_project
 from readthedocs.projects.templatetags.projects_tags import sort_version_aware
-from readthedocs.projects.validators import validate_language
+from readthedocs.projects.validators import validate_project_language
 from readthedocs.redirects.models import Redirect
 
 
@@ -651,7 +651,7 @@ class UpdateProjectForm(
         language = self.cleaned_data["language"]
         project = self.instance
         if project:
-            validate_language(language, project)
+            validate_project_language(language, project)
         return language
 
     def clean_tags(self):

--- a/readthedocs/projects/tests/test_validators.py
+++ b/readthedocs/projects/tests/test_validators.py
@@ -1,7 +1,9 @@
 import pytest
 from django.core.exceptions import ValidationError
+from django_dynamic_fixture import get
 
 from readthedocs.projects import validators
+from readthedocs.projects.models import Project
 
 
 def test_repository_path_validator():
@@ -40,3 +42,41 @@ def test_repository_path_validator():
     validators.validate_build_config_file("this_is_okay/.readthedocs.yaml")
     validators.validate_build_config_file("this-is-okay/.readthedocs.yaml")
     validators.validate_build_config_file(".readthedocs.yaml")
+
+
+@pytest.mark.django_db
+class TestValidateLanguage:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.main = get(Project, language="es", main_language_project=None)
+        self.translation_en = get(Project, language="en", main_language_project=None)
+        self.translation_br = get(Project, language="br", main_language_project=None)
+        self.main.translations.add(self.translation_en)
+        self.main.translations.add(self.translation_br)
+
+    def test_unused_language_is_valid(self):
+        assert validators.validate_language("fr", self.main) == "fr"
+
+    def test_same_language_as_self_is_valid(self):
+        # A project keeping its own language is fine.
+        assert validators.validate_language("es", self.main) == "es"
+        assert validators.validate_language("en", self.translation_en) == "en"
+
+    def test_main_cant_use_translation_language(self):
+        with pytest.raises(ValidationError) as excinfo:
+            validators.validate_language("en", self.main)
+        assert 'There is already a "en" translation' in str(excinfo.value)
+
+    def test_translation_cant_use_main_language(self):
+        with pytest.raises(ValidationError) as excinfo:
+            validators.validate_language("es", self.translation_en)
+        assert 'There is already a "es" translation' in str(excinfo.value)
+
+    def test_translation_cant_use_sibling_language(self):
+        with pytest.raises(ValidationError) as excinfo:
+            validators.validate_language("br", self.translation_en)
+        assert 'There is already a "br" translation' in str(excinfo.value)
+
+    def test_project_without_translations_is_valid(self):
+        project = get(Project, language="en", main_language_project=None)
+        assert validators.validate_language("ru", project) == "ru"

--- a/readthedocs/projects/tests/test_validators.py
+++ b/readthedocs/projects/tests/test_validators.py
@@ -55,28 +55,28 @@ class TestValidateLanguage:
         self.main.translations.add(self.translation_br)
 
     def test_unused_language_is_valid(self):
-        assert validators.validate_language("fr", self.main) == "fr"
+        assert validators.validate_project_language("fr", self.main) == "fr"
 
     def test_same_language_as_self_is_valid(self):
         # A project keeping its own language is fine.
-        assert validators.validate_language("es", self.main) == "es"
-        assert validators.validate_language("en", self.translation_en) == "en"
+        assert validators.validate_project_language("es", self.main) == "es"
+        assert validators.validate_project_language("en", self.translation_en) == "en"
 
     def test_main_cant_use_translation_language(self):
         with pytest.raises(ValidationError) as excinfo:
-            validators.validate_language("en", self.main)
+            validators.validate_project_language("en", self.main)
         assert 'There is already a "en" translation' in str(excinfo.value)
 
     def test_translation_cant_use_main_language(self):
         with pytest.raises(ValidationError) as excinfo:
-            validators.validate_language("es", self.translation_en)
+            validators.validate_project_language("es", self.translation_en)
         assert 'There is already a "es" translation' in str(excinfo.value)
 
     def test_translation_cant_use_sibling_language(self):
         with pytest.raises(ValidationError) as excinfo:
-            validators.validate_language("br", self.translation_en)
+            validators.validate_project_language("br", self.translation_en)
         assert 'There is already a "br" translation' in str(excinfo.value)
 
     def test_project_without_translations_is_valid(self):
         project = get(Project, language="en", main_language_project=None)
-        assert validators.validate_language("ru", project) == "ru"
+        assert validators.validate_project_language("ru", project) == "ru"

--- a/readthedocs/projects/validators.py
+++ b/readthedocs/projects/validators.py
@@ -228,6 +228,41 @@ def _clean_prefix(prefix):
     return f"/{prefix}/"
 
 
+def validate_language(language, project):
+    """
+    Ensure that the given language isn't already used by the project's translations.
+
+    A project can't have a translation in the same language as itself,
+    nor in the same language as any of its sibling translations.
+
+    Raises ``ValidationError`` if the language is already in use.
+
+    :param language: Language code to validate
+    :param project: Project the language is being assigned to
+    """
+    msg = _(
+        'There is already a "{lang}" translation for the {proj} project.',
+    )
+    if project.translations.filter(language=language).exists():
+        raise ValidationError(
+            msg.format(lang=language, proj=project.slug),
+        )
+    main_project = project.main_language_project
+    if main_project:
+        if main_project.language == language:
+            raise ValidationError(
+                msg.format(lang=language, proj=main_project.slug),
+            )
+        siblings = (
+            main_project.translations.filter(language=language).exclude(pk=project.pk).exists()
+        )
+        if siblings:
+            raise ValidationError(
+                msg.format(lang=language, proj=main_project.slug),
+            )
+    return language
+
+
 def validate_environment_variable_size(project, new_env_value, error_class=ValidationError):
     existing_size = (
         project.environmentvariable_set.annotate(size=Length("value")).aggregate(

--- a/readthedocs/projects/validators.py
+++ b/readthedocs/projects/validators.py
@@ -228,7 +228,7 @@ def _clean_prefix(prefix):
     return f"/{prefix}/"
 
 
-def validate_language(language, project):
+def validate_project_language(language, project):
     """
     Ensure that the given language isn't already used by the project's translations.
 


### PR DESCRIPTION
Refactor the language validation logic from the project form into a reusable validator function, improving code organization and testability.

**Summary**

This change extracts the language validation logic that was previously embedded in `ProjectForm.clean_language()` into a dedicated `validate_language()` function in the validators module. This makes the validation logic reusable across different parts of the codebase and easier to test independently.

**Key changes**

- Added `validate_language(language, project)` function to `readthedocs/projects/validators.py` that ensures a language isn't already used by the project's translations, its main project, or sibling translations
- Updated `ProjectForm.clean_language()` to use the new validator function instead of duplicating the validation logic
- Added comprehensive test coverage in `TestValidateLanguage` class with tests for:
  - Unused languages (valid)
  - Same language as the project itself (valid)
  - Main project using a translation's language (invalid)
  - Translation using the main project's language (invalid)
  - Translation using a sibling translation's language (invalid)
  - Projects without translations (valid)

**Implementation details**

The validator function handles three validation scenarios:
1. Checks if the language is already used by any of the project's translations
2. For translation projects, checks if the language matches the main project's language
3. For translation projects, checks if the language matches any sibling translation's language

The function raises `ValidationError` with a descriptive message if validation fails, or returns the language if valid.

---
*Generated by AI agent*

https://claude.ai/code/session_01NUrZ2ih4st8HNZoCu4ZsWz