### PR TITLE
Refactor: Extract shared validation logic into reusable validator classes

### DIFF
--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -16,6 +16,7 @@ from readthedocs.builds.constants import LATEST
 from readthedocs.builds.constants import STABLE
 from readthedocs.builds.models import Build
 from readthedocs.builds.models import Version
+from readthedocs.builds.validators import VersionValidator
 from readthedocs.core.permissions import AdminPermission
 from readthedocs.core.resolver import Resolver
 from readthedocs.core.utils import slugify
@@ -31,6 +32,8 @@ from readthedocs.projects.constants import PROGRAMMING_LANGUAGES
 from readthedocs.projects.models import EnvironmentVariable
 from readthedocs.projects.models import Project
 from readthedocs.projects.models import ProjectRelationship
+from readthedocs.projects.validators import EnvironmentVariableValidator
+from readthedocs.projects.validators import ProjectValidator
 from readthedocs.projects.validators import validate_environment_variable_size
 from readthedocs.redirects.constants import TYPE_CHOICES as REDIRECT_TYPE_CHOICES
 from readthedocs.redirects.models import Redirect
@@ -393,7 +396,7 @@ class VersionSerializer(serializers.ModelSerializer):
         return []
 
 
-class VersionUpdateSerializer(serializers.ModelSerializer):
+class VersionUpdateSerializer(VersionValidator, serializers.ModelSerializer):
     """
     Used when modifying (update action) a ``Version``.
 
@@ -688,7 +691,7 @@ class ProjectCreateSerializer(SettingsOverrideObject):
     _default_class = ProjectCreateSerializerBase
 
 
-class ProjectUpdateSerializerBase(TaggitSerializer, serializers.ModelSerializer):
+class ProjectUpdateSerializerBase(ProjectValidator, TaggitSerializer, serializers.ModelSerializer):
     """Serializer used to modify a Project once imported."""
 
     repository = RepositorySerializer(source="*")
@@ -1141,7 +1144,7 @@ class EnvironmentVariableLinksSerializer(BaseLinksSerializer):
         return self._absolute_url(path)
 
 
-class EnvironmentVariableSerializer(serializers.ModelSerializer):
+class EnvironmentVariableSerializer(EnvironmentVariableValidator, serializers.ModelSerializer):
     project = serializers.SlugRelatedField(slug_field="slug", read_only=True)
     _links = EnvironmentVariableLinksSerializer(source="*", read_only=True)
 

--- a/readthedocs/api/v3/tests/test_environmentvariables.py
+++ b/readthedocs/api/v3/tests/test_environmentvariables.py
@@ -234,6 +234,48 @@ class EnvironmentVariablessEndpointTests(APIEndpointMixin):
         self.assertEqual(env_var.value, "test_value")
         self.assertTrue(env_var.public)
 
+    def test_create_environment_variable_invalid_name(self):
+        url = reverse(
+            "projects-environmentvariables-list",
+            kwargs={
+                "parent_lookup_project__slug": self.project.slug,
+            },
+        )
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+
+        invalid_names = [
+            "__PRIVATE",
+            "READTHEDOCS_TOKEN",
+            "WITH SPACE",
+            "WITH-DASH",
+        ]
+        for name in invalid_names:
+            response = self.client.post(
+                url,
+                data={"name": name, "value": "value", "public": True},
+            )
+            assert response.status_code == 400, name
+            assert "name" in response.json()
+
+        # An invalid name doesn't create the variable.
+        self.assertEqual(self.project.environmentvariable_set.count(), 1)
+
+    def test_create_environment_variable_duplicated_name(self):
+        url = reverse(
+            "projects-environmentvariables-list",
+            kwargs={
+                "parent_lookup_project__slug": self.project.slug,
+            },
+        )
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.post(
+            url,
+            data={"name": "ENVVAR", "value": "value", "public": True},
+        )
+        assert response.status_code == 400
+        assert "name" in response.json()
+        self.assertEqual(self.project.environmentvariable_set.count(), 1)
+
     def test_create_environment_variable_without_public_flag(self):
         self.assertEqual(self.project.environmentvariable_set.count(), 1)
         data = {

--- a/readthedocs/api/v3/tests/test_projects.py
+++ b/readthedocs/api/v3/tests/test_projects.py
@@ -715,6 +715,37 @@ class ProjectsEndpointTests(APIEndpointMixin):
         self.assertEqual(list(self.project.tags.names()), ["partial tags", "updated"])
         self.assertNotEqual(self.project.default_version, "updated-default-branch")
 
+    def test_partial_update_project_existing_translation_language(self):
+        # ``self.project`` already has a Spanish translation.
+        get(
+            Project,
+            users=[self.me],
+            main_language_project=self.project,
+            language="es",
+        )
+        url = reverse(
+            "projects-detail",
+            kwargs={
+                "project_slug": self.project.slug,
+            },
+        )
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.patch(url, {"language": "es"})
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("language", response.json())
+
+    def test_partial_update_project_tag_too_long(self):
+        url = reverse(
+            "projects-detail",
+            kwargs={
+                "project_slug": self.project.slug,
+            },
+        )
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.patch(url, {"tags": ["a" * 101]}, format="json")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("tags", response.json())
+
     def test_partial_update_project_readthedocs_yaml_path(self):
         """Test that readthedocs_yaml_path can be set via PATCH and is returned in GET."""
         url = reverse(

--- a/readthedocs/api/v3/tests/test_versions.py
+++ b/readthedocs/api/v3/tests/test_versions.py
@@ -281,6 +281,24 @@ class VersionsEndpointTests(APIEndpointMixin):
         self.assertFalse(self.version.built)
         self.assertEqual(self.version.type, TAG)
 
+    def test_projects_versions_partial_update_deactivate_default_version(self):
+        self.project.default_version = self.version.slug
+        self.project.save()
+        url = reverse(
+            "projects-versions-detail",
+            kwargs={
+                "parent_lookup_project__slug": self.project.slug,
+                "version_slug": self.version.slug,
+            },
+        )
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.patch(url, {"active": False})
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("active", response.json())
+
+        self.version.refresh_from_db()
+        self.assertTrue(self.version.active)
+
     def test_projects_versions_partial_update_privacy_levels_disabled(self):
         self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
         data = {

--- a/readthedocs/builds/forms.py
+++ b/readthedocs/builds/forms.py
@@ -10,10 +10,11 @@ from django.template.loader import render_to_string
 from django.utils.translation import gettext_lazy as _
 
 from readthedocs.builds.models import Version
+from readthedocs.builds.validators import VersionValidator
 from readthedocs.builds.version_slug import generate_version_slug
 
 
-class VersionForm(forms.ModelForm):
+class VersionForm(VersionValidator, forms.ModelForm):
     project = forms.CharField(widget=forms.HiddenInput(), required=False)
 
     class Meta:
@@ -69,21 +70,6 @@ class VersionForm(forms.ModelForm):
         # We use this value in the save method.
         self._was_active = self.instance.active if self.instance else False
         self._previous_slug = self.instance.slug if self.instance else None
-
-    def clean_active(self):
-        active = self.cleaned_data["active"]
-        if self._is_default_version() and not active:
-            msg = _(
-                "{version} is the default version of the project, it should be active.",
-            )
-            raise forms.ValidationError(
-                msg.format(version=self.instance.verbose_name),
-            )
-        return active
-
-    def _is_default_version(self):
-        project = self.instance.project
-        return project.default_version == self.instance.slug
 
     def clean_slug(self):
         slug = self.cleaned_data["slug"]

--- a/readthedocs/builds/validators.py
+++ b/readthedocs/builds/validators.py
@@ -1,0 +1,41 @@
+"""Validators for the builds app."""
+
+from django import forms
+from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers
+
+
+class VersionValidator:
+    """
+    Shared validation for ``Version`` fields.
+
+    Forms enter through ``clean_<field>`` and API serializers through
+    ``validate_<field>``. Both extract the data they need and delegate to a
+    private ``_validate_<field>`` method that holds the shared logic and raises
+    the error class given to it (``forms.ValidationError`` or
+    ``serializers.ValidationError``).
+    """
+
+    def _validate_active(self, active, version, error_class):
+        """The default version of a project must remain active."""
+        if version and not active and version.project.default_version == version.slug:
+            raise error_class(
+                _("{version} is the default version of the project, it should be active.").format(
+                    version=version.verbose_name,
+                ),
+            )
+        return active
+
+    def clean_active(self):
+        return self._validate_active(
+            self.cleaned_data["active"],
+            version=self.instance,
+            error_class=forms.ValidationError,
+        )
+
+    def validate_active(self, active):
+        return self._validate_active(
+            active,
+            version=self.instance,
+            error_class=serializers.ValidationError,
+        )

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -3,7 +3,6 @@
 import json
 import re
 from random import choice
-from re import fullmatch
 from urllib.parse import urlparse
 
 import dns.name
@@ -52,6 +51,8 @@ from readthedocs.projects.models import WebHook
 from readthedocs.projects.notifications import MESSAGE_PROJECT_SEARCH_INDEXING_DISABLED
 from readthedocs.projects.tasks.search import index_project
 from readthedocs.projects.templatetags.projects_tags import sort_version_aware
+from readthedocs.projects.validators import EnvironmentVariableValidator
+from readthedocs.projects.validators import ProjectValidator
 from readthedocs.redirects.models import Redirect
 
 
@@ -477,6 +478,7 @@ class ProjectConfigForm(forms.Form):
 
 
 class UpdateProjectForm(
+    ProjectValidator,
     ProjectTriggerBuildMixin,
     ProjectForm,
     ProjectPRBuildsMixin,
@@ -644,46 +646,6 @@ class UpdateProjectForm(
             all_versions = [(version.slug, version.verbose_name) for version in version_qs]
             return all_versions
         return None
-
-    def clean_language(self):
-        """Ensure that language isn't already active."""
-        language = self.cleaned_data["language"]
-        project = self.instance
-        if project:
-            msg = _(
-                'There is already a "{lang}" translation for the {proj} project.',
-            )
-            if project.translations.filter(language=language).exists():
-                raise forms.ValidationError(
-                    msg.format(lang=language, proj=project.slug),
-                )
-            main_project = project.main_language_project
-            if main_project:
-                if main_project.language == language:
-                    raise forms.ValidationError(
-                        msg.format(lang=language, proj=main_project.slug),
-                    )
-                siblings = (
-                    main_project.translations.filter(language=language)
-                    .exclude(pk=project.pk)
-                    .exists()
-                )
-                if siblings:
-                    raise forms.ValidationError(
-                        msg.format(lang=language, proj=main_project.slug),
-                    )
-        return language
-
-    def clean_tags(self):
-        tags = self.cleaned_data.get("tags", [])
-        for tag in tags:
-            if len(tag) > 100:
-                raise forms.ValidationError(
-                    _(
-                        "Length of each tag must be less than or equal to 100 characters.",
-                    ),
-                )
-        return tags
 
     def clean_git_checkout_command(self):
         """Parse and validate git_checkout_command as a JSON array."""
