### PR TITLE
Builds: fix invalid except tuple syntax that broke builder scale-in

### DIFF
--- a/readthedocs/api/v2/serializers.py
+++ b/readthedocs/api/v2/serializers.py
@@ -402,7 +402,7 @@ class NotificationAttachedToRelatedField(serializers.RelatedField):
 
         try:
             return self.queryset.get(pk=pk)
-        except ObjectDoesNotExist, ValueError, TypeError:
+        except (ObjectDoesNotExist, ValueError, TypeError):
             self.fail("does_not_exist")
 
 

--- a/readthedocs/api/v2/views/integrations.py
+++ b/readthedocs/api/v2/views/integrations.py
@@ -156,7 +156,7 @@ class WebhookMixin:
         if hasattr(self, "project") and self.project:
             try:
                 integration = self.get_integration()
-            except Http404, ParseError:
+            except (Http404, ParseError):
                 # If we can't get a single integration (either none or multiple exist),
                 # we can't store the HTTP exchange
                 integration = None
@@ -408,7 +408,7 @@ class GitHubWebhookView(WebhookMixin, APIView):
         if self.request.content_type == "application/x-www-form-urlencoded":
             try:
                 return json.loads(self.request.data["payload"])
-            except ValueError, KeyError:
+            except (ValueError, KeyError):
                 pass
         return super().get_data()
 

--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -100,7 +100,7 @@ def delete_closed_external_versions(limit=200, days=30 * 3):
                     commit=last_build.commit,
                     status=status,
                 )
-        except TokenExpiredError, InvalidGrantError:
+        except (TokenExpiredError, InvalidGrantError):
             log.info("Failed to send status due to expired/invalid token.")
         except Exception:
             log.exception(

--- a/readthedocs/core/apps.py
+++ b/readthedocs/core/apps.py
@@ -18,5 +18,5 @@ class CoreAppConfig(AppConfig):
 
         try:
             import readthedocsext.monitoring.metrics.tasks  # noqa
-        except ModuleNotFoundError, ImportError:
+        except (ModuleNotFoundError, ImportError):
             log.info("Metrics tasks could not be imported.")

--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -842,7 +842,7 @@ class BuildDirector:
         if self.data.config.is_using_uv:
             try:
                 UV_PROJECT = self.data.config.python.install[0].path
-            except AttributeError, IndexError:
+            except (AttributeError, IndexError):
                 UV_PROJECT = self.data.project.checkout_path(self.data.version.slug)
 
             env.update(

--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -193,7 +193,7 @@ class BuildCommand(BuildCommandResultMixin):
         decoded = ""
         try:
             decoded = output.decode("utf-8", "replace")
-        except TypeError, AttributeError:
+        except (TypeError, AttributeError):
             pass
         return decoded
 
@@ -219,7 +219,7 @@ class BuildCommand(BuildCommandResultMixin):
             # Replace NULL (\x00) character to avoid PostgreSQL db to fail
             # https://code.djangoproject.com/ticket/28201
             sanitized = output.replace("\x00", "")
-        except TypeError, AttributeError:
+        except (TypeError, AttributeError):
             pass
 
         # Chunk the output data to be less than ``DATA_UPLOAD_MAX_MEMORY_SIZE``
@@ -732,7 +732,7 @@ class DockerBuildEnvironment(BaseBuildEnvironment):
             )
         # Catch direct failures from Docker API or with an HTTP request.
         # These errors should not surface to the user.
-        except DockerAPIError, ConnectionError, ReadTimeout:
+        except (DockerAPIError, ConnectionError, ReadTimeout):
             log.exception("Couldn't remove container")
 
         self.raise_container_error(state)

--- a/readthedocs/integrations/models.py
+++ b/readthedocs/integrations/models.py
@@ -192,7 +192,7 @@ class HttpExchange(models.Model):
             formatter = HtmlFormatter()
             html = highlight(json_value, JsonLexer(), formatter)
             return mark_safe(html)
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             return value
 
     @property
@@ -347,7 +347,7 @@ class GitHubWebhook(Integration):
     def can_sync(self):
         try:
             return all((k in self.provider_data) for k in ["id", "url"])
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             return False
 
 
@@ -421,7 +421,7 @@ class BitbucketWebhook(Integration):
     def can_sync(self):
         try:
             return all((k in self.provider_data) for k in ["uuid", "url"])
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             return False
 
 
@@ -436,7 +436,7 @@ class GitLabWebhook(Integration):
     def can_sync(self):
         try:
             return all((k in self.provider_data) for k in ["id", "url"])
-        except ValueError, TypeError:
+        except (ValueError, TypeError):
             return False
 
 
@@ -451,7 +451,7 @@ class GenericAPIWebhook(Integration):
         """Ensure model has token data before saving."""
         try:
             token = self.provider_data.get("token")
-        except AttributeError, TypeError:
+        except (AttributeError, TypeError):
             token = None
         finally:
             if token is None:

--- a/readthedocs/oauth/migrations/0003_move_github.py
+++ b/readthedocs/oauth/migrations/0003_move_github.py
@@ -106,7 +106,7 @@ def forwards_move_repos(apps, schema_editor):
             else:
                 new_repo.clone_url = data.get("clone_url")
             new_repo.json = json.dumps(data)
-        except SyntaxError, ValueError:
+        except (SyntaxError, ValueError):
             pass
         new_repo.save()
         log.info("Migrated project.", project_slug=project.slug)
@@ -145,7 +145,7 @@ def forwards_move_repos(apps, schema_editor):
                 new_repo.clone_url = clone_urls.get("ssh", project.git_url)
             else:
                 new_repo.clone_url = clone_urls.get("https", project.html_url)
-        except SyntaxError, ValueError:
+        except (SyntaxError, ValueError):
             pass
         new_repo.save()
         log.info("Migrated project.", project_slug=project.slug)

--- a/readthedocs/oauth/services/base.py
+++ b/readthedocs/oauth/services/base.py
@@ -249,7 +249,7 @@ class UserService(Service):
                 )
             )
         # Catch exceptions with request or deserializing JSON
