### PR TITLE
AWS: add tests for build-uploads security token service credentials

### DIFF
--- a/readthedocs/aws/security_token_service.py
+++ b/readthedocs/aws/security_token_service.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass
 import boto3
 import structlog
 from django.conf import settings
+from django.core.files.storage import storages
 
 
 log = structlog.get_logger(__name__)
@@ -252,6 +253,57 @@ def get_s3_build_tools_scoped_credentials(
         ],
     }
     session_name = f"rtd-{build.id}-{project.slug}-{version.slug}"
+    credentials = _get_scoped_credentials(
+        session_name=session_name,
+        policy=policy,
+        duration=duration,
+    )
+    return AWSS3TemporaryCredentials(
+        access_key_id=credentials.access_key_id,
+        secret_access_key=credentials.secret_access_key,
+        session_token=credentials.session_token,
+        region_name=settings.AWS_S3_REGION_NAME,
+        bucket_name=bucket,
+    )
+
+
+def get_s3_build_uploads_scoped_credentials(
+    *,
+    build,
+    duration=60 * 15,
+) -> AWSS3TemporaryCredentials:
+    """
+    Get temporary credentials with read-only access to the build-uploads bucket.
+
+    :param build: The build to get the credentials for.
+    :param duration: The duration of the credentials in seconds. Default is 15 minutes.
+     Note that the minimum duration time is 15 minutes and the maximum is given by the role (defaults to 1 hour).
+    """
+    storage = storages["build-uploads"]
+    project = build.project
+    bucket = storage.bucket_name
+    bucket_arn = f"arn:aws:s3:::{bucket}"
+
+    # Inline policy to limit the permissions of the temporary credentials.
+    # We only need to read the uploaded zip from the build-uploads bucket,
+    # so we limit the permissions to the specific path of the build.
+    policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Action": [
+                    "s3:GetObject",
+                    "s3:ListBucket",
+                ],
+                "Resource": [
+                    bucket_arn,
+                    f"{bucket_arn}/{build.uploaded_artifacts_storage_path}",
+                ],
+            },
+        ],
+    }
+    session_name = f"rtd-{build.id}-{project.slug}"
     credentials = _get_scoped_credentials(
         session_name=session_name,
         policy=policy,

--- a/readthedocs/aws/tests/test_security_token_service.py
+++ b/readthedocs/aws/tests/test_security_token_service.py
@@ -12,6 +12,7 @@ from readthedocs.aws.security_token_service import (
     AWSS3TemporaryCredentials,
     get_s3_build_media_scoped_credentials,
     get_s3_build_tools_scoped_credentials,
+    get_s3_build_uploads_scoped_credentials,
 )
 
 
@@ -290,4 +291,86 @@ class TestSecurityTokenService(TestCase):
             Policy=json.dumps(policy, separators=(",", ":")),
             Tags=[],
             DurationSeconds=15 * 60,
+        )
+
+    @mock.patch("readthedocs.aws.security_token_service.storages")
+    @override_settings(USING_AWS=False, DEBUG=True)
+    def test_get_s3_build_uploads_global_credentials(self, storages):
+        storages.__getitem__.return_value.bucket_name = "readthedocs-build-uploads"
+        credentials = get_s3_build_uploads_scoped_credentials(build=self.build)
+        assert credentials == AWSS3TemporaryCredentials(
+            access_key_id="global_access_key_id",
+            secret_access_key="global_secret_access_key",
+            session_token=None,
+            region_name="us-east-1",
+            bucket_name="readthedocs-build-uploads",
+        )
+        storages.__getitem__.assert_called_once_with("build-uploads")
+
+    @mock.patch("readthedocs.aws.security_token_service.storages")
+    @mock.patch("readthedocs.aws.security_token_service.boto3.client")
+    def test_get_s3_build_uploads_scoped_credentials(self, boto3_client, storages):
+        storages.__getitem__.return_value.bucket_name = "readthedocs-build-uploads"
+        boto3_client().assume_role.return_value = {
+            "Credentials": {
+                "AccessKeyId": "access_key_id",
+                "SecretAccessKey": "secret_access_key",
+                "SessionToken": "session_token",
+            }
+        }
+        credentials = get_s3_build_uploads_scoped_credentials(build=self.build)
+        assert credentials == AWSS3TemporaryCredentials(
+            access_key_id="access_key_id",
+            secret_access_key="secret_access_key",
+            session_token="session_token",
+            region_name="us-east-1",
+            bucket_name="readthedocs-build-uploads",
+        )
+
+        policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "s3:GetObject",
+                        "s3:ListBucket",
+                    ],
+                    "Resource": [
+                        "arn:aws:s3:::readthedocs-build-uploads",
+                        f"arn:aws:s3:::readthedocs-build-uploads/{self.project.id}/{self.build.id}/artifacts.zip",
+                    ],
+                },
+            ],
+        }
+
+        boto3_client().assume_role.assert_called_once_with(
+            RoleArn="arn:aws:iam::1234:role/RoleName",
+            RoleSessionName=f"rtd-{self.build.id}-project",
+            Policy=json.dumps(policy, separators=(",", ":")),
+            Tags=[],
+            DurationSeconds=15 * 60,
+        )
+
+    @mock.patch("readthedocs.aws.security_token_service.storages")
+    @mock.patch("readthedocs.aws.security_token_service.boto3.client")
+    def test_get_s3_build_uploads_scoped_credentials_custom_duration(
+        self, boto3_client, storages
+    ):
+        storages.__getitem__.return_value.bucket_name = "readthedocs-build-uploads"
+        boto3_client().assume_role.return_value = {
+            "Credentials": {
+                "AccessKeyId": "access_key_id",
+                "SecretAccessKey": "secret_access_key",
+                "SessionToken": "session_token",
+            }
+        }
+        get_s3_build_uploads_scoped_credentials(build=self.build, duration=60 * 30)
+
+        boto3_client().assume_role.assert_called_once_with(
+            RoleArn="arn:aws:iam::1234:role/RoleName",
+            RoleSessionName=f"rtd-{self.build.id}-project",
+            Policy=mock.ANY,
+            Tags=[],
+            DurationSeconds=30 * 60,
         )

--- a/readthedocs/builds/models.py
+++ b/readthedocs/builds/models.py
@@ -966,6 +966,17 @@ class Build(models.Model):
         date = self.date.date()
         return f"{date}/{self.id}.json"
 
+    @property
+    def uploaded_artifacts_storage_path(self):
+        """
+        Storage path where the uploaded zip with the build artifacts are stored.
+
+        The path is in the format: <project_id>/<build_id>/artifacts.zip
+
+        Example: 1234/1111/artifacts.zip
+        """
+        return f"{self.project.id}/{self.id}/artifacts.zip"
+
     def get_absolute_url(self):
         return reverse("builds_detail", args=[self.project.slug, self.pk])
 


### PR DESCRIPTION
Adds `get_s3_build_uploads_scoped_credentials()` to `readthedocs/aws/security_token_service.py` (ported from #13178, the direct-artifacts-upload work) along with the `Build.uploaded_artifacts_storage_path` property it depends on, and adds test coverage for it in `readthedocs/aws/tests/test_security_token_service.py`, mirroring the existing tests for the build-media and build-tools scoped credentials:

- Global (non-AWS/debug) credentials
- Scoped credentials with the correct inline policy and session name
- Custom `duration` override

Related to #13178.

---
_Generated by [Claude Code](https://claude.ai/code/session_013My5Hgj5E2kuMXyfrZPzJA)_