### PR TITLE
llms.txt: allow serving from private version

### DIFF
--- a/docs/user/reference/llms-txt.rst
+++ b/docs/user/reference/llms-txt.rst
@@ -31,10 +31,12 @@ To use this feature:
 
    The ``llms.txt`` file will only be served if:
 
-   * Your default version is **public**
    * Your default version is **active**
    * Your default version has been **built**
    * The ``llms.txt`` file exists in your build output
+
+   If your default version is **private**,
+   the ``llms.txt`` file is served only to users that have access to that version.
 
 Tool integration
 ----------------

--- a/docs/user/reference/llms-txt.rst
+++ b/docs/user/reference/llms-txt.rst
@@ -35,9 +35,6 @@ To use this feature:
    * Your default version has been **built**
    * The ``llms.txt`` file exists in your build output
 
-   If your default version is **private**,
-   the ``llms.txt`` file is served only to users that have access to that version.
-
 Tool integration
 ----------------
 

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -27,6 +27,7 @@ from readthedocs.projects.constants import (
     SPHINX_SINGLEHTML,
 )
 from readthedocs.projects.models import Domain, Feature, HTMLFile, Project
+from readthedocs.proxito.views.serve import ServeLLMSTXTBase
 from readthedocs.redirects.models import Redirect
 from readthedocs.rtd_tests.storage import (
     BuildMediaFileSystemStorageTest,
@@ -1048,6 +1049,7 @@ class TestAdditionalDocViews(BaseDocServing):
             response["x-accel-redirect"],
             "/proxito/media/html/project/latest/llms.txt",
         )
+        self.assertEqual(response["CDN-Cache-Control"], "public")
 
     def test_custom_llms_full_txt(self):
         """Test serving a custom llms-full.txt file from the default version."""
@@ -1078,11 +1080,29 @@ class TestAdditionalDocViews(BaseDocServing):
         )
         self.assertEqual(response.status_code, 404)
 
+    @override_settings(ALLOW_PRIVATE_REPOS=True)
     def test_llms_txt_private_version(self):
-        """Test that 404 is returned when default version is private."""
+        """Test that llms.txt from a private version is served, but not cached."""
         self.project.versions.update(active=True, built=True, privacy_level=constants.PRIVATE)
         response = self.client.get(reverse("llms_txt"), headers={"host": "project.readthedocs.io"})
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response["x-accel-redirect"],
+            "/proxito/media/html/project/latest/llms.txt",
+        )
+        self.assertEqual(response["CDN-Cache-Control"], "private")
+
+    @override_settings(ALLOW_PRIVATE_REPOS=True)
+    @mock.patch.object(ServeLLMSTXTBase, "get_unauthed_response", create=True)
+    @mock.patch.object(ServeLLMSTXTBase, "allowed_user")
+    def test_llms_txt_private_version_unauthorized_user(self, allowed_user, get_unauthed_response):
+        """Test that users without access to the private version get an unauthorized response."""
+        allowed_user.return_value = False
+        get_unauthed_response.return_value = HttpResponse(status=401)
+        self.project.versions.update(active=True, built=True, privacy_level=constants.PRIVATE)
+        response = self.client.get(reverse("llms_txt"), headers={"host": "project.readthedocs.io"})
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response["CDN-Cache-Control"], "private")
 
     def test_llms_txt_inactive_version(self):
         """Test that 404 is returned when default version is inactive."""

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -1085,24 +1085,19 @@ class TestAdditionalDocViews(BaseDocServing):
         """Test that llms.txt from a private version is served, but not cached."""
         self.project.versions.update(active=True, built=True, privacy_level=constants.PRIVATE)
         response = self.client.get(reverse("llms_txt"), headers={"host": "project.readthedocs.io"})
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response["x-accel-redirect"],
-            "/proxito/media/html/project/latest/llms.txt",
-        )
-        self.assertEqual(response["CDN-Cache-Control"], "private")
+        assert response.status_code == 200
+        assert response["x-accel-redirect"] == "/proxito/media/html/project/latest/llms.txt"
+        assert response["CDN-Cache-Control"], "private"
 
     @override_settings(ALLOW_PRIVATE_REPOS=True)
-    @mock.patch.object(ServeLLMSTXTBase, "get_unauthed_response", create=True)
     @mock.patch.object(ServeLLMSTXTBase, "allowed_user")
-    def test_llms_txt_private_version_unauthorized_user(self, allowed_user, get_unauthed_response):
+    def test_llms_txt_private_version_unauthorized_user(self, allowed_user):
         """Test that users without access to the private version get an unauthorized response."""
         allowed_user.return_value = False
-        get_unauthed_response.return_value = HttpResponse(status=401)
         self.project.versions.update(active=True, built=True, privacy_level=constants.PRIVATE)
         response = self.client.get(reverse("llms_txt"), headers={"host": "project.readthedocs.io"})
-        self.assertEqual(response.status_code, 401)
-        self.assertEqual(response["CDN-Cache-Control"], "private")
+        assert response.status_code == 401
+        assert response["CDN-Cache-Control"] == "private"
 
     def test_llms_txt_inactive_version(self):
         """Test that 404 is returned when default version is inactive."""

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -1084,7 +1084,7 @@ class TestAdditionalDocViews(BaseDocServing):
         response = self.client.get(reverse("llms_txt"), headers={"host": "project.readthedocs.io"})
         assert response.status_code == 200
         assert response["x-accel-redirect"] == "/proxito/media/html/project/latest/llms.txt"
