### PR TITLE
Api: Make subproject alias optional, defaulting to child slug

### DIFF
--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -919,23 +919,26 @@ class SubprojectCreateSerializer(FlexFieldsModelSerializer):
             "Project with {slug_name}={value} is not valid as subproject"
         )
 
-    def validate_alias(self, value):
+    def validate(self, data):  # pylint: disable=arguments-renamed
+        self.parent_project.is_valid_as_superproject(serializers.ValidationError)
+
+        # Alias is optional, it defaults to the child's slug when not given.
+        alias = data.get("alias") or data["child"].slug
+
         # Check there is not a subproject with this alias already
-        subproject = self.parent_project.subprojects.filter(alias=value)
+        subproject = self.parent_project.subprojects.filter(alias=alias)
         if subproject.exists():
             raise serializers.ValidationError(
-                _("A subproject with this alias already exists"),
+                {"alias": _("A subproject with this alias already exists")},
             )
 
         validate_subproject_alias(
             parent_project=self.parent_project,
-            alias=value,
+            alias=alias,
             error_class=serializers.ValidationError,
         )
-        return value
 
-    def validate(self, data):  # pylint: disable=arguments-renamed
-        self.parent_project.is_valid_as_superproject(serializers.ValidationError)
+        data["alias"] = alias
         return data
 
 

--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -919,7 +919,7 @@ class SubprojectCreateSerializer(FlexFieldsModelSerializer):
             "Project with {slug_name}={value} is not valid as subproject"
         )
 
-    def validate(self, data):  # pylint: disable=arguments-renamed
+    def validate(self, data):
         self.parent_project.is_valid_as_superproject(serializers.ValidationError)
 
         # Alias is optional, it defaults to the child's slug when not given.

--- a/readthedocs/api/v3/tests/test_subprojects.py
+++ b/readthedocs/api/v3/tests/test_subprojects.py
@@ -233,6 +233,33 @@ class SubprojectsEndpointTests(APIEndpointMixin):
         # The alias defaults to the child's slug when explicitly set to null.
         assert response.json()["alias"] == newproject.slug
 
+    def test_projects_subprojects_list_post_with_invalid_alias(self):
+        newproject = self._create_new_project()
+
+        assert self.project.subprojects.count() == 1
+        url = reverse(
+            "projects-subprojects-list",
+            kwargs={
+                "parent_lookup_parent__slug": self.project.slug,
+            },
+        )
+        data = {
+            "child": newproject.slug,
+            "alias": "subproject/alias",
+        }
+        invalid_alias = [
+            "alias with spaces",
+            "alias!with@special-char$",
+            "alias.with.periods",
+            "alias:with;some.punctuation",
+        ]
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        for alias in invalid_alias:
+            data["alias"] = alias
+            response = self.client.post(url, data)
+            assert response.status_code == 400, f"Alias '{alias}' should be invalid"
+            assert self.project.subprojects.count() == 1
+
     def test_projects_subprojects_list_post_with_slash_in_alias(self):
         newproject = self._create_new_project()
 

--- a/readthedocs/api/v3/tests/test_subprojects.py
+++ b/readthedocs/api/v3/tests/test_subprojects.py
@@ -188,6 +188,51 @@ class SubprojectsEndpointTests(APIEndpointMixin):
             self._get_response_dict("projects-subprojects-list_POST"),
         )
 
+    def test_projects_subprojects_list_post_without_alias(self):
+        newproject = self._create_new_project()
+
+        assert self.project.subprojects.count() == 1
+        url = reverse(
+            "projects-subprojects-list",
+            kwargs={
+                "parent_lookup_parent__slug": self.project.slug,
+            },
+        )
+        data = {
+            "child": newproject.slug,
+        }
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.post(url, data)
+
+        assert response.status_code == 201
+        assert self.project.subprojects.count() == 2
+        # The alias defaults to the child's slug when not given.
+        assert response.json()["alias"] == newproject.slug
+
+    def test_projects_subprojects_list_post_with_null_alias(self):
+        newproject = self._create_new_project()
+
+        assert self.project.subprojects.count() == 1
+        url = reverse(
+            "projects-subprojects-list",
+            kwargs={
+                "parent_lookup_parent__slug": self.project.slug,
+            },
+        )
+        data = {
+            "child": newproject.slug,
+            "alias": None,
+        }
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.post(url, data, format="json")
+
+        assert response.status_code == 201
+        assert self.project.subprojects.count() == 2
+        # The alias defaults to the child's slug when explicitly set to null.
+        assert response.json()["alias"] == newproject.slug
+
     def test_projects_subprojects_list_post_with_slash_in_alias(self):
         newproject = self._create_new_project()
 


### PR DESCRIPTION
The alias is optional, it defaults to the child slug.

Fixes https://read-the-docs.sentry.io/issues/7678634010/?alert_rule_id=229005&alert_timestamp=1787063322148&alert_type=email&environment=production&notification_uuid=b08d2e40-fd96-4391-899a-58ebdd9955e1&project=148442&referrer=alert_email