### PR TITLE
Automation rules: don't skip builds from other version types

### DIFF
--- a/readthedocs/oauth/tasks.py
+++ b/readthedocs/oauth/tasks.py
@@ -597,8 +597,8 @@ class GitHubAppWebhookHandler:
             # However, if there are no webhook automation rules configured,
             # we continue with the build as usual.
             webhook_rules = [
-                rule for rule in
-                project.automation_rules.filter(
+                rule
+                for rule in project.automation_rules.filter(
                     enabled=True,
                     action__in=AutomationRule.BUILD_ACTIONS,
                     # NOTE: we cannot use __contains on JSON field on SQLite because it's not supported.
@@ -678,8 +678,8 @@ class GitHubAppWebhookHandler:
                 # However, if there are no webhook automation rules configured,
                 # we continue with the build as usual.
                 webhook_rules = [
-                    rule for rule in
-                    project.automation_rules.filter(
+                    rule
+                    for rule in project.automation_rules.filter(
                         enabled=True,
                         action__in=AutomationRule.BUILD_ACTIONS,
                         # NOTE: we cannot use __contains on JSON field on SQLite because it's not supported.

--- a/readthedocs/oauth/tasks.py
+++ b/readthedocs/oauth/tasks.py
@@ -596,22 +596,25 @@ class GitHubAppWebhookHandler:
             # If none one matches, it finishes here.
             # However, if there are no webhook automation rules configured,
             # we continue with the build as usual.
-            webhook_rules = project.automation_rules.filter(
-                enabled=True,
-                action__in=AutomationRule.BUILD_ACTIONS,
-                # NOTE: we cannot use __contains on JSON field on SQLite because it's not supported.
-                # We are using `rule.match_version` below to check this instead.
-                # version_types__contains=version_type,
-            )
-            if webhook_rules.exists():
+            webhook_rules = [
+                rule for rule in
+                project.automation_rules.filter(
+                    enabled=True,
+                    action__in=AutomationRule.BUILD_ACTIONS,
+                    # NOTE: we cannot use __contains on JSON field on SQLite because it's not supported.
+                    # We are using `rule.match_version` below to check this instead.
+                    # version_types__contains=version_type,
+                )
+                if version_type in rule.version_types
+            ]
+            if webhook_rules:
                 changed_files = self._get_changed_files_from_push_event()
                 commit_message = self.data["head_commit"]["message"]
                 labels = []  # We don't have labels in push events, so we leave it empty.
 
                 rule_triggered_for_project = False
                 for version in project.versions_from_name(version_name, version_type):
-                    rule_triggered_for_version = False
-                    for rule in webhook_rules.iterator():
+                    for rule in webhook_rules:
                         if rule.match_version(version=version) and rule.match_webhook(
                             changed_files=changed_files,
                             commit_message=commit_message,
@@ -627,12 +630,10 @@ class GitHubAppWebhookHandler:
                                 version_type=version_type,
                             )
                             rule_triggered_for_project = True
-                            rule_triggered_for_version = True
                             rule.run(version)
 
-                        # We only trigger the first matching rule per version
-                        # to avoid triggering multiple builds for the same tag/branches.
-                        if rule_triggered_for_version:
+                            # We only trigger the first matching rule per version
+                            # to avoid triggering multiple builds for the same tag/branches.
                             break
 
                 if not rule_triggered_for_project:
@@ -676,14 +677,18 @@ class GitHubAppWebhookHandler:
                 # If none one matches, it finishes here.
                 # However, if there are no webhook automation rules configured,
                 # we continue with the build as usual.
-                webhook_rules = project.automation_rules.filter(
-                    enabled=True,
-                    action__in=AutomationRule.BUILD_ACTIONS,
-                    # NOTE: we cannot use __contains on JSON field on SQLite because it's not supported.
-                    # We are using `rule.match_version` below to check this instead.
-                    # version_types__contains=EXTERNAL,
-                )
-                if webhook_rules.exists():
+                webhook_rules = [
+                    rule for rule in
+                    project.automation_rules.filter(
+                        enabled=True,
+                        action__in=AutomationRule.BUILD_ACTIONS,
+                        # NOTE: we cannot use __contains on JSON field on SQLite because it's not supported.
+                        # We are using `rule.match_version` below to check this instead.
+                        # version_types__contains=EXTERNAL,
+                    )
+                    if EXTERNAL in rule.version_types
+                ]
+                if webhook_rules:
                     rule_triggered = False
                     changed_files = self._get_changed_files_from_pull_request_event(
                         project,
@@ -692,7 +697,7 @@ class GitHubAppWebhookHandler:
                     commit_message = self._get_commit_message_from_pull_request_event(project)
                     labels = self._get_labels_from_pull_request_event()
 
-                    for rule in webhook_rules.iterator():
+                    for rule in webhook_rules:
                         if rule.match_version(version=external_version) and rule.match_webhook(
                             changed_files=changed_files,
                             commit_message=commit_message,

--- a/readthedocs/oauth/tests/test_githubapp_webhook.py
+++ b/readthedocs/oauth/tests/test_githubapp_webhook.py
@@ -1733,3 +1733,101 @@ class TestGitHubAppWebhookWithAutomationRules(TestCase):
             commit=external_version.identifier,
             from_webhook=True,
         )
+
+    @mock.patch("readthedocs.core.views.hooks.trigger_build")
+    def test_push_branch_with_pr_only_webhook_rule(self, trigger_build):
+        """Test that a rule for PRs (EXTERNAL) doesn't skip push builds for branches."""
+        # Create a webhook automation rule that only matches PRs (EXTERNAL),
+        # not branches or tags.
+        get(
+            AutomationRule,
+            project=self.project,
+            priority=0,
+            version_predefined_match_pattern=ALL_VERSIONS,
+            webhook_files_match_pattern=["docs/*.rst"],
+            action=AutomationRule.TRIGGER_BUILD_ACTION,
+            version_types=[EXTERNAL],
+        )
+
+        payload = {
+            "installation": {
+                "id": self.installation.installation_id,
+                "target_id": self.installation.target_id,
+                "target_type": self.installation.target_type,
+            },
+            "created": False,
+            "deleted": False,
+            "ref": "refs/heads/main",
+            "repository": {
+                "id": self.remote_repository.remote_id,
+                "full_name": self.remote_repository.full_name,
+            },
+            "commits": [
+                {
+                    "added": ["src/code.py"],
+                    "modified": [],
+                    "removed": [],
+                }
+            ],
+        }
+        r = self.post_webhook("push", payload)
+        assert r.status_code == 200
+
+        # Should trigger build normally since the rule is for PRs only, not branches.
+        trigger_build.assert_has_calls(
+            [
+                mock.call(project=self.project, version=self.version_main, from_webhook=True),
+                mock.call(project=self.project, version=self.version_latest, from_webhook=True),
+            ]
+        )
+
+    @mock.patch("readthedocs.oauth.tasks.trigger_build")
+    def test_pull_request_with_branch_only_webhook_rule(self, trigger_build):
+        """Test that a rule for branches (BRANCH) doesn't skip PR builds."""
+        self.project.external_builds_enabled = True
+        self.project.save()
+
+        # Create a webhook automation rule that only matches branches, not PRs.
+        get(
+            AutomationRule,
+            project=self.project,
+            priority=0,
+            version_predefined_match_pattern=ALL_VERSIONS,
+            webhook_files_match_pattern=["docs/*.rst"],
+            action=AutomationRule.TRIGGER_BUILD_ACTION,
+            version_types=[BRANCH],
+        )
+
+        payload = {
+            "installation": {
+                "id": self.installation.installation_id,
+                "target_id": self.installation.target_id,
+                "target_type": self.installation.target_type,
+            },
+            "action": "opened",
+            "pull_request": {
+                "number": 1,
+                "head": {
+                    "ref": "new-feature",
+                    "sha": "1234abcd",
+                },
+                "base": {
+                    "ref": "main",
+                },
+            },
+            "repository": {
+                "id": self.remote_repository.remote_id,
+                "full_name": self.remote_repository.full_name,
+            },
+        }
+        r = self.post_webhook("pull_request", payload)
+        assert r.status_code == 200
+
+        # Should trigger build normally since the rule is for branches only, not PRs.
+        external_version = self.project.versions.get(verbose_name="1", type=EXTERNAL)
+        trigger_build.assert_called_once_with(
+            project=self.project,
+            version=external_version,
+            commit=external_version.identifier,
+            from_webhook=True,
+        )


### PR DESCRIPTION
Rules created to match PRs shouldn't affect builds from normal versions and the other way around. That was the intended logic, but looks like the workaround for the sqlite error broke that.