### PR TITLE
Storage: add tests for generate_presigned_post

### DIFF
--- a/readthedocs/storage/tests/test_s3_storage.py
+++ b/readthedocs/storage/tests/test_s3_storage.py
@@ -62,3 +62,72 @@ class TestRTDS3Storage(TestCase):
                 "Quiet": True,
             }
         )
+
+    def test_generate_presigned_post(self):
+        mock_bucket = mock.MagicMock()
+        self.storage._bucket = mock_bucket
+        self.storage.bucket_name = "my-bucket"
+        self.storage.default_acl = "private"
+        mock_client = mock_bucket.meta.client
+        mock_client.generate_presigned_post.return_value = {
+            "url": "https://my-bucket.s3.amazonaws.com/",
+            "fields": {},
+        }
+
+        response = self.storage.generate_presigned_post(
+            key="projects/my-project/en/latest/artifact.zip",
+            content_type="application/zip",
+        )
+
+        mock_client.generate_presigned_post.assert_called_once_with(
+            Bucket="my-bucket",
+            Key="projects/my-project/en/latest/artifact.zip",
+            Fields={
+                "bucket": "my-bucket",
+                "acl": "private",
+                "Content-Type": "application/zip",
+            },
+            Conditions=[
+                {"bucket": "my-bucket"},
+                {"acl": "private"},
+                {"Content-Type": "application/zip"},
+                ["content-length-range", 1, 1024 * 1024 * 1024],
+            ],
+            ExpiresIn=3600,
+        )
+        assert response == {
+            "url": "https://my-bucket.s3.amazonaws.com/",
+            "fields": {},
+        }
+
+    def test_generate_presigned_post_custom_options(self):
+        mock_bucket = mock.MagicMock()
+        self.storage._bucket = mock_bucket
+        self.storage.bucket_name = "my-bucket"
+        self.storage.default_acl = "private"
+        mock_client = mock_bucket.meta.client
+
+        self.storage.generate_presigned_post(
+            key="projects/my-project/en/latest/artifact.zip",
+            content_type="application/zip",
+            expires_in=60,
+            min_size=10,
+            max_size=2048,
+        )
+
+        mock_client.generate_presigned_post.assert_called_once_with(
+            Bucket="my-bucket",
+            Key="projects/my-project/en/latest/artifact.zip",
+            Fields={
+                "bucket": "my-bucket",
+                "acl": "private",
+                "Content-Type": "application/zip",
+            },
+            Conditions=[
+                {"bucket": "my-bucket"},
+                {"acl": "private"},
+                {"Content-Type": "application/zip"},
+                ["content-length-range", 10, 2048],
+            ],
+            ExpiresIn=60,
+        )


### PR DESCRIPTION
Adds test coverage for `RTDS3Storage.generate_presigned_post()` (introduced in #13178) in `readthedocs/storage/tests/test_s3_storage.py`.

This follows the existing mock-`_bucket` pattern already used in that file for `delete_directory`/`delete_paths`, mocking `bucket.meta.client.generate_presigned_post` and asserting the `Bucket`, `Key`, `Fields`, `Conditions`, and `ExpiresIn` passed to boto3, both with default arguments and with custom `expires_in`/`min_size`/`max_size` overrides.

Stacked on #13178.

Note for reviewers: I couldn't run the full local test suite in this session — the checked-out base branch fails to import (`SyntaxError` from Python-2-style `except X, Y:` clauses in several unrelated files, e.g. `readthedocs/core/apps.py`, `readthedocs/integrations/models.py`). This looks like a pre-existing/environment issue unconnected to this change, so I verified the new tests directly against `RTDS3Storage.generate_presigned_post()` outside of the full Django app registry, and ran `ruff format`/`ruff check` on the changed file (both clean).

---
_Generated by [Claude Code](https://claude.ai/code/session_01U7muj3LqvSL625pgLBAk4n)_