### PR TITLE
Requirements: downgrade pip to avoid requiring `allow_editables` and …

### DIFF
--- a/.github/workflows/pip-tools.yaml
+++ b/.github/workflows/pip-tools.yaml
@@ -39,7 +39,9 @@ jobs:
 
       - name: Install piptools and invoke
         # Install pip-tools from Git and pip>=26 to get the "--uploaded-prior-to" flag.
-        run: python -m pip install --upgrade "pip>=26" "pip-tools @ git+https://github.com/jazzband/pip-tools" invoke
+        # pip<26.2 because pip 26.2 made "allow_editables" a required argument and pip-tools breaks:
+        # https://github.com/jazzband/pip-tools/issues/2437
+        run: python -m pip install --upgrade "pip>=26,<26.2" "pip-tools @ git+https://github.com/jazzband/pip-tools" invoke
 
       - name: Update dependencies from requirements/*.txt
         run: invoke requirements.update


### PR DESCRIPTION
…break

This fixes the GitHub workflow for pip-tools.