### PR TITLE
Builds: Use VersionData dataclass for tags and branches data

### DIFF
--- a/readthedocs/api/v2/dataclasses.py
+++ b/readthedocs/api/v2/dataclasses.py
@@ -1,0 +1,15 @@
+"""Dataclasses used by the API v2 utils."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class VersionData:
+    """Represents version data from a repository (tag or branch).
+
+    :param verbose_name: Human-readable name of the version (e.g. "v1.0.0").
+    :param identifier: Git commit identifier (e.g. SHA hash) for the version.
+    """
+
+    verbose_name: str
+    identifier: str

--- a/readthedocs/api/v2/utils.py
+++ b/readthedocs/api/v2/utils.py
@@ -7,6 +7,7 @@ import structlog
 from django.conf import settings
 from rest_framework.pagination import PageNumberPagination
 
+from readthedocs.api.v2.dataclasses import VersionData
 from readthedocs.builds.constants import BRANCH
 from readthedocs.builds.constants import INTERNAL
 from readthedocs.builds.constants import LATEST
@@ -33,7 +34,7 @@ def sync_versions_to_db(project, versions, type):
     - it does not delete versions
 
     :param project: project to update versions
-    :param versions: list of VCSVersion fetched from the repository
+    :param versions: list of VersionData fetched from the repository
     :param type: internal or external version
     :returns: set of versions' slug added
     """
@@ -49,8 +50,8 @@ def sync_versions_to_db(project, versions, type):
     has_user_stable = False
     has_user_latest = False
     for version in versions:
-        version_id = version["identifier"]
-        version_name = version["verbose_name"]
+        version_id = version.identifier
+        version_name = version.verbose_name
         if version_name == STABLE_VERBOSE_NAME:
             has_user_stable = True
             created_version, created = _set_or_create_version(
@@ -171,8 +172,8 @@ def _set_or_create_version(project, slug, version_id, verbose_name, type_):
 def _get_deleted_versions_qs(project, tags_data, branches_data):
     # We use verbose_name for tags
     # because several tags can point to the same identifier.
-    versions_tags = [version["verbose_name"] for version in tags_data]
-    versions_branches = [version["identifier"] for version in branches_data]
+    versions_tags = [version.verbose_name for version in tags_data]
+    versions_branches = [version.identifier for version in branches_data]
 
     to_delete_qs = (
         project.versions(manager=INTERNAL)

--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -11,6 +11,7 @@ from oauthlib.oauth2.rfc6749.errors import InvalidGrantError
 from oauthlib.oauth2.rfc6749.errors import TokenExpiredError
 
 from readthedocs import __version__
+from readthedocs.api.v2.dataclasses import VersionData
 from readthedocs.api.v2.utils import delete_versions_from_db
 from readthedocs.api.v2.utils import get_deleted_active_versions
 from readthedocs.api.v2.utils import run_version_automation_rules
@@ -150,27 +151,29 @@ def sync_versions_task(project_pk, tags_data, branches_data, **kwargs):
         added_versions = set()
         result = sync_versions_to_db(
             project=project,
-            versions=tags_data,
+            versions=[VersionData(**v) for v in tags_data],
             type=TAG,
         )
         added_versions.update(result)
 
         result = sync_versions_to_db(
             project=project,
-            versions=branches_data,
+            versions=[VersionData(**v) for v in branches_data],
             type=BRANCH,
         )
         added_versions.update(result)
 
+        tags = [VersionData(**v) for v in tags_data]
+        branches = [VersionData(**v) for v in branches_data]
         delete_versions_from_db(
             project=project,
-            tags_data=tags_data,
-            branches_data=branches_data,
+            tags_data=tags,
+            branches_data=branches,
         )
         deleted_active_versions = get_deleted_active_versions(
             project=project,
-            tags_data=tags_data,
-            branches_data=branches_data,
+            tags_data=tags,
+            branches_data=branches,
         )
     except Exception:
         log.exception("Sync Versions Error")


### PR DESCRIPTION
This PR introduces a `VersionData` dataclass to replace raw dictionaries when passing tag and branch version data through the sync-version pipeline.

## Context

Previously, `sync_versions_to_db()`, `_get_deleted_versions_qs()`, `delete_versions_from_db()`, and `get_deleted_active_versions()` received version data as `List[Dict[str, str]]` with `verbose_name` and `identifier` keys. This was error-prone — a missing or misspelled key would fail at runtime.

The new `VersionData` dataclass (`readthedocs/api/v2/dataclasses.py`) provides:
- Type-safe access (`version.verbose_name`, `version.identifier`)
- Self-documenting fields
- Backward-compatible: Celery task parameters remain JSON-serializable dicts, converted at the call site

## Changes

- **New file:** `readthedocs/api/v2/dataclasses.py` — `VersionData` dataclass
- **Modified:** `readthedocs/api/v2/utils.py` — function signatures and internal access updated to use `VersionData`
- **Modified:** `readthedocs/builds/tasks.py` — converts Celery dict params to `VersionData` before passing to utils

Fixes #7798

---

*This PR was generated by an AI agent (墨渊Flux) on behalf of @kekewater.*