### PR TITLE
Projects: expose repository list state to the import page

### DIFF
--- a/readthedocs/projects/views/private.py
+++ b/readthedocs/projects/views/private.py
@@ -44,7 +44,10 @@ from readthedocs.integrations.models import Integration
 from readthedocs.invitations.models import Invitation
 from readthedocs.notifications.models import Notification
 from readthedocs.oauth.constants import GITHUB
+from readthedocs.oauth.constants import GITHUB_APP
+from readthedocs.oauth.models import RemoteRepository
 from readthedocs.oauth.services import GitHubService
+from readthedocs.oauth.services import registry
 from readthedocs.oauth.tasks import attach_webhook
 from readthedocs.projects.filters import ProjectListFilterSet
 from readthedocs.projects.filters import RedirectListFilterSet
@@ -474,6 +477,22 @@ class ImportView(PrivateViewMixin, TemplateView):
         context["socialaccount_providers"] = self.request.user.socialaccount_set.values_list(
             "provider", flat=True
         )
+
+        # Repository list state, so the automatic import UI can explain an
+        # empty repository list (no Git provider connected, or a GitHub App
+        # account with no repositories granted yet) instead of showing a
+        # search box that can never have results.
+        vcs_providers = [service_cls.allauth_provider.id for service_cls in registry]
+        context["has_connected_vcs_account"] = self.request.user.socialaccount_set.filter(
+            provider__in=vcs_providers,
+        ).exists()
+        context["has_remote_repositories"] = RemoteRepository.objects.api(
+            self.request.user,
+        ).exists()
+        context["has_github_app_repositories"] = RemoteRepository.objects.filter(
+            users=self.request.user,
+            vcs_provider=GITHUB_APP,
+        ).exists()
 
         return context
 

--- a/readthedocs/rtd_tests/tests/test_project_views.py
+++ b/readthedocs/rtd_tests/tests/test_project_views.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 from allauth.socialaccount.models import SocialAccount
+from allauth.socialaccount.providers.github.provider import GitHubProvider
 from django.contrib.auth.models import User
 from django.http.response import HttpResponseRedirect
 from django.test import TestCase, override_settings
@@ -8,8 +9,10 @@ from django.urls import reverse
 from django.views.generic.base import ContextMixin
 from django_dynamic_fixture import get
 
+from readthedocs.allauth.providers.githubapp.provider import GitHubAppProvider
 from readthedocs.builds.constants import BUILD_STATE_FINISHED, EXTERNAL
 from readthedocs.builds.models import Build, Version
+from readthedocs.oauth.constants import GITHUB, GITHUB_APP
 from readthedocs.integrations.models import GenericAPIWebhook, GitHubWebhook
 from readthedocs.oauth.models import RemoteRepository, RemoteRepositoryRelation
 from readthedocs.organizations.models import Organization
@@ -63,6 +66,69 @@ class TestImportProjectBannedUser(RequestFactoryTestMixin, TestCase):
         resp = ImportWizardView.as_view()(req)
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp["location"], "/")
+
+
+class TestImportViewContext(TestCase):
+    """The import page context explains why the repository list is empty."""
+
+    def setUp(self):
+        self.user = get(User)
+        self.client.force_login(self.user)
+        self.url = reverse("projects_import")
+
+    def test_no_connected_accounts(self):
+        resp = self.client.get(self.url)
+        assert resp.status_code == 200
+        assert resp.context["has_connected_vcs_account"] is False
+        assert resp.context["has_remote_repositories"] is False
+        assert resp.context["has_github_app_repositories"] is False
+
+    def test_non_vcs_account_is_not_a_vcs_connection(self):
+        get(SocialAccount, user=self.user, provider="google")
+        resp = self.client.get(self.url)
+        assert resp.context["has_connected_vcs_account"] is False
+
+    def test_vcs_account_without_repositories(self):
+        get(SocialAccount, user=self.user, provider=GitHubProvider.id)
+        resp = self.client.get(self.url)
+        assert resp.context["has_connected_vcs_account"] is True
+        assert resp.context["has_remote_repositories"] is False
+        assert resp.context["has_github_app_repositories"] is False
+
+    def test_github_app_account_without_repositories(self):
+        get(SocialAccount, user=self.user, provider=GitHubAppProvider.id)
+        resp = self.client.get(self.url)
+        assert resp.context["has_connected_vcs_account"] is True
+        assert resp.context["has_remote_repositories"] is False
+        assert resp.context["has_github_app_repositories"] is False
+
+    def test_github_app_account_with_repositories(self):
+        account = get(SocialAccount, user=self.user, provider=GitHubAppProvider.id)
+        remote_repository = get(RemoteRepository, vcs_provider=GITHUB_APP)
+        get(
+            RemoteRepositoryRelation,
+            remote_repository=remote_repository,
+            user=self.user,
+            account=account,
+        )
+        resp = self.client.get(self.url)
+        assert resp.context["has_connected_vcs_account"] is True
+        assert resp.context["has_remote_repositories"] is True
+        assert resp.context["has_github_app_repositories"] is True
+
+    def test_legacy_github_account_with_repositories(self):
+        account = get(SocialAccount, user=self.user, provider=GitHubProvider.id)
+        remote_repository = get(RemoteRepository, vcs_provider=GITHUB)
+        get(
+            RemoteRepositoryRelation,
+            remote_repository=remote_repository,
+            user=self.user,
+            account=account,
+        )
+        resp = self.client.get(self.url)
+        assert resp.context["has_connected_vcs_account"] is True
+        assert resp.context["has_remote_repositories"] is True
+        assert resp.context["has_github_app_repositories"] is False
 
 
 @mock.patch("readthedocs.projects.tasks.builds.update_docs_task", mock.MagicMock())


### PR DESCRIPTION
The import page renders an empty search UI even when a search can never return results — the user has no Git provider connected, or a connected account with nothing synced. The dashboard templates can't distinguish these cases today, which is where a large share of trials stall.

This adds two context flags to `ImportView`: `has_connected_vcs_account` (any VCS provider connector) and `has_remote_repositories`, the latter using the same `RemoteRepository.objects.api(user)` queryset as the APIv3 endpoint that backs the page's repository list, so the flag can never disagree with what the list returns (including the legacy GitHub vs GitHub App cross-exclusion). Consumed by readthedocs/ext-theme#770, which falls back to current behavior until this lands — either side can merge first.

Reviewers should double-check the queryset choice: `.api(user)` rather than `for_project_linking(user)`, because the endpoint also lists non-admin repositories (shown as locked), and the emptiness flag needs to match that breadth.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yjYstmBb2HiscZUc5eKH4