### PR TITLE
Use django's content_disposition_header utility

### DIFF
--- a/readthedocs/projects/tests/test_views.py
+++ b/readthedocs/projects/tests/test_views.py
@@ -550,6 +550,7 @@ class TestTrafficAnalyticsView(TestCase):
         self.assertIn("/en/latest/index.html", paths)
         # filename should be for traffic analytics (200)
         content_disposition = resp["Content-Disposition"]
+        self.assertTrue(content_disposition.startswith("attachment; filename="))
         self.assertIn(f"readthedocs_traffic_analytics_{self.project.slug}_http200_", content_disposition)
 
     def test_download_traffic_404_csv(self):
@@ -572,6 +573,7 @@ class TestTrafficAnalyticsView(TestCase):
         self.assertIn("/en/latest/missing.html", paths)
         # filename should be for 404 analytics
         content_disposition = resp["Content-Disposition"]
+        self.assertTrue(content_disposition.startswith("attachment; filename="))
         self.assertIn(f"readthedocs_traffic_analytics_{self.project.slug}_http404_", content_disposition)
 
     def test_download_traffic_404_csv_excludes_200_pages(self):

--- a/readthedocs/projects/utils.py
+++ b/readthedocs/projects/utils.py
@@ -4,6 +4,7 @@ import csv
 
 import structlog
 from django.http import StreamingHttpResponse
+from django.utils.http import content_disposition_header
 
 
 log = structlog.get_logger(__name__)
@@ -30,5 +31,7 @@ def get_csv_file(filename, csv_data):
         (writer.writerow(row) for row in csv_data),
         content_type="text/csv",
     )
-    response["Content-Disposition"] = f'attachment; filename="{filename}"'
+    response["Content-Disposition"] = content_disposition_header(
+        as_attachment=True, filename=filename
+    )
     return response

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -556,7 +556,7 @@ class TestDocServingBackends(BaseDocServing):
             )
             self.assertEqual(resp["CDN-Cache-Control"], "public")
             self.assertTrue(
-                resp["Content-Disposition"].startswith("attachment; filename=")
+                resp["Content-Disposition"].startswith("inline; filename=")
             )
             self.assertTrue(
                 resp["Content-Disposition"].endswith(f'.{extension}"')

--- a/readthedocs/proxito/tests/test_full.py
+++ b/readthedocs/proxito/tests/test_full.py
@@ -555,6 +555,12 @@ class TestDocServingBackends(BaseDocServing):
                 f"/proxito/media/{type_}/project/latest/project.{extension}",
             )
             self.assertEqual(resp["CDN-Cache-Control"], "public")
+            self.assertTrue(
+                resp["Content-Disposition"].startswith("attachment; filename=")
+            )
+            self.assertTrue(
+                resp["Content-Disposition"].endswith(f'.{extension}"')
+            )
 
             # Translation
             resp = self.client.get(

--- a/readthedocs/proxito/views/mixins.py
+++ b/readthedocs/proxito/views/mixins.py
@@ -111,7 +111,7 @@ class ServeDocsMixin:
         else:
             filename = f"{domain}-{project.language}-{version.slug}.{filename_ext}"
         response["Content-Disposition"] = content_disposition_header(
-            as_attachment=True, filename=filename
+            as_attachment=False, filename=filename
         )
         return response
 

--- a/readthedocs/proxito/views/mixins.py
+++ b/readthedocs/proxito/views/mixins.py
@@ -11,6 +11,7 @@ from django.http import HttpResponsePermanentRedirect
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.utils.encoding import iri_to_uri
+from django.utils.http import content_disposition_header
 from django.views.static import serve
 from slugify import slugify as unicode_slugify
 
@@ -109,7 +110,9 @@ class ServeDocsMixin:
             filename = f"{domain}-{project.alias}-{project.language}-{version.slug}.{filename_ext}"
         else:
             filename = f"{domain}-{project.language}-{version.slug}.{filename_ext}"
-        response["Content-Disposition"] = f"filename={filename}"
+        response["Content-Disposition"] = content_disposition_header(
+            as_attachment=True, filename=filename
+        )
         return response
 
     def _serve_file(self, request, storage_path, storage_backend):

--- a/readthedocs/rtd_tests/tests/test_privacy.py
+++ b/readthedocs/rtd_tests/tests/test_privacy.py
@@ -238,7 +238,7 @@ class PrivacyTests(TestCase):
         )
         self.assertEqual(
             r.headers["content-disposition"],
-            'attachment; filename="django-kong-readthedocs-io-en-latest.pdf"',
+            'inline; filename="django-kong-readthedocs-io-en-latest.pdf"',
         )
 
         r = self.client.get("/projects/django-kong/downloads/epub/latest/")
@@ -249,7 +249,7 @@ class PrivacyTests(TestCase):
         )
         self.assertEqual(
             r.headers["content-disposition"],
-            'attachment; filename="django-kong-readthedocs-io-en-latest.epub"',
+            'inline; filename="django-kong-readthedocs-io-en-latest.epub"',
         )
 
         r = self.client.get("/projects/django-kong/downloads/htmlzip/latest/")
@@ -260,7 +260,7 @@ class PrivacyTests(TestCase):
         )
         self.assertEqual(
             r.headers["content-disposition"],
-            'attachment; filename="django-kong-readthedocs-io-en-latest.zip"',
+            'inline; filename="django-kong-readthedocs-io-en-latest.zip"',
         )
 
     # Public download tests
@@ -283,7 +283,7 @@ class PrivacyTests(TestCase):
         )
         self.assertEqual(
             r.headers["content-disposition"],
-            'attachment; filename="django-kong-readthedocs-io-en-latest.pdf"',
+            'inline; filename="django-kong-readthedocs-io-en-latest.pdf"',
         )
 
         # Auth'd user
