### PR TITLE
OAuth: fetch 100 items per page from the GitHub API

### DIFF
--- a/readthedocs/oauth/clients.py
+++ b/readthedocs/oauth/clients.py
@@ -84,4 +84,9 @@ def get_gh_app_client() -> GithubIntegration:
         # PyGithub will handle the token expiration and renew it automatically.
         jwt_expiry=60 * 10,
     )
-    return GithubIntegration(auth=app_auth)
+    return GithubIntegration(
+        auth=app_auth,
+        # Fetch the maximum number of items per page (default is 30),
+        # so paginated requests consume less of the API rate limit.
+        per_page=100,
+    )


### PR DESCRIPTION
The GitHub App clients use PyGithub's default page size of 30, so paginated requests (listing installation repositories, collaborators, pull request files, etc.) use more of the per-installation rate limit than needed. [100 is the maximum GitHub allows](https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api), cutting pagination traffic roughly 4×.

Context: large installations are hitting the [per-installation rate limit](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/rate-limits-for-github-apps) during webhook-triggered syncs (#13240).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVjkPjH3EDEQmtywJvDVau