### PR TITLE
Redirects: serve heavy redirects at the Cloudflare edge

### DIFF
--- a/docs/dev/design/redirects-at-the-edge.rst
+++ b/docs/dev/design/redirects-at-the-edge.rst
@@ -1,0 +1,310 @@
+Moving heavy redirects to the edge
+==================================
+
+Redirects are one of the most requested paths on our documentation domains,
+and also one of the most expensive to serve from the origin.
+A recent attack targeted our documentation domains with high volumes of
+requests that resolved to redirects,
+which bypassed our CDN cache and put load on the origin and the database.
+
+This document proposes moving the *heavy* redirects out of the Python
+origin (Proxito) and onto the Cloudflare edge,
+so that the platform stays available and scalable under this kind of load.
+
+.. contents::
+   :local:
+   :depth: 2
+
+Goals
+-----
+
+- Serve the redirects that are cheap to evaluate but expensive to host
+  entirely from the Cloudflare edge, without hitting the origin or the database.
+- Make redirect serving resilient to cache-busting attacks
+  (many unique URLs against our documentation domains).
+- Keep the source of truth for redirect data in our database,
+  and keep the user-facing experience (dashboard, API) unchanged.
+- Fail open: if the edge can't make a decision, fall back to the origin,
+  never serve a wrong redirect or a hard error.
+
+Non-goals
+---------
+
+- Move *all* redirect logic to the edge.
+  Some redirects depend on origin-only state (does this file exist?
+  is this version private?) and must stay at the origin.
+- Replace the redirects feature, models, or dashboard UX.
+  This is an infrastructure change, not a product change.
+- Change how users author redirects.
+  The :doc:`redirects` design (status codes, ``*``/``:splat`` wildcards,
+  ordering, disabling) is orthogonal and complementary to this work.
+
+Background: why redirects are expensive at the origin
+-----------------------------------------------------
+
+Today every redirect decision is made in Python inside Proxito.
+A redirect costs us a full request to the origin, and most of them also
+cost one or more database queries:
+
+- **Domain resolution.** Custom domains require a DB lookup
+  (``Domain.objects.filter(domain=...)``) to map host to project.
+- **Path resolution.** Resolving ``/en/latest/foo`` to a project, version,
+  and filename queries translations and versions.
+- **User redirect matching.** ``get_matching_redirect_with_path()`` runs a
+  query against the project's redirects on every 404 and every forced redirect.
+- **404 handling.** A request to a path that doesn't exist is internally
+  re-routed to ``ServeError404``, which re-resolves the path, queries for a
+  matching redirect, and then queries storage for a custom ``404.html``.
+
+The important property for an attacker is that **unique URLs are cache misses**.
+A flood of distinct paths against a documentation domain bypasses the CDN
+cache entirely and lands on the origin, where each request can cost
+several DB queries before we even decide to issue a 301/302.
+The redirects that are structurally simple (HTTP→HTTPS, root→default version,
+canonical domain) are exactly the ones we should never need the origin for.
+
+Taxonomy: what can move to the edge
+------------------------------------
+
+Not all redirects are equal. We can split them into three tiers by the data
+they need to make a decision.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 38 20 20
+
+   * - Redirect
+     - What it needs to decide
+     - Origin state?
+     - Edge tier
+   * - HTTP → HTTPS
+     - The request scheme only
+     - No
+     - Tier 0 (native)
+   * - Trailing slash / double slash normalization
+     - The path only
+     - No
+     - Tier 0 (native)
+   * - Root → default version (``/`` → ``/en/latest/``)
+     - Project default version + language + versioning scheme
+     - No (metadata)
+     - Tier 1 (Worker + KV)
+   * - Canonical domain (public domain → custom domain)
+     - Project's canonical domain
+     - No (metadata)
+     - Tier 1 (Worker + KV)
+   * - Subproject domain → parent domain
+     - Project's parent + prefix
+     - No (metadata)
+     - Tier 1 (Worker + KV)
+   * - Forced user redirects (exact / page / clean-url ↔ html)
+     - The project's redirect rules
+     - No (metadata)
+     - Tier 2 (Worker + KV)
+   * - Non-forced user redirects (only fire on 404)
+     - Whether the target file exists
+     - **Yes**
+     - Stays at origin
+   * - Custom ``404.html`` serving, private version auth
+     - Storage + privacy state
+     - **Yes**
+     - Stays at origin
+
+The key insight: **everything except non-forced redirects and authenticated
+file serving can be decided from project metadata alone.**
+That metadata is small, changes infrequently, and can be replicated to the edge.
+
+Proposed architecture
+---------------------
+
+A Cloudflare Worker sits in front of the origin on our documentation domains.
+On each request it does a single key/value lookup and decides whether it can
+answer with a redirect itself, or whether it should pass the request through
+to the origin unchanged.
+
+.. code-block:: text
+
+   request ──> Cloudflare Worker
+                 │
+                 ├─ Tier 0: scheme/path normalization ──> 301/302 at edge
+                 │
+                 ├─ KV lookup: host -> project config
+                 │     ├─ Tier 1: structural redirect ──> 301/302 at edge
+                 │     └─ Tier 2: forced user redirect ──> 301/302 at edge
+                 │
+                 └─ no match / KV miss / private ──> origin (Proxito, unchanged)
+
+Edge data store
+~~~~~~~~~~~~~~~
+
+We replicate a compact, read-optimized view of the data the edge needs into
+**Cloudflare Workers KV** (eventually-consistent, globally replicated,
+read-optimized — a good fit for "read on every request, write rarely").
+
+Two logical namespaces, both keyed for O(1) lookup:
+
+``domain:{host}`` → project routing config
+   .. code-block:: json
+
+      {
+        "project": "pip",
+        "canonical_domain": "pip.example.com",
+        "https": true,
+        "parent": null,
+        "subproject_prefix": null,
+        "default_version": "stable",
+        "default_language": "en",
+        "versioning_scheme": "multiple_versions_with_translations",
+        "custom_prefix": null,
+        "has_redirects": true
+      }
+
+``redirects:{project}`` → ordered list of *edge-eligible* redirect rules
+   .. code-block:: json
+
+      [
+        {"type": "exact", "from": "/old/*", "to": "/new/:splat",
+         "status": 301, "force": true},
+        {"type": "clean_url_to_html", "status": 301, "force": true}
+      ]
+
+Only **forced** user redirects, plus the always-evaluatable
+clean-url ↔ html types, are pushed to ``redirects:{project}``.
+Non-forced redirects are intentionally left out, because they depend on
+whether the origin can serve the file, which the edge cannot know.
+
+Sizing: with on the order of 10⁵ projects and ~10⁶ redirect rules, the full
+data set is a few hundred MB — comfortably within KV, and most projects have
+no redirects at all (``has_redirects: false`` lets the Worker skip the second
+lookup entirely).
+
+Why this is not blocked by Cloudflare's rule limits
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A previous note in :doc:`redirects` dismissed edge redirects because
+Cloudflare's native *Redirect Rules* have a per-zone limit
+(low thousands of rules) that we'd blow past instantly.
+
+This proposal sidesteps that entirely: redirect data lives in **KV**, and the
+matching logic lives in **Worker code**. There is no per-rule platform limit —
+we're limited by KV storage (gigabytes) and per-request CPU time, not by a
+fixed rule count. Native Redirect Rules are still the right tool for the
+Tier 0 global redirects (HTTP→HTTPS), which need no per-project data.
+
+Matching at the edge
+~~~~~~~~~~~~~~~~~~~~~
+
+The Worker reproduces the origin's matching semantics for the edge-eligible
+subset:
+
+1. **Normalize** the path (collapse double slashes, handle trailing slash) —
+   Tier 0, no data needed.
+2. **Look up** ``domain:{host}``. On a miss, pass through to origin.
+3. **Structural redirects** (Tier 1): if the host is non-canonical and a
+   canonical domain exists, or the project is a subproject, or the path is the
+   root and a default version is configured, build the target URL and redirect.
+4. **Forced user redirects** (Tier 2): if ``has_redirects`` is true, fetch
+   ``redirects:{project}`` and evaluate rules in order, applying ``:splat``
+   wildcard substitution. First match wins, mirroring origin ordering.
+5. **Otherwise**, pass through to the origin untouched.
+
+To keep parity provable, the matching algorithm should be extracted into a
+small, well-tested module that we can validate against the existing
+``redirects`` test suite — ideally sharing fixtures so the edge and origin
+can't silently diverge.
+
+Keeping the edge in sync
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The database stays the source of truth. We propagate changes to KV
+asynchronously so the dashboard and API are unaffected:
+
+- On ``Project``, ``Domain``, ``Version``, and ``Redirect`` save/delete,
+  enqueue a Celery task that rebuilds the affected ``domain:{host}`` and/or
+  ``redirects:{project}`` entries and writes them to KV via the Cloudflare API.
+- A periodic reconciliation task does a full re-sync to repair any drift from
+  missed signals (belt and suspenders).
+- KV is eventually consistent (propagation on the order of seconds to a minute).
+  This is acceptable for redirects, and it matches the existing CDN cache
+  behavior, where redirect responses are already cached and purged by tag.
+
+This reuses the same mental model we already have for CDN cache purging by
+``Cache-Tag``; we're adding a second, more granular replica of the routing data.
+
+Why this defends against the attack
+------------------------------------
+
+Under the attack we saw, a flood of unique URLs against our documentation
+domains bypassed the CDN cache and hit the origin. With this design:
+
+- Tier 0/1 redirects (HTTPS, root, canonical, subproject) are answered by the
+  Worker from a single KV read. The origin and database see **zero** of this
+  traffic, regardless of how many unique URLs are requested.
+- Forced user redirects are answered the same way.
+- Cloudflare's edge absorbs the volume on infrastructure built to scale
+  horizontally for exactly this, and the per-IP/zone protections
+  (rate limiting, WAF) apply before our Worker runs.
+
+The only traffic that still reaches the origin is the traffic that genuinely
+needs origin state: real file serving, non-forced 404-driven redirects, and
+authenticated private docs. Those can be protected with rate limiting
+independently, and they're a small fraction of an attack made of random URLs.
+
+Failure modes and safety
+------------------------
+
+- **KV miss or stale data.** The Worker passes the request through to the
+  origin, which still has the full, authoritative redirect logic.
+  Worst case we lose the edge optimization for a few seconds after a change;
+  we never serve a wrong answer.
+- **Worker error / timeout.** Fail open to origin. A bug in edge matching must
+  never take down doc serving.
+- **Edge/origin divergence.** Mitigated by sharing the matching algorithm and
+  test fixtures, and by emitting the same ``X-RTD-Redirect`` header from the
+  edge so we can attribute redirects in analytics.
+- **Privacy.** Only public, non-authenticated routing metadata is replicated to
+  KV. Private-version decisions and any auth stay at the origin; the edge never
+  makes an access-control decision.
+
+Observability
+-------------
+
+- Have the Worker set ``X-RTD-Redirect`` (and a marker like
+  ``X-RTD-Redirect-Source: edge``) so existing dashboards distinguish
+  edge-served from origin-served redirects.
+- Track edge hit ratio, KV read latency, and pass-through rate.
+- Alert on a rising origin redirect rate, which would indicate the edge is not
+  catching what it should (sync lag, missing data, or a logic gap).
+
+Rollout plan
+------------
+
+#. **Tier 0 first.** Move HTTP→HTTPS and path normalization to native
+   Cloudflare rules / a thin Worker. No data sync required; immediate relief.
+#. **Build the sync pipeline.** Replicate ``domain:{host}`` config to KV and
+   verify it matches the origin's resolver for a sample of projects (shadow
+   mode: compute the edge decision, log it, but still serve from origin).
+#. **Enable Tier 1 structural redirects** behind the shadow comparison until
+   the divergence rate is effectively zero.
+#. **Add Tier 2 forced user redirects**, syncing ``redirects:{project}`` and
+   again validating in shadow mode before serving from the edge.
+#. **Keep the origin as the permanent fallback.** Non-forced redirects, custom
+   404s, and private docs are explicitly out of scope and stay at the origin.
+
+Open questions
+--------------
+
+- **KV vs. D1 vs. Durable Objects** for the redirect rules.
+  KV is simplest and matches the read pattern; D1 (SQLite at the edge) may be
+  worth it if we want richer matching (query-argument matching from
+  :doc:`redirects`) without shipping all rules per project.
+- **Per-project rule volume.** A handful of projects have thousands of
+  redirects. We should cap the per-project payload pushed to KV and fall back
+  to origin matching above the cap, rather than ship multi-MB values.
+- **Single shared matching implementation.** Can we compile/port the Python
+  matcher to the Worker runtime (or express the rules declaratively enough that
+  both sides interpret them identically) to guarantee parity?
+- **Non-forced redirects on 404.** Out of scope here, but a future option is to
+  let the Worker catch a ``404`` from the origin and apply a redirect at the
+  edge, keeping the DB query off the origin while preserving "only redirect if
+  the file is missing" semantics.