@@ -298,7 +298,7 @@ class PrivacyTests(TestCase):
         )
         self.assertEqual(
             r.headers["content-disposition"],
-            'attachment; filename="django-kong-readthedocs-io-en-latest.pdf"',
+            'inline; filename="django-kong-readthedocs-io-en-latest.pdf"',
         )
 
     @override_settings(
@@ -327,7 +327,7 @@ class PrivacyTests(TestCase):
         )
         self.assertEqual(
             r.headers["content-disposition"],
-            'attachment; filename="django-kong-readthedocs-io-en-latest.pdf"',
+            'inline; filename="django-kong-readthedocs-io-en-latest.pdf"',
         )
 
     @override_settings(
@@ -346,7 +346,7 @@ class PrivacyTests(TestCase):
         )
         self.assertEqual(
             r.headers["content-disposition"],
-            'attachment; filename="django-kong-readthedocs-io-en-latest.pdf"',
+            'inline; filename="django-kong-readthedocs-io-en-latest.pdf"',
         )
 
         r = self.client.get("/projects/django-kong/downloads/epub/latest/")
@@ -357,7 +357,7 @@ class PrivacyTests(TestCase):
         )
         self.assertEqual(
             r.headers["content-disposition"],
-            'attachment; filename="django-kong-readthedocs-io-en-latest.epub"',
+            'inline; filename="django-kong-readthedocs-io-en-latest.epub"',
         )
 
         r = self.client.get("/projects/django-kong/downloads/htmlzip/latest/")
@@ -368,7 +368,7 @@ class PrivacyTests(TestCase):
         )
         self.assertEqual(
             r.headers["content-disposition"],
-            'attachment; filename="django-kong-readthedocs-io-en-latest.zip"',
+            'inline; filename="django-kong-readthedocs-io-en-latest.zip"',
         )
 
     # Build Filtering

--- a/readthedocs/rtd_tests/tests/test_privacy.py
+++ b/readthedocs/rtd_tests/tests/test_privacy.py
@@ -238,7 +238,7 @@ class PrivacyTests(TestCase):
         )
         self.assertEqual(
             r.headers["content-disposition"],
-            "filename=django-kong-readthedocs-io-en-latest.pdf",
+            'attachment; filename="django-kong-readthedocs-io-en-latest.pdf"',
         )
 
         r = self.client.get("/projects/django-kong/downloads/epub/latest/")
@@ -249,7 +249,7 @@ class PrivacyTests(TestCase):
         )
         self.assertEqual(
             r.headers["content-disposition"],
-            "filename=django-kong-readthedocs-io-en-latest.epub",
+            'attachment; filename="django-kong-readthedocs-io-en-latest.epub"',
         )
 
         r = self.client.get("/projects/django-kong/downloads/htmlzip/latest/")
@@ -260,7 +260,7 @@ class PrivacyTests(TestCase):
         )
         self.assertEqual(
             r.headers["content-disposition"],
-            "filename=django-kong-readthedocs-io-en-latest.zip",
+            'attachment; filename="django-kong-readthedocs-io-en-latest.zip"',
         )
 
     # Public download tests
@@ -283,7 +283,7 @@ class PrivacyTests(TestCase):
         )
         self.assertEqual(
             r.headers["content-disposition"],
-            "filename=django-kong-readthedocs-io-en-latest.pdf",
+            'attachment; filename="django-kong-readthedocs-io-en-latest.pdf"',
         )
 
         # Auth'd user
@@ -298,7 +298,7 @@ class PrivacyTests(TestCase):
         )
         self.assertEqual(
             r.headers["content-disposition"],
-            "filename=django-kong-readthedocs-io-en-latest.pdf",
+            'attachment; filename="django-kong-readthedocs-io-en-latest.pdf"',
         )
 
     @override_settings(
@@ -327,7 +327,7 @@ class PrivacyTests(TestCase):
         )
         self.assertEqual(
             r.headers["content-disposition"],
-            "filename=django-kong-readthedocs-io-en-latest.pdf",
+            'attachment; filename="django-kong-readthedocs-io-en-latest.pdf"',
         )
 
     @override_settings(
@@ -346,7 +346,7 @@ class PrivacyTests(TestCase):
         )
         self.assertEqual(
             r.headers["content-disposition"],
-            "filename=django-kong-readthedocs-io-en-latest.pdf",
+            'attachment; filename="django-kong-readthedocs-io-en-latest.pdf"',
         )
 
         r = self.client.get("/projects/django-kong/downloads/epub/latest/")
@@ -357,7 +357,7 @@ class PrivacyTests(TestCase):
         )
         self.assertEqual(
             r.headers["content-disposition"],
-            "filename=django-kong-readthedocs-io-en-latest.epub",
+            'attachment; filename="django-kong-readthedocs-io-en-latest.epub"',
         )
 
         r = self.client.get("/projects/django-kong/downloads/htmlzip/latest/")
@@ -368,7 +368,7 @@ class PrivacyTests(TestCase):
         )
         self.assertEqual(
             r.headers["content-disposition"],
-            "filename=django-kong-readthedocs-io-en-latest.zip",
+            'attachment; filename="django-kong-readthedocs-io-en-latest.zip"',
         )
 
     # Build Filtering


### PR DESCRIPTION
Filenames have user input, escaping from the header is an exploitable point. Here all the values are very restricted, so escaping the header wasn't possible, this is mostly an extra protection. We always want to trigger a download for these files, we don't want to render them in the browser (especially files under the app domain).