### PR TITLE
Proxito: un-prefix /_/ paths served under a custom path prefix

### DIFF
--- a/dockerfiles/nginx/proxito.conf.template
+++ b/dockerfiles/nginx/proxito.conf.template
@@ -29,6 +29,17 @@ server {
         proxy_pass http://addons:8000/readthedocs-addons.js.map;
     }
 
+    # Un-prefix proxied API paths (`/_/…`) served under a custom path prefix.
+    #
+    # Projects with a custom path prefix (`Project.custom_prefix`) and the
+    # `USE_PROXIED_APIS_WITH_PREFIX` feature generate their proxied URLs under
+    # that prefix (e.g. `/docs/_/addons/`), so a customer only needs to proxy a
+    # single path to us. Django only routes these paths at the domain root, so
+    # we strip the prefix back off here before handing the request to Proxito.
+    location ~ ^/.+/(_/(?:addons|api|downloads|static)(?:/.*)?)$ {
+        rewrite ^/.+/(_/(?:addons|api|downloads|static)(?:/.*)?)$ /$1 last;
+    }
+
     # Proxito doc serving
     location / {
         proxy_pass http://proxito:8000;


### PR DESCRIPTION
## Why

We want a customer to serve their docs under a single path on their own site (e.g. `https://example.com/docs/…`) by reverse-proxying **one** path prefix to us. Doc *pages* already work under a custom prefix, but the proxied API paths (`/_/addons`, `/_/static`, `/_/api`, `/_/downloads`) don't — so addons, search, static assets and downloads escape the prefix the customer proxies, and a single proxy rule isn't enough.

The `USE_PROXIED_APIS_WITH_PREFIX` feature already makes us **generate** those URLs under the prefix (`Project.proxied_api_host` → `/docs/_`), and the code comment on `Project.proxied_api_prefix` notes the other half is meant to live in nginx:

> these paths will be manually un-prefixed in nginx.

This PR adds that missing half.

## What

A single, prefix-agnostic nginx rule that strips any leading path prefix off proxied API paths before handing the request to Proxito, which only routes `/_/…` at the domain root. Because `/_/` is a unique sentinel, one rewrite covers any prefix without per-project config.

This completes the existing feature end-to-end: a project with a `custom_prefix` and `USE_PROXIED_APIS_WITH_PREFIX` can now serve everything — pages and `/_/` — under one path the customer proxies.

## Notes

- URL generation is already covered by `test_proxied_api_prefix`. The nginx rewrite itself isn't exercised by the Django test suite (the test client hits Django directly, where `/_/` is at the root), so it needs manual verification on a deploy: confirm `/<prefix>/_/addons/`, `/<prefix>/_/static/…` and a download resolve.
- The rewrite is scoped to the known proxied roots (`addons|api|downloads|static`) to avoid matching documentation filenames that happen to contain a `/_/` segment.

---

🤖 Draft generated by Claude Code (AI agent), for review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPEKF2tcrc5DqDLMsdkNUz)_