--- a/docs/dev/design/redirects-at-the-edge.rst
+++ b/docs/dev/design/redirects-at-the-edge.rst
@@ -213,11 +213,66 @@ small, well-tested module that we can validate against the existing
 ``redirects`` test suite — ideally sharing fixtures so the edge and origin
 can't silently diverge.
 
-Keeping the edge in sync
+Reference implementation
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The database stays the source of truth. We propagate changes to KV
-asynchronously so the dashboard and API are unaffected:
+A first cut lives in the ``redirects`` app:
+
+- ``readthedocs/redirects/edge.py`` — serializes a project's routing config
+  and edge-eligible redirects, a reference matcher (``match_redirect``) for
+  parity testing, the ``X-RTD-Edge-Redirects`` header builder, and the
+  ``EdgeStore`` abstraction (in-memory ``LocalEdgeStore`` plus the Cloudflare
+  KV backend in ``edge_cloudflare.py``).
+- ``readthedocs/proxito/middleware.py`` — emits the ``X-RTD-Edge-Redirects``
+  header (Option A), behind ``RTD_EDGE_REDIRECTS_ENABLED``.
+- ``readthedocs/redirects/edge_worker.js`` — the reference Worker, supporting
+  both header learning (Option A) and pre-warmed KV (Option B).
+
+The first cut deliberately serves only **forced exact redirects**: they match
+on the whole request path, so the edge needs no version list or language
+parsing. Page and clean-URL redirects need the edge to split the language and
+version out of the path first, which requires more project metadata; they are
+a follow-up, and until then they remain at the origin.
+
+Getting the data to the edge
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There are two ways to get the routing data from the origin to the edge.
+They are complementary, and we can ship the first on its own.
+
+**Option A — header delivery (no config).**
+The origin already talks to our Cloudflare Workers through response headers
+(for example ``X-RTD-Force-Addons``). We reuse that channel: the origin emits
+the project's forced redirects on an ``X-RTD-Edge-Redirects`` response header,
+and the Worker caches them per host (in the Cloudflare Cache API) for a short
+TTL. The next requests for that host are answered at the edge.
+
+This needs **no Cloudflare API credentials, no KV namespace, and no sync
+pipeline** — the data simply rides on responses the origin is already sending,
+and the edge learns it lazily. To keep this from adding a database query to
+every response, the origin caches the serialized header value per project for
+a short TTL, so the cost is roughly one query per project per TTL.
+
+Under the attack we saw, the first request to a host warms the edge with that
+project's forced redirects; every subsequent (unique, cache-busting) URL under
+those rules is then served at the edge without touching the origin.
+
+**Option B — pre-warmed KV (for the first request too).**
+Header delivery only protects the origin *after* the edge has seen one
+response for a host. To also absorb the very first request, we can push the
+same data into Workers KV ahead of time via the Cloudflare API. The Worker
+checks its learned cache first, then falls back to KV, then to the origin.
+
+The trade-off: Option B removes the cold-start window but adds the operational
+cost Option A avoids (credentials, a sync pipeline, and an eventually-consistent
+replica to reason about). We start with Option A and add B only if the
+cold-start window proves to matter under load.
+
+Keeping the pre-warmed KV in sync
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If we adopt Option B, the database stays the source of truth and we propagate
+changes to KV asynchronously so the dashboard and API are unaffected:
 
 - On ``Project``, ``Domain``, ``Version``, and ``Redirect`` save/delete,
   enqueue a Celery task that rebuilds the affected ``domain:{host}`` and/or

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -32,6 +32,7 @@ from readthedocs.proxito.cache import add_cache_tags
 from readthedocs.proxito.cache import cache_response
 from readthedocs.proxito.cache import private_response
 from readthedocs.proxito.redirects import redirect_to_https
