### PR TITLE
Builds: obfuscate Git clone token in build command output

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -208,7 +208,7 @@ class BuildCommand(BuildCommandResultMixin):
             2. Chunk at around ``DATA_UPLOAD_MAX_MEMORY_SIZE`` bytes to be sent
                over the API call request
 
-            3. Obfuscate private environment variables.
+            3. Obfuscate private environment variables and the Git clone token.
 
         :param output: stdout/stderr to be sanitized
 
@@ -252,6 +252,18 @@ class BuildCommand(BuildCommandResultMixin):
                     value = spec["value"]
                     obfuscated_value = f"{value[:4]}****"
                     sanitized = sanitized.replace(value, obfuscated_value)
+
+            # Obfuscate the Git clone token. The token is exposed via the
+            # ``READTHEDOCS_GIT_CLONE_TOKEN`` environment variable, and Git
+            # stores it in ``.git/config`` as part of the remote URL, so any
+            # command echoing either would expose it in the build output.
+            clone_token = self.build_env.project.clone_token
+            if clone_token:
+                # The clone token has the ``<username>:<secret>`` format.
+                secret = clone_token.split(":", 1)[-1]
+                for value in (clone_token, secret):
+                    if value:
+                        sanitized = sanitized.replace(value, "****")
 
         return sanitized
 

--- a/readthedocs/rtd_tests/tests/test_doc_building.py
+++ b/readthedocs/rtd_tests/tests/test_doc_building.py
@@ -314,6 +314,7 @@ class TestBuildCommand(TestCase):
     def test_obfuscate_output_private_variables(self):
         build_env = mock.MagicMock()
         build_env.project = mock.MagicMock()
+        build_env.project.clone_token = None
         build_env.project._environment_variables = mock.MagicMock()
         build_env.project._environment_variables.items.return_value = [
             (
@@ -335,6 +336,20 @@ class TestBuildCommand(TestCase):
         checks = (
             ("public-value", "public-value"),
             ("private-value", "priv****"),
+        )
+        for output, sanitized in checks:
+            self.assertEqual(cmd.sanitize_output(output), sanitized)
+
+    def test_obfuscate_output_clone_token(self):
+        build_env = mock.MagicMock()
+        build_env.project = mock.MagicMock()
+        build_env.project.clone_token = "x-access-token:1234"
+        build_env.project._environment_variables = {}
+        cmd = BuildCommand(["/bin/bash", "-c", "echo"], build_env=build_env)
+        checks = (
+            ("https://x-access-token:1234@github.com/org/repo", "https://****@github.com/org/repo"),
+            ("the token is 1234", "the token is ****"),
+            ("no token here", "no token here"),
         )
         for output, sanitized in checks:
             self.assertEqual(cmd.sanitize_output(output), sanitized)


### PR DESCRIPTION
A user's build output exposed the clone token used for private repositories. The token is passed to the checkout step via the `READTHEDOCS_GIT_CLONE_TOKEN` environment variable and ends up stored in `.git/config` as part of the remote URL, so any command that echoes the environment or the remote URL (e.g. `git remote -v`) writes it into the recorded build output, which is visible on the build page.

This obfuscates the token at the point where command output is saved (`BuildCommand.sanitize_output`), the same way we already handle private environment variables. Both the full `<username>:<secret>` value and the bare secret part are replaced, covering the remote-URL form and the env-var form.

Things a reviewer may want to double-check:

- The token is scoped to a single repository with `contents:read` and expires after one hour, so the masking is about keeping it out of (potentially public) build logs rather than the only line of defense.
- Obfuscation is an exact substring replacement, so encoded forms of the token would not be caught — same limitation as the existing private-variable obfuscation.
- Deeper changes (keeping the token out of `.git/config`, revoking it after checkout) were intentionally left out since the build process is moving externally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQsmfAx7JW6ze8rkBqeCP9

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQsmfAx7JW6ze8rkBqeCP9)_