### PR TITLE
Docs: update GitHub App mentions

### DIFF
--- a/docs/user/guides/pull-requests.rst
+++ b/docs/user/guides/pull-requests.rst
@@ -17,6 +17,11 @@ See `Limitations`_ for more information.
    Pull requests opened before enabling pull request builds will not trigger new builds automatically.
    Push a new commit to the pull request to trigger its first build.
 
+.. note::
+
+   The previous method of pull request previews using a GitHub workflow that called `@readthedocs/actions <https://github.com/readthedocs/actions/>_ is now deprecated.
+   If you used that method, you should remove its configuration.
+
 Privacy levels
 --------------
 

--- a/docs/user/reference/git-integration.rst
+++ b/docs/user/reference/git-integration.rst
@@ -272,10 +272,6 @@ depending on where the project you are trying to access has permissions from.
 GitHub App
 ----------
 
-.. warning::
-
-   Our GitHub App is currently in beta, see our `blog post <https://about.readthedocs.com/blog/2025/06/announcing-our-github-app-beta/>`__ for more information.
-
 We are in the process of migrating our GitHub OAuth application to a `GitHub App <https://docs.github.com/en/apps/overview>`__.
 We have two GitHub Apps, one for each of our platforms:
 

--- a/docs/user/reference/git-integration.rst
+++ b/docs/user/reference/git-integration.rst
@@ -253,7 +253,7 @@ depending on where the project you are trying to access has permissions from.
    If you are using the :ref:`GitHub App <reference/git-integration:GitHub App>`,
    you only need to make sure that the GitHub App is installed in your account or organization,
    and that it has access to the repository you want to use for your project.
-   See :ref:`the troubleshooting steps <reference/git-integration:Troubleshooting>` for more information.
+   See :ref:`GitHub App troubleshooting <reference/git-integration:Troubleshooting>` for more information.
 
 .. tabs::
 
@@ -279,9 +279,9 @@ depending on where the project you are trying to access has permissions from.
 GitHub App
 ----------
 
-Our `GitHub App <https://docs.github.com/en/apps/overview>`__ is a new way to connect your GitHub account to Read the Docs,
-replacing the old OAuth application.
-We have two GitHub Apps, one for each of our platforms:
+A `GitHub App <https://docs.github.com/en/apps/overview>`__ is a new way to connect your GitHub account to Read the Docs,
+and is replacing the old OAuth application.
+Read the Docs provides two GitHub Apps, one for each of our platforms:
 
 - `Read the Docs Community <https://github.com/apps/read-the-docs-community>`__
 - `Read the Docs Business <https://github.com/apps/read-the-docs-business>`__

--- a/docs/user/reference/git-integration.rst
+++ b/docs/user/reference/git-integration.rst
@@ -279,7 +279,8 @@ depending on where the project you are trying to access has permissions from.
 GitHub App
 ----------
 
-We are in the process of migrating our GitHub OAuth application to a `GitHub App <https://docs.github.com/en/apps/overview>`__.
+Our `GitHub App <https://docs.github.com/en/apps/overview>`__ is a new way to connect your GitHub account to Read the Docs,
+replacing the old OAuth application.
 We have two GitHub Apps, one for each of our platforms:
 
 - `Read the Docs Community <https://github.com/apps/read-the-docs-community>`__

--- a/docs/user/reference/git-integration.rst
+++ b/docs/user/reference/git-integration.rst
@@ -279,8 +279,8 @@ depending on where the project you are trying to access has permissions from.
 GitHub App
 ----------
 
-A `GitHub App <https://docs.github.com/en/apps/overview>`__ is a new way to connect your GitHub account to Read the Docs,
-and is replacing the old OAuth application.
+We now provide a `GitHub App <https://docs.github.com/en/apps/overview>`__ for connecting your GitHub account to Read the Docs.
+This will replace the old OAuth GitHub integration.
 Read the Docs provides two GitHub Apps, one for each of our platforms:
 
 - `Read the Docs Community <https://github.com/apps/read-the-docs-community>`__