+from readthedocs.redirects.edge import cached_edge_redirects_header
 
 from .exceptions import DomainDNSHttp404
 from .exceptions import ProjectHttp404
@@ -300,6 +301,31 @@ class ProxitoMiddleware(MiddlewareMixin):
                 if addons.enabled:
                     response["X-RTD-Force-Addons"] = "true"
 
+    def add_edge_redirects_header(self, request, response):
+        """
+        Communicate a project's forced redirects to the Cloudflare edge.
+
+        This is the "no-config" delivery path for serving heavy redirects at
+        the edge (see ``docs/dev/design/redirects-at-the-edge.rst``). Instead
+        of pushing data to the edge through the Cloudflare API, the origin
+        emits the project's edge-eligible redirects on the
+        ``X-RTD-Edge-Redirects`` response header. The Worker learns and caches
+        them, so subsequent (cache-busting) requests are answered at the edge
+        without reaching the origin.
+
+        This reuses the same mechanism as ``X-RTD-Force-Addons``.
+        """
+        if not settings.RTD_EDGE_REDIRECTS_ENABLED:
+            return
+
+        unresolved_domain = request.unresolved_domain
+        if not unresolved_domain:
+            return
+
+        header_value = cached_edge_redirects_header(unresolved_domain.project)
+        if header_value:
+            response["X-RTD-Edge-Redirects"] = header_value
+
     def add_cors_headers(self, request, response):
         """
         Add CORS headers only to files from docs.
@@ -377,6 +403,7 @@ class ProxitoMiddleware(MiddlewareMixin):
         self.add_hsts_headers(request, response)
         self.add_user_headers(request, response)
         self.add_hosting_integrations_headers(request, response)
+        self.add_edge_redirects_header(request, response)
         self.add_resolver_headers(request, response)
         self.add_cors_headers(request, response)
         return response

--- a/readthedocs/redirects/apps.py
+++ b/readthedocs/redirects/apps.py
@@ -1,0 +1,10 @@
+"""Redirects app config."""
+
+from django.apps import AppConfig
+
+
+class RedirectsConfig(AppConfig):
+    name = "readthedocs.redirects"
+
+    def ready(self):
+        import readthedocs.redirects.signals  # noqa

--- a/readthedocs/redirects/edge.py
+++ b/readthedocs/redirects/edge.py
@@ -1,0 +1,287 @@
+"""
+Serialize redirect/routing data for the Cloudflare edge.
+
+This is the origin side of the "heavy redirects at the edge" design
+(see ``docs/dev/design/redirects-at-the-edge.rst``).
+
+We replicate a compact, read-optimized view of the data the edge needs
+into an :class:`EdgeStore` (Cloudflare Workers KV in production):
+
+- ``domain:{host}`` -> the project a host belongs to.
+- ``project:{slug}`` -> routing config + the edge-eligible redirect rules.
+
+Only redirects that can be decided *without* origin state are replicated.
+In practice that means **forced exact redirects**: they match on the whole
+request path and don't depend on whether the target file exists, the version
+list, or the privacy level. Everything else stays at the origin, which keeps
+the full, authoritative redirect logic.
+"""
+
+import json
+from urllib.parse import urlparse
+
+import structlog
+from django.conf import settings
+from django.core.cache import cache
+from django.utils.module_loading import import_string
+
+from readthedocs.redirects.constants import EXACT_REDIRECT
+from readthedocs.redirects.constants import SPLAT_PLACEHOLDER
+
+
+log = structlog.get_logger(__name__)
+
+# Redirect types that the edge can evaluate from the request path alone.
+# Forced exact redirects are the only ones that don't need origin state
+# (file existence, version list, privacy). See the design doc for the
+# follow-up needed to support page/clean-url redirects at the edge.
+EDGE_REDIRECT_TYPES = (EXACT_REDIRECT,)
+
+
+def is_edge_eligible(redirect):
+    """
+    Whether a redirect can be served entirely from the edge.
+
+    Only enabled, forced redirects of an edge-eligible type qualify.
+    Non-forced redirects only fire when the origin can't serve the file,
+    which the edge can't know, so they stay at the origin.
+    """
+    return bool(
+        redirect.enabled
+        and redirect.force
+        and redirect.redirect_type in EDGE_REDIRECT_TYPES
+    )
+
+
+def serialize_redirect(redirect):
+    """Serialize a single redirect into the compact edge representation."""
+    return {
+        "type": redirect.redirect_type,
+        "from": redirect.from_url,
+        # Precomputed prefix for wildcard (``*``) matching, so the edge
+        # doesn't need to re-derive it. ``None`` means an exact match.
+        "from_prefix": redirect.from_url_without_rest,
+        "to": redirect.to_url,
+        "status": redirect.http_status,
+    }
+
+
+def get_edge_redirects(project):
+    """Return the ordered, edge-eligible redirects for a project."""
+    redirects = project.redirects.all().order_by("position", "-update_dt")
+    return [
+        serialize_redirect(redirect)
+        for redirect in redirects
+        if is_edge_eligible(redirect)
+    ]
+
+
+def get_project_hosts(project):
+    """
+    Return all hostnames that serve this project's docs.
+
+    This is the project's subdomain on our public domain plus any custom
+    domains. These are the keys the edge uses to map a request to a project.
+    """
+    hosts = []
+    subdomain = project.subdomain(use_canonical_domain=False)
+    if subdomain:
+        hosts.append(subdomain)
+    for domain in project.domains.all():
+        hosts.append(domain.domain)
+    return hosts
+
+
+def serialize_project(project):
+    """
+    Build the routing payload the edge needs to serve this project.
+
+    This includes the canonical-domain configuration (for structural
+    redirects) and the edge-eligible redirect rules.
+    """
+    canonical_domain = project.canonical_custom_domain
+    return {
+        "project": project.slug,
+        "canonical_domain": canonical_domain.domain if canonical_domain else None,
+        "https": bool(canonical_domain.https) if canonical_domain else False,
+        "default_version": project.get_default_version(),
+        "default_language": project.language,
+        "single_version": project.is_single_version,
+        "redirects": get_edge_redirects(project),
+    }
+
+
+def _normalize_path(path):
+    """Drop the query string and ensure a single leading slash."""
+    parsed = urlparse(path)
+    path = parsed._replace(query="", fragment="").geturl()
+    return "/" + path.lstrip("/")
+
+
+def match_redirect(payload, path):
+    """
+    Reference implementation of the edge redirect matcher.
+
+    This mirrors what the Cloudflare Worker does, and exists so we can test
+    parity with the origin's matching in Python. Returns a
+    ``(to_url, status)`` tuple or ``None`` when no rule matches.
+
+    :param payload: A project payload from :func:`serialize_project`.
+    :param path: The request path (may include a query string).
+    """
+    normalized = _normalize_path(path)
+    without_slash = normalized.rstrip("/") or "/"
+
+    for redirect in payload["redirects"]:
+        if redirect["type"] != EXACT_REDIRECT:
+            # Only exact redirects are supported at the edge for now.
+            continue
+
+        from_prefix = redirect["from_prefix"]
+        to_url = redirect["to"]
+
+        if from_prefix is None:
+            # Exact match, with or without a trailing slash.
+            if without_slash == redirect["from"].rstrip("/"):
+                return to_url, redirect["status"]
+            continue
+
+        # Wildcard (``*``) match: everything after the prefix becomes the splat.
+        if normalized.startswith(from_prefix):
+            splat = normalized[len(from_prefix) :]
+            resolved = to_url.replace(SPLAT_PLACEHOLDER, splat)
+            if _will_cause_infinite_redirect(from_prefix, to_url, normalized):
+                log.debug("Skipping edge redirect to avoid a loop", path=normalized)
+                continue
+            return resolved, redirect["status"]
+
+    return None
+
+
+def _will_cause_infinite_redirect(from_prefix, to_url, current_path):
+    """Mirror ``Redirect._will_cause_infinite_redirect`` for the edge."""
+    if SPLAT_PLACEHOLDER not in to_url:
+        return False
+    to_without_splat = to_url.split(SPLAT_PLACEHOLDER, maxsplit=1)[0]
+    redirects_to_subpath = to_without_splat.startswith(from_prefix)
+    return redirects_to_subpath and current_path.startswith(to_without_splat)
+
+
+def edge_redirects_header(project):
+    """
+    Build the value for the ``X-RTD-Edge-Redirects`` response header.
+
+    This is the "no-config" delivery path: instead of pushing data to the
+    edge through the Cloudflare API, the origin emits the project's
+    edge-eligible redirects on a response header, and the Worker caches them.
+    The value is a compact JSON array of rules. Returns ``None`` when the
+    project has no edge-eligible redirects (so we don't emit an empty header).
+    """
+    redirects = get_edge_redirects(project)
+    if not redirects:
+        return None
+    return json.dumps(redirects, separators=(",", ":"))
+
+
+def cached_edge_redirects_header(project):
+    """
+    Cached wrapper around :func:`edge_redirects_header`.
+
+    The header is emitted on origin responses, so we cache the serialized
+    value per project to avoid querying redirects on every response. A short
+    TTL keeps the edge reasonably fresh while bounding origin cost to roughly
+    one query per project per TTL.
+    """
+    cache_key = f"edge-redirects-header:{project.slug}"
+    sentinel = ""  # Cache "no redirects" as well, to avoid repeated queries.
+    value = cache.get(cache_key, sentinel)
+    if value is sentinel:
+        value = edge_redirects_header(project)
+        cache.set(cache_key, value, settings.RTD_EDGE_REDIRECTS_HEADER_TTL)
+    return value
+
+
+def get_edge_store():
+    """Return the configured edge store backend."""
+    store_class = import_string(settings.RTD_EDGE_REDIRECTS_STORE_CLASS)
+    return store_class()
+
+
+def sync_project(project, store=None):
+    """Replicate a project's routing config and redirects to the edge."""
+    store = store or get_edge_store()
+    payload = serialize_project(project)
+    store.set_project(project.slug, payload)
+    for host in get_project_hosts(project):
+        store.set_domain(host, project.slug)
+    log.info(
+        "Synced project to the edge.",
+        project_slug=project.slug,
+        redirects=len(payload["redirects"]),
+    )
+
+
+def remove_project(slug, hosts, store=None):
+    """Remove a project (and its hosts) from the edge."""
+    store = store or get_edge_store()
+    store.delete_project(slug)
+    for host in hosts:
+        store.delete_domain(host)
+    log.info("Removed project from the edge.", project_slug=slug)
+
+
+class EdgeStore:
+    """Interface for a backend that holds the edge routing data."""
+
+    def set_project(self, slug, payload):
+        raise NotImplementedError
+
+    def get_project(self, slug):
+        raise NotImplementedError
+
+    def delete_project(self, slug):
+        raise NotImplementedError
+
+    def set_domain(self, host, slug):
+        raise NotImplementedError
+
+    def get_domain(self, host):
+        raise NotImplementedError
+
+    def delete_domain(self, host):
+        raise NotImplementedError
+
+
+class LocalEdgeStore(EdgeStore):
+    """
+    In-memory edge store for development and tests.
+
+    The data lives in class-level dicts so it behaves like a single shared
+    store within a process, mirroring the global namespace of a real KV store.
+    """
+
+    projects = {}
+    domains = {}
+
+    def set_project(self, slug, payload):
+        self.projects[slug] = payload
+
+    def get_project(self, slug):
+        return self.projects.get(slug)
+
+    def delete_project(self, slug):
+        self.projects.pop(slug, None)
+
+    def set_domain(self, host, slug):
+        self.domains[host] = slug
+
+    def get_domain(self, host):
+        return self.domains.get(host)
+
+    def delete_domain(self, host):
+        self.domains.pop(host, None)
+
+    @classmethod
+    def reset(cls):
+        cls.projects = {}
+        cls.domains = {}

--- a/readthedocs/redirects/edge.py
+++ b/readthedocs/redirects/edge.py
@@ -31,27 +31,6 @@ from readthedocs.redirects.constants import SPLAT_PLACEHOLDER
 
 log = structlog.get_logger(__name__)
 
-# Redirect types that the edge can evaluate from the request path alone.
-# Forced exact redirects are the only ones that don't need origin state
-# (file existence, version list, privacy). See the design doc for the
-# follow-up needed to support page/clean-url redirects at the edge.
-EDGE_REDIRECT_TYPES = (EXACT_REDIRECT,)
-
-
-def is_edge_eligible(redirect):
-    """
-    Whether a redirect can be served entirely from the edge.
-
-    Only enabled, forced redirects of an edge-eligible type qualify.
-    Non-forced redirects only fire when the origin can't serve the file,
-    which the edge can't know, so they stay at the origin.
-    """
-    return bool(
-        redirect.enabled
-        and redirect.force
-        and redirect.redirect_type in EDGE_REDIRECT_TYPES
-    )
-
 
 def serialize_redirect(redirect):
     """Serialize a single redirect into the compact edge representation."""
@@ -67,13 +46,21 @@ def serialize_redirect(redirect):
 
 
 def get_edge_redirects(project):
-    """Return the ordered, edge-eligible redirects for a project."""
-    redirects = project.redirects.all().order_by("position", "-update_dt")
-    return [
-        serialize_redirect(redirect)
-        for redirect in redirects
-        if is_edge_eligible(redirect)
-    ]
+    """
+    Return the ordered, edge-eligible redirects for a project.
+
+    Only enabled, forced exact redirects can be served at the edge: they match
+    on the whole request path and don't depend on origin state (file existence,
+    version list, privacy). Everything else stays at the origin. Page and
+    clean-URL redirects are a follow-up (see the design doc).
+    """
+    redirects = (
+        project.redirects.filter(force=True, redirect_type=EXACT_REDIRECT)
+        # ``enabled`` is nullable, so exclude only explicit ``False``.
+        .exclude(enabled=False)
+        .order_by("position", "-update_dt")
+    )
+    return [serialize_redirect(redirect) for redirect in redirects]
 
 
 def get_project_hosts(project):
@@ -94,19 +81,14 @@ def get_project_hosts(project):
 
 def serialize_project(project):
     """
-    Build the routing payload the edge needs to serve this project.
+    Build the routing payload the edge needs to serve a project.
 
-    This includes the canonical-domain configuration (for structural
-    redirects) and the edge-eligible redirect rules.
+    For now this is just the edge-eligible redirect rules. When structural
+    redirects (canonical domain, default version) move to the edge, their
+    config gets added here as the Worker grows to consume it.
     """
-    canonical_domain = project.canonical_custom_domain
     return {
         "project": project.slug,
-        "canonical_domain": canonical_domain.domain if canonical_domain else None,
-        "https": bool(canonical_domain.https) if canonical_domain else False,
-        "default_version": project.get_default_version(),
-        "default_language": project.language,
-        "single_version": project.is_single_version,
         "redirects": get_edge_redirects(project),
     }
 
@@ -193,12 +175,15 @@ def cached_edge_redirects_header(project):
     one query per project per TTL.
     """
     cache_key = f"edge-redirects-header:{project.slug}"
-    sentinel = ""  # Cache "no redirects" as well, to avoid repeated queries.
-    value = cache.get(cache_key, sentinel)
-    if value is sentinel:
-        value = edge_redirects_header(project)
+    # We cache "no redirects" as ``""`` (not ``None``) so that the common case
+    # of a project without forced redirects is a cache hit, not a miss that
+    # re-queries on every response. ``cache.get`` returns ``None`` only on a
+    # true miss.
+    value = cache.get(cache_key)
+    if value is None:
+        value = edge_redirects_header(project) or ""
         cache.set(cache_key, value, settings.RTD_EDGE_REDIRECTS_HEADER_TTL)
-    return value
+    return value or None
 
 
 def get_edge_store():

--- a/readthedocs/redirects/edge_cloudflare.py
+++ b/readthedocs/redirects/edge_cloudflare.py
@@ -1,0 +1,96 @@
+"""
+Cloudflare Workers KV backend for the edge redirect store.
+
+This writes the routing data produced by :mod:`readthedocs.redirects.edge`
+into a Cloudflare Workers KV namespace, which the edge Worker reads on each
+request. See ``docs/dev/design/redirects-at-the-edge.rst``.
+
+Configuration (settings):
+
+- ``RTD_EDGE_REDIRECTS_CLOUDFLARE_ACCOUNT_ID``
+- ``RTD_EDGE_REDIRECTS_CLOUDFLARE_NAMESPACE_ID``
+- ``RTD_EDGE_REDIRECTS_CLOUDFLARE_TOKEN``
+"""
+
+import json
+
+import requests
+import structlog
+from django.conf import settings
+
+from readthedocs.redirects.edge import EdgeStore
+
+
+log = structlog.get_logger(__name__)
+
+API_BASE = "https://api.cloudflare.com/client/v4"
+# KV is read-on-every-request; keep keys namespaced to avoid collisions.
+DOMAIN_PREFIX = "domain:"
+PROJECT_PREFIX = "project:"
+
+
+class CloudflareKVStore(EdgeStore):
+    """Read/write the edge routing data in a Cloudflare Workers KV namespace."""
+
+    def __init__(self):
+        self.account_id = settings.RTD_EDGE_REDIRECTS_CLOUDFLARE_ACCOUNT_ID
+        self.namespace_id = settings.RTD_EDGE_REDIRECTS_CLOUDFLARE_NAMESPACE_ID
+        self.token = settings.RTD_EDGE_REDIRECTS_CLOUDFLARE_TOKEN
+
+    @property
+    def _base_url(self):
+        return (
+            f"{API_BASE}/accounts/{self.account_id}"
+            f"/storage/kv/namespaces/{self.namespace_id}"
+        )
+
+    @property
+    def _headers(self):
+        return {"Authorization": f"Bearer {self.token}"}
+
+    def _put(self, key, value):
+        response = requests.put(
+            f"{self._base_url}/values/{key}",
+            headers=self._headers,
+            data=json.dumps(value),
+            timeout=10,
+        )
+        response.raise_for_status()
+
+    def _get(self, key):
+        response = requests.get(
+            f"{self._base_url}/values/{key}",
+            headers=self._headers,
+            timeout=10,
+        )
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+        return response.json()
+
+    def _delete(self, key):
+        response = requests.delete(
+            f"{self._base_url}/values/{key}",
+            headers=self._headers,
+            timeout=10,
+        )
+        if response.status_code != 404:
+            response.raise_for_status()
+
+    def set_project(self, slug, payload):
+        self._put(f"{PROJECT_PREFIX}{slug}", payload)
+
+    def get_project(self, slug):
+        return self._get(f"{PROJECT_PREFIX}{slug}")
+
+    def delete_project(self, slug):
+        self._delete(f"{PROJECT_PREFIX}{slug}")
+
+    def set_domain(self, host, slug):
+        self._put(f"{DOMAIN_PREFIX}{host}", {"project": slug})
+
+    def get_domain(self, host):
+        return self._get(f"{DOMAIN_PREFIX}{host}")
+
+    def delete_domain(self, host):
+        self._delete(f"{DOMAIN_PREFIX}{host}")

--- a/readthedocs/redirects/edge_worker.js
+++ b/readthedocs/redirects/edge_worker.js
@@ -1,0 +1,155 @@
+/**
+ * Reference Cloudflare Worker for serving heavy redirects at the edge.
+ *
+ * There are two ways the routing data reaches this Worker. Both are
+ * supported here; see docs/dev/design/redirects-at-the-edge.rst.
+ *
+ *   1. No-config (header learning): the origin emits a project's forced
+ *      redirects on the `X-RTD-Edge-Redirects` response header. The Worker
+ *      caches them per-host in the Cache API and serves subsequent requests
+ *      at the edge. This needs no Cloudflare API credentials or sync pipeline.
+ *
+ *   2. Pre-warmed (KV): a backend pipeline writes the rules into a Workers KV
+ *      namespace ahead of time. Useful to absorb an attack from the very
+ *      first request, before the edge has learned anything.
+ *
+ * The matching here must stay in parity with `match_redirect()` in
+ * `readthedocs/redirects/edge.py`.
+ *
+ * Bindings (both optional):
+ *   - REDIRECTS_KV: a Workers KV namespace (pre-warmed path).
+ */
+
+const SPLAT_PLACEHOLDER = ":splat";
+const EXACT_REDIRECT = "exact";
+const HEADER = "X-RTD-Edge-Redirects";
+// How long the edge trusts header-learned rules (seconds).
+const CACHE_TTL = 60;
+
+export default {
+  async fetch(request, env, ctx) {
+    try {
+      const rules = await getRules(request, env);
+      if (rules) {
+        const redirect = buildRedirect(request, rules);
+        if (redirect) {
+          return redirect;
+        }
+      }
+    } catch (err) {
+      // Fail open: never let an edge bug take down doc serving.
+      console.error("edge redirect error", err);
+    }
+
+    // Pass through to the origin, and learn any rules it advertises.
+    const response = await fetch(request);
+    ctx.waitUntil(learnFromResponse(request, response));
+    return response;
+  },
+};
+
+async function getRules(request, env) {
+  const cached = await readCachedRules(request);
+  if (cached) {
+    return cached;
+  }
+  // Fall back to the pre-warmed KV namespace, if configured.
+  if (env.REDIRECTS_KV) {
+    const url = new URL(request.url);
+    const domain = await env.REDIRECTS_KV.get(`domain:${url.hostname}`, "json");
+    if (domain) {
+      const project = await env.REDIRECTS_KV.get(`project:${domain.project}`, "json");
+      if (project && project.redirects) {
+        return project.redirects;
+      }
+    }
+  }
+  return null;
+}
+
+function cacheKey(request) {
+  const url = new URL(request.url);
+  // Key only on the host: the rules are per-project, not per-path.
+  return new Request(`https://edge-redirects.invalid/${url.hostname}`);
+}
+
+async function readCachedRules(request) {
+  const hit = await caches.default.match(cacheKey(request));
+  if (!hit) {
+    return null;
+  }
+  return hit.json();
+}
+
+async function learnFromResponse(request, response) {
+  const header = response.headers.get(HEADER);
+  if (!header) {
+    return;
+  }
+  let rules;
+  try {
+    rules = JSON.parse(header);
+  } catch (err) {
+    return;
+  }
+  const body = new Response(JSON.stringify(rules), {
+    headers: { "Cache-Control": `max-age=${CACHE_TTL}` },
+  });
+  await caches.default.put(cacheKey(request), body);
+}
+
+function buildRedirect(request, rules) {
+  const url = new URL(request.url);
+  const match = matchRedirect(rules, url.pathname);
+  if (!match) {
+    return null;
+  }
+  const target = new URL(match.to, url).toString();
+  return new Response(null, {
+    status: match.status,
+    headers: {
+      Location: target,
+      // Mirror the origin so analytics can attribute edge redirects.
+      "X-RTD-Redirect": "user",
+      "X-RTD-Redirect-Source": "edge",
+    },
+  });
+}
+
+function matchRedirect(rules, pathname) {
+  const normalized = "/" + pathname.replace(/^\/+/, "");
+  const withoutSlash = normalized.replace(/\/+$/, "") || "/";
+
+  for (const redirect of rules) {
+    if (redirect.type !== EXACT_REDIRECT) {
+      continue;
+    }
+
+    if (redirect.from_prefix === null) {
+      if (withoutSlash === redirect.from.replace(/\/+$/, "")) {
+        return { to: redirect.to, status: redirect.status };
+      }
+      continue;
+    }
+
+    if (normalized.startsWith(redirect.from_prefix)) {
+      if (willCauseInfiniteRedirect(redirect.from_prefix, redirect.to, normalized)) {
+        continue;
+      }
+      const splat = normalized.slice(redirect.from_prefix.length);
+      const to = redirect.to.replace(SPLAT_PLACEHOLDER, splat);
+      return { to, status: redirect.status };
+    }
+  }
+
+  return null;
+}
+
+function willCauseInfiniteRedirect(fromPrefix, toUrl, currentPath) {
+  if (!toUrl.includes(SPLAT_PLACEHOLDER)) {
+    return false;
+  }
+  const toWithoutSplat = toUrl.split(SPLAT_PLACEHOLDER)[0];
+  const redirectsToSubpath = toWithoutSplat.startsWith(fromPrefix);
+  return redirectsToSubpath && currentPath.startsWith(toWithoutSplat);
+}

--- a/readthedocs/redirects/signals.py
+++ b/readthedocs/redirects/signals.py
@@ -1,6 +1,5 @@
 """Signals to keep the edge redirect store in sync with the database."""
 
-import structlog
 from django.conf import settings
 from django.db.models.signals import post_delete
 from django.db.models.signals import post_save
@@ -10,9 +9,6 @@ from readthedocs.projects.models import Domain
 from readthedocs.redirects.models import Redirect
 from readthedocs.redirects.tasks import remove_domain_from_edge
 from readthedocs.redirects.tasks import sync_project_to_edge
-
-
-log = structlog.get_logger(__name__)
 
 
 def _enabled():

--- a/readthedocs/redirects/signals.py
+++ b/readthedocs/redirects/signals.py
@@ -1,0 +1,42 @@
+"""Signals to keep the edge redirect store in sync with the database."""
+
+import structlog
+from django.conf import settings
+from django.db.models.signals import post_delete
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from readthedocs.projects.models import Domain
+from readthedocs.redirects.models import Redirect
+from readthedocs.redirects.tasks import remove_domain_from_edge
+from readthedocs.redirects.tasks import sync_project_to_edge
+
+
+log = structlog.get_logger(__name__)
+
+
+def _enabled():
+    return settings.RTD_EDGE_REDIRECTS_ENABLED
+
+
+@receiver(post_save, sender=Redirect)
+@receiver(post_delete, sender=Redirect)
+def resync_edge_on_redirect_change(sender, instance, **kwargs):
+    """Re-sync a project's redirects to the edge when one changes."""
+    if _enabled():
+        sync_project_to_edge.delay(instance.project_id)
+
+
+@receiver(post_save, sender=Domain)
+def resync_edge_on_domain_save(sender, instance, **kwargs):
+    """Re-sync the project when a custom domain changes (canonical/https/host)."""
+    if _enabled():
+        sync_project_to_edge.delay(instance.project_id)
+
+
+@receiver(post_delete, sender=Domain)
+def cleanup_edge_on_domain_delete(sender, instance, **kwargs):
+    """Drop the deleted host and refresh the project's canonical config."""
+    if _enabled():
+        remove_domain_from_edge.delay(instance.domain)
+        sync_project_to_edge.delay(instance.project_id)

--- a/readthedocs/redirects/tasks.py
+++ b/readthedocs/redirects/tasks.py
@@ -1,0 +1,44 @@
+"""Tasks to keep the edge redirect store in sync with the database."""
+
+import structlog
+from django.conf import settings
+
+from readthedocs.redirects.edge import get_edge_store
+from readthedocs.redirects.edge import remove_project
+from readthedocs.redirects.edge import sync_project
+from readthedocs.worker import app
+
+
+log = structlog.get_logger(__name__)
+
+
+@app.task(queue="web")
+def sync_project_to_edge(project_pk):
+    """Replicate a project's routing config and redirects to the edge."""
+    if not settings.RTD_EDGE_REDIRECTS_ENABLED:
+        return
+
+    # Imported here to avoid a circular import at module load time.
+    from readthedocs.projects.models import Project
+
+    project = Project.objects.filter(pk=project_pk).first()
+    if not project:
+        log.debug("Project not found, skipping edge sync.", project_pk=project_pk)
+        return
+    sync_project(project)
+
+
+@app.task(queue="web")
+def remove_project_from_edge(slug, hosts):
+    """Remove a project and its hosts from the edge store."""
+    if not settings.RTD_EDGE_REDIRECTS_ENABLED:
+        return
+    remove_project(slug, hosts)
+
+
+@app.task(queue="web")
+def remove_domain_from_edge(host):
+    """Drop a single host mapping from the edge store."""
+    if not settings.RTD_EDGE_REDIRECTS_ENABLED:
+        return
+    get_edge_store().delete_domain(host)

--- a/readthedocs/redirects/tests/test_edge.py
+++ b/readthedocs/redirects/tests/test_edge.py
@@ -67,12 +67,9 @@ class EdgeSerializationTests(TestCase):
         )
         assert edge.get_edge_redirects(self.project) == []
 
