### PR TITLE
Downloads: use the external domain for external version download URLs

### DIFF
--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -524,6 +524,7 @@ class Version(TimeStampedModel):
                 "pdf",
                 self.slug,
                 resolver=resolver,
+                external=self.is_external,
             )
 
         if self.has_htmlzip:
@@ -531,12 +532,14 @@ class Version(TimeStampedModel):
                 "htmlzip",
                 self.slug,
                 resolver=resolver,
+                external=self.is_external,
             )
         if self.has_epub:
             data[prettify("Epub")] = project.get_production_media_url(
                 "epub",
                 self.slug,
                 resolver=resolver,
+                external=self.is_external,
             )
         return data
 

--- a/readthedocs/core/resolver.py
+++ b/readthedocs/core/resolver.py
@@ -218,7 +218,9 @@ class Resolver:
         protocol = "https" if use_https else "http"
         return urlunparse((protocol, domain, "", "", "", ""))
 
-    def get_domain_without_protocol(self, project, use_canonical_domain=True):
+    def get_domain_without_protocol(
+        self, project, use_canonical_domain=True, external_version_slug=None
+    ):
         """
         Get the domain from where the documentation of ``project`` is served from.
 
@@ -226,8 +228,13 @@ class Resolver:
 
         :param project: Project object
         :param bool use_canonical_domain: If `True` use its canonical custom domain if available.
+        :param external_version_slug: If given, use the domain for this external version.
         """
-        domain, _ = self._get_project_domain(project, use_canonical_domain=use_canonical_domain)
+        domain, _ = self._get_project_domain(
+            project,
+            use_canonical_domain=use_canonical_domain,
+            external_version_slug=external_version_slug,
+        )
         return domain
 
     def resolve(

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -844,11 +844,15 @@ class Project(models.Model):
         storage_paths.extend(f"{EXTERNAL}/{type_}/{self.slug}" for type_ in MEDIA_TYPES)
         return storage_paths
 
-    def get_production_media_url(self, type_, version_slug, resolver=None):
+    def get_production_media_url(self, type_, version_slug, resolver=None, external=False):
         """Get the URL for downloading a specific media file."""
         # Use project domain for full path --same domain as docs
-        # (project-slug.{PUBLIC_DOMAIN} or docs.project.com)
-        domain = self.subdomain(resolver=resolver)
+        # (project-slug.{PUBLIC_DOMAIN} or docs.project.com).
+        # External versions are only served from the external version domain.
+        domain = self.subdomain(
+            resolver=resolver,
+            external_version_slug=version_slug if external else None,
+        )
 
         # NOTE: we can't use ``reverse('project_download_media')`` here
         # because this URL only exists in El Proxito and this method is
@@ -970,10 +974,14 @@ class Project(models.Model):
         """Return whether or not this project supports translations."""
         return self.versioning_scheme == MULTIPLE_VERSIONS_WITH_TRANSLATIONS
 
-    def subdomain(self, use_canonical_domain=True, resolver=None):
+    def subdomain(self, use_canonical_domain=True, resolver=None, external_version_slug=None):
         """Get project subdomain from resolver."""
         resolver = resolver or Resolver()
-        return resolver.get_domain_without_protocol(self, use_canonical_domain=use_canonical_domain)
+        return resolver.get_domain_without_protocol(
+            self,
+            use_canonical_domain=use_canonical_domain,
+            external_version_slug=external_version_slug,
+        )
 
     def get_downloads(self, resolver=None):
         downloads = {}

--- a/readthedocs/rtd_tests/tests/test_version.py
+++ b/readthedocs/rtd_tests/tests/test_version.py
@@ -125,6 +125,21 @@ class TestVersionModel(VersionMixin, TestCase):
     @override_settings(
         PRODUCTION_DOMAIN="readthedocs.org",
         PUBLIC_DOMAIN="readthedocs.io",
+        RTD_EXTERNAL_VERSION_DOMAIN="org.readthedocs.build",
+    )
+    def test_get_downloads_external_version(self):
+        version = self.external_version
+        version.has_pdf = True
+        version.save()
+
+        expected = {
+            "pdf": "//pip--pr-9999.org.readthedocs.build/_/downloads/en/pr-9999/pdf/",
+        }
+        self.assertDictEqual(version.get_downloads(), expected)
+
+    @override_settings(
+        PRODUCTION_DOMAIN="readthedocs.org",
+        PUBLIC_DOMAIN="readthedocs.io",
     )
     def test_get_downloads_subproject(self):
         version = self.subproject.versions.get(slug=LATEST)


### PR DESCRIPTION
Offline-format downloads 404 on pull request builds: the addons API builds flyout download URLs with `Project.get_production_media_url()`, which always resolves the project's canonical domain, but external versions are only served from `RTD_EXTERNAL_VERSION_DOMAIN`. For example, on the PR build for readthedocs/test-builds#2125 the flyout points at `https://test-builds.readthedocs.io/_/downloads/en/2125/pdf/` (404), while the same path on `test-builds--2125.org.readthedocs.build` serves the PDF fine.

This threads the version's external flag through to domain resolution — mirroring what `Resolver.resolve()` already does for docs URLs — so download links on external versions now point at the external version domain.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)