### PR TITLE
Proxito: serve multiple projects under one domain by path

### DIFF
--- a/readthedocs/core/unresolver.py
+++ b/readthedocs/core/unresolver.py
@@ -419,6 +419,55 @@ class Unresolver:
             return response
         return None
 
+    def _match_project_by_path(self, parent_project, path, external_version_slug=None):
+        """
+        Try to match another project served under this project's domain by path.
+
+        This mirrors ``_match_subproject``, but resolves the leading path segment
+        to a project by its slug directly, instead of via a ``ProjectRelationship``.
+        It lets a single domain serve many projects under one prefix
+        (e.g. ``example.com/docs/<project-slug>/``) without modeling each one as a
+        subproject.
+
+        Opt-in via the ``SERVE_PROJECTS_BY_PATH`` feature on ``parent_project``, and
+        scoped to projects that share an owner with it, so a domain can't expose
+        unrelated projects.
+
+        :returns: A tuple with the current project, version and filename.
+         Returns `None` if there isn't a total or partial match.
+        """
+        if not parent_project.has_feature(Feature.SERVE_PROJECTS_BY_PATH):
+            return None
+
+        prefix = parent_project.custom_subproject_prefix or "/projects/"
+        if not path.startswith(prefix):
+            return None
+        # pep8 and black don't agree on having a space before :,
+        # so syntax is black with noqa for pep8.
+        path = self._normalize_filename(path[len(prefix) :])  # noqa
+
+        match = self.subproject_pattern.match(path)
+        if not match:
+            return None
+
+        project_slug = match.group("subproject")
+        filename = self._normalize_filename(match.group("filename"))
+
+        project = Project.objects.filter(
+            slug=project_slug,
+            users__in=parent_project.users.all(),
+        ).first()
+        if project:
+            # We use the matched project as the new parent project
+            # to resolve the rest of the path relative to it.
+            return self._unresolve_path_with_parent_project(
+                parent_project=project,
+                path=filename,
+                check_subprojects=False,
+                external_version_slug=external_version_slug,
+            )
+        return None
+
     def _match_single_version_without_translations_project(
         self, parent_project, path, external_version_slug=None
     ):