@@ -1356,7 +1318,7 @@ class FeatureForm(forms.ModelForm):
         self.fields["feature_id"].choices = Feature.FEATURES
 
 
-class EnvironmentVariableForm(forms.ModelForm):
+class EnvironmentVariableForm(EnvironmentVariableValidator, forms.ModelForm):
     """
     Form to add an EnvironmentVariable to a Project.
 
@@ -1380,33 +1342,6 @@ class EnvironmentVariableForm(forms.ModelForm):
 
     def clean_project(self):
         return self.project
-
-    def clean_name(self):
-        """Validate environment variable name chosen."""
-        name = self.cleaned_data["name"]
-        if name.startswith("__"):
-            raise forms.ValidationError(
-                _("Variable name can't start with __ (double underscore)"),
-            )
-        if name.startswith("READTHEDOCS"):
-            raise forms.ValidationError(
-                _("Variable name can't start with READTHEDOCS"),
-            )
-        if self.project.environmentvariable_set.filter(name=name).exists():
-            raise forms.ValidationError(
-                _(
-                    "There is already a variable with this name for this project",
-                ),
-            )
-        if " " in name:
-            raise forms.ValidationError(
-                _("Variable name can't contain spaces"),
-            )
-        if not fullmatch("[a-zA-Z0-9_]+", name):
-            raise forms.ValidationError(
-                _("Only letters, numbers and underscore are allowed"),
-            )
-        return name
 
 
 # TODO if you are extending this form or reusing this pattern for any similar views,

--- a/readthedocs/projects/validators.py
+++ b/readthedocs/projects/validators.py
@@ -3,6 +3,7 @@
 import re
 from urllib.parse import urlparse
 
+from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
@@ -11,6 +12,7 @@ from django.db.models.functions import Length
 from django.utils.deconstruct import deconstructible
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers
 
 from readthedocs.projects.constants import LANGUAGES
 
@@ -238,4 +240,121 @@ def validate_environment_variable_size(project, new_env_value, error_class=Valid
     if existing_size + len(new_env_value) > MAX_SIZE_ENV_VARS_PER_PROJECT:
         raise error_class(
             _("The total size of all environment variables in the project cannot exceed 256 KB.")
+        )
+
+
+class ProjectValidator:
+    """
+    Shared validation for ``Project`` fields.
+
+    Forms enter through ``clean_<field>`` and API serializers through
+    ``validate_<field>``. Both extract the data they need and delegate to a
+    private ``_validate_<field>`` method that holds the shared logic and raises
+    the error class given to it (``forms.ValidationError`` or
+    ``serializers.ValidationError``).
+    """
+
+    def _validate_language(self, language, project, error_class):
+        """Ensure the language isn't already used by a translation of the project."""
+        if not project:
+            return language
+
+        msg = _('There is already a "{lang}" translation for the {proj} project.')
+        if project.translations.filter(language=language).exists():
+            raise error_class(msg.format(lang=language, proj=project.slug))
+
+        main_project = project.main_language_project
+        if main_project:
+            if main_project.language == language:
+                raise error_class(msg.format(lang=language, proj=main_project.slug))
+            siblings = (
+                main_project.translations.filter(language=language)
+                .exclude(pk=project.pk)
+                .exists()
+            )
+            if siblings:
+                raise error_class(msg.format(lang=language, proj=main_project.slug))
+        return language
+
+    def clean_language(self):
+        return self._validate_language(
+            self.cleaned_data["language"],
+            project=self.instance,
+            error_class=forms.ValidationError,
+        )
+
+    def validate_language(self, language):
+        return self._validate_language(
+            language,
+            project=self.instance,
+            error_class=serializers.ValidationError,
+        )
+
+    def _validate_tags(self, tags, error_class):
+        for tag in tags:
+            if len(tag) > 100:
+                raise error_class(
+                    _("Length of each tag must be less than or equal to 100 characters."),
+                )
+        return tags
+
+    def clean_tags(self):
+        return self._validate_tags(
+            self.cleaned_data.get("tags", []),
+            error_class=forms.ValidationError,
+        )
+
+    def validate_tags(self, tags):
+        return self._validate_tags(tags, error_class=serializers.ValidationError)
+
+
+class EnvironmentVariableValidator:
+    """
+    Shared validation for ``EnvironmentVariable`` names.
+
+    See :py:class:`ProjectValidator` for the ``clean_*``/``validate_*``/
+    ``_validate_*`` pattern used here.
+    """
+
+    def _validate_name(self, name, project, error_class):
+        """Validate environment variable name chosen."""
+        if name.startswith("__"):
+            raise error_class(
+                _("Variable name can't start with __ (double underscore)"),
+            )
+        if name.startswith("READTHEDOCS"):
+            raise error_class(
+                _("Variable name can't start with READTHEDOCS"),
+            )
+        if project and project.environmentvariable_set.filter(name=name).exists():
+            raise error_class(
+                _("There is already a variable with this name for this project"),
+            )
+        if " " in name:
+            raise error_class(
+                _("Variable name can't contain spaces"),
+            )
+        if not re.fullmatch("[a-zA-Z0-9_]+", name):
+            raise error_class(
+                _("Only letters, numbers and underscore are allowed"),
+            )
+        return name
+
+    def clean_name(self):
+        return self._validate_name(
+            self.cleaned_data["name"],
+            project=self.project,
+            error_class=forms.ValidationError,
+        )
+
+    def validate_name(self, name):
+        if self.instance:
+            project = self.instance.project
+        else:
+            view = self.context.get("view")
+            project = view._get_parent_project() if view else None
+        return self._validate_name(
+            name,
+            project=project,
+            error_class=serializers.ValidationError,
         )