-        except RequestException, ValueError:
+        except (RequestException, ValueError):
             # Response data should always be JSON, still try to log if not
             # though
             try:

--- a/readthedocs/oauth/services/bitbucket.py
+++ b/readthedocs/oauth/services/bitbucket.py
@@ -58,7 +58,7 @@ class BitbucketService(UserService):
             workspace_slugs = [
                 workspace_base["slug"] for workspace_base in self._get_workspaces_base()
             ]
-        except TypeError, ValueError, KeyError:
+        except (TypeError, ValueError, KeyError):
             log.warning("Error syncing Bitbucket workspaces")
             raise SyncServiceError(
                 SyncServiceError.INVALID_OR_REVOKED_ACCESS_TOKEN.format(
@@ -76,7 +76,7 @@ class BitbucketService(UserService):
                     remote_repository = self.create_repository(repo)
                     if remote_repository:
                         remote_ids.append(remote_repository.remote_id)
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 log.warning(
                     "Error syncing Bitbucket repositories for workspace.",
                     workspace=workspace_slug,
@@ -102,7 +102,7 @@ class BitbucketService(UserService):
                         remote_repository__vcs_provider=self.vcs_provider_slug,
                         remote_repository__remote_id__in=admin_repos_ids,
                     ).update(admin=True)
-            except TypeError, ValueError:
+            except (TypeError, ValueError):
                 log.warning(
                     "Error syncing Bitbucket admin repositories for workspace.",
                     workspace=workspace_slug,
@@ -389,7 +389,7 @@ class BitbucketService(UserService):
                 )
 
         # Catch exceptions with request or deserializing JSON
-        except RequestException, ValueError:
+        except (RequestException, ValueError):
             log.exception("Bitbucket webhook creation failed for project.")
 
         return False
@@ -446,7 +446,7 @@ class BitbucketService(UserService):
             )
 
         # Catch exceptions with request or deserializing JSON
-        except KeyError, RequestException, TypeError, ValueError:
+        except (KeyError, RequestException, TypeError, ValueError):
             log.exception("Bitbucket webhook update failed for project.")
 
         return False

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -46,7 +46,7 @@ class GitHubService(UserService):
                 remote_repository = self.create_repository(repo)
                 if remote_repository:
                     remote_ids.append(remote_repository.remote_id)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             log.warning("Error syncing GitHub repositories")
             raise SyncServiceError(
                 SyncServiceError.INVALID_OR_REVOKED_ACCESS_TOKEN.format(
@@ -339,7 +339,7 @@ class GitHubService(UserService):
                 )
 
         # Catch exceptions with request or deserializing JSON
-        except RequestException, ValueError:
+        except (RequestException, ValueError):
             log.exception("GitHub webhook creation failed for project.")
 
         return False
@@ -404,7 +404,7 @@ class GitHubService(UserService):
             )
 
         # Catch exceptions with request or deserializing JSON
-        except AttributeError, RequestException, ValueError:
+        except (AttributeError, RequestException, ValueError):
             log.exception("GitHub webhook update failed for project.")
 
         return False
@@ -544,7 +544,7 @@ class GitHubService(UserService):
             )
 
         # Catch exceptions with request or deserializing JSON