-        assert response["CDN-Cache-Control"], "private"
+        assert response["CDN-Cache-Control"] == "private"
 
     @override_settings(ALLOW_PRIVATE_REPOS=True)
     @mock.patch.object(ServeLLMSTXTBase, "allowed_user")

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -1045,11 +1045,8 @@ class TestAdditionalDocViews(BaseDocServing):
         """Test serving a custom llms.txt file from the default version."""
         self.project.versions.update(active=True, built=True)
         response = self.client.get(reverse("llms_txt"), headers={"host": "project.readthedocs.io"})
-        self.assertEqual(
-            response["x-accel-redirect"],
-            "/proxito/media/html/project/latest/llms.txt",
-        )
-        self.assertEqual(response["CDN-Cache-Control"], "public")
+        assert response["x-accel-redirect"] == "/proxito/media/html/project/latest/llms.txt"
+        assert response["CDN-Cache-Control"] == "public"
 
     def test_custom_llms_full_txt(self):
         """Test serving a custom llms-full.txt file from the default version."""

--- a/readthedocs/proxito/views/mixins.py
+++ b/readthedocs/proxito/views/mixins.py
@@ -252,6 +252,9 @@ class ServeDocsMixin:
             if is_serve_docs_denied(project):
                 return render(request, template_name="errors/proxito/spam.html", status=410)
 
+    def get_unauthed_response(self, request, project):
+        return self._serve_401(request, project)
+
 
 class ServeRedirectMixin:
     def system_redirect(

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -721,11 +721,9 @@ class ServeRobotsTXT(SettingsOverrideObject):
     _default_class = ServeRobotsTXTBase
 
 
-class ServeLLMSTXT(CDNCacheControlMixin, CDNCacheTagsMixin, ServeDocsMixin, View):
+class ServeLLMSTXTBase(CDNCacheControlMixin, CDNCacheTagsMixin, ServeDocsMixin, View):
     """Serve llms.txt files from the domain's root."""
 
-    # Always cache this view, since it's the same for all users.
-    cache_response = True
     # Extra cache tag to invalidate only this view if needed.
     project_cache_tag = "llms.txt"
 
@@ -734,7 +732,8 @@ class ServeLLMSTXT(CDNCacheControlMixin, CDNCacheTagsMixin, ServeDocsMixin, View
         Serve custom user's defined ``/llms.txt`` or ``/llms-full.txt``.
 
         If the user added one of these files in the "default version" of the
-        project, we serve it directly.
+        project, we serve it directly. Private versions are served only to
+        users that have access to them.
         """
         project = request.unresolved_domain.project
         self.project_cache_tag = filename
@@ -746,9 +745,7 @@ class ServeLLMSTXT(CDNCacheControlMixin, CDNCacheTagsMixin, ServeDocsMixin, View
 
         no_serve_llms_txt = any(
             [
-                # If the default version is private or,
-                version.is_private,
-                # default version is not active or,
+                # If the default version is not active or,
                 not version.active,
                 # default version is not built
                 not version.built,
@@ -759,10 +756,18 @@ class ServeLLMSTXT(CDNCacheControlMixin, CDNCacheTagsMixin, ServeDocsMixin, View
             # ... we do return a 404
             raise Http404()
 
+        # Only public versions can be cached,
+        # since private versions check for authorization.
+        self.cache_response = version.is_public
+
         structlog.contextvars.bind_contextvars(
             project_slug=project.slug,
             version_slug=version.slug,
         )
+
+        # Check user permissions and return an unauthed response if needed.
+        if not self.allowed_user(request, version):
+            return self.get_unauthed_response(request, project)
 
         try:
             response = self._serve_docs(
@@ -791,6 +796,10 @@ class ServeLLMSTXT(CDNCacheControlMixin, CDNCacheTagsMixin, ServeDocsMixin, View
         project = self._get_project()
         version_slug = project.get_default_version()
         return project.versions.filter(slug=version_slug).first()
+
+
+class ServeLLMSTXT(SettingsOverrideObject):
+    _default_class = ServeLLMSTXTBase
 
 
 class ServeSitemapXMLBase(CDNCacheControlMixin, CDNCacheTagsMixin, ServeDocsMixin, View):

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -732,8 +732,7 @@ class ServeLLMSTXTBase(CDNCacheControlMixin, CDNCacheTagsMixin, ServeDocsMixin, 
         Serve custom user's defined ``/llms.txt`` or ``/llms-full.txt``.
 
         If the user added one of these files in the "default version" of the
-        project, we serve it directly. Private versions are served only to
-        users that have access to them.
+        project, we serve it directly.
         """
         project = request.unresolved_domain.project
         self.project_cache_tag = filename
@@ -743,17 +742,9 @@ class ServeLLMSTXTBase(CDNCacheControlMixin, CDNCacheTagsMixin, ServeDocsMixin, 
         version = get_object_or_404(project.versions, slug=version_slug)
         self._llms_version = version
 
-        no_serve_llms_txt = any(
-            [
-                # If the default version is not active or,
-                not version.active,
-                # default version is not built
-                not version.built,
-            ]
-        )
-
-        if no_serve_llms_txt:
-            # ... we do return a 404
+        # Serve only for active and built versions.
+        serve_llms_txt = version.active and version.built
+        if not serve_llms_txt:
             raise Http404()
 
         # Only public versions can be cached,


### PR DESCRIPTION
ref https://github.com/readthedocs/readthedocs.org/issues/13085. I want to refactor this in a next PR, so we share the logic for serving a file from the default version with robots.txt, and sitemap.