### PR TITLE
Search: download version with rclone before indexing

### DIFF
--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -1735,8 +1735,12 @@ class HTMLFile(ImportedFile):
 
     objects = HTMLFileManager()
 
+    # Optional parser instance to generate the processed JSON with. When not
+    # set, pages are read from the version's path in the build media storage.
+    parser = None
+
     def get_processed_json(self):
-        parser = GenericParser(self.version)
+        parser = self.parser or GenericParser(self.version)
         return parser.parse(self.path)
 
     @cached_property

--- a/readthedocs/projects/tasks/search.py
+++ b/readthedocs/projects/tasks/search.py
@@ -1,3 +1,6 @@
+import os
+import subprocess
+import tempfile
 from fnmatch import fnmatch
 
 import structlog
@@ -18,9 +21,11 @@ from readthedocs.projects.models import HTMLFile
 from readthedocs.projects.models import Project
 from readthedocs.projects.signals import files_changed
 from readthedocs.search.documents import PageDocument
+from readthedocs.search.parsers import GenericParser
 from readthedocs.search.utils import index_objects
 from readthedocs.search.utils import remove_indexed_files
 from readthedocs.storage import build_media_storage
+from readthedocs.storage.filesystem import RTDFileSystemStorage
 from readthedocs.worker import app
 
 
@@ -248,47 +253,65 @@ def _process_files(*, version: Version, indexers: list[Indexer]):
         sync_id=sync_id,
     )
 
-    for root, __, filenames in build_media_storage.walk(storage_path):
-        for filename in filenames:
-            # We don't care about non-HTML files (for now?).
-            if not filename.endswith(".html"):
-                continue
-
-            full_path = build_media_storage.join(root, filename)
-            # Generate a relative path for storage similar to os.path.relpath
-            relpath = full_path.removeprefix(storage_path).lstrip("/")
-
-            html_file = HTMLFile(
-                project=version.project,
-                version=version,
-                path=relpath,
-                name=filename,
-                # TODO: We are setting the commit field since it's required,
-                # but it isn't used, and will be removed in the future
-                # together with other fields.
-                commit="unknown",
-                build=sync_id,
-            )
-            for indexer in indexers:
-                try:
-                    indexer.process(html_file, sync_id)
-                except Exception:
-                    log.exception(
-                        "Failed to process HTML file",
-                        html_file=html_file.path,
-                        indexer=indexer.__class__.__name__,
-                        version_slug=version.slug,
-                    )
-
-    for indexer in indexers:
+    # Download the whole version with rclone and parse the files from the
+    # local copy. This is much faster than reading each file from storage
+    # individually, since that results in one or more requests per file.
+    with tempfile.TemporaryDirectory(prefix="index-build-") as tmp_dir:
         try:
-            indexer.collect(sync_id)
-        except Exception:
-            log.exception(
-                "Failed to collect indexer results",
-                indexer=indexer.__class__.__name__,
-                version_slug=version.slug,
-            )
+            build_media_storage.rclone_download_directory(storage_path, tmp_dir)
+        except subprocess.CalledProcessError as exc:
+            # Exit code 3 is "directory not found". Continue with the empty
+            # local copy — same as walking a missing path in storage — so
+            # indexers can still clean up previously indexed files. Any other
+            # error is fatal, so a transient storage failure never wipes the
+            # search index for the version.
+            if exc.returncode != 3:
+                raise
+
+        parser = GenericParser(version, storage=RTDFileSystemStorage(location=tmp_dir))
+        for root, __, filenames in os.walk(tmp_dir):
+            for filename in filenames:
+                # We don't care about non-HTML files (for now?).
+                if not filename.endswith(".html"):
+                    continue
+
+                relpath = os.path.relpath(os.path.join(root, filename), tmp_dir)
+
+                html_file = HTMLFile(
+                    project=version.project,
+                    version=version,
+                    path=relpath,
+                    name=filename,
+                    # TODO: We are setting the commit field since it's required,
+                    # but it isn't used, and will be removed in the future
+                    # together with other fields.
+                    commit="unknown",
+                    build=sync_id,
+                )
+                html_file.parser = parser
+                for indexer in indexers:
+                    try:
+                        indexer.process(html_file, sync_id)
+                    except Exception:
+                        log.exception(
+                            "Failed to process HTML file",
+                            html_file=html_file.path,
+                            indexer=indexer.__class__.__name__,
+                            version_slug=version.slug,
+                        )
+
+        # Indexers read the page contents lazily through
+        # ``HTMLFile.processed_json``, so they must be collected while the
+        # local copy still exists.
+        for indexer in indexers:
+            try:
+                indexer.collect(sync_id)
+            except Exception:
+                log.exception(
+                    "Failed to collect indexer results",
+                    indexer=indexer.__class__.__name__,
+                    version_slug=version.slug,
+                )
 
     # This signal is used for purging the CDN.
     files_changed.send(

--- a/readthedocs/rtd_tests/tests/test_build_storage.py
+++ b/readthedocs/rtd_tests/tests/test_build_storage.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import subprocess
 import tempfile
 from pathlib import Path
 
@@ -193,3 +194,28 @@ class TestBuildMediaStorage(TestCase):
         with override_settings(DOCROOT=tmp_docroot):
             with pytest.raises(SuspiciousFileOperation, match="outside the docroot"):
                 self.storage.rclone_sync_directory(tmp_dir, "files")
+
+    def test_rclone_download_directory(self):
+        with override_settings(DOCROOT=files_dir):
+            self.storage.rclone_sync_directory(files_dir, "files")
+
+        download_dir = tempfile.mkdtemp()
+        self.storage.rclone_download_directory("files", download_dir)
+        self.assertCountEqual(
+            os.listdir(download_dir),
+            ["api", "404.html", "api.fjson", "conf.py", "index.html", "test.html"],
+        )
+        self.assertEqual(os.listdir(os.path.join(download_dir, "api")), ["index.html"])
+
+    def test_rclone_download_directory_not_found(self):
+        # rclone exits with code 3 when the source directory doesn't exist.
+        # ``_process_files`` relies on this to handle versions without files.
+        download_dir = tempfile.mkdtemp()
+        with pytest.raises(subprocess.CalledProcessError) as exc:
+            self.storage.rclone_download_directory("does-not-exist", download_dir)
+        assert exc.value.returncode == 3
+        self.assertEqual(os.listdir(download_dir), [])
+
+    def test_rclone_download_all_storage(self):
+        with pytest.raises(SuspiciousFileOperation):
+            self.storage.rclone_download_directory("/", tempfile.mkdtemp())

--- a/readthedocs/search/parsers.py
+++ b/readthedocs/search/parsers.py
@@ -63,16 +63,24 @@ class GenericParser:
         "video",
     ]
 
