### PR TITLE
Builds: skip sending build status when the build has no commit

### DIFF
--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -91,7 +91,9 @@ def delete_closed_external_versions(limit=200, days=30 * 3):
     for version in queryset:
         try:
             last_build = version.last_build
-            if last_build:
+            # Builds without a commit failed before checking out the
+            # repository, so there is no commit to report the status on.
+            if last_build and last_build.commit:
                 status = BUILD_STATUS_PENDING
                 if last_build.finished:
                     status = BUILD_STATUS_SUCCESS if last_build.success else BUILD_STATUS_FAILURE
@@ -224,9 +226,11 @@ def send_build_status(build_pk, commit, status):
     :param status: build status failed, pending, success, or skipped to be sent.
     """
     build = Build.objects.filter(pk=build_pk).select_related("version").first()
-    # Bulds without a verion shouldn't send status, it can happen when
+    # Builds without a version shouldn't send status, it can happen when
     # a build from a deleted version is being processed (race condition).
-    if not build or not build.version:
+    # Builds without a commit failed before checking out the repository,
+    # so there is no commit to report the status on.
+    if not build or not build.version or not commit:
         return
 
     structlog.contextvars.bind_contextvars(
@@ -235,12 +239,6 @@ def send_build_status(build_pk, commit, status):
         commit=commit,
         status=status,
     )
-
-    # Builds that failed before checking out the repository don't have
-    # a commit, so there is nothing to report the status on.
-    if not commit:
-        log.info("Build doesn't have a commit, not sending build status.")
-        return False
 
     log.debug("Sending build status.")
 

--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -236,6 +236,12 @@ def send_build_status(build_pk, commit, status):
         status=status,
     )
 
+    # Builds that failed before checking out the repository don't have
+    # a commit, so there is nothing to report the status on.
+    if not commit:
+        log.info("Build doesn't have a commit, not sending build status.")
+        return False
+
     log.debug("Sending build status.")
 
     # Get the service class for the project e.g: GitHubService.

--- a/readthedocs/builds/tests/test_tasks.py
+++ b/readthedocs/builds/tests/test_tasks.py
@@ -101,6 +101,35 @@ class TestTasks(TestCase):
         self.assertEqual(Version.external.all().count(), 2)
         self.assertFalse(Version.objects.filter(slug="external-inactive-old").exists())
 
+    def test_delete_closed_external_versions_build_without_commit(self):
+        """Closed external versions are deleted even if their last build has no commit."""
+        github_app_installation = get(
+            GitHubAppInstallation,
+            installation_id=1111,
+            target_id=1111,
+            target_type=GitHubAccountType.USER,
+        )
+        remote_repository = get(
+            RemoteRepository,
+            remote_id="1234",
+            vcs_provider=GITHUB_APP,
+            github_app_installation=github_app_installation,
+        )
+        project = get(Project, remote_repository=remote_repository)
+        version = get(
+            Version,
+            project=project,
+            slug="external-closed",
+            type=EXTERNAL,
+            state=EXTERNAL_VERSION_STATE_CLOSED,
+            modified=datetime.now() - timedelta(days=7),
+        )
+        get(Build, project=project, version=version, commit=None)
+
+        delete_closed_external_versions(days=6)
+
+        self.assertFalse(Version.objects.filter(slug="external-closed").exists())
+
     @override_settings(RTD_SAVE_BUILD_COMMANDS_TO_STORAGE=True)
     @mock.patch("readthedocs.builds.models.build_commands_storage")
     def test_archive_builds(self, build_commands_storage):

--- a/readthedocs/rtd_tests/tests/test_celery.py
+++ b/readthedocs/rtd_tests/tests/test_celery.py
@@ -98,7 +98,9 @@ class TestCeleryBuilding(TestCase):
         )
 
         external_version = get(Version, project=self.project, type=EXTERNAL)
-        external_build = get(Build, project=self.project, version=external_version)
+        external_build = get(
+            Build, project=self.project, version=external_version, commit="1234abcd"
+        )
         build_tasks.send_build_status(
             external_build.id, external_build.commit, BUILD_STATUS_SUCCESS
         )
@@ -118,7 +120,9 @@ class TestCeleryBuilding(TestCase):
         self.project.save()
 
         external_version = get(Version, project=self.project, type=EXTERNAL)
-        external_build = get(Build, project=self.project, version=external_version)
+        external_build = get(
+            Build, project=self.project, version=external_version, commit="1234abcd"
+        )
         build_tasks.send_build_status(
             external_build.id, external_build.commit, BUILD_STATUS_SUCCESS
         )
@@ -137,7 +141,9 @@ class TestCeleryBuilding(TestCase):
         self.project.repo = "https://github.com/test/test/"
         self.project.save()
         external_version = get(Version, project=self.project, type=EXTERNAL)
-        external_build = get(Build, project=self.project, version=external_version)
+        external_build = get(
+            Build, project=self.project, version=external_version, commit="1234abcd"
+        )
         build_tasks.send_build_status(
             external_build.id, external_build.commit, BUILD_STATUS_SUCCESS
         )
@@ -177,7 +183,9 @@ class TestCeleryBuilding(TestCase):
         )
 
         external_version = get(Version, project=self.project, type=EXTERNAL)
-        external_build = get(Build, project=self.project, version=external_version)
+        external_build = get(
+            Build, project=self.project, version=external_version, commit="1234abcd"
+        )
         build_tasks.send_build_status(
             external_build.id, external_build.commit, BUILD_STATUS_SUCCESS
         )
@@ -187,6 +195,22 @@ class TestCeleryBuilding(TestCase):
             commit=external_build.commit,
             status=BUILD_STATUS_SUCCESS,
         )
+        self.assertEqual(Notification.objects.count(), 0)
+
+    @patch("readthedocs.oauth.services.github.GitHubService.send_build_status")
+    def test_send_build_status_without_commit(self, send_build_status):
+        get(SocialAccount, user=self.eric, provider="github")
+
+        self.project.repo = "https://github.com/test/test/"
+        self.project.save()
+
+        external_version = get(Version, project=self.project, type=EXTERNAL)
+        external_build = get(
+            Build, project=self.project, version=external_version, commit=None
+        )
+        build_tasks.send_build_status(external_build.id, None, BUILD_STATUS_SUCCESS)
+
+        send_build_status.assert_not_called()
         self.assertEqual(Notification.objects.count(), 0)
 
     @patch("readthedocs.oauth.services.gitlab.GitLabService.send_build_status")
@@ -205,7 +229,9 @@ class TestCeleryBuilding(TestCase):
         )
 
         external_version = get(Version, project=self.project, type=EXTERNAL)
-        external_build = get(Build, project=self.project, version=external_version)
+        external_build = get(
+            Build, project=self.project, version=external_version, commit="1234abcd"
+        )
         build_tasks.send_build_status(
             external_build.id, external_build.commit, BUILD_STATUS_SUCCESS
         )
@@ -225,7 +251,9 @@ class TestCeleryBuilding(TestCase):
         self.project.save()
 
         external_version = get(Version, project=self.project, type=EXTERNAL)
-        external_build = get(Build, project=self.project, version=external_version)
+        external_build = get(
+            Build, project=self.project, version=external_version, commit="1234abcd"
+        )
         build_tasks.send_build_status(
             external_build.id, external_build.commit, BUILD_STATUS_SUCCESS
         )
@@ -244,7 +272,9 @@ class TestCeleryBuilding(TestCase):
         self.project.repo = "https://gitlab.com/test/test/"
         self.project.save()
         external_version = get(Version, project=self.project, type=EXTERNAL)
-        external_build = get(Build, project=self.project, version=external_version)
+        external_build = get(
+            Build, project=self.project, version=external_version, commit="1234abcd"
+        )
         build_tasks.send_build_status(
             external_build.id, external_build.commit, BUILD_STATUS_SUCCESS
         )

--- a/readthedocs/rtd_tests/tests/test_celery.py
+++ b/readthedocs/rtd_tests/tests/test_celery.py
@@ -213,6 +213,29 @@ class TestCeleryBuilding(TestCase):
         send_build_status.assert_not_called()
         self.assertEqual(Notification.objects.count(), 0)
 
+    @patch("readthedocs.oauth.services.githubapp.GitHubAppService.send_build_status")
+    def test_send_build_status_without_commit_github_app(self, send_build_status):
+        self.project.repo = "https://github.com/test/test/"
+        self.project.save()
+
+        github_app_installation = get(
+            GitHubAppInstallation,
+            installation_id=1111,
+            target_id=1111,
+            target_type=GitHubAccountType.USER,
+        )
+        remote_repo = get(RemoteRepository, vcs_provider=GITHUB_APP, github_app_installation=github_app_installation)
+        remote_repo.projects.add(self.project)
+
+        external_version = get(Version, project=self.project, type=EXTERNAL)
+        external_build = get(
+            Build, project=self.project, version=external_version, commit=None
+        )
+        build_tasks.send_build_status(external_build.id, None, BUILD_STATUS_SUCCESS)
+
+        send_build_status.assert_not_called()
+        self.assertEqual(Notification.objects.count(), 0)
+
     @patch("readthedocs.oauth.services.gitlab.GitLabService.send_build_status")
     def test_send_build_status_with_remote_repo_gitlab(self, send_build_status):
         self.project.repo = "https://gitlab.com/test/test/"


### PR DESCRIPTION
`delete_closed_external_versions` sends a final commit status before deleting each version, using `last_build.commit`. Builds that failed before checking out the repository have no commit, and the GitHub App service passes it straight to PyGithub, which asserts the SHA is a string:

```
File "readthedocs/oauth/services/githubapp.py", line 419, in send_build_status
    gh_repo.get_commit(commit).create_status(
File "github/Repository.py", line 2399, in get_commit
    assert isinstance(sha, str), sha
AssertionError: None
```

Besides the noise, the crash prevents `version.delete()` from running, so the affected versions are retried — and crash again — on every run of the task.

This skips sending the status in the `send_build_status` task when the build has no commit, covering all Git services and callers. The existing celery tests relied on the build fixture's commit being `None` and flowing through to the (mocked) service, so they now set an explicit commit.

Sentry issue: READTHEDOCS-ORG-V6Z (7517023021)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxmFs9ZfJE92nHYEQnkkUr

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxmFs9ZfJE92nHYEQnkkUr)_