-    def test_serialize_project_includes_routing_config(self):
+    def test_serialize_project_includes_redirects(self):
         payload = edge.serialize_project(self.project)
         assert payload["project"] == "pip"
-        assert payload["default_version"] == "latest"
-        assert payload["default_language"] == "en"
-        assert payload["canonical_domain"] is None
         assert payload["redirects"] == []
 
     def test_get_project_hosts_includes_subdomain(self):

--- a/readthedocs/redirects/tests/test_edge.py
+++ b/readthedocs/redirects/tests/test_edge.py
@@ -1,0 +1,235 @@
+"""Tests for serving heavy redirects at the edge."""
+
+import json
+
+from django.core.cache import cache
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from readthedocs.projects.models import Project
+from readthedocs.redirects import edge
+from readthedocs.redirects.constants import EXACT_REDIRECT
+from readthedocs.redirects.constants import PAGE_REDIRECT
+from readthedocs.redirects.edge import LocalEdgeStore
+from readthedocs.redirects.models import Redirect
+
+
+@override_settings(PUBLIC_DOMAIN="readthedocs.io")
+class EdgeSerializationTests(TestCase):
+    def setUp(self):
+        LocalEdgeStore.reset()
+        self.project = Project.objects.create(
+            name="Pip",
+            slug="pip",
+            repo="https://github.com/pip/pip",
+            default_version="latest",
+            language="en",
+        )
+
+    def test_only_forced_redirects_are_edge_eligible(self):
+        forced = Redirect.objects.create(
+            project=self.project,
+            redirect_type=EXACT_REDIRECT,
+            from_url="/old/*",
+            to_url="/new/:splat",
+            force=True,
+        )
+        # Not forced -> excluded.
+        Redirect.objects.create(
+            project=self.project,
+            redirect_type=EXACT_REDIRECT,
+            from_url="/other",
+            to_url="/elsewhere",
+            force=False,
+        )
+        # Disabled -> excluded.
+        Redirect.objects.create(
+            project=self.project,
+            redirect_type=EXACT_REDIRECT,
+            from_url="/disabled",
+            to_url="/somewhere",
+            force=True,
+            enabled=False,
+        )
+        redirects = edge.get_edge_redirects(self.project)
+        assert len(redirects) == 1
+        assert redirects[0]["from"] == forced.from_url
+        assert redirects[0]["to"] == "/new/:splat"
+        assert redirects[0]["from_prefix"] == "/old/"
+
+    def test_page_redirects_are_not_edge_eligible_yet(self):
+        Redirect.objects.create(
+            project=self.project,
+            redirect_type=PAGE_REDIRECT,
+            from_url="/page.html",
+            to_url="/new.html",
+            force=True,
+        )
+        assert edge.get_edge_redirects(self.project) == []
+
+    def test_serialize_project_includes_routing_config(self):
+        payload = edge.serialize_project(self.project)
+        assert payload["project"] == "pip"
+        assert payload["default_version"] == "latest"
+        assert payload["default_language"] == "en"
+        assert payload["canonical_domain"] is None
+        assert payload["redirects"] == []
+
+    def test_get_project_hosts_includes_subdomain(self):
+        hosts = edge.get_project_hosts(self.project)
+        assert "pip.readthedocs.io" in hosts
+
+    def test_sync_writes_project_and_domains_to_store(self):
+        Redirect.objects.create(
+            project=self.project,
+            redirect_type=EXACT_REDIRECT,
+            from_url="/old/*",
+            to_url="/new/:splat",
+            force=True,
+        )
+        store = LocalEdgeStore()
+        edge.sync_project(self.project, store=store)
+
+        assert store.get_project("pip")["redirects"][0]["to"] == "/new/:splat"
+        assert store.get_domain("pip.readthedocs.io") == "pip"
+
+    def test_remove_project_clears_store(self):
+        store = LocalEdgeStore()
+        edge.sync_project(self.project, store=store)
+        hosts = edge.get_project_hosts(self.project)
+        edge.remove_project("pip", hosts, store=store)
+        assert store.get_project("pip") is None
+        assert store.get_domain("pip.readthedocs.io") is None
+
+
+@override_settings(PUBLIC_DOMAIN="readthedocs.io")
+class EdgeHeaderDeliveryTests(TestCase):
+    """The no-config delivery path: rules ride on a response header."""
+
+    def setUp(self):
+        cache.clear()
+        self.project = Project.objects.create(
+            name="Pip",
+            slug="pip",
+            repo="https://github.com/pip/pip",
+            default_version="latest",
+            language="en",
+        )
+
+    def test_header_is_none_without_forced_redirects(self):
+        assert edge.edge_redirects_header(self.project) is None
+
+    def test_header_serializes_forced_redirects_as_json(self):
+        Redirect.objects.create(
+            project=self.project,
+            redirect_type=EXACT_REDIRECT,
+            from_url="/old/*",
+            to_url="/new/:splat",
+            force=True,
+        )
+        header = edge.edge_redirects_header(self.project)
+        rules = json.loads(header)
+        assert rules[0]["from"] == "/old/*"
+        assert rules[0]["to"] == "/new/:splat"
+
+    def test_cached_header_is_reused(self):
+        value = edge.cached_edge_redirects_header(self.project)
+        assert value is None
+        # A redirect added after caching is not seen until the cache expires.
+        Redirect.objects.create(
+            project=self.project,
+            redirect_type=EXACT_REDIRECT,
+            from_url="/old",
+            to_url="/new",
+            force=True,
+        )
+        assert edge.cached_edge_redirects_header(self.project) is None
+        cache.clear()
+        assert edge.cached_edge_redirects_header(self.project) is not None
+
+
+class EdgeMatcherTests(TestCase):
+    """The reference matcher must stay in parity with the Worker/origin."""
+
+    def _payload(self, redirects):
+        return {"project": "pip", "redirects": redirects}
+
+    def test_exact_match_without_wildcard(self):
+        payload = self._payload(
+            [
+                {
+                    "type": EXACT_REDIRECT,
+                    "from": "/old",
+                    "from_prefix": None,
+                    "to": "/new",
+                    "status": 301,
+                }
+            ]
+        )
+        assert edge.match_redirect(payload, "/old") == ("/new", 301)
+        # Trailing slash is normalized away.
+        assert edge.match_redirect(payload, "/old/") == ("/new", 301)
+        assert edge.match_redirect(payload, "/other") is None
+
+    def test_wildcard_match_applies_splat(self):
+        payload = self._payload(
+            [
+                {
+                    "type": EXACT_REDIRECT,
+                    "from": "/old/*",
+                    "from_prefix": "/old/",
+                    "to": "/new/:splat",
+                    "status": 302,
+                }
+            ]
+        )
+        assert edge.match_redirect(payload, "/old/a/b.html") == ("/new/a/b.html", 302)
+
+    def test_query_string_is_ignored_for_matching(self):
+        payload = self._payload(
+            [
+                {
+                    "type": EXACT_REDIRECT,
+                    "from": "/old",
+                    "from_prefix": None,
+                    "to": "/new",
+                    "status": 301,
+                }
+            ]
+        )
+        assert edge.match_redirect(payload, "/old?foo=bar") == ("/new", 301)
+
+    def test_infinite_redirect_is_skipped(self):
+        payload = self._payload(
+            [
+                {
+                    "type": EXACT_REDIRECT,
+                    "from": "/dir/*",
+                    "from_prefix": "/dir/",
+                    "to": "/dir/sub/:splat",
+                    "status": 301,
+                }
+            ]
+        )
+        assert edge.match_redirect(payload, "/dir/sub/page.html") is None
+
+    def test_first_match_wins(self):
+        payload = self._payload(
+            [
+                {
+                    "type": EXACT_REDIRECT,
+                    "from": "/a/*",
+                    "from_prefix": "/a/",
+                    "to": "/first/:splat",
+                    "status": 301,
+                },
+                {
+                    "type": EXACT_REDIRECT,
+                    "from": "/a/*",
+                    "from_prefix": "/a/",
+                    "to": "/second/:splat",
+                    "status": 301,
+                },
+            ]
+        )
+        assert edge.match_redirect(payload, "/a/x") == ("/first/x", 301)

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -184,6 +184,17 @@ class CommunityBaseSettings(Settings):
     # Number of days the validation process for a domain will be retried.
     RTD_CUSTOM_DOMAINS_VALIDATION_PERIOD = 30
 