--- a/docs/user/reference/git-integration.rst
+++ b/docs/user/reference/git-integration.rst
@@ -145,6 +145,34 @@ so that you can log in to Read the Docs with your connected account credentials.
 
 .. tabs::
 
+   .. tab:: GitHub App
+
+      Read the Docs requests the following permissions when connecting your Read the Docs account to our :ref:`GitHub App <reference/git-integration:GitHub App>`.
+
+      Account email addresses (read only)
+          We ask for this so we can verify your email address and create a Read the Docs account.
+
+      When installing the Read the Docs GitHub App in a repository, you will be asked to grant the following permissions:
+
+      Repository permissions
+        Commit statuses (read and write)
+          This allows Read the Docs to report the status of the build to GitHub.
+        Contents (read only)
+          This allows Read the Docs to clone the repository and build the documentation.
+        Metadata (read only)
+          This allows Read the Docs to read the repository collaborators and the permissions they have on the repository.
+          This is used to determine if the user can connect a repository to a Read the Docs project.
+        Pull requests (read and write)
+          This allows Read the Docs to subscribe to pull request events,
+          and to create a comment on the pull request with information about the build.
+        Checks (read and write)
+          This allows Read the Docs to use the GitHub Checks API to report the status of the build.
+          This isn't used yet, but we may use it in the future.
+
+      Organization permissions
+        Members (read only)
+          This allows Read the Docs to read the organization members.
+
    .. tab:: GitHub
 
       Read the Docs requests the following permissions (more precisely, `OAuth scopes`_)
@@ -175,34 +203,6 @@ so that you can log in to Read the Docs with your connected account credentials.
           Unfortunately, this is the permission for read/write control of the repository
           but there isn't a more granular permission
           that only allows setting up SSH keys for read access.
-
-   .. tab:: GitHub App
-
-      Read the Docs requests the following permissions when connecting your Read the Docs account to our :ref:`GitHub App <reference/git-integration:GitHub App>`.
-
-      Account email addresses (read only)
-          We ask for this so we can verify your email address and create a Read the Docs account.
-
-      When installing the Read the Docs GitHub App in a repository, you will be asked to grant the following permissions:
-
-      Repository permissions
-        Commit statuses (read and write)
-          This allows Read the Docs to report the status of the build to GitHub.
-        Contents (read only)
-          This allows Read the Docs to clone the repository and build the documentation.
-        Metadata (read only)
-          This allows Read the Docs to read the repository collaborators and the permissions they have on the repository.
-          This is used to determine if the user can connect a repository to a Read the Docs project.
-        Pull requests (read and write)
-          This allows Read the Docs to subscribe to pull request events,
-          and to create a comment on the pull request with information about the build.
-        Checks (read and write)
-          This allows Read the Docs to use the GitHub Checks API to report the status of the build.
-          This isn't used yet, but we may use it in the future.
-
-      Organization permissions
-        Members (read only)
-          This allows Read the Docs to read the organization members.
 
    .. tab:: Bitbucket
 
@@ -247,6 +247,13 @@ Many organizations require approval for each OAuth application that is used,
 or you might have disabled it in the past for your personal account.
 This can happen at the personal or organization level,
 depending on where the project you are trying to access has permissions from.
+
+.. note::
+   
+   If you are using the :ref:`GitHub App <reference/git-integration:GitHub App>`,
+   you only need to make sure that the GitHub App is installed in your account or organization,
+   and that it has access to the repository you want to use for your project.
+   See :ref:`the troubleshooting steps <reference/git-integration:Troubleshooting>` for more information.
 
 .. tabs::
 

--- a/docs/user/reference/git-integration.rst
+++ b/docs/user/reference/git-integration.rst
@@ -249,7 +249,7 @@ This can happen at the personal or organization level,
 depending on where the project you are trying to access has permissions from.
 
 .. note::
-   
+
    If you are using the :ref:`GitHub App <reference/git-integration:GitHub App>`,
    you only need to make sure that the GitHub App is installed in your account or organization,
    and that it has access to the repository you want to use for your project.


### PR DESCRIPTION
- Remove beta mention
- Put the permissions required for the GitHub App first
- Link to the GH App from the permission troubleshooting section.