### PR TITLE
Proxito: stop serving docs for organizations disabled ~90 days

### DIFF
--- a/readthedocs/organizations/querysets.py
+++ b/readthedocs/organizations/querysets.py
@@ -127,12 +127,10 @@ class BaseOrganizationQuerySet(NoReprQuerySet, models.QuerySet):
 
     def disable_serving(self):
         """
-        Filter organizations which docs serving must be blocked.
+        Filter organizations which docs shouldn't be served anymore.
 
-        These are organizations that have been disabled for at least
-        3*DISABLE_AFTER_DAYS (~3 months) after their subscription ended.
-        Their docs keep being served during that grace window, so a
-        billing mistake doesn't take customer docs down immediately.
+        These organizations are disabled, and at least 3*DISABLE_AFTER_DAYS
+        (~3 months) passed since their subscription ended.
         """
         return self.subscription_ended(days=3 * DISABLE_AFTER_DAYS, exact=False).filter(
             disabled=True,
@@ -142,10 +140,9 @@ class BaseOrganizationQuerySet(NoReprQuerySet, models.QuerySet):
         """
         Filter organizations which their artifacts can be cleaned up.
 
-        These organizations are at least 3*DISABLE_AFTER_DAYS (~3 months) that
-        are disabled and their artifacts weren't cleaned already. We should be
-        safe to cleanup all their artifacts at this point,
-        since their docs aren't being served anymore (see ``disable_serving``).
+        These organizations aren't serving their docs anymore, and their
+        artifacts weren't cleaned already. We should be safe to cleanup all
+        their artifacts at this point.
         """
         return self.disable_serving().filter(
             artifacts_cleaned=False,

--- a/readthedocs/organizations/querysets.py
+++ b/readthedocs/organizations/querysets.py
@@ -125,16 +125,29 @@ class BaseOrganizationQuerySet(NoReprQuerySet, models.QuerySet):
             .exclude(disabled=True)
         )
 
+    def disable_serving(self):
+        """
+        Filter organizations which docs serving must be blocked.
+
+        These are organizations that have been disabled for at least
+        3*DISABLE_AFTER_DAYS (~3 months) after their subscription ended.
+        Their docs keep being served during that grace window, so a
+        billing mistake doesn't take customer docs down immediately.
+        """
+        return self.subscription_ended(days=3 * DISABLE_AFTER_DAYS, exact=False).filter(
+            disabled=True,
+        )
+
     def clean_artifacts(self):
         """
         Filter organizations which their artifacts can be cleaned up.
 
         These organizations are at least 3*DISABLE_AFTER_DAYS (~3 months) that
         are disabled and their artifacts weren't cleaned already. We should be
-        safe to cleanup all their artifacts at this point.
+        safe to cleanup all their artifacts at this point,
+        since their docs aren't being served anymore (see ``disable_serving``).
         """
-        return self.subscription_ended(days=3 * DISABLE_AFTER_DAYS, exact=False).filter(
-            disabled=True,
+        return self.disable_serving().filter(
             artifacts_cleaned=False,
         )
 

--- a/readthedocs/organizations/tests/test_querysets.py
+++ b/readthedocs/organizations/tests/test_querysets.py
@@ -219,3 +219,110 @@ class TestOrganizationQuerysets(PaymentMixin, TestCase):
             set(Organization.objects.disable_soon(days=30, exact=False)),
             {organization_canceled_35_days_ago, organization_past_due_35_days_ago},
         )
+
+    def test_organizations_disable_serving(self):
+        subscription_active = get(
+            djstripe.Subscription,
+            customer=get(djstripe.Customer),
+            status=SubscriptionStatus.active,
+        )
+        get(
+            Organization,
+            stripe_subscription=subscription_active,
+            stripe_customer=subscription_active.customer,
+        )
+
+        # Disabled recently: keep serving docs during the grace window.
+        subscription_ended_35_days_ago = get(
+            djstripe.Subscription,
+            customer=get(djstripe.Customer),
+            status=SubscriptionStatus.canceled,
+            ended_at=timezone.now() - timedelta(days=35),
+        )
+        get(
+            Organization,
+            disabled=True,
+            stripe_subscription=subscription_ended_35_days_ago,
+            stripe_customer=subscription_ended_35_days_ago.customer,
+        )
+
+        # Subscription ended long ago, but the organization was never
+        # marked as disabled (e.g. never_disable): keep serving docs.
+        subscription_ended_100_days_ago = get(
+            djstripe.Subscription,
+            customer=get(djstripe.Customer),
+            status=SubscriptionStatus.canceled,
+            ended_at=timezone.now() - timedelta(days=100),
+        )
+        get(
+            Organization,
+            disabled=False,
+            stripe_subscription=subscription_ended_100_days_ago,
+            stripe_customer=subscription_ended_100_days_ago.customer,
+        )
+
+        subscription_ended_100_days_ago_disabled = get(
+            djstripe.Subscription,
+            customer=get(djstripe.Customer),
+            status=SubscriptionStatus.canceled,
+            ended_at=timezone.now() - timedelta(days=100),
+        )
+        organization_long_disabled = get(
+            Organization,
+            disabled=True,
+            stripe_subscription=subscription_ended_100_days_ago_disabled,
+            stripe_customer=subscription_ended_100_days_ago_disabled.customer,
+        )
+
+        # Artifacts already cleaned: serving is still disabled.
+        subscription_ended_100_days_ago_cleaned = get(
+            djstripe.Subscription,
+            customer=get(djstripe.Customer),
+            status=SubscriptionStatus.canceled,
+            ended_at=timezone.now() - timedelta(days=100),
+        )
+        organization_long_disabled_cleaned = get(
+            Organization,
+            disabled=True,
+            artifacts_cleaned=True,
+            stripe_subscription=subscription_ended_100_days_ago_cleaned,
+            stripe_customer=subscription_ended_100_days_ago_cleaned.customer,
+        )
+
+        assert set(Organization.objects.disable_serving()) == {
+            organization_long_disabled,
+            organization_long_disabled_cleaned,
+        }
+
+    def test_organizations_clean_artifacts(self):
+        subscription_ended_100_days_ago = get(
+            djstripe.Subscription,
+            customer=get(djstripe.Customer),
+            status=SubscriptionStatus.canceled,
+            ended_at=timezone.now() - timedelta(days=100),
+        )
+        organization_long_disabled = get(
+            Organization,
+            disabled=True,
+            stripe_subscription=subscription_ended_100_days_ago,
+            stripe_customer=subscription_ended_100_days_ago.customer,
+        )
+
+        # Artifacts already cleaned: nothing left to clean.
+        subscription_ended_100_days_ago_cleaned = get(
+            djstripe.Subscription,
+            customer=get(djstripe.Customer),
+            status=SubscriptionStatus.canceled,
+            ended_at=timezone.now() - timedelta(days=100),
+        )
+        get(
+            Organization,
+            disabled=True,
+            artifacts_cleaned=True,
+            stripe_subscription=subscription_ended_100_days_ago_cleaned,
+            stripe_customer=subscription_ended_100_days_ago_cleaned.customer,
+        )
+
+        assert set(Organization.objects.clean_artifacts()) == {
+            organization_long_disabled,
+        }

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -387,9 +387,6 @@ class ProjectDownloadMediaBase(CDNCacheControlMixin, CDNCacheTagsMixin, ServeDoc
             request, version.project
         )
         if disabled_organization_response:
-            # Don't cache this response on the CDN,
-            # so re-enabling the organization takes effect immediately.
-            self.cache_response = False
             return disabled_organization_response
 
         return self._serve_dowload(

--- a/readthedocs/projects/views/public.py
+++ b/readthedocs/projects/views/public.py
@@ -383,6 +383,15 @@ class ProjectDownloadMediaBase(CDNCacheControlMixin, CDNCacheTagsMixin, ServeDoc
         self.project = version.project
         self.version = version
 
+        disabled_organization_response = self._disabled_organization_response(
+            request, version.project
+        )
+        if disabled_organization_response:
+            # Don't cache this response on the CDN,
+            # so re-enabling the organization takes effect immediately.
+            self.cache_response = False
+            return disabled_organization_response
+
         return self._serve_dowload(
             request=request,
             project=version.project,

--- a/readthedocs/proxito/tests/test_disabled_organizations.py
+++ b/readthedocs/proxito/tests/test_disabled_organizations.py
@@ -65,9 +65,8 @@ class TestDisabledOrganizationServing(PaymentMixin, TestCase):
         assert "errors/proxito/organization_disabled.html" in [
             template.name for template in resp.templates
         ]
-        # Don't cache the response on the CDN,
-        # so re-enabling the organization takes effect immediately.
-        assert resp.headers["CDN-Cache-Control"] == "private"
+        # The response is purged from the CDN when the project is built again.
+        assert resp.headers["CDN-Cache-Control"] == "public"
 
     def test_serving_recently_disabled_organization_docs(self):
         self._create_organization(subscription_ended_days_ago=35, disabled=True)
@@ -79,6 +78,15 @@ class TestDisabledOrganizationServing(PaymentMixin, TestCase):
 
     def test_serving_enabled_organization_docs(self):
         self._create_organization(subscription_ended_days_ago=100, disabled=False)
+
+        resp = self.client.get("/en/latest/index.html", headers={"host": self.host})
+
+        assert resp.status_code == 200
+        assert resp["x-accel-redirect"] == "/proxito/media/html/project/latest/index.html"
+
+    @override_settings(RTD_ALLOW_ORGANIZATIONS=False)
+    def test_serving_disabled_organization_docs_without_organizations(self):
+        self._create_organization(subscription_ended_days_ago=100, disabled=True)
 
         resp = self.client.get("/en/latest/index.html", headers={"host": self.host})
 

--- a/readthedocs/proxito/tests/test_disabled_organizations.py
+++ b/readthedocs/proxito/tests/test_disabled_organizations.py
@@ -1,0 +1,107 @@
+"""Serving docs of organizations that have been disabled for a long time."""
+
+from datetime import timedelta
+
+import django_dynamic_fixture as fixture
+import pytest
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.utils import timezone
+from django_dynamic_fixture import get
+from djstripe import models as djstripe
+from djstripe.enums import SubscriptionStatus
+
+from readthedocs.builds.constants import LATEST
+from readthedocs.organizations.models import Organization
+from readthedocs.payments.tests.utils import PaymentMixin
+from readthedocs.projects.constants import PUBLIC
+from readthedocs.projects.models import Project
+
+
+@pytest.mark.proxito
+@override_settings(
+    PYTHON_MEDIA=False,
+    PUBLIC_DOMAIN="dev.readthedocs.io",
+    RTD_ALLOW_ORGANIZATIONS=True,
+)
+class TestDisabledOrganizationServing(PaymentMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.eric = fixture.get(User, username="eric")
+        self.project = fixture.get(
+            Project,
+            slug="project",
+            privacy_level=PUBLIC,
+            external_builds_privacy_level=PUBLIC,
+            users=[self.eric],
+            main_language_project=None,
+        )
+        self.project.versions.update(privacy_level=PUBLIC, built=True, active=True)
+        self.version = self.project.versions.get(slug=LATEST)
+        self.host = "project.dev.readthedocs.io"
+
+    def _create_organization(self, subscription_ended_days_ago, disabled):
+        stripe_subscription = get(
+            djstripe.Subscription,
+            customer=get(djstripe.Customer),
+            status=SubscriptionStatus.canceled,
+            ended_at=timezone.now() - timedelta(days=subscription_ended_days_ago),
+        )
+        return get(
+            Organization,
+            disabled=disabled,
+            projects=[self.project],
+            stripe_subscription=stripe_subscription,
+            stripe_customer=stripe_subscription.customer,
+        )
+
+    def test_serving_disabled_organization_docs(self):
+        self._create_organization(subscription_ended_days_ago=100, disabled=True)
+
+        resp = self.client.get("/en/latest/index.html", headers={"host": self.host})
+
+        assert resp.status_code == 404
+        assert "errors/proxito/organization_disabled.html" in [
+            template.name for template in resp.templates
+        ]
+        # Don't cache the response on the CDN,
+        # so re-enabling the organization takes effect immediately.
+        assert resp.headers["CDN-Cache-Control"] == "private"
+
+    def test_serving_recently_disabled_organization_docs(self):
+        self._create_organization(subscription_ended_days_ago=35, disabled=True)
+
+        resp = self.client.get("/en/latest/index.html", headers={"host": self.host})
+
+        assert resp.status_code == 200
+        assert resp["x-accel-redirect"] == "/proxito/media/html/project/latest/index.html"
+
+    def test_serving_enabled_organization_docs(self):
+        self._create_organization(subscription_ended_days_ago=100, disabled=False)
+
+        resp = self.client.get("/en/latest/index.html", headers={"host": self.host})
+
+        assert resp.status_code == 200
+        assert resp["x-accel-redirect"] == "/proxito/media/html/project/latest/index.html"
+
+    def test_downloading_disabled_organization_docs(self):
+        self._create_organization(subscription_ended_days_ago=100, disabled=True)
+
+        resp = self.client.get("/_/downloads/en/latest/pdf/", headers={"host": self.host})
+
+        assert resp.status_code == 404
+        assert "errors/proxito/organization_disabled.html" in [
+            template.name for template in resp.templates
+        ]
+
+    def test_downloading_enabled_organization_docs(self):
+        self._create_organization(subscription_ended_days_ago=100, disabled=False)
+
+        resp = self.client.get("/_/downloads/en/latest/pdf/", headers={"host": self.host})
+
+        assert resp.status_code == 200
+        assert (
+            resp["x-accel-redirect"]
+            == "/proxito/media/pdf/project/latest/project.pdf"
+        )

--- a/readthedocs/proxito/views/mixins.py
+++ b/readthedocs/proxito/views/mixins.py
@@ -17,6 +17,7 @@ from slugify import slugify as unicode_slugify
 
 from readthedocs.audit.models import AuditLog
 from readthedocs.core.resolver import Resolver
+from readthedocs.organizations.models import Organization
 from readthedocs.projects.constants import MEDIA_TYPE_HTML
 from readthedocs.proxito.constants import RedirectType
 from readthedocs.redirects.exceptions import InfiniteRedirectException
@@ -254,6 +255,33 @@ class ServeDocsMixin:
 
             if is_serve_docs_denied(project):
                 return render(request, template_name="errors/proxito/spam.html", status=410)
+
+    def _disabled_organization_response(self, request, project):
+        """
+        Return an error response if the project's organization is disabled.
+
+        Organizations keep serving their docs for a grace window after being
+        disabled (see ``OrganizationQuerySet.disable_serving``), so a billing
+        mistake doesn't take customer docs down immediately.
+        """
+        organization = project.organization
+        if not organization or not organization.disabled:
+            return None
+
+        serving_disabled = (
+            Organization.objects.disable_serving()
+            .filter(
+                pk=organization.pk,
+            )
+            .exists()
+        )
+        if serving_disabled:
+            return render(
+                request,
+                template_name="errors/proxito/organization_disabled.html",
+                status=404,
+            )
+        return None
 
     def get_unauthed_response(self, request, project):
         return self._serve_401(request, project)

--- a/readthedocs/proxito/views/mixins.py
+++ b/readthedocs/proxito/views/mixins.py
@@ -257,25 +257,11 @@ class ServeDocsMixin:
                 return render(request, template_name="errors/proxito/spam.html", status=410)
 
     def _disabled_organization_response(self, request, project):
-        """
-        Return an error response if the project's organization is disabled.
-
-        Organizations keep serving their docs for a grace window after being
-        disabled (see ``OrganizationQuerySet.disable_serving``), so a billing
-        mistake doesn't take customer docs down immediately.
-        """
-        organization = project.organization
-        if not organization or not organization.disabled:
+        """Return an error response if the docs of this project shouldn't be served anymore."""
+        if not settings.RTD_ALLOW_ORGANIZATIONS:
             return None
 
-        serving_disabled = (
-            Organization.objects.disable_serving()
-            .filter(
-                pk=organization.pk,
-            )
-            .exists()
-        )
-        if serving_disabled:
+        if Organization.objects.disable_serving().filter(projects=project).exists():
             return render(
                 request,
                 template_name="errors/proxito/organization_disabled.html",

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -309,6 +309,13 @@ class ServeDocsBase(CDNCacheControlMixin, ServeRedirectMixin, ServeDocsMixin, Vi
             self.cache_response = True
             return spam_response
 
+        disabled_organization_response = self._disabled_organization_response(request, project)
+        if disabled_organization_response:
+            # Don't cache this response on the CDN,
+            # so re-enabling the organization takes effect immediately.
+            self.cache_response = False
+            return disabled_organization_response
+
         # Trailing slash redirect.
         # We don't want to serve documentation at:
         # - `/en/latest`

--- a/readthedocs/proxito/views/serve.py
+++ b/readthedocs/proxito/views/serve.py
@@ -311,9 +311,6 @@ class ServeDocsBase(CDNCacheControlMixin, ServeRedirectMixin, ServeDocsMixin, Vi
 
         disabled_organization_response = self._disabled_organization_response(request, project)
         if disabled_organization_response:
-            # Don't cache this response on the CDN,
-            # so re-enabling the organization takes effect immediately.
-            self.cache_response = False
             return disabled_organization_response
 
         # Trailing slash redirect.

--- a/readthedocs/templates/errors/proxito/organization_disabled.html
+++ b/readthedocs/templates/errors/proxito/organization_disabled.html
@@ -1,0 +1,40 @@
+{% extends "errors/proxito/base.html" %}
+
+{% load blocktrans trans from i18n %}
+
+{% block title %}
+  {% trans "Documentation unavailable" %}
+{% endblock title %}
+
+{% block error_status %}
+  404
+{% endblock error_status %}
+{% block error_title %}
+  {{ block.super }}
+  {% trans "Documentation unavailable" %}
+{% endblock error_title %}
+
+{% block error_content %}
+  <p>
+    {% blocktrans trimmed %}
+      This documentation is not available because the organization that owns it is disabled.
+    {% endblocktrans %}
+  </p>
+{% endblock error_content %}
+
+{% block error_content_help %}
+  <p>
+    {% blocktrans trimmed %}
+      If you are an owner of this organization, renew your subscription to restore your documentation.
+    {% endblocktrans %}
+  </p>
+  <p>
+    {% url 'support' as url_support %}
+    {% blocktrans trimmed with url_support=url_support %}
+      Please <a href="{{ url_support }}">contact us</a> if you think this is a mistake.
+    {% endblocktrans %}
+  </p>
+{% endblock error_content_help %}
+
+{% block content_extra_link %}
+{% endblock content_extra_link %}


### PR DESCRIPTION
Disabling an organization today only blocks builds — its docs keep serving indefinitely until an admin runs the `clean_artifacts` admin action, which is both irreversible (deletes all artifacts from storage) and the de-facto serving cutoff. This separates the two concerns: serving now stops automatically, and artifact deletion becomes routine storage cleanup with no time pressure.

The check is dynamic, reusing the same `subscription_ended` window that already gates artifact cleanup (`3 * DISABLE_AFTER_DAYS`, ~90 days) — no new model field, no migration, no scheduled task. The window is the safety valve against bad invoices or Stripe glitches: a wrongly-disabled customer gets ~3 months of failing builds and owner notifications before their docs would go dark, and support fixes it by just re-enabling the organization.

Both docs serving and downloads (PDF/ePub/zip) are covered, following the same shape as the on-trial `noindex` check from #13248. On the community site this is a no-op. Responses are cached at the CDN like any other; a re-enabled organization's docs come back when its projects build again.

The error page template ships here as a plain community fallback; readthedocs/ext-theme#769 adds the styled version, which takes template precedence once merged (ext-theme's template dir is first in `TEMPLATES["DIRS"]`). The two PRs can merge in either order.

Worth a second look: `clean_artifacts()` is now defined in terms of the new `disable_serving()` queryset. The behavior is pinned by a test, but it gates irreversible deletion, so the equivalence is worth confirming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)