+    # Edge redirects: replicate routing config and forced redirects to the
+    # Cloudflare edge so they can be served without hitting the origin.
+    # See docs/dev/design/redirects-at-the-edge.rst.
+    RTD_EDGE_REDIRECTS_ENABLED = False
+    RTD_EDGE_REDIRECTS_STORE_CLASS = "readthedocs.redirects.edge.LocalEdgeStore"
+    # TTL (seconds) for the cached ``X-RTD-Edge-Redirects`` header value.
+    RTD_EDGE_REDIRECTS_HEADER_TTL = 60
+    RTD_EDGE_REDIRECTS_CLOUDFLARE_ACCOUNT_ID = None
+    RTD_EDGE_REDIRECTS_CLOUDFLARE_NAMESPACE_ID = None
+    RTD_EDGE_REDIRECTS_CLOUDFLARE_TOKEN = None
+
     # Keep BuildData models on database during this time
     RTD_TELEMETRY_DATA_RETENTION_DAYS = 30 * 6  # 180 days / 6 months
 


### PR DESCRIPTION
## Why

We were hit by an attack that flooded our documentation domains with high volumes of requests resolving to redirects. Redirects are decided in Python in Proxito today, and unique URLs are CDN cache misses, so the flood bypassed the cache and put load on the origin and the database — each redirect costing several DB queries before we even return a 301/302.