-    def __init__(self, version):
+    def __init__(self, version, storage=None):
         self.version = version
         self.project = self.version.project
-        self.storage = build_media_storage
+        # A custom storage can be given to read pages from an alternative
+        # location (e.g. a local copy of the version's HTML files). Page
+        # paths are then resolved relative to that storage's root instead
+        # of the version's path in the build media storage.
+        self._custom_storage = storage is not None
+        self.storage = storage or build_media_storage
 
     def _get_page_content(self, page):
         """Gets the page content from storage."""
         content = None
         try:
-            file_path = self.version.get_storage_path(media_type=MEDIA_TYPE_HTML, filename=page)
+            if self._custom_storage:
+                file_path = page
+            else:
+                file_path = self.version.get_storage_path(media_type=MEDIA_TYPE_HTML, filename=page)
             with self.storage.open(file_path, mode="r") as f:
                 content = f.read()
         except Exception:

--- a/readthedocs/storage/mixins.py
+++ b/readthedocs/storage/mixins.py
@@ -52,6 +52,13 @@ class RTDBaseStorage:
         self._check_suspicious_path(source)
         return self._rclone.sync(source, destination)
 
+    def rclone_download_directory(self, source, destination):
+        """Download a directory recursively from storage using rclone copy."""
+        if source in ("", "/"):
+            raise SuspiciousFileOperation("Downloading all storage cannot be right")
+
+        return self._rclone.copy_to_local(source, destination)
+
     def delete_directory(self, path):
         raise NotImplementedError
 

--- a/readthedocs/storage/rclone.py
+++ b/readthedocs/storage/rclone.py
@@ -123,6 +123,17 @@ class BaseRClone:
         """
         return self.execute("sync", args=[source, self.get_target(destination)])
 
+    def copy_to_local(self, source, destination):
+        """
+        Run the `rclone copy` command from the remote to a local directory.
+
+        See https://rclone.org/commands/rclone_copy/.
+
+        :params source: Remote path to the source directory.
+        :params destination: Local path to the destination directory.
+        """
+        return self.execute("copy", args=[self.get_target(source), destination])
+
 
 class RCloneLocal(BaseRClone):
     """


### PR DESCRIPTION
`index_build` currently fetches every HTML page from storage one at a time. New Relic shows this is ~83% of the task's runtime — an average transaction spends 15.3s on 730 serial S3 round-trips (319 GETs + 411 HEADs) and only 73ms on Elasticsearch. Big versions take minutes per build, which held all the shared web/reindex worker slots and caused the recurring web-celery queue spikes (readthedocs/readthedocs-ops#1832 has the incident details).

This downloads the whole version once with `rclone copy` (parallel transfers, no per-file HEADs) into a temp dir and parses from the local copy. `rclone_download_directory` mirrors the existing `rclone_sync_directory`, so it works for both storage backends — and .com's storage class inherits it.

Things to double-check:

- Indexers read page contents lazily through `HTMLFile.processed_json`, so `collect()` now runs inside the temp dir context; the injected parser resolves paths relative to the local copy.
- rclone exit code 3 (directory not found) is treated like walking a missing storage path — indexers still run so they clean up previously indexed files. Any other rclone failure aborts the task so a transient storage error can't wipe a version's search index.
- Disk usage on web-celery instances: one version's HTML at a time in `$TMPDIR`, deleted on exit. Worth a sanity check on p99 version size vs instance disk.
- The `search`-marked tests (`test_imported_file.py`) exercise the new path end-to-end in CI; they need ES so they didn't run locally. Storage and parser tests pass locally on 3.14 with real rclone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