-        except RequestException, ValueError:
+        except (RequestException, ValueError):
             log.exception("GitHub commit status creation failed for project.")
         except InvalidGrantError:
             log.info("Invalid GitHub grant for user.", exc_info=True)

--- a/readthedocs/oauth/services/gitlab.py
+++ b/readthedocs/oauth/services/gitlab.py
@@ -97,7 +97,7 @@ class GitLabService(UserService):
                 remote_repository = self.create_repository(repo)
                 if remote_repository:
                     remote_ids.append(remote_repository.remote_id)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             log.warning("Error syncing GitLab repositories")
             raise SyncServiceError(
                 SyncServiceError.INVALID_OR_REVOKED_ACCESS_TOKEN.format(
@@ -551,7 +551,7 @@ class GitLabService(UserService):
             return False
 
         # Catch exceptions with request or deserializing JSON
-        except RequestException, ValueError:
+        except (RequestException, ValueError):
             # Response data should always be JSON, still try to log if not
             # though
             if resp is not None:

--- a/readthedocs/organizations/templatetags/organizations.py
+++ b/readthedocs/organizations/templatetags/organizations.py
@@ -48,7 +48,7 @@ def org_owner(user, obj):  # noqa
             organization__owners=user,
             organization=obj.organization,
         ).exists()
-    except FieldError, AttributeError:
+    except (FieldError, AttributeError):
         return False
 
 

--- a/readthedocs/projects/forms.py
+++ b/readthedocs/projects/forms.py
@@ -1272,7 +1272,7 @@ class DomainForm(forms.ModelForm):
             # dnspython doesn't recursively resolve CNAME records.
             # We always have one response or none.
             return str(answers[0].target)
-        except dns.resolver.NoAnswer, dns.resolver.NXDOMAIN:
+        except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
             return None
         except dns.resolver.LifetimeTimeout:
             raise forms.ValidationError(

--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -225,7 +225,7 @@ def set_builder_scale_in_protection(builder, protected_from_scale_in, build_id=N
             AutoScalingGroupName=scaling_group,
             ProtectedFromScaleIn=protected_from_scale_in,
         )
-    except ValidationError, ClientError:
+    except (ValidationError, ClientError):
         # Don't log these as exceptions,
         # since there isn't much we can do about it here.
         log.info("Failed when trying to set instance protection.")
@@ -301,7 +301,7 @@ def terminate_builder_instance(instance_id, build_id=None):
             InstanceId=instance_id,
             ShouldDecrementDesiredCapacity=False,
         )
-    except ValidationError, ClientError:
+    except (ValidationError, ClientError):
         # Don't log these as exceptions,
         # since there isn't much we can do about it here.
         log.info("Failed when trying to terminate instance.", instance_id=instance_id)

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -251,7 +251,7 @@ class ProjectBadgeView(View):
                     fd.read(),
                     content_type="image/svg+xml",
                 )
-        except IOError, OSError:
+        except (IOError, OSError):
             log.exception(
                 "Failed to read local filesystem while serving a docs badge",
             )

--- a/readthedocs/search/api/pagination.py
+++ b/readthedocs/search/api/pagination.py
@@ -48,7 +48,7 @@ class SearchPagination(PageNumberPagination):
             if isinstance(number, float) and not number.is_integer():
                 raise ValueError
             number = int(number)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             number = -1
         return number
 


### PR DESCRIPTION
The `2026.07.21` release shipped commit `ec4ff4248` ("Update common/ (#13175)"), whose message says it was upgrading versions for Python 3.14. Instead it rewrote valid `except (A, B):` tuples into Python-2 `except A, B:` across 17 modules — which is a hard `SyntaxError` on Python 3 (`multiple exception types must be parenthesized`).

The most damaging cases are `set_builder_scale_in_protection()` and `terminate_builder_instance()` in `readthedocs/projects/tasks/utils.py` — the functions that remove scale-in protection and terminate a builder when a build finishes. With `utils.py` unable to import, protection set at build start is never lifted and idle instances are never terminated, so builders accumulate and the ASG can't scale them in. This matches the production symptom of builder instance count exceeding active build count starting 7/21, made worse by Redis disconnects that kill workers mid-build (leaving instances stuck-protected).

This restores the parenthesized tuple form everywhere that commit corrupted it. The restored clauses exactly match the pre-corruption originals (`ec4ff4248^`); the whole package now parses and `ruff` is green.

> ⚠️ Worth confirming what commit the pre-7/21 builders were actually running: this same bug also breaks OAuth/webhook/integration code paths (github/gitlab/bitbucket services, `integrations/models.py`, etc.), so if only scaling misbehaved in prod, the deployed tree may differ from `main`.

🤖 Generated by Claude Code at the request of @ericholscher
