### PR TITLE
Builds: missing chunks of code to make isolated builders work

### DIFF
--- a/readthedocs/api/v2/views/model_views.py
+++ b/readthedocs/api/v2/views/model_views.py
@@ -266,13 +266,14 @@ class BuildViewSet(DisableListEndpoint, UpdateModelMixin, UserSelectViewSet):
         Run the post-build tasks when an isolated build reaches a final state.
         """
         # Read before saving: this is still the state stored in the database.
-        previous_state = serializer.instance.state
+        was_finished = serializer.instance.finished
         build = serializer.save()
 
-        entered_final_state = (
-            previous_state not in BUILD_FINAL_STATES and build.state in BUILD_FINAL_STATES
-        )
-        if entered_final_state and build.project.has_feature(Feature.USE_ISOLATED_BUILDER):
+        if (
+            not was_finished
+            and build.finished
+            and build.project.has_feature(Feature.USE_ISOLATED_BUILDER)
+        ):
             run_post_build_tasks.delay(build_pk=build.pk)
 
     def get_serializer_class(self):

--- a/readthedocs/api/v2/views/model_views.py
+++ b/readthedocs/api/v2/views/model_views.py
@@ -37,11 +37,13 @@ from readthedocs.builds.constants import INTERNAL
 from readthedocs.builds.models import Build
 from readthedocs.builds.models import BuildCommandResult
 from readthedocs.builds.models import Version
+from readthedocs.builds.tasks import run_post_build_tasks
 from readthedocs.notifications.models import Notification
 from readthedocs.oauth.models import RemoteOrganization
 from readthedocs.oauth.models import RemoteRepository
 from readthedocs.oauth.services import registry
 from readthedocs.projects.models import Domain
+from readthedocs.projects.models import Feature
 from readthedocs.projects.models import Project
 from readthedocs.storage import build_commands_storage
 
@@ -258,6 +260,20 @@ class BuildViewSet(DisableListEndpoint, UpdateModelMixin, UserSelectViewSet):
     renderer_classes = (JSONRenderer, PlainTextBuildRenderer)
     model = Build
     filterset_fields = ("project__slug", "commit")
+
+    def perform_update(self, serializer):
+        """
+        Run the post-build tasks when an isolated build reaches a final state.
+        """
+        # Read before saving: this is still the state stored in the database.
+        previous_state = serializer.instance.state
+        build = serializer.save()
+
+        entered_final_state = (
+            previous_state not in BUILD_FINAL_STATES and build.state in BUILD_FINAL_STATES
+        )
+        if entered_final_state and build.project.has_feature(Feature.USE_ISOLATED_BUILDER):
+            run_post_build_tasks.delay(build_pk=build.pk)
 
     def get_serializer_class(self):
         """