### PR DESCRIPTION
This PR extracts validation logic from forms and serializers into reusable validator classes that can be shared between both interfaces. This follows the DRY principle and ensures consistent validation rules across the API and web forms.

## Summary

Validation logic for `Project`, `EnvironmentVariable`, and `Version` models is now centralized in dedicated validator classes that provide a clean pattern for sharing validation between Django forms and DRF serializers.

## Key Changes

- **New validator classes** in `readthedocs/projects/validators.py`:
  - `ProjectValidator`: Handles `language` and `tags` field validation
  - `EnvironmentVariableValidator`: Handles `name` field validation

- **New validator class** in `readthedocs/builds/validators.py`:
  - `VersionValidator`: Handles `active` field validation

- **Validation pattern**: Each validator uses a `_validate_<field>` private method that accepts an error class parameter, allowing the same logic to raise either `forms.ValidationError` or `serializers.ValidationError`. Public `clean_<field>` and `validate_<field>` methods delegate to the private method.

- **Updated forms** to inherit from validator classes:
  - `UpdateProjectForm` now inherits from `ProjectValidator`
  - `EnvironmentVariableForm` now inherits from `EnvironmentVariableValidator`
  - `VersionForm` now inherits from `VersionValidator`

- **Updated serializers** to inherit from validator classes:
  - `VersionUpdateSerializer` now inherits from `VersionValidator`
  - `ProjectUpdateSerializer` now inherits from `ProjectValidator`
  - `EnvironmentVariableSerializer` now inherits from `EnvironmentVariableValidator`

- **Removed duplicate validation code** from forms and serializers that is now handled by the validator classes

- **Added test coverage** for API validation:
  - Tests for invalid environment variable names via API
  - Tests for duplicate environment variable names via API
  - Tests for invalid project language via API
  - Tests for invalid project tags via API
  - Tests for deactivating default version via API

---
*Generated by AI agent*

https://claude.ai/code/session_01BNBHYtAsqTRF82Z9bmgG1j