### PR TITLE
Docs: use the latest version of sphinxcontrib-video

### DIFF
--- a/docs/user/science.rst
+++ b/docs/user/science.rst
@@ -73,7 +73,6 @@ Here's a brief overview of some :doc:`features </reference/features>` that peopl
     Build and publish your project for every change made through Git (GitHub, GitLab, Bitbucket etc). Preview changes via pull requests. Receive notifications when something is wrong. How does this work? Have a look at this video:
 
     .. video:: https://anti-pattern-sphinx-video-downloader.readthedocs.io/_static/videos/enable-pull-request-builders.mp4
-       :width: 100%
        :height: 300
 
 .. dropdown:: 💬 Collaboration and community

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -27,5 +27,4 @@ sphinx-copybutton
 # Markdown
 myst_parser
 
-# spinxcontrib-video
-git+https://github.com/readthedocs/sphinxcontrib-video/
+sphinxcontrib-video

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -77,8 +77,6 @@ packaging==26.2
     # via
     #   matplotlib
     #   sphinx
-pbr==7.0.3
-    # via sphinxcontrib-video
 pillow==12.3.0
     # via matplotlib
 pygments==2.20.0
@@ -118,6 +116,7 @@ sphinx==8.2.3
     #   sphinx-tabs
     #   sphinxcontrib-httpdomain
     #   sphinxcontrib-jquery
+    #   sphinxcontrib-video
     #   sphinxemoji
     #   sphinxext-opengraph
 sphinx-autobuild==2025.8.25
@@ -154,7 +153,7 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sphinxcontrib-video @ git+https://github.com/readthedocs/sphinxcontrib-video/
+sphinxcontrib-video==0.4.2
     # via -r requirements/docs.in
 sphinxemoji==0.3.2
     # via -r requirements/docs.in
@@ -172,6 +171,3 @@ watchfiles==1.2.0
     # via sphinx-autobuild
 websockets==16.1.1
     # via sphinx-autobuild
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools


### PR DESCRIPTION
We were using a fork of sphinxcontrib-video.
Closes #9489