### PR TITLE
Core: Cache /welcome/ redirect for non-logged-in users

### DIFF
--- a/readthedocs/core/tests/test_homepage.py
+++ b/readthedocs/core/tests/test_homepage.py
@@ -38,6 +38,7 @@ class HomepageTest(TestCase):
             reverse("welcome"),
         )
         assert response.headers.get("Location") == reverse("projects_dashboard")
+        assert response["CDN-Cache-Control"] == "private"
 
     @override_settings(PRODUCTION_DOMAIN="readthedocs.org")
     def test_welcome_unauth(self):
@@ -46,3 +47,4 @@ class HomepageTest(TestCase):
             reverse("welcome"),
         )
         assert response.headers.get("Location") == "https://about.readthedocs.com/?ref=readthedocs.org"
+        assert response["CDN-Cache-Control"] == "public"

--- a/readthedocs/core/views/__init__.py
+++ b/readthedocs/core/views/__init__.py
@@ -48,7 +48,7 @@ class HomepageView(View):
         return redirect(reverse("account_login"))
 
 
-class WelcomeView(View):
+class WelcomeView(CDNCacheControlMixin, View):
     """
     Conditionally redirect to website home page or to dashboard.
 
@@ -62,6 +62,9 @@ class WelcomeView(View):
       1. when user is logged in, redirect to dashboard
       2. when user is logged off, redirect to login page
     """
+
+    def can_be_cached(self, request):
+        return not request.user.is_authenticated
 
     def get(self, request, *args, **kwargs):
         # Redirect to user dashboard for logged in users


### PR DESCRIPTION
The `/welcome/` endpoint gets hit by every unauthenticated visitor arriving at readthedocs.org or readthedocs.com. Currently every request goes all the way to the application server, even though the response is always the same 302 redirect to `about.readthedocs.com`.

This adds `CDNCacheControlMixin` to `WelcomeView` with a `can_be_cached()` override that returns `True` for anonymous users and `False` for authenticated ones. The CDN can now serve the redirect directly for unauthenticated traffic, which is the vast majority of hits on this endpoint.

---

*Generated by Claude Code*

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWRcgLe3EVxXTRd593FHL1)_