--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -702,11 +702,8 @@ def run_post_build_tasks(build_pk):
     """
     Run the post-build work for a build from the isolated-builders fleet.
 
-    On the legacy path ``update_docs_task`` does this from ``on_success`` /
-    ``on_failure``, because the builder is itself a Celery worker with database
-    access. The isolated runner has neither: it only PATCHes the API, so the
-    dispatch has to happen here instead. Triggered from ``BuildViewSet`` when a
-    build reaches a final state — see ``perform_update`` there for the gating.
+    Triggered from ``BuildViewSet`` when a build reaches a final state — 
+    see ``perform_update`` there for the gating.
 
     The Version is *not* updated here: ``built``, ``has_pdf`` and friends are
     derived from the artifacts the build produced, which only the runner can see.

--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -3,6 +3,7 @@ import json
 import requests
 import structlog
 from django.conf import settings
+from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.urls import reverse
 from django.utils import timezone
@@ -18,6 +19,7 @@ from readthedocs.api.v2.utils import sync_versions_to_db
 from readthedocs.builds.constants import BRANCH
 from readthedocs.builds.constants import BUILD_STATUS_FAILURE
 from readthedocs.builds.constants import BUILD_STATUS_PENDING
+from readthedocs.builds.constants import BUILD_STATUS_SKIPPED
 from readthedocs.builds.constants import BUILD_STATUS_SUCCESS
 from readthedocs.builds.constants import EXTERNAL
 from readthedocs.builds.constants import EXTERNAL_VERSION_STATE_CLOSED
@@ -693,3 +695,87 @@ def remove_build_commands_storage_paths(paths):
         build_commands_storage.delete_paths(paths)
     except Exception:
         log.info("Failed to delete build commands from storage.", exc_info=True)
+
+
+@app.task(queue="web")
+def run_post_build_tasks(build_pk):
+    """
+    Run the post-build work for a build from the isolated-builders fleet.
+
+    On the legacy path ``update_docs_task`` does this from ``on_success`` /
+    ``on_failure``, because the builder is itself a Celery worker with database
+    access. The isolated runner has neither: it only PATCHes the API, so the
+    dispatch has to happen here instead. Triggered from ``BuildViewSet`` when a
+    build reaches a final state — see ``perform_update`` there for the gating.
+
+    The Version is *not* updated here: ``built``, ``has_pdf`` and friends are
+    derived from the artifacts the build produced, which only the runner can see.
+    It PATCHes them itself before finishing.
+    """
+    # Avoid circular imports: readthedocs.projects.tasks imports from this module.
+    from readthedocs.doc_builder.exceptions import BuildCancelled
+    from readthedocs.projects.tasks.search import index_build
+
+    build = Build.objects.filter(pk=build_pk).select_related("project", "version").first()
+    if not build:
+        log.warning("Build not found; skipping post-build tasks.", build_id=build_pk)
+        return
+
+    structlog.contextvars.bind_contextvars(
+        build_id=build.pk,
+        project_slug=build.project.slug,
+        version_slug=build.version.slug if build.version else None,
+    )
+
+    if build.success:
+        index_build.delay(build_id=build.pk)
+
+        if "readthedocsext.spamfighting" in settings.INSTALLED_APPS:
+            from readthedocsext.spamfighting.tasks import spam_check_after_build_complete  # noqa
+
+            spam_check_after_build_complete.delay(build_id=build.pk)
+
+        send_build_notifications.delay(
+            version_pk=build.version_id,
+            build_pk=build.pk,
+            event=WebHookEvent.BUILD_PASSED,
+        )
+
+        if build.commit:
+            send_build_status.delay(build.pk, build.commit, BUILD_STATUS_SUCCESS)
+    else:
+        notification = (
+            Notification.objects.filter(
+                attached_to_content_type=ContentType.objects.get_for_model(Build),
+                attached_to_id=build.pk,
+            )
+            .order_by("-modified")
+            .first()
+        )
+        message_id = notification.message_id if notification else None
+
+        cancelled = message_id in (
+            BuildCancelled.CANCELLED_BY_USER,
+            BuildCancelled.SKIPPED_EXIT_CODE_183,
+        )
+        if not cancelled:
+            send_build_notifications.delay(
+                version_pk=build.version_id,
+                build_pk=build.pk,
+                event=WebHookEvent.BUILD_FAILED,
+            )
+
+        if build.commit:
+            status = BUILD_STATUS_FAILURE
+            if message_id == BuildCancelled.SKIPPED_EXIT_CODE_183:
+                # A build skipped via the magic exit code is reported to the Git
+                # provider as a success, so it doesn't block the pull request.
+                status = BUILD_STATUS_SKIPPED
+            send_build_status.delay(build.pk, build.commit, status)
+
+        # Only community disables projects for repeated failures.
+        if not settings.ALLOW_PRIVATE_REPOS and build.version:
+            check_and_disable_project_for_consecutive_failed_builds.delay(
+                project_slug=build.project.slug,
+                version_slug=build.version.slug,
+            )

--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -702,7 +702,7 @@ def run_post_build_tasks(build_pk):
     """
     Run the post-build work for a build from the isolated-builders fleet.
 
-    Triggered from ``BuildViewSet`` when a build reaches a final state — 
+    Triggered from ``BuildViewSet`` when a build reaches a final state —
     see ``perform_update`` there for the gating.
 
     The Version is *not* updated here: ``built``, ``has_pdf`` and friends are
@@ -712,6 +712,7 @@ def run_post_build_tasks(build_pk):
     # Avoid circular imports: readthedocs.projects.tasks imports from this module.
     from readthedocs.doc_builder.exceptions import BuildCancelled
     from readthedocs.projects.tasks.search import index_build
+    from readthedocs.projects.tasks.utils import send_external_build_status
 
     build = Build.objects.filter(pk=build_pk).select_related("project", "version").first()
     if not build:
@@ -738,8 +739,13 @@ def run_post_build_tasks(build_pk):
             event=WebHookEvent.BUILD_PASSED,
         )
 
