### PR TITLE
Build: define `READTHEDOCS_VIRTUALENV_PATH` when building with `uv`

### DIFF
--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -836,37 +836,32 @@ class BuildDirector:
                 }
             )
 
+        # UV_PROJECT_ENVIRONMENT and READTHEDOCS_VIRTUALENV_PATH are the same
+        venv_path = os.path.join(
+            self.data.project.doc_path,
+            "envs",
+            self.data.version.slug,
+        )
         if self.data.config.is_using_uv:
             try:
                 UV_PROJECT = self.data.config.python.install[0].path
             except (AttributeError, IndexError):
                 UV_PROJECT = self.data.project.checkout_path(self.data.version.slug)
+
             env.update(
                 {
                     # UV_PYTHON is set in `install_build_tools` once we have Python installed,
                     # here I'm setting just an empty string.
                     "UV_PYTHON": "",
                     "UV_PROJECT": UV_PROJECT,
-                    # UV_PROJECT_ENVIRONMENT is the same as READTHEDOCS_VIRTUALENV_PATH
-                    "UV_PROJECT_ENVIRONMENT": os.path.join(
-                        self.data.project.doc_path,
-                        "envs",
-                        self.data.version.slug,
-                    ),
-                }
-            )
-        else:
-            env.update(
-                {
-                    "READTHEDOCS_VIRTUALENV_PATH": os.path.join(
-                        self.data.project.doc_path, "envs", self.data.version.slug
-                    ),
+                    "UV_PROJECT_ENVIRONMENT": venv_path,
                 }
             )
 
         env.update(
             {
                 "READTHEDOCS_CANONICAL_URL": self.data.version.canonical_url,
+                "READTHEDOCS_VIRTUALENV_PATH": venv_path,
             }
         )
 

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -426,6 +426,42 @@ class TestBuildTask(BuildEnvironmentBase):
             expected_build_env_vars["PRIVATE_TOKEN"] = "a1b2c3"
         assert build_env_vars == expected_build_env_vars
 
+    @mock.patch("readthedocs.projects.tasks.builds.LocalBuildEnvironment")
+    @mock.patch("readthedocs.doc_builder.director.load_yaml_config")
+    def test_get_env_vars_using_uv(self, load_yaml_config, build_environment):
+        config = {
+            "version": 2,
+            "build": {
+                "os": "ubuntu-22.04",
+                "tools": {
+                    "python": "3.10",
+                },
+            },
+            "python": {
+                "install": [
+                    {
+                        "method": "uv",
+                        "command": "sync",
+                    },
+                ],
+            },
+        }
+        load_yaml_config.return_value = get_build_config(config, validate=True)
+
+        self._trigger_update_docs_task()
+
+        build_env_vars = build_environment.call_args_list[1][1]["environment"]
+
+        venv_path = os.path.join(
+            self.project.doc_path,
+            "envs",
+            self.version.slug,
+        )
+        # `READTHEDOCS_VIRTUALENV_PATH` must be defined even when building with `uv`,
+        # and it must match `UV_PROJECT_ENVIRONMENT`.
+        assert build_env_vars["READTHEDOCS_VIRTUALENV_PATH"] == venv_path
+        assert build_env_vars["UV_PROJECT_ENVIRONMENT"] == venv_path
+
     @override_settings(
         DOCROOT="/tmp/readthedocs-tests/git-repository/",
         RTD_BUILD_MEDIA_STORAGE = "readthedocs.storage.s3_storage.S3BuildMediaStorage",


### PR DESCRIPTION
We weren't defining the `READTHEDOCS_VIRTUALENV_PATH` environment variable when building with `uv`,
which was causing then venv being created at `.venv` instead of the expected `envs/<version>`.

## Before

<img width="755" height="97" alt="Screenshot_2026-07-02_11-01-26" src="https://github.com/user-attachments/assets/fe161b82-9e25-4c76-9f0e-7406972e8fdb" />


## After

<img width="1115" height="122" alt="Screenshot_2026-07-02_11-01-34" src="https://github.com/user-attachments/assets/86d86942-47e5-4878-be81-04ca11520ef9" />



Related:
- https://github.com/readthedocs/readthedocs.org/issues/13168
- https://github.com/readthedocs/readthedocs.org/issues/13099