### PR TITLE
Builds: test trigger_build for uploaded versions

### DIFF
--- a/readthedocs/rtd_tests/tests/test_core_utils.py
+++ b/readthedocs/rtd_tests/tests/test_core_utils.py
@@ -47,9 +47,9 @@ class CoreUtilTests(TestCase):
             project=self.project,
             version=self.version,
         )
-        self.assertEqual(result, (None, None))
-        self.assertFalse(update_docs_task.signature.called)
-        self.assertFalse(update_docs_task.signature().apply_async.called)
+        assert result == (None, None)
+        assert not update_docs_task.signature.called
+        assert not update_docs_task.signature().apply_async.called
 
     @mock.patch("readthedocs.projects.tasks.builds.update_docs_task")
     def test_trigger_build_when_version_not_provided_default_version_exist(

--- a/readthedocs/rtd_tests/tests/test_core_utils.py
+++ b/readthedocs/rtd_tests/tests/test_core_utils.py
@@ -40,6 +40,18 @@ class CoreUtilTests(TestCase):
         self.assertFalse(update_docs_task.signature().apply_async.called)
 
     @mock.patch("readthedocs.projects.tasks.builds.update_docs_task")
+    def test_trigger_skipped_uploaded_version(self, update_docs_task):
+        self.version.is_uploaded = True
+        self.version.save()
+        result = trigger_build(
+            project=self.project,
+            version=self.version,
+        )
+        self.assertEqual(result, (None, None))
+        self.assertFalse(update_docs_task.signature.called)
+        self.assertFalse(update_docs_task.signature().apply_async.called)
+
+    @mock.patch("readthedocs.projects.tasks.builds.update_docs_task")
     def test_trigger_build_when_version_not_provided_default_version_exist(
         self, update_docs_task
     ):


### PR DESCRIPTION
`prepare_build` (called from `trigger_build`) skips creating a `Build` and returns `(None, None)` when `version.is_uploaded` is `True` — this path didn't have test coverage yet. This adds a test mirroring the existing `test_trigger_skipped_project` case, asserting the build is skipped and `update_docs_task` is never invoked when the version is marked as uploaded.

Built on top of #13178.

---
*Generated by an AI agent.*

---
_Generated by [Claude Code](https://claude.ai/code/session_015dDz3bSrPhVZNMwSJsnGx3)_