### PR TITLE
Build: don't sync or install dev dependencies when using `uv run`

### DIFF
--- a/readthedocs/doc_builder/backends/mkdocs.py
+++ b/readthedocs/doc_builder/backends/mkdocs.py
@@ -90,6 +90,8 @@ class BaseMkdocs(BaseBuilder):
             return (
                 "uv",
                 "run",
+                "--no-sync",
+                "--no-dev",
                 "mkdocs",
             )
 

--- a/readthedocs/doc_builder/backends/sphinx.py
+++ b/readthedocs/doc_builder/backends/sphinx.py
@@ -181,6 +181,8 @@ class BaseSphinx(BaseBuilder):
             return (
                 "uv",
                 "run",
+                "--no-sync",
+                "--no-dev",
                 "sphinx-build",
             )
 

--- a/readthedocs/rtd_tests/tests/test_doc_builder.py
+++ b/readthedocs/rtd_tests/tests/test_doc_builder.py
@@ -11,6 +11,7 @@ from readthedocs.config.tests.test_config import get_build_config
 from readthedocs.doc_builder.backends.mkdocs import BaseMkdocs
 from readthedocs.doc_builder.backends.mkdocs import MkdocsHTML
 from readthedocs.doc_builder.backends.sphinx import BaseSphinx
+from readthedocs.doc_builder.backends.sphinx import HtmlBuilder
 from readthedocs.doc_builder.python_environments import UvEnv
 from readthedocs.doc_builder.python_environments import Virtualenv
 from readthedocs.projects.exceptions import ProjectConfigurationError
@@ -117,6 +118,82 @@ class SphinxBuilderTest(TestCase):
             with override_settings(DOCROOT=tmp_docs_dir):
                 base_sphinx.show_conf()
 
+    @patch("readthedocs.doc_builder.backends.sphinx.BaseSphinx.run")
+    @patch("readthedocs.projects.models.Project.checkout_path")
+    @patch("readthedocs.doc_builder.python_environments.load_yaml_config")
+    def test_get_sphinx_cmd_uses_uv_run_for_uv_env(
+        self,
+        load_yaml_config,
+        checkout_path,
+        _,
+    ):
+        """
+        When the python env is uv-managed, the sphinx builder
+        should invoke ``uv run sphinx-build`` instead of ``python -m sphinx``.
+        """
+        tmp_dir = tempfile.mkdtemp()
+        checkout_path.return_value = tmp_dir
+        config = get_build_config(
+            {
+                "sphinx": {"configuration": "conf.py"},
+                "python": {
+                    "install": [{"method": "uv", "command": "sync"}],
+                },
+            },
+            validate=True,
+            source_file=f"{tmp_dir}/readthedocs.yml",
+        )
+        python_env = UvEnv(
+            version=self.version,
+            build_env=self.build_env,
+            config=config,
+        )
+        builder = HtmlBuilder(
+            build_env=self.build_env,
+            python_env=python_env,
+        )
+
+        assert builder.get_sphinx_cmd() == (
+            "uv",
+            "run",
+            "--no-sync",
+            "--no-dev",
+            "sphinx-build",
+        )
+
+    @patch("readthedocs.doc_builder.backends.sphinx.BaseSphinx.run")
+    @patch("readthedocs.projects.models.Project.checkout_path")
+    @patch("readthedocs.doc_builder.python_environments.load_yaml_config")
+    def test_get_sphinx_cmd_uses_python_module_for_virtualenv(
+        self,
+        load_yaml_config,
+        checkout_path,
+        _,
+    ):
+        """A non-uv environment should keep using ``python -m sphinx``."""
+        tmp_dir = tempfile.mkdtemp()
+        checkout_path.return_value = tmp_dir
+        config = get_build_config(
+            {"sphinx": {"configuration": "conf.py"}},
+            validate=True,
+            source_file=f"{tmp_dir}/readthedocs.yml",
+        )
+        python_env = Virtualenv(
+            version=self.version,
+            build_env=self.build_env,
+            config=config,
+        )
+        builder = HtmlBuilder(
+            build_env=self.build_env,
+            python_env=python_env,
+        )
+
+        assert builder.get_sphinx_cmd() == (
+            python_env.venv_bin(filename="python"),
+            "-m",
+            "sphinx",
+        )
+
 
 @override_settings(PRODUCTION_DOMAIN="readthedocs.org")
 class MkDocsBuilderTest(TestCase):
@@ -211,7 +288,7 @@ class MkDocsBuilderTest(TestCase):
             python_env=python_env,
         )
 
-        assert builder.get_mkdocs_cmd() == ("uv", "run", "mkdocs")
+        assert builder.get_mkdocs_cmd() == ("uv", "run", "--no-sync", "--no-dev", "mkdocs")
 
     @patch("readthedocs.doc_builder.backends.mkdocs.BaseMkdocs.run")
     @patch("readthedocs.projects.models.Project.checkout_path")


### PR DESCRIPTION
The `uv sync` step does this for us in a previous step. At the moment we are calling `uv run` the environment should have all the dependencies installed, so we don't need to install them again.

Using `--no-sync` and `--no-dev` makes UV to not install dependencies that were skipped on purpose in the `uv sync` step, like dev dependencies.

Closes #13099