### PR TITLE
Docs: fix contributing documentation links

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -1,1 +1,1 @@
-Please review our contributing documentation located at https://docs.readthedocs.io/en/latest/contribute.html
+Please review our contributing documentation located at https://docs.readthedocs.com/dev/latest/contribute.html

--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -10,7 +10,7 @@ responseRequiredLabel: 'Needed: more information'
 # Comment to post when closing an Issue for lack of response. Set to `false` to disable
 closeComment: >
   This issue has been automatically closed because
-  [there has been no response to our request for more information](https://docs.readthedocs.io/en/latest/contribute.html#initial-triage)
+  [there has been no response to our request for more information](https://docs.readthedocs.com/dev/latest/contribute.html#initial-triage)
   from the original author. With only the information that is currently in the issue,
   we don't have enough information to take action.
   Please reach out if you have or find the answers we need so that we can investigate further.


### PR DESCRIPTION
## Summary
- update `.github/CONTRIBUTING.rst` to point at the current Read the Docs contributor documentation
- update `.github/no-response.yml` to use the same current contributor docs URL while preserving the `#initial-triage` anchor

Closes #13110

## Tests
- `curl -L -s -o /tmp/rtd-contribute-fixed.html -w "%{http_code} %{url_effective}\n" https://docs.readthedocs.com/dev/latest/contribute.html` returns `200 https://docs.readthedocs.com/dev/latest/contribute.html`
- `rg -n 'id="initial-triage"' /tmp/rtd-contribute-fixed.html`\n- `ruby -e 'require "yaml"; YAML.load_file(".github/no-response.yml"); puts "yaml ok"'`\n- `git diff --check`