### PR TITLE
Build: use signal to update has_valid_clone

### DIFF
--- a/readthedocs/builds/signals_receivers.py
+++ b/readthedocs/builds/signals_receivers.py
@@ -22,3 +22,18 @@ def update_latest_build_for_project(sender, instance, created, **kwargs):
         Project.objects.filter(pk=instance.project_id).update(
             latest_build=instance,
         )
+
+
+@receiver(post_save, sender=Build)
+def set_valid_clone_after_successful_build(sender, instance, created, **kwargs):
+    """
+    Set the valid_clone flag to True after a successful build.
+
+    This is used to indicate that the project has been successfully built at least once.
+    """
+    build = instance
+    if build.finished and build.success:
+        project = build.project
+        if not project.has_valid_clone:
+            project.has_valid_clone = True
+            project.save(update_fields=["has_valid_clone"])

--- a/readthedocs/organizations/signals.py
+++ b/readthedocs/organizations/signals.py
@@ -7,7 +7,6 @@ from django.db.models.signals import pre_delete
 from django.dispatch import receiver
 from djstripe.enums import SubscriptionStatus
 
-from readthedocs.builds.constants import BUILD_FINAL_STATES
 from readthedocs.builds.models import Build
 from readthedocs.organizations.models import Organization
 from readthedocs.organizations.models import Team
@@ -70,7 +69,7 @@ def remove_organization_completely(sender, instance, using, **kwargs):
 def mark_organization_assets_not_cleaned(sender, instance, created, **kwargs):
     """Mark the organization assets as not cleaned if there is a new successful build."""
     build = instance
-    if build.state in BUILD_FINAL_STATES and build.success:
+    if build.finished and build.success:
         organization = build.project.organization
         if organization and organization.artifacts_cleaned:
             log.info(
@@ -78,4 +77,4 @@ def mark_organization_assets_not_cleaned(sender, instance, created, **kwargs):
                 origanization_slug=organization.slug,
             )
             organization.artifacts_cleaned = False
-            organization.save()
+            organization.save(update_fields=["artifacts_cleaned"])

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -716,9 +716,6 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
 
             spam_check_after_build_complete.delay(build_id=self.data.build["id"])
 
-        if not self.data.project.has_valid_clone:
-            self.set_valid_clone()
-
         self.send_notifications(
             self.data.version.pk,
             self.data.build["id"],
@@ -929,14 +926,6 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         :param build_pk: Build primary key
         """
         return self.data.api_client.build(build_pk).get()
-
-    # NOTE: this can be just updated on `self.data.build['']` and sent once the
-    # build has finished to reduce API calls.
-    def set_valid_clone(self):
-        """Mark on the project that it has been cloned properly."""
-        self.data.api_client.project(self.data.project.pk).patch({"has_valid_clone": True})
-        self.data.project.has_valid_clone = True
-        self.data.version.project.has_valid_clone = True
 
     def store_build_artifacts(self):
         """

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -708,12 +708,8 @@ class TestBuildTask(BuildEnvironmentBase):
             "identifier": mock.ANY,
             "type": "branch",
         }
-        # Set project has valid clone
-        assert self.requests_mock.request_history[11]._request.method == "PATCH"
-        assert self.requests_mock.request_history[11].path == "/api/v2/project/1/"
-        assert self.requests_mock.request_history[11].json() == {"has_valid_clone": True}
         # Update build state: finished, success and builder
-        assert self.requests_mock.request_history[12].json() == {
+        assert self.requests_mock.request_history[11].json() == {
             "id": 1,
             "state": "finished",
             "commit": "a1b2c3",
@@ -725,8 +721,8 @@ class TestBuildTask(BuildEnvironmentBase):
             "success": True,
         }
 
-        assert self.requests_mock.request_history[13]._request.method == "POST"
-        assert self.requests_mock.request_history[13].path == "/api/v2/revoke/"
+        assert self.requests_mock.request_history[12]._request.method == "POST"
+        assert self.requests_mock.request_history[12].path == "/api/v2/revoke/"
 
         assert BuildData.objects.all().exists()
 


### PR DESCRIPTION
We don't need an API call for this, similar to setting the artifacts_cleaned attribute on organizations. We can also stop updating this field, and maybe delete it, we aren't using it for anything (checked all repos).