This moves the redirects that are cheap to decide but expensive to host onto the Cloudflare edge, so the platform stays available under that kind of load. The edge absorbs the volume on infrastructure built to scale for it, and the origin only sees traffic that genuinely needs origin state.

## Approach

The design doc (`docs/dev/design/redirects-at-the-edge.rst`) has the full reasoning. The short version: only redirects decidable **without origin state** can move. In this first cut that's **forced exact redirects** — they match on the whole request path and don't depend on whether the target file exists, the version list, or privacy. Page/clean-URL redirects need the edge to parse language and version out of the path first, so they remain at the origin for now (noted as a follow-up).

Two ways to get the rules to the edge, both supported here:

- **No-config (default).** The origin emits a project's forced redirects on an `X-RTD-Edge-Redirects` response header — reusing the same Worker header channel we already use for `X-RTD-Force-Addons`. The Worker learns and caches them per host, then serves subsequent cache-busting URLs at the edge. No Cloudflare API credentials, no sync pipeline; the header value is cached per project so it doesn't add a query per response.
- **Pre-warmed (optional).** A Celery task + signals replicate the same rules into Workers KV ahead of time, to absorb the very first request before the edge has learned anything.

A reference Worker (`edge_worker.js`) implements both paths and fails open to the origin at every step. A Python reference matcher (`match_redirect`) mirrors the Worker so we can test parity against the origin's logic.

Everything is gated behind `RTD_EDGE_REDIRECTS_ENABLED` (off by default), so this is inert until enabled. No model changes, so no migrations.

## Status

Basic implementation for review. The edge currently serves forced exact redirects only; structural redirects (canonical domain, default version, subproject) and the remaining user-redirect types are described in the design doc as next steps.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NURdKGzKDvGixoL3jcDg33)_