### PR TITLE
Build: don't rely on director to send notifications

### DIFF
--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -521,21 +521,14 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
             message_id = BuildAppError.GENERIC_WITH_BUILD_ID
 
         # Grab the format values from the exception in case it contains
-        format_values = exc.format_values if hasattr(exc, "format_values") else None
-
-        # Attach the notification to the build, only when ``BuildDirector`` is available.
-        # It may happens the director is not created because the API failed to retrieve
-        # required data to initialize it on ``before_start``.
-        if self.data.build_director:
-            self.data.build_director.attach_notification(
-                attached_to=f"build/{self.data.build['id']}",
-                message_id=message_id,
-                format_values=format_values,
-            )
-        else:
-            log.warning(
-                "We couldn't attach a notification to the build since it failed on an early stage."
-            )
+        format_values = getattr(exc, "format_values", None) or {}
+        self.data.api_client.notifications.post(
+            {
+                "attached_to": f"build/{self.data.build_pk}",
+                "message_id": message_id,
+                "format_values": format_values,
+            }
+        )
 
         # Send notifications for unhandled errors
         if message_id not in self.exceptions_without_notifications:

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -787,9 +787,6 @@ class TestBuildTask(BuildEnvironmentBase):
         assert notification_request.json() == {
             "attached_to": f"build/{self.build.pk}",
             "message_id": BuildUserError.GENERIC,
-            "state": "unread",
-            "dismissable": False,
-            "news": False,
             "format_values": {},
         }
 
@@ -841,9 +838,6 @@ class TestBuildTask(BuildEnvironmentBase):
         assert notification_request.json() == {
             "attached_to": f"build/{self.build.pk}",
             "message_id": BuildCancelled.CANCELLED_BY_USER,
-            "state": "unread",
-            "dismissable": False,
-            "news": False,
             "format_values": {},
         }
 
@@ -2992,9 +2986,6 @@ class TestBuildTaskExceptionHandler(BuildEnvironmentBase):
         assert notification_request.json() == {
             "attached_to": f"build/{self.build.pk}",
             "message_id": ConfigError.INVALID_VERSION,
-            "state": "unread",
-            "dismissable": False,
-            "news": False,
             "format_values": {},
         }
 


### PR DESCRIPTION
There is no reason to rely on the director when the build has failed. The post upload task doesn't have a director. The deleted values from the API are the defaults, so they don't need to be included.