-        if build.commit:
-            send_build_status.delay(build.pk, build.commit, BUILD_STATUS_SUCCESS)
+        if build.commit and build.version:
+            send_external_build_status(
+                version_type=build.version.type,
+                build_pk=build.pk,
+                commit=build.commit,
+                status=BUILD_STATUS_SUCCESS,
+            )
     else:
         notification = (
             Notification.objects.filter(
@@ -762,13 +768,18 @@ def run_post_build_tasks(build_pk):
                 event=WebHookEvent.BUILD_FAILED,
             )
 
-        if build.commit:
+        if build.commit and build.version:
             status = BUILD_STATUS_FAILURE
             if message_id == BuildCancelled.SKIPPED_EXIT_CODE_183:
                 # A build skipped via the magic exit code is reported to the Git
                 # provider as a success, so it doesn't block the pull request.
                 status = BUILD_STATUS_SKIPPED
-            send_build_status.delay(build.pk, build.commit, status)
+            send_external_build_status(
+                version_type=build.version.type,
+                build_pk=build.pk,
+                commit=build.commit,
+                status=status,
+            )
 
         # Only community disables projects for repeated failures.
         if not settings.ALLOW_PRIVATE_REPOS and build.version:

--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -284,6 +284,7 @@ def submit_to_isolated_builders(*, project, build):
     environment = {
         "RTD_API_URL": getattr(settings, "RTD_API_URL", settings.PUBLIC_API_URL),
         "RTD_PRODUCTION_DOMAIN": settings.PRODUCTION_DOMAIN,
+        "RTD_HEALTHCHECK_API_HOST": settings.SLUMBER_API_HOST,
     }
     if settings.RTD_DOCKER_COMPOSE:
         # Local dev: rustfs endpoint for storage boto3 calls, root user

--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -293,6 +293,11 @@ def submit_to_isolated_builders(*, project, build):
         # build container can reach us on the compose network.
         environment["AWS_S3_ENDPOINT_URL"] = settings.AWS_S3_ENDPOINT_URL or ""
         environment["RTD_DOCKER_USER"] = "root"
+        # Tells the builder it's running under docker-compose so it symlinks
+        # ``/root/.asdf`` -> ``docs``' asdf install. Required because we run as
+        # ``root`` here (above): ``asdf`` resolves plugins from ``$HOME/.asdf``,
+        # which is ``/root/.asdf`` for root.
+        environment["RTD_DOCKER_COMPOSE"] = "1"
         # TODO: update ``RTD_API_URL`` in ``docker_compose.py`` once we
         # are fully migrated and remove this override here.
         environment["RTD_API_URL"] = "http://nginx"

--- a/readthedocs/doc_builder/exceptions.py
+++ b/readthedocs/doc_builder/exceptions.py
@@ -42,6 +42,7 @@ class BuildUserError(BuildBaseException):
     BUILD_OUTPUT_OLD_DIRECTORY_USED = "build:user:output:old-directory-used"
     FILE_TOO_LARGE = "build:user:output:file-too-large"
     TEX_FILE_NOT_FOUND = "build:user:tex-file-not-found"
+    PDF_NOT_FOUND = "build:user:pdf-not-found"
 
     NO_CONFIG_FILE_DEPRECATED = "build:user:config:no-config-file"
     BUILD_IMAGE_CONFIG_KEY_DEPRECATED = "build:user:config:build-image-deprecated"

--- a/readthedocs/notifications/messages.py
+++ b/readthedocs/notifications/messages.py
@@ -438,7 +438,7 @@ BUILD_MESSAGES = [
         body=_(
             textwrap.dedent(
                 """
-            Read the Docs could not find a PDF file to publish after running the PDF build.
+            Read the Docs could not find a PDF file to publish after running the PDF build step.
             """
             ).strip(),
         ),

--- a/readthedocs/notifications/messages.py
+++ b/readthedocs/notifications/messages.py
@@ -432,6 +432,18 @@ BUILD_MESSAGES = [
         ),
         type=ERROR,
     ),
+    Message(
+        id=BuildUserError.PDF_NOT_FOUND,
+        header=_("No PDF file was found"),
+        body=_(
+            textwrap.dedent(
+                """
+            Read the Docs could not find a PDF file to publish after running the PDF build.
+            """
+            ).strip(),
+        ),
+        type=ERROR,
+    ),
 ]
 
 BUILD_MKDOCS_MESSAGES = [


### PR DESCRIPTION
- Trigger server-side tasks (search, notifications, etc) once the build is finished
- Pass an extra environment variable to report healthcheck