### PR TITLE
Revise robots.txt with guidelines and more disallowed crawling

### DIFF
--- a/media/robots.txt
+++ b/media/robots.txt
@@ -1,8 +1,16 @@
+# Guidelines for automated access and crawling Read the Docs: https://docs.readthedocs.com/platform/stable/automated-access.html
+#
+# Bots should not be scraping from the Read the Docs maintainer dashboard in bulk.
+# Automated access to documentation sites is allowed in accordance with the policies above.
+# For everything else, use our API: https://docs.readthedocs.com/platform/stable/api/index.html 
+
 User-agent: *
-Disallow: /search/
+Disallow: /accounts/
 Disallow: /api/
-Disallow: /builds/
-Disallow: /sustainability/click/
+Disallow: /profiles/
+Disallow: /projects/*/builds/
+Disallow: /projects/tags/
+Disallow: /search/
 
 # This was hitting our site and causing a lot of issues
 User-agent: AhrefsBot

--- a/media/robots.txt
+++ b/media/robots.txt
@@ -2,7 +2,7 @@
 #
 # Bots should not be scraping from the Read the Docs maintainer dashboard in bulk.
 # Automated access to documentation sites is allowed in accordance with the policies above.
-# For everything else, use our API: https://docs.readthedocs.com/platform/stable/api/index.html 
+# For everything else, use our API: https://docs.readthedocs.com/platform/stable/api/index.html
 
 User-agent: *
 Disallow: /accounts/


### PR DESCRIPTION
This is for the dashboard's robots.txt not docs sites so it's different from #13116. This will update https://app.readthedocs.org/robots.txt (and eventually https://app.readthedocs.com/robots.txt which currently 404s).

I want to start a discussion around what should be indexed by crawlers on the dashboard and what is meant for exclusively human consumption. We might reduce our spam signups if the payoff for doing so (profile pages) are reduced.

## Changes

- Link to the scraping/crawler guidelines
- Instruct search engines **NOT** to index the following:
  * Profile pages - spammers are interested in this (eg. https://app.readthedocs.org/profiles/davidfischer/)
  * Tags overview and tags detail pages (eg. https://app.readthedocs.org/projects/tags/sphinx-doc/)
  * Project build list and build detail pages (eg. https://app.readthedocs.org/projects/docs/builds/ and https://app.readthedocs.org/projects/docs/builds/33090900/). The project detail page **will still be indexed** as will project badges.
  * Anything related to accounts like the login/signup pages. These may be OK and could possibly be removed from the robots.txt, GETs are probably OK here.

There's probably some SEO value from tags and build pages, but I can't imagine much. [GitHub for example](https://github.com/robots.txt), largely lets indexes index project details and the actual code, but many things are restricted.

## Didn't change
- We can almost certainly remove AhrefsBot from here if we dial in our other rate limiting rules.