### PR TITLE
Projects: order subprojects list to fix pagination showing duplicated/missing entries

### DIFF
--- a/readthedocs/api/v3/tests/mixins.py
+++ b/readthedocs/api/v3/tests/mixins.py
@@ -222,7 +222,7 @@ class APIEndpointMixin(TestCase):
             privacy_level=PUBLIC,
         )
 
-    def _create_subproject(self):
+    def _create_subproject(self, slug="subproject"):
         """Helper to create a sub-project with all the fields set."""
         self.subproject = fixture.get(
             Project,
@@ -231,8 +231,8 @@ class APIEndpointMixin(TestCase):
             description="SubProject description",
             repo="https://github.com/rtfd/subproject",
             project_url="http://subproject.com",
-            name="subproject",
-            slug="subproject",
+            name=slug,
+            slug=slug,
             related_projects=[],
             main_language_project=None,
             users=[self.me],

--- a/readthedocs/api/v3/tests/test_subprojects.py
+++ b/readthedocs/api/v3/tests/test_subprojects.py
@@ -1,7 +1,7 @@
 from django.test import override_settings
 from django.urls import reverse
 
-from readthedocs.projects.constants import PRIVATE
+from readthedocs.projects.constants import PRIVATE, PUBLIC
 from readthedocs.projects.models import Feature, Project
 from django_dynamic_fixture import get
 
@@ -61,6 +61,36 @@ class SubprojectsEndpointTests(APIEndpointMixin):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(response.json(), expected_response)
+
+    def test_projects_subprojects_list_is_ordered_by_child_slug(self):
+        # Create subprojects in non-alphabetical order to make sure the list
+        # is ordered by the queryset, and not by creation order.
+        for slug in ["delta", "alpha", "charlie"]:
+            subproject = get(
+                Project,
+                slug=slug,
+                related_projects=[],
+                main_language_project=None,
+                users=[self.me],
+                versions=[],
+                privacy_level=PUBLIC,
+            )
+            self.project.add_subproject(subproject)
+
+        url = reverse(
+            "projects-subprojects-list",
+            kwargs={
+                "parent_lookup_parent__slug": self.project.slug,
+            },
+        )
+        response = self.client.get(url)
+        assert response.status_code == 200
+        assert [result["child"]["slug"] for result in response.json()["results"]] == [
+            "alpha",
+            "charlie",
+            "delta",
+            "subproject",
+        ]
 
     def test_projects_subprojects_list_other_user(self):
         url = reverse(

--- a/readthedocs/api/v3/tests/test_subprojects.py
+++ b/readthedocs/api/v3/tests/test_subprojects.py
@@ -1,7 +1,7 @@
 from django.test import override_settings
 from django.urls import reverse
 
-from readthedocs.projects.constants import PRIVATE, PUBLIC
+from readthedocs.projects.constants import PRIVATE
 from readthedocs.projects.models import Feature, Project
 from django_dynamic_fixture import get
 
@@ -64,18 +64,9 @@ class SubprojectsEndpointTests(APIEndpointMixin):
 
     def test_projects_subprojects_list_is_ordered_by_child_slug(self):
         # Create subprojects in non-alphabetical order to make sure the list
-        # is ordered by the queryset, and not by creation order.
+        # is ordered by slug, and not by creation order.
         for slug in ["delta", "alpha", "charlie"]:
-            subproject = get(
-                Project,
-                slug=slug,
-                related_projects=[],
-                main_language_project=None,
-                users=[self.me],
-                versions=[],
-                privacy_level=PUBLIC,
-            )
-            self.project.add_subproject(subproject)
+            self._create_subproject(slug=slug)
 
         url = reverse(
             "projects-subprojects-list",

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -287,6 +287,12 @@ class SubprojectRelationshipViewSet(
     lookup_value_regex = SUBPROJECT_ALIAS_REGEX
     permission_classes = [ReadOnlyPermission | (IsAuthenticated & IsProjectAdmin)]
 
+    def get_queryset(self):
+        # ``ProjectRelationship`` has no default ordering, and limit/offset
+        # pagination over an unordered queryset returns rows in a
+        # database-dependent order for each page.
+        return super().get_queryset().order_by("child__slug")
+
     def get_serializer_class(self):
         """
         Return correct serializer depending on the action.

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -133,6 +133,17 @@ class ProjectRelationship(models.Model):
 
     objects = ChildRelatedProjectQuerySet.as_manager()
 
+    # NOTE: this model intentionally has no default ordering. A ``Meta.ordering``
+    # on a related field would add a JOIN + ORDER BY to every query over this
+    # model, including the unresolver's subproject lookups on the hot
+    # document-serving path. The ordering below is instead applied explicitly on
+    # each place that lists these relationships (dashboard views and the APIv3
+    # subprojects endpoint), since paginating an unordered queryset returns rows
+    # in a database-dependent order that changes between page queries.
+    #
+    # class Meta:
+    #     ordering = ("child__slug",)
+
     def save(self, *args, **kwargs):
         if not self.alias:
             self.alias = self.child.slug

--- a/readthedocs/projects/views/mixins.py
+++ b/readthedocs/projects/views/mixins.py
@@ -69,7 +69,7 @@ class ProjectRelationListMixin:
         subprojects_and_urls = []
 
         project = self.get_project()
-        subprojects = project.subprojects.select_related("child")
+        subprojects = project.subprojects.select_related("child").order_by("child__slug")
 
         if not subprojects.exists():
             return subprojects_and_urls

--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -486,7 +486,11 @@ class ProjectRelationshipMixin(PrivateViewMixin, ProjectAdminMixin):
 
     def get_queryset(self):
         self.project = self.get_project()
-        return self.model.objects.filter(parent=self.project)
+        # ``ProjectRelationship`` has no default ordering. The list view is
+        # paginated, and paginating an unordered queryset returns rows in a
+        # database-dependent order for each page, so entries can show up
+        # duplicated or missing across pages.
+        return self.model.objects.filter(parent=self.project).order_by("child__slug")
 
     def get_form(self, data=None, files=None, **kwargs):
         kwargs["user"] = self.request.user

--- a/readthedocs/rtd_tests/tests/test_subprojects.py
+++ b/readthedocs/rtd_tests/tests/test_subprojects.py
@@ -308,29 +308,18 @@ class SubprojectFormTests(TestCase):
 
 
 class SubprojectListViewTests(TestCase):
-    def setUp(self):
-        self.user = fixture.get(User)
-        self.project = fixture.get(Project, slug="mainproject", users=[self.user])
-        # Create subprojects in non-alphabetical order to make sure the list
-        # is ordered by the queryset, and not by creation order.
-        for slug in ["delta", "alpha", "charlie", "bravo"]:
-            subproject = fixture.get(Project, slug=slug, users=[self.user])
-            self.project.add_subproject(subproject)
-
-        self.client.force_login(self.user)
-        self.response = self.client.get(
-            reverse("projects_subprojects", args=[self.project.slug]),
-        )
-
     def test_list_is_ordered_by_subproject_slug(self):
-        assert self.response.status_code == 200
-        assert [
-            relationship.child.slug for relationship in self.response.context["object_list"]
-        ] == ["alpha", "bravo", "charlie", "delta"]
+        user = fixture.get(User)
+        project = fixture.get(Project, slug="mainproject", users=[user])
+        # Create subprojects in non-alphabetical order to make sure the list
+        # is ordered by slug, and not by creation order.
+        for slug in ["delta", "alpha", "charlie"]:
+            project.add_subproject(fixture.get(Project, slug=slug))
 
-    def test_subprojects_and_urls_are_ordered_by_subproject_slug(self):
-        assert self.response.status_code == 200
-        assert [
-            relationship.child.slug
-            for relationship, _ in self.response.context["subprojects_and_urls"]
-        ] == ["alpha", "bravo", "charlie", "delta"]
+        self.client.force_login(user)
+        response = self.client.get(reverse("projects_subprojects", args=[project.slug]))
+
+        assert response.status_code == 200
+        expected = ["alpha", "charlie", "delta"]
+        assert [rel.child.slug for rel in response.context["object_list"]] == expected
+        assert [rel.child.slug for rel, _ in response.context["subprojects_and_urls"]] == expected

--- a/readthedocs/rtd_tests/tests/test_subprojects.py
+++ b/readthedocs/rtd_tests/tests/test_subprojects.py
@@ -1,6 +1,7 @@
 import django_dynamic_fixture as fixture
 from django.contrib.auth.models import User
 from django.test import TestCase
+from django.urls import reverse
 
 from readthedocs.projects.forms import ProjectRelationshipForm
 from readthedocs.projects.models import Project, ProjectRelationship
@@ -304,3 +305,32 @@ class SubprojectFormTests(TestCase):
         form.save()
         self.relation.refresh_from_db()
         self.assertEqual(self.relation.alias, "subproject")
+
+
+class SubprojectListViewTests(TestCase):
+    def setUp(self):
+        self.user = fixture.get(User)
+        self.project = fixture.get(Project, slug="mainproject", users=[self.user])
+        # Create subprojects in non-alphabetical order to make sure the list
+        # is ordered by the queryset, and not by creation order.
+        for slug in ["delta", "alpha", "charlie", "bravo"]:
+            subproject = fixture.get(Project, slug=slug, users=[self.user])
+            self.project.add_subproject(subproject)
+
+        self.client.force_login(self.user)
+        self.response = self.client.get(
+            reverse("projects_subprojects", args=[self.project.slug]),
+        )
+
+    def test_list_is_ordered_by_subproject_slug(self):
+        assert self.response.status_code == 200
+        assert [
+            relationship.child.slug for relationship in self.response.context["object_list"]
+        ] == ["alpha", "bravo", "charlie", "delta"]
+
+    def test_subprojects_and_urls_are_ordered_by_subproject_slug(self):
+        assert self.response.status_code == 200
+        assert [
+            relationship.child.slug
+            for relationship, _ in self.response.context["subprojects_and_urls"]
+        ] == ["alpha", "bravo", "charlie", "delta"]


### PR DESCRIPTION
A support report for a project with 101 subprojects showed the dashboard subprojects page rendering two subprojects **duplicated** on different pages and two others **missing entirely**, while the total count (101, across 7 pages) stayed correct. Querying the same list through API v3 returned all entries.

`ProjectRelationship` has no default ordering, and the subprojects dashboard view paginates `ProjectRelationship.objects.filter(parent=...)` without an `order_by()`. Each page is a separate `LIMIT/OFFSET` query, and without `ORDER BY`, PostgreSQL may return rows in a different order per query (heap order changes with row updates/vacuum, plan changes, synchronized sequential scans). When the order shifts between page requests, rows near a page boundary show up on two pages while others fall between pages — the count query is unaffected, so totals look fine. Django's paginator does flag this (`UnorderedObjectListWarning`), but only as a warning in logs.

The fix orders the queryset by `child__slug`: since `Project.slug` is unique, this is a fully deterministic total order (ordering by a non-unique column would still let ties swap between queries), and it makes the list alphabetical instead of effectively random. The same ordering is applied to:

- the dashboard subprojects list view (the reported bug),
- the `subprojects_and_urls` context helper used by the legacy dashboard template, and
- the API v3 subprojects endpoint, where limit/offset pagination over the unordered queryset had the same latent problem for clients paging across requests.

This is intentionally done at the view/API level rather than with `Meta.ordering` on the model: a model-level default ordering on a related field would add a JOIN + `ORDER BY` to every `ProjectRelationship` query, including the unresolver's subproject lookups on the hot document-serving path.

## Why `child__slug` and not `pk`?

Any total order fixes the pagination bug — `pk` included — so the key is a display choice, not a correctness one:

- The three places that apply the ordering already join or serialize the child row (`select_related("child")`, and the API serializer embeds the child project), so sorting by `child__slug` adds no extra JOIN there. The JOIN concern only applies to a model-level `Meta.ordering`, which is exactly what this PR avoids — the unresolver's hot-path lookups stay untouched.
- Order is user-facing at scale here: with 101 subprojects across 7 pages, `pk` renders whatever order subprojects happened to be attached over the years, so finding a specific one means scanning every page. Alphabetical is scannable and gives paging a predictable meaning ("T is near the end").
- It matches the rest of the dashboard: every other project list is alphabetical via `Project.Meta.ordering = ("slug",)`, so `pk` would make subprojects the one project list in arbitrary order.

The new tests create subprojects in non-alphabetical order and were verified to fail without the fix.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BB6HHBjvZJsSgYC1aL1N2p

---
_Generated by [Claude Code](https://claude.ai/code/session_01BB6HHBjvZJsSgYC1aL1N2p)_