@@ -503,6 +552,16 @@ class Unresolver:
         # Subprojects.
         if check_subprojects:
             response = self._match_subproject(
+                parent_project=parent_project,
+                path=path,
+                external_version_slug=external_version_slug,
+            )
+            if response:
+                return response
+
+            # Other projects served under this domain by path (no subproject
+            # relationship). Checked after subprojects so those take precedence.
+            response = self._match_project_by_path(
                 parent_project=parent_project,
                 path=path,
                 external_version_slug=external_version_slug,

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -2071,6 +2071,7 @@ class Feature(models.Model):
     DISABLE_PAGEVIEWS = "disable_pageviews"
     RESOLVE_PROJECT_FROM_HEADER = "resolve_project_from_header"
     USE_PROXIED_APIS_WITH_PREFIX = "use_proxied_apis_with_prefix"
+    SERVE_PROJECTS_BY_PATH = "serve_projects_by_path"
     ALLOW_VERSION_WARNING_BANNER = "allow_version_warning_banner"
     DONT_SYNC_WITH_REMOTE_REPO = "dont_sync_with_remote_repo"
 
@@ -2106,6 +2107,13 @@ class Feature(models.Model):
             USE_PROXIED_APIS_WITH_PREFIX,
             _(
                 "Proxito: Use proxied APIs (/_/*) with the custom prefix if the project has one (Project.custom_prefix)."
+            ),
+        ),
+        (
+            SERVE_PROJECTS_BY_PATH,
+            _(
+                "Proxito: Serve other projects under this project's domain by path "
+                "(/<subproject-prefix>/<project-slug>/), without a subproject relationship."
             ),
         ),
         (

--- a/readthedocs/rtd_tests/tests/test_unresolver.py
+++ b/readthedocs/rtd_tests/tests/test_unresolver.py
@@ -20,7 +20,7 @@ from readthedocs.core.unresolver import (
     unresolver,
 )
 from readthedocs.projects.constants import SINGLE_VERSION_WITHOUT_TRANSLATIONS
-from readthedocs.projects.models import Domain
+from readthedocs.projects.models import Domain, Feature, Project
 from readthedocs.rtd_tests.tests.test_resolver import ResolverBase
 
 
@@ -40,6 +40,39 @@ class UnResolverTests(ResolverBase):
         self.assertEqual(parts.filename, "/foo.html")
         self.assertEqual(parts.parsed_url.fragment, "fragment")
         self.assertEqual(parts.parsed_url.query, "search=api")
+
+    def test_serve_projects_by_path(self):
+        sibling = get(
+            Project,
+            slug="sibling",
+            users=[self.owner],
+            main_language_project=None,
+        )
+
+        # Without the feature, the path doesn't resolve to the sibling project.
+        with pytest.raises(InvalidPathForVersionedProjectError):
+            unresolve("https://pip.readthedocs.io/projects/sibling/en/latest/")
+
+        get(Feature, projects=[self.pip], feature_id=Feature.SERVE_PROJECTS_BY_PATH)
+
+        parts = unresolve("https://pip.readthedocs.io/projects/sibling/en/latest/")
+        self.assertEqual(parts.parent_project, self.pip)
+        self.assertEqual(parts.project, sibling)
+        self.assertEqual(parts.version, sibling.versions.first())
+        self.assertEqual(parts.filename, "/index.html")
+
+    def test_serve_projects_by_path_requires_shared_owner(self):
+        # A project owned by a different user is not served under this domain.
+        get(
+            Project,
+            slug="stranger",
+            users=[self.tester],
+            main_language_project=None,
+        )
+        get(Feature, projects=[self.pip], feature_id=Feature.SERVE_PROJECTS_BY_PATH)
+
+        with pytest.raises(InvalidPathForVersionedProjectError):
+            unresolve("https://pip.readthedocs.io/projects/stranger/en/latest/")
 
     def test_filename_wihtout_index(self):
         parts = unresolve(


### PR DESCRIPTION
## Why

A customer wants to host many projects under a single path on their own company domain (e.g. `https://example.com/docs/<project>/…`) but can't point that DNS at us. Today the only way to serve several projects under one domain by path is to model them as **subprojects** of a parent project. That works, but it forces customers to bend their project layout into a parent/child tree they don't otherwise want, and inherits subproject limitations.

This is a **draft / RFC** exploring the alternative: serve projects under a domain by path **without** a subproject relationship.

## What

Adds a `SERVE_PROJECTS_BY_PATH` feature on the domain's project. When enabled, the unresolver matches the leading path segment to a project **by slug** (mirroring how `_match_subproject` works, but without a `ProjectRelationship`), so `example.com/<subproject-prefix>/<project-slug>/…` resolves directly.

- Reuses `custom_subproject_prefix` as the mount prefix (defaults to `/projects/`).
- Checked **after** subprojects, so existing subproject routing keeps precedence.
- Scoped to projects that **share an owner** with the domain's project, so a domain can't expose unrelated projects. No migration needed (`feature_id` has no DB-level choices).

Combine with `X-RTD-Slug` (`RESOLVE_PROJECT_FROM_HEADER`) so the customer's reverse proxy can identify the domain's project without DNS, and with the prefix work in the base PR so `/_/` paths stay under the proxied path.

## Open questions for reviewers

- **Scoping:** shared-owner is a placeholder. On .com this should almost certainly be **organization**-scoped (or an explicit allowlist on the domain), not owner-overlap.
- **Mount prefix:** is reusing `custom_subproject_prefix` the right knob, or should this be a dedicated field on `Domain`/the project?
- **Modeling:** should "projects served under this domain" be an explicit relation rather than a global slug lookup?

This is stacked on #13139 (un-prefix `/_/` in nginx); review that first.

---

🤖 Draft generated by Claude Code (AI agent), for review.