### PR TITLE
Logging: downgrade high-volume messages to debug

### DIFF
--- a/readthedocs/api/v2/utils.py
+++ b/readthedocs/api/v2/utils.py
@@ -255,7 +255,7 @@ def run_version_automation_rules(project, added_versions, deleted_active_version
             enabled=True,
             action__in=allowed_actions,
         ).order_by("priority")
-        log.info(
+        log.debug(
             "Running version automation rules.",
             project_slug=project.slug,
             version_slugs=version_slugs,

--- a/readthedocs/api/v2/views/integrations.py
+++ b/readthedocs/api/v2/views/integrations.py
@@ -247,7 +247,7 @@ class WebhookMixin:
         """
         to_build, not_building = build_versions_from_names(project, versions_info)
         if not_building:
-            log.info(
+            log.debug(
                 "Skipping project versions.",
                 versions=not_building,
             )

--- a/readthedocs/core/views/hooks.py
+++ b/readthedocs/core/views/hooks.py
@@ -148,7 +148,7 @@ def get_or_create_external_version(project, version_data):
         external_version.state = EXTERNAL_VERSION_STATE_OPEN
         external_version.active = True
         external_version.save()
-        log.info(
+        log.debug(
             "External version updated.",
             project_slug=project.slug,
             version_slug=external_version.slug,

--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -246,7 +246,7 @@ class BuildDirector:
         # and the default branch is already checked out.
         if not is_latest_without_default_branch:
             identifier = self.data.build_commit or self.data.version.identifier
-            log.info("Checking out.", identifier=identifier)
+            log.debug("Checking out.", identifier=identifier)
             self.vcs_repository.checkout(identifier)
 
         # The director is responsible for understanding which config file to use for a build.

--- a/readthedocs/oauth/services/github.py
+++ b/readthedocs/oauth/services/github.py
@@ -273,7 +273,7 @@ class GitHubService(UserService):
                         )
                         break
             else:
-                log.warning(
+                log.debug(
                     "GitHub project does not exist or user does not have permissions.",
                     https_status_code=resp.status_code,
                 )
@@ -326,7 +326,7 @@ class GitHubService(UserService):
                 return True
 
             if resp.status_code in [401, 403, 404]:
-                log.warning("GitHub project does not exist or user does not have permissions.")
+                log.debug("GitHub project does not exist or user does not have permissions.")
             else:
                 # Unknown response from GitHub
                 try:
@@ -522,7 +522,7 @@ class GitHubService(UserService):
                 return True
 
             if resp.status_code in [401, 403, 404]:
-                log.info("GitHub project does not exist or user does not have permissions.")
+                log.debug("GitHub project does not exist or user does not have permissions.")
                 return False
 
             if resp.status_code == 422 and "No commit found for SHA" in resp.json()["message"]:

--- a/readthedocs/oauth/views.py
+++ b/readthedocs/oauth/views.py
@@ -46,7 +46,7 @@ class GitHubAppWebhookView(APIView):
             event_id=event_id,
         )
         if event not in GitHubAppWebhookHandler(request.data, event).event_handlers:
-            log.info("Unsupported event")
+            log.debug("Unsupported event")
             raise ValidationError(f"Unsupported event: {event}")
 
         log.info("Handling event from view.")

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -241,7 +241,7 @@ class SyncRepositoryTask(SyncRepositoryMixin, Task):
                 version=self.data.version,
                 environment=environment,
             )
-            log.info("Syncing repository via remote listing.")
+            log.debug("Syncing repository via remote listing.")
             self.sync_versions(vcs_repository)
 
 
@@ -930,7 +930,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
         Remove build artifacts of types not included in this build (PDF, ePub, zip only).
         """
         time_before_store_build_artifacts = timezone.now()
-        log.info("Writing build artifacts to media storage")
+        log.debug("Writing build artifacts to media storage")
         self.update_build(state=BUILD_STATE_UPLOADING)
 
         valid_artifacts = self.get_valid_artifact_types()
@@ -1002,7 +1002,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
                     exception_message="Error deleting files from storage.",
                 ) from exc
 
-        log.info(
+        log.debug(
             "Store build artifacts finished.",
             time=(timezone.now() - time_before_store_build_artifacts).seconds,
         )
@@ -1012,7 +1012,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
             output = subprocess.check_output(["du", "--summarize", "-m", "--", directory])
             # The output is something like: "5\t/path/to/directory".
             directory_size = int(output.decode().split()[0])
-            log.info(
+            log.debug(
                 "Build artifacts directory size.",
                 directory=directory,
                 size=directory_size,  # Size in mega bytes

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -953,13 +953,14 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
                 types_to_delete.append(artifact_type)
 
         # Upload formats
+        artifact_sizes = {}
         for media_type in types_to_copy:
             from_path = self.data.project.artifact_path(
                 version=self.data.version.slug,
                 type_=media_type,
             )
             to_path = self.data.version.get_storage_path(media_type=media_type)
-            self._log_directory_size(from_path, media_type)
+            artifact_sizes[media_type] = self._get_directory_size(from_path)
 
             try:
                 build_media_storage.rclone_sync_directory(from_path, to_path)
@@ -1002,27 +1003,26 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
                     exception_message="Error deleting files from storage.",
                 ) from exc
 
-        log.debug(
+        # This is the only artifacts log at INFO level,
+        # useful to debug storage slowness and artifacts size abuse.
+        log.info(
             "Store build artifacts finished.",
             time=(timezone.now() - time_before_store_build_artifacts).seconds,
+            sizes=artifact_sizes,  # Sizes in mega bytes
         )
 
-    def _log_directory_size(self, directory, media_type):
+    def _get_directory_size(self, directory) -> int | None:
+        """Return the size of the directory in megabytes, or None on error."""
         try:
             output = subprocess.check_output(["du", "--summarize", "-m", "--", directory])
             # The output is something like: "5\t/path/to/directory".
-            directory_size = int(output.decode().split()[0])
-            log.debug(
-                "Build artifacts directory size.",
-                directory=directory,
-                size=directory_size,  # Size in mega bytes
-                media_type=media_type,
-            )
+            return int(output.decode().split()[0])
         except Exception:
             log.info(
                 "Error getting build artifacts directory size.",
                 exc_info=True,
             )
+            return None
 
     def send_notifications(self, version_pk, build_pk, event):
         """Send notifications to all subscribers of `event`."""

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -1733,7 +1733,7 @@ class GitHubOAuthTests(TestCase):
 
         self.assertFalse(success)
         mock_structlog.contextvars.bind_contextvars.assert_called_with(http_status_code=404)
-        mock_logger.info.assert_called_with(
+        mock_logger.debug.assert_called_with(
             "GitHub project does not exist or user does not have permissions.",
         )
 
@@ -1797,7 +1797,7 @@ class GitHubOAuthTests(TestCase):
         self.assertFalse(success)
         self.assertIsNotNone(self.integration.secret)
         mock_structlog.contextvars.bind_contextvars.assert_called_with(http_status_code=404)
-        mock_logger.warning.assert_called_with(
+        mock_logger.debug.assert_called_with(
             "GitHub project does not exist or user does not have permissions.",
         )
 
@@ -1924,7 +1924,7 @@ class GitHubOAuthTests(TestCase):
         self.integration.refresh_from_db()
 
         self.assertEqual(self.integration.provider_data, {})
-        mock_logger.warning.assert_called_with(
+        mock_logger.debug.assert_called_with(
             "GitHub project does not exist or user does not have permissions.",
             https_status_code=404,
         )

--- a/readthedocs/search/utils.py
+++ b/readthedocs/search/utils.py
@@ -60,7 +60,7 @@ def remove_indexed_files(project_slug, version_slug=None, sync_id=None, index_na
         document._index._name = index_name
 
     try:
-        log.info("Deleting old files from search index.")
+        log.debug("Deleting old files from search index.")
         documents = document().search().filter("term", project=project_slug)
         if version_slug:
             documents = documents.filter("term", version=version_slug)


### PR DESCRIPTION
Our most-logged messages (1-day sample) are all expected, per-build/per-webhook events that aren't actionable at INFO/WARNING level. This PR downgrades them to DEBUG, following one rule: **state changes and terminal failures stay at INFO; routine "about to do X" markers move to DEBUG**.

| Message (volume/day) | Why DEBUG is safe |
|---|---|
| Checking out. (21k) | Commit is stored on the Build and shown in build output |
| Skipping project versions. (19.1k) | Webhook response returns `build_triggered: false` + versions, visible in the provider's webhook delivery UI |
| Unsupported event (18.8k) | The 400 response body already says `Unsupported event: <name>` |
| Writing build artifacts to media storage (18k) | Build transitions to `uploading` state in the DB on the next line |
| GitHub project does not exist or user does not have permissions. (12.6k, 3 call sites) | Per-attempt noise from loops over users' tokens; terminal failures still log at INFO and create user-facing notifications (`MESSAGE_OAUTH_BUILD_STATUS_FAILURE`, `MESSAGE_OAUTH_WEBHOOK_NO_PERMISSIONS`) |
| Running version automation rules. (11.9k) | "Automation rule matched." stays at INFO |
| Syncing repository via remote listing. (11.6k) | "Re-syncing versions: versions added/deleted." stay at INFO; failures log exceptions |
| Deleting old files from search index. (10.4k) | Failures log "Unable to delete a subset of files." |
| External version updated. (10.1k) | Fires on every push to an open PR; "External version created."/"marked as closed" (state changes) stay at INFO |

The artifact size/timing logs kept their INFO-level signal but consolidated: "Store build artifacts finished." now carries the upload `time` **and** per-type `sizes` in a single line per build, replacing the separate "Build artifacts directory size." lines. Storage slowness and artifact-size abuse remain debuggable from INFO logs at a third of the volume (~57k → ~18k/day).

Not addressed here: "Spam rule matched." (13.9k) and "Show ads denied." (8.35k) come from `readthedocsext.spamfighting` and need a matching pass in that repo.

Total: roughly 150k log lines/day drop out of INFO.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfZV9pHCFW5iU1J7nDt3sd

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfZV9pHCFW5iU1J7nDt3sd)_