### PR TITLE
OAuth: don't delete repositories when rate limited by GitHub

### DIFF
--- a/readthedocs/oauth/services/githubapp.py
+++ b/readthedocs/oauth/services/githubapp.py
@@ -7,6 +7,7 @@ from allauth.socialaccount.models import SocialAccount
 from django.conf import settings
 from github import Github
 from github import GithubException
+from github import RateLimitExceededException
 from github.Installation import Installation as GHInstallation
 from github.Organization import Organization as GHOrganization
 from github.Repository import Repository as GHRepository
@@ -247,6 +248,15 @@ class GitHubAppService(Service):
                 # status code if the app is not installed on the repository.
                 if not repo.private:
                     self.gh_app_client.get_repo_installation(owner=repo.owner.login, repo=repo.name)
+            except RateLimitExceededException:
+                # Being rate limited doesn't mean we lost access to the repository.
+                # Abort the operation, all remaining requests will fail as well.
+                log.info(
+                    "Rate limit exceeded while fetching repositories from GitHub",
+                    installation_id=self.installation.installation_id,
+                    exc_info=True,
+                )
+                raise
             except GithubException as e:
                 log.info(
                     "Failed to fetch repository from GitHub",

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -2,9 +2,11 @@ import copy
 import json
 from unittest import mock
 
+import pytest
 from allauth.socialaccount.providers.bitbucket_oauth2.provider import BitbucketOAuth2Provider
 from allauth.socialaccount.providers.gitlab.provider import GitLabProvider
 import requests_mock
+from github import RateLimitExceededException
 from allauth.socialaccount.models import SocialAccount, SocialToken
 from allauth.socialaccount.providers.github.provider import GitHubProvider
 from django.conf import settings
@@ -595,6 +597,33 @@ class GitHubAppTests(TestCase):
         assert not RemoteRepository.objects.filter(
             id=self.remote_repository.id
         ).exists()
+
+    @requests_mock.Mocker(kw="request")
+    def test_update_repository_rate_limited(self, request):
+        request.post(
+            f"{self.api_url}/app/installations/1111/access_tokens",
+            json=self._get_access_token_json(),
+        )
+        request.get(
+            f"{self.api_url}/repositories/{self.remote_repository.remote_id}",
+            status_code=403,
+            json={
+                "message": f"API rate limit exceeded for installation ID {self.installation.installation_id}.",
+                "documentation_url": "https://docs.github.com/en/rest/using-the-rest-api/getting-started-with-the-rest-api#rate-limiting",
+            },
+        )
+
+        service = self.installation.service
+        # The second repository isn't mocked, requesting it would fail the test,
+        # the operation should be aborted after the first rate limited response.
+        with pytest.raises(RateLimitExceededException):
+            service.update_or_create_repositories(
+                [int(self.remote_repository.remote_id), 5555]
+            )
+
+        # Being rate limited doesn't mean we lost access to the repository,
+        # it shouldn't be deleted.
+        assert RemoteRepository.objects.filter(id=self.remote_repository.id).exists()
 
     @requests_mock.Mocker(kw="request")
     def test_sync(self, request):


### PR DESCRIPTION
A rate-limited GitHub API request [fails with a 403](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api), and `update_or_create_repositories()` treats any 403 as if we lost access to the repository — deleting the `RemoteRepository` and silently disconnecting its projects. Large installations are currently hitting the rate limit during webhook-triggered syncs, so this is actively waiting to happen.

A rate limit now aborts the operation without deleting anything, and without making further doomed requests. The task still fails visibly — no retries. PyGithub raises `RateLimitExceededException` (a `GithubException` subclass) for both [primary and secondary rate limits](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api#about-secondary-rate-limits), so catching it before the generic 403/404 handling covers both.

Reducing the API usage that triggers the rate limits is handled separately in #13241, #13242, and #13243. Likely related to #13101, since build statuses and PR comments share the same per-installation budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVjkPjH3EDEQmtywJvDVau