### PR TITLE
Build: don't remove attribute from build API response

### DIFF
--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -940,17 +940,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
 
         :param build_pk: Build primary key
         """
-        build = {}
-        if build_pk:
-            build = self.data.api_client.build(build_pk).get()
-        private_keys = [
-            "project",
-            "version",
-            "resource_uri",
-            "absolute_uri",
-        ]
-        # TODO: try to use the same technique than for ``APIProject``.
-        return {key: val for key, val in build.items() if key not in private_keys}
+        return self.data.api_client.build(build_pk).get()
 
     # NOTE: this can be just updated on `self.data.build['']` and sent once the
     # build has finished to reduce API calls.


### PR DESCRIPTION
Traced back to this old commit: https://github.com/readthedocs/readthedocs.org/commit/ff432361a606da4b9b9952b1eee17589202acc62, but there is no need to remove these attributes,
the version attribute for example has the version ID, which would let the task accept only the build ID instead of the build and version ID.

The other attributes don't even exist in the serializer, project and version are read-only too.