### PR TITLE
Build: point UV_PYTHON to the Python binary inside the venv

### DIFF
--- a/readthedocs/doc_builder/director.py
+++ b/readthedocs/doc_builder/director.py
@@ -677,19 +677,6 @@ class BuildDirector:
                     *cmd,
                     record=True,
                 )
-                # Save the Python path under UV_PYTHON to define it as an environment variable
-                cmd = ["asdf", "which", "python"]
-                command = self.build_environment.run(
-                    *cmd,
-                    record=True,
-                )
-                # Add UV_PYTHON to build environment variables now we have Python installed.
-                # NOTE: we can't do this at `get_build_env_vars` because we need to have Python installed to get the path of it.
-                self.build_environment._environment.update(
-                    {
-                        "UV_PYTHON": command.output.strip(),
-                    },
-                )
 
             if all(
                 [
@@ -850,9 +837,9 @@ class BuildDirector:
 
             env.update(
                 {
-                    # UV_PYTHON is set in `install_build_tools` once we have Python installed,
-                    # here I'm setting just an empty string.
-                    "UV_PYTHON": "",
+                    # Point UV_PYTHON to the Python binary inside the virtualenv created by UV.
+                    # This is used by `uv run/sync` but also by `uv pip install` to find the correct Python binary to use.
+                    "UV_PYTHON": os.path.join(venv_path, "bin", "python"),
                     "UV_PROJECT": UV_PROJECT,
                     "UV_PROJECT_ENVIRONMENT": venv_path,
                 }

--- a/readthedocs/doc_builder/python_environments.py
+++ b/readthedocs/doc_builder/python_environments.py
@@ -238,6 +238,9 @@ class UvEnv(Virtualenv):
 
     def setup_base(self):
         """Create the base environment using ``uv venv``."""
+        # Temporarily remove UV_PYTHON from the environment to avoid interference with `uv venv`.
+        # We can't use the UV_PYTHON from inside the environment because it doesn't exist yet.
+        UV_PYTHON = self.build_env._environment.pop("UV_PYTHON", None)
         self.build_env.run(
             "uv",
             "venv",
@@ -247,6 +250,7 @@ class UvEnv(Virtualenv):
             # Don't use the project's root, some config files can interfere
             cwd=None,
         )
+        self.build_env._environment["UV_PYTHON"] = UV_PYTHON
 
     def install_core_requirements(self):
         """Skip RTD core pip/sphinx bootstrap for uv-managed environments."""

--- a/readthedocs/doc_builder/tests/test_director.py
+++ b/readthedocs/doc_builder/tests/test_director.py
@@ -89,3 +89,29 @@ class TestBuildDirectorEnvironmentVariables(TestCase):
 
         checkout_path = self.project.checkout_path(self.version.slug)
         self.assertEqual(env_vars["UV_PROJECT"], checkout_path)
+
+    def test_uv_python_points_to_the_python_inside_the_virtualenv(self):
+        """
+        UV_PYTHON is the venv's Python, not the one installed by asdf.
+
+        Otherwise `uv pip install` installs the packages at system level
+        instead of inside the virtualenv created by `uv venv`.
+        """
+        self.data.config.is_using_uv = True
+        self.data.config.python.install = []
+
+        env_vars = self.director.get_build_env_vars()
+
+        venv_path = os.path.join(self.project.doc_path, "envs", self.version.slug)
+        self.assertEqual(env_vars["UV_PYTHON"], os.path.join(venv_path, "bin", "python"))
+        # UV_PROJECT_ENVIRONMENT and READTHEDOCS_VIRTUALENV_PATH are the same venv.
+        self.assertEqual(env_vars["UV_PROJECT_ENVIRONMENT"], venv_path)
+        self.assertEqual(env_vars["READTHEDOCS_VIRTUALENV_PATH"], venv_path)
+
+    def test_uv_env_vars_not_defined_when_not_using_uv(self):
+        """The UV_* variables are only defined for uv-managed environments."""
+        env_vars = self.director.get_build_env_vars()
+
+        self.assertNotIn("UV_PYTHON", env_vars)
+        self.assertNotIn("UV_PROJECT", env_vars)
+        self.assertNotIn("UV_PROJECT_ENVIRONMENT", env_vars)

--- a/readthedocs/doc_builder/tests/test_director.py
+++ b/readthedocs/doc_builder/tests/test_director.py
@@ -5,7 +5,9 @@ from django.test import TestCase, override_settings
 from django_dynamic_fixture import get
 
 from readthedocs.builds.models import Build, Version
+from readthedocs.config.tests.test_config import get_build_config
 from readthedocs.doc_builder.director import BuildDirector
+from readthedocs.doc_builder.python_environments import UvEnv
 from readthedocs.projects.models import Project
 
 
@@ -115,3 +117,31 @@ class TestBuildDirectorEnvironmentVariables(TestCase):
         self.assertNotIn("UV_PYTHON", env_vars)
         self.assertNotIn("UV_PROJECT", env_vars)
         self.assertNotIn("UV_PROJECT_ENVIRONMENT", env_vars)
+
+    def test_uv_python_removed_while_running_uv_venv(self):
+        """
+        UV_PYTHON is removed while running ``uv venv`` and re-added afterwards.
+
+        It points to the Python binary inside the virtualenv, which doesn't
+        exist yet when creating it.
+        """
+        build_env = mock.MagicMock()
+        build_env._environment = {"UV_PYTHON": "/envs/latest/bin/python"}
+        python_env = UvEnv(
+            version=self.version,
+            build_env=build_env,
+            config=get_build_config(
+                {"python": {"install": [{"method": "uv", "command": "sync"}]}},
+                validate=True,
+            ),
+        )
+
+        environment_during_run = {}
+        build_env.run.side_effect = lambda *args, **kwargs: environment_during_run.update(
+            build_env._environment
+        )
+
+        python_env.setup_base()
+
+        self.assertNotIn("UV_PYTHON", environment_during_run)
+        self.assertEqual(build_env._environment["UV_PYTHON"], "/envs/latest/bin/python")

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -2014,7 +2014,6 @@ class TestBuildTask(BuildEnvironmentBase):
                 mock.call("asdf", "plugin", "add", "uv", record=True),
                 mock.call("asdf", "install", "uv", "latest", record=True),
                 mock.call("asdf", "global", "uv", "latest", record=True),
-                mock.call("asdf", "which", "python", record=True),
                 mock.call(
                     "python",
                     "-mpip",


### PR DESCRIPTION
We were pointing UV_PYTHON to the Python binary installed via `asdf install python`. That was causing issues when running `uv pip install` because it was using the system Python binary to install dependencies and they were installed at system level, instead of inside the virtualenv created by UV.

This commit defines UV_PYTHON to point to the Python binary inside the virtualenv, and temporarily removes UV_PYTHON from the environment when running `uv venv` since it doesn't exist yet.

Closes #13168