### PR TITLE
Builds: remove Ubuntu 20.04 from the list of supported versions

### DIFF
--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -216,7 +216,7 @@ save some work while typing docker compose commands. This section explains these
 ``inv docker.pull``
     Downloads and tags all the Docker images required for builders.
 
-    * ``--only-required`` pulls only the image ``ubuntu-20.04``.
+    * ``--only-required`` pulls only the image ``ubuntu-24.04``.
 
 ``inv docker.buildassets``
     Build all the assets and "deploy" them to the storage.

--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -232,7 +232,7 @@ To avoid this, it's possible to unshallow the :program:`git clone`:
 
    version: 2
    build:
-     os: "ubuntu-20.04"
+     os: "ubuntu-24.04"
      tools:
        python: "3.10"
      jobs:
@@ -246,7 +246,7 @@ If your build also relies on the contents of other branches, it may also be nece
 
    version: 2
    build:
-     os: "ubuntu-20.04"
+     os: "ubuntu-24.04"
      tools:
        python: "3.10"
      jobs:
@@ -266,7 +266,7 @@ It's possible to run Doxygen as part of the build process to generate documentat
 
    version: 2
    build:
-     os: "ubuntu-20.04"
+     os: "ubuntu-24.04"
      tools:
        python: "3.10"
      jobs:
@@ -289,7 +289,7 @@ For example, `pydoc-markdown <http://niklasrosenstein.github.io/pydoc-markdown/>
    mkdocs:
      configuration: mkdocs.yml
    build:
-     os: "ubuntu-20.04"
+     os: "ubuntu-24.04"
      tools:
        python: "3.10"
      jobs:
@@ -311,7 +311,7 @@ In that case, the Git index can be updated to ignore the files that Read the Doc
 
    version: 2
    build:
-     os: "ubuntu-20.04"
+     os: "ubuntu-24.04"
      tools:
        python: "3.10"
      jobs:
@@ -331,7 +331,7 @@ This helps ensure that all external links are still valid and readers aren't lin
 
    version: 2
    build:
-     os: "ubuntu-20.04"
+     os: "ubuntu-24.04"
      tools:
        python: "3.10"
      jobs:
@@ -351,7 +351,7 @@ It's possible to use ``post_checkout`` user-defined job for this.
 
    version: 2
    build:
-     os: "ubuntu-20.04"
+     os: "ubuntu-24.04"
      tools:
        python: "3.10"
      jobs:

--- a/docs/user/config-file/v2.rst
+++ b/docs/user/config-file/v2.rst
@@ -364,7 +364,7 @@ Image names refer to the operating system Read the Docs uses to build them.
    Arbitrary Docker images are not supported.
 
 :Type: ``string``
-:Options: ``ubuntu-20.04`` (deprecated), ``ubuntu-22.04``, ``ubuntu-24.04``, ``ubuntu-26.04``, ``ubuntu-lts-latest``
+:Options: ``ubuntu-22.04``, ``ubuntu-24.04``, ``ubuntu-26.04``, ``ubuntu-lts-latest``
 :Required: ``true``
 
 .. note::

--- a/readthedocs/builds/constants_docker.py
+++ b/readthedocs/builds/constants_docker.py
@@ -23,7 +23,6 @@ DOCKER_DEFAULT_IMAGE = "readthedocs/build"
 RTD_DOCKER_BUILD_SETTINGS = {
     # Mapping of build.os options to docker image.
     "os": {
-        "ubuntu-20.04": f"{DOCKER_DEFAULT_IMAGE}:ubuntu-20.04",
         "ubuntu-22.04": f"{DOCKER_DEFAULT_IMAGE}:ubuntu-22.04",
         "ubuntu-24.04": f"{DOCKER_DEFAULT_IMAGE}:ubuntu-24.04",
         "ubuntu-26.04": f"{DOCKER_DEFAULT_IMAGE}:ubuntu-26.04",

--- a/readthedocs/builds/tests/test_buildconfig.py
+++ b/readthedocs/builds/tests/test_buildconfig.py
@@ -51,7 +51,7 @@ class TestBuildReadthedocsYamlData:
         """Test that builds with different configs create separate BuildConfigs."""
         project = fixture.get(Project)
         config_data1 = {"build": {"os": "ubuntu-22.04"}, "python": {"version": "3.11"}}
-        config_data2 = {"build": {"os": "ubuntu-20.04"}, "python": {"version": "3.10"}}
+        config_data2 = {"build": {"os": "ubuntu-24.04"}, "python": {"version": "3.10"}}
 
         # Create first build
         build1 = fixture.get(Build, project=project)

--- a/readthedocs/builds/tests/test_tasks.py
+++ b/readthedocs/builds/tests/test_tasks.py
@@ -209,7 +209,7 @@ class TestTasks(TestCase):
         version = project.versions.get(slug=LATEST)
 
         # Create BuildConfig objects
-        config_with_build = get(BuildConfig, data={"version": 2, "build": {"os": "ubuntu-20.04"}})
+        config_with_build = get(BuildConfig, data={"version": 2, "build": {"os": "ubuntu-24.04"}})
         orphan_config_1 = get(BuildConfig, data={"version": 2, "build": {"os": "ubuntu-22.04"}})
         orphan_config_2 = get(BuildConfig, data={"version": 2, "build": {"os": "ubuntu-24.04"}})
 
@@ -245,7 +245,7 @@ class TestTasks(TestCase):
         version = project.versions.get(slug=LATEST)
 
         # Create BuildConfig objects
-        config_1 = get(BuildConfig, data={"version": 2, "build": {"os": "ubuntu-20.04"}})
+        config_1 = get(BuildConfig, data={"version": 2, "build": {"os": "ubuntu-24.04"}})
         config_2 = get(BuildConfig, data={"version": 2, "build": {"os": "ubuntu-22.04"}})
 
         # Create Builds and manually assign the BuildConfig objects

--- a/readthedocs/config/tests/test_config.py
+++ b/readthedocs/config/tests/test_config.py
@@ -447,7 +447,7 @@ class TestBuildConfigV2:
         build = get_build_config(
             {
                 "build": {
-                    "os": "ubuntu-20.04",
+                    "os": "ubuntu-24.04",
                     "tools": value,
                 },
             },
@@ -468,7 +468,7 @@ class TestBuildConfigV2:
         build = get_build_config(
             {
                 "build": {
-                    "os": "ubuntu-20.04",
+                    "os": "ubuntu-24.04",
                     "tools": {"python": "2.6"},
                 },
             },
@@ -485,14 +485,14 @@ class TestBuildConfigV2:
         build = get_build_config(
             {
                 "build": {
-                    "os": "ubuntu-20.04",
+                    "os": "ubuntu-24.04",
                     "tools": {"python": "3.9"},
                 },
             },
         )
         build.validate()
         assert isinstance(build.build, BuildWithOs)
-        assert build.build.os == "ubuntu-20.04"
+        assert build.build.os == "ubuntu-24.04"
         assert build.build.tools["python"].version == "3.9"
         full_version = settings.RTD_DOCKER_BUILD_SETTINGS["tools"]["python"]["3.9"]
         assert build.build.tools["python"].full_version == full_version
@@ -503,7 +503,7 @@ class TestBuildConfigV2:
             {
                 "build": {
                     "image": "latest",
-                    "os": "ubuntu-20.04",
+                    "os": "ubuntu-24.04",
                     "tools": {"python": "3.9"},
                 },
             },
@@ -517,7 +517,7 @@ class TestBuildConfigV2:
         build = get_build_config(
             {
                 "build": {
-                    "os": "ubuntu-20.04",
+                    "os": "ubuntu-24.04",
                     "tools": {"python": "3.8"},
                 },
                 "python": {"version": "3.8"},
@@ -535,7 +535,7 @@ class TestBuildConfigV2:
         build = get_build_config(
             {
                 "build": {
-                    "os": "ubuntu-20.04",
+                    "os": "ubuntu-24.04",
                     "tools": {"python": "3.8"},
                     "commands": ["pip install pelican", "pelican content"],
                 },
@@ -568,7 +568,7 @@ class TestBuildConfigV2:
         build = get_build_config(
             {
                 "build": {
-                    "os": "ubuntu-20.04",
+                    "os": "ubuntu-24.04",
                     "tools": {"python": "3.8"},
                     "commands": "command as string",
                 },
@@ -613,7 +613,7 @@ class TestBuildConfigV2:
         build = get_build_config(
             {
                 "build": {
-                    "os": "ubuntu-20.04",
+                    "os": "ubuntu-24.04",
                     "tools": {"python": "3.8"},
                     "jobs": {value: ["echo 1234", "git fetch --unshallow"]},
                 },
@@ -629,7 +629,7 @@ class TestBuildConfigV2:
         build = get_build_config(
             {
                 "build": {
-                    "os": "ubuntu-20.04",
+                    "os": "ubuntu-24.04",
                     "tools": {"python": "3.8"},
                     "jobs": {
                         "pre_install": value,
@@ -646,7 +646,7 @@ class TestBuildConfigV2:
         build = get_build_config(
             {
                 "build": {
-                    "os": "ubuntu-20.04",
+                    "os": "ubuntu-24.04",
                     "tools": {"python": "3.8"},
                     "jobs": {
                         "pre_checkout": ["echo pre_checkout"],
@@ -699,7 +699,7 @@ class TestBuildConfigV2:
             {
                 "formats": ["pdf", "htmlzip", "epub"],
                 "build": {
-                    "os": "ubuntu-20.04",
+                    "os": "ubuntu-24.04",
                     "tools": {"python": "3"},
                     "jobs": {
                         "create_environment": ["echo make_environment"],
@@ -2002,7 +2002,7 @@ class TestBuildConfigV2:
                 "version": 2,
                 "formats": ["pdf"],
                 "build": {
-                    "os": "ubuntu-20.04",
+                    "os": "ubuntu-24.04",
                     "tools": {
                         "python": "3.9",
                         "nodejs": "16",
@@ -2030,7 +2030,7 @@ class TestBuildConfigV2:
                 ],
             },
             "build": {
-                "os": "ubuntu-20.04",
+                "os": "ubuntu-24.04",
                 "tools": {
                     "python": {
                         "version": "3.9",

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -638,9 +638,9 @@ class DockerBuildEnvironment(BaseBuildEnvironment):
         # Override the ``container_image`` if we pass it via argument.
         #
         # FIXME: This is a temporal fix while we explore how to make
-        # ``ubuntu-20.04`` the default build image without breaking lot of
+        # ``ubuntu-22.04`` the default build image without breaking lot of
         # builds. For now, we are passing
-        # ``container_image='readthedocs/build:ubuntu-20.04'`` for the setup
+        # ``container_image='readthedocs/build:ubuntu-22.04'`` for the setup
         # VCS step.
         if container_image:
             self.container_image = container_image

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -1750,7 +1750,7 @@ class TestBuildTask(BuildEnvironmentBase):
             {
                 "version": 2,
                 "build": {
-                    "os": "ubuntu-20.04",
+                    "os": "ubuntu-24.04",
                     "tools": {
                         "python": "3.10",
                         "nodejs": "16",
@@ -1802,7 +1802,7 @@ class TestBuildTask(BuildEnvironmentBase):
             {
                 "version": 2,
                 "build": {
-                    "os": "ubuntu-20.04",
+                    "os": "ubuntu-24.04",
                     "tools": {"python": "3.7"},
                     "jobs": {
                         "post_checkout": ["git fetch --unshallow"],
@@ -2175,7 +2175,7 @@ class TestBuildTask(BuildEnvironmentBase):
             {
                 "version": 2,
                 "build": {
-                    "os": "ubuntu-20.04",
+                    "os": "ubuntu-24.04",
                     "tools": {
                         "python": "3.10",
                         "nodejs": "16",
@@ -2488,7 +2488,7 @@ class TestBuildTask(BuildEnvironmentBase):
             {
                 "version": 2,
                 "build": {
-                    "os": "ubuntu-20.04",
+                    "os": "ubuntu-24.04",
                     "tools": {
                         "python": "mambaforge-4.10",
                     },

--- a/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
+++ b/readthedocs/rtd_tests/fixtures/spec/v2/schema.json
@@ -49,7 +49,6 @@
           "title": "Operating System",
           "description": "Operating system to be used in the build.",
           "enum": [
-            "ubuntu-20.04",
             "ubuntu-22.04",
             "ubuntu-24.04",
             "ubuntu-26.04",


### PR DESCRIPTION
https://about.readthedocs.com/blog/2026/03/ubuntu-20-04-deprecated/

<img width="1178" height="668" alt="Screenshot_2026-06-09_17-54-48" src="https://github.com/user-attachments/assets/5ff48ef6-8106-46d4-99ce-d792464dbac8" />


Closes https://github.com/readthedocs/readthedocs-ops/issues/1786