### PR TITLE
Automation rules: post commit status when triggering a build

### DIFF
--- a/readthedocs/builds/automation_actions.py
+++ b/readthedocs/builds/automation_actions.py
@@ -17,10 +17,10 @@ from readthedocs.projects.constants import PUBLIC
 log = structlog.get_logger(__name__)
 
 
-def trigger_build_for_version(version, *args, **kwargs):
+def trigger_build_for_version(version, *args, commit=None, **kwargs):
     """Trigger a build for this version."""
     if version.active:
-        trigger_build(project=version.project, version=version, from_webhook=True)
+        trigger_build(project=version.project, version=version, commit=commit, from_webhook=True)
 
 
 def activate_version(version, *args, **kwargs):

--- a/readthedocs/oauth/tasks.py
+++ b/readthedocs/oauth/tasks.py
@@ -707,7 +707,7 @@ class GitHubAppWebhookHandler:
                                 version_type=EXTERNAL,
                             )
                             rule_triggered = True
-                            rule.run(external_version)
+                            rule.run(external_version, commit=external_version.identifier)
 
                             # We only trigger the first matching rule, to avoid triggering multiple builds for the same PR.
                             break

--- a/readthedocs/oauth/tests/test_githubapp_webhook.py
+++ b/readthedocs/oauth/tests/test_githubapp_webhook.py
@@ -1223,8 +1223,8 @@ class TestGitHubAppWebhookWithAutomationRules(TestCase):
         # Should trigger build because commit message matches '^docs:'
         trigger_build.assert_has_calls(
             [
-                mock.call(project=self.project, version=self.version_main, from_webhook=True),
-                mock.call(project=self.project, version=self.version_latest, from_webhook=True),
+                mock.call(project=self.project, version=self.version_main, commit=None, from_webhook=True),
+                mock.call(project=self.project, version=self.version_latest, commit=None, from_webhook=True),
             ]
         )
 
@@ -1384,6 +1384,7 @@ class TestGitHubAppWebhookWithAutomationRules(TestCase):
             ],
         )
 
+        commit = "1234abcd"
         payload = {
             "installation": {
                 "id": self.installation.installation_id,
@@ -1395,7 +1396,7 @@ class TestGitHubAppWebhookWithAutomationRules(TestCase):
                 "number": 1,
                 "head": {
                     "ref": "new-feature",
-                    "sha": "1234abcd",
+                    "sha": commit,
                 },
                 "base": {
                     "ref": "main",
@@ -1419,6 +1420,7 @@ class TestGitHubAppWebhookWithAutomationRules(TestCase):
         trigger_build.assert_called_once_with(
             project=self.project,
             version=external_version,
+            commit=commit,
             from_webhook=True,
         )
 
@@ -1559,6 +1561,7 @@ class TestGitHubAppWebhookWithAutomationRules(TestCase):
             },
         )
 
+        commit = "1234abcd"
         payload = {
             "installation": {
                 "id": self.installation.installation_id,
@@ -1570,7 +1573,7 @@ class TestGitHubAppWebhookWithAutomationRules(TestCase):
                 "number": 1,
                 "head": {
                     "ref": "new-feature",
-                    "sha": "1234abcd",
+                    "sha": commit,
                 },
                 "base": {
                     "ref": "main",
@@ -1593,6 +1596,7 @@ class TestGitHubAppWebhookWithAutomationRules(TestCase):
         trigger_build.assert_called_once_with(
             project=self.project,
             version=external_version,
+            commit=commit,
             from_webhook=True,
         )
 

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -2611,11 +2611,13 @@ class AutomationRule(TimeStampedModel):
                 return False
         return True
 
-    def run(self, version):
+    def run(self, version, *args, **kwargs):
         """
         Run the rule.
 
         :param version: Version instance to check and act upon
+        :param args: Additional positional arguments to pass to the action function
+        :param kwargs: Additional keyword arguments to pass to the action function
         :return: True if the action was performed, False otherwise
         """
         # Avoid circular imports
@@ -2633,7 +2635,7 @@ class AutomationRule(TimeStampedModel):
 
         action_func = actions_map.get(self.action)
         if action_func:
-            action_func(version)
+            action_func(version, *args, **kwargs)
         else:
             raise NotImplementedError(f"Action {self.action} is not implemented")
 

--- a/readthedocs/rtd_tests/tests/test_automation_rules.py
+++ b/readthedocs/rtd_tests/tests/test_automation_rules.py
@@ -883,6 +883,7 @@ class TestWebhookAutomationRules:
         trigger_build.assert_called_once_with(
             project=self.project,
             version=self.version,
+            commit=None,
             from_webhook=True,
         )
 
@@ -955,6 +956,7 @@ class TestWebhookAutomationRules:
         trigger_build.assert_called_once_with(
             project=self.project,
             version=external_version,
+            commit=None,
             from_webhook=True,
         )
 


### PR DESCRIPTION
When triggering a build using automation rules we weren't passing a commit, passing a commit is needed to post the commit status to GH.