### PR TITLE
Proxito: noindex projects from organizations on trial

### DIFF
--- a/docs/user/commercial/index.rst
+++ b/docs/user/commercial/index.rst
@@ -8,6 +8,13 @@ We offer |com_brand| for building and hosting documentation for private reposito
 
 In order to get started quickly, you can start a `free 30-day trial <https://about.readthedocs.com/pricing/>`__ to test out the platform.
 
+.. note::
+
+   During the trial period,
+   your documentation is served with a ``noindex`` robots directive,
+   so search engines won't index it.
+   Subscribe to a paid plan to make your documentation indexable.
+
 .. seealso::
 
    `Read the Docs features <https://about.readthedocs.com/features/>`__

--- a/readthedocs/organizations/querysets.py
+++ b/readthedocs/organizations/querysets.py
@@ -44,6 +44,18 @@ class BaseOrganizationQuerySet(NoReprQuerySet, models.QuerySet):
         query_filter[field + "__day"] = when.day
         return self.filter(**query_filter)
 
+    def on_trial(self):
+        """
+        Organizations that are on a trial of the default plan.
+
+        These are organizations subscribed to the Trial Plan
+        that are still within their trial period.
+        """
+        return self.filter(
+            stripe_subscription__status=SubscriptionStatus.trialing,
+            stripe_subscription__items__price__id=settings.RTD_ORG_DEFAULT_STRIPE_SUBSCRIPTION_PRICE,
+        ).distinct()
+
     def subscription_trial_plan_ended(self):
         """
         Organizations with subscriptions to Trial Plan ended.

--- a/readthedocs/organizations/tests/test_querysets.py
+++ b/readthedocs/organizations/tests/test_querysets.py
@@ -34,6 +34,66 @@ class TestOrganizationQuerysets(PaymentMixin, TestCase):
             {org_three}, set(Organization.objects.single_owner(another_user))
         )
 
+    def test_on_trial(self):
+        trial_price = get(djstripe.Price, id="trialing")
+        paid_price = get(djstripe.Price, id="advanced")
+
+        # Organization on the trial plan, still within its trial period.
+        trialing_subscription = get(
+            djstripe.Subscription,
+            status=SubscriptionStatus.trialing,
+            customer=get(djstripe.Customer),
+        )
+        get(
+            djstripe.SubscriptionItem,
+            price=trial_price,
+            quantity=1,
+            subscription=trialing_subscription,
+        )
+        org_on_trial = get(
+            Organization,
+            stripe_subscription=trialing_subscription,
+            stripe_customer=trialing_subscription.customer,
+        )
+
+        # Organization with a trial plan subscription that was canceled.
+        canceled_subscription = get(
+            djstripe.Subscription,
+            status=SubscriptionStatus.canceled,
+            customer=get(djstripe.Customer),
+        )
+        get(
+            djstripe.SubscriptionItem,
+            price=trial_price,
+            quantity=1,
+            subscription=canceled_subscription,
+        )
+        org_trial_ended = get(
+            Organization,
+            stripe_subscription=canceled_subscription,
+            stripe_customer=canceled_subscription.customer,
+        )
+
+        # Organization with a paid plan subscription within its trial period.
+        paid_trialing_subscription = get(
+            djstripe.Subscription,
+            status=SubscriptionStatus.trialing,
+            customer=get(djstripe.Customer),
+        )
+        get(
+            djstripe.SubscriptionItem,
+            price=paid_price,
+            quantity=1,
+            subscription=paid_trialing_subscription,
+        )
+        org_paid_trialing = get(
+            Organization,
+            stripe_subscription=paid_trialing_subscription,
+            stripe_customer=paid_trialing_subscription.customer,
+        )
+
+        assert list(Organization.objects.on_trial()) == [org_on_trial]
+
     def test_organizations_with_trial_subscription_plan_ended(self):
         price = get(djstripe.Price, id="trialing")
 

--- a/readthedocs/proxito/middleware.py
+++ b/readthedocs/proxito/middleware.py
@@ -27,6 +27,7 @@ from readthedocs.core.unresolver import InvalidXRTDSlugHeaderError
 from readthedocs.core.unresolver import SuspiciousHostnameError
 from readthedocs.core.unresolver import unresolver
 from readthedocs.core.utils import get_cache_tag
+from readthedocs.organizations.models import Organization
 from readthedocs.projects.models import AddonsConfig
 from readthedocs.proxito.cache import add_cache_tags
 from readthedocs.proxito.cache import cache_response
@@ -194,10 +195,24 @@ class ProxitoMiddleware(MiddlewareMixin):
             cache_response(response, force=False)
 
     def add_x_robots_tag_headers(self, request, response):
-        """Add `X-Robots-Tag: noindex` header for external versions."""
+        """
+        Add `X-Robots-Tag: noindex` header to keep documentation out of search engines.
+
+        The header is added to external versions,
+        and to projects owned by an organization on trial (to fight spam).
+        """
         unresolved_domain = request.unresolved_domain
-        if unresolved_domain and unresolved_domain.is_from_external_domain:
+        if not unresolved_domain:
+            return
+
+        if unresolved_domain.is_from_external_domain:
             response["X-Robots-Tag"] = "noindex"
+            return
+
+        if settings.RTD_ALLOW_ORGANIZATIONS:
+            project = unresolved_domain.project
+            if Organization.objects.on_trial().filter(projects=project).exists():
+                response["X-Robots-Tag"] = "noindex"
 
     def _set_request_attributes(self, request, unresolved_domain):
         """

--- a/readthedocs/proxito/tests/test_headers.py
+++ b/readthedocs/proxito/tests/test_headers.py
@@ -6,6 +6,8 @@ from corsheaders.middleware import (
 )
 from django.test import override_settings
 from django_dynamic_fixture import get
+from djstripe import models as djstripe
+from djstripe.enums import SubscriptionStatus
 
 from readthedocs.builds.constants import EXTERNAL
 from readthedocs.builds.models import Version
@@ -420,3 +422,64 @@ class ProxitoHeaderTests(BaseDocServing):
         )
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r["X-Robots-Tag"], "noindex")
+
+    def _create_stripe_subscription(self, status, price_id):
+        price = get(djstripe.Price, id=price_id)
+        stripe_subscription = get(
+            djstripe.Subscription,
+            status=status,
+            customer=get(djstripe.Customer),
+        )
+        get(
+            djstripe.SubscriptionItem,
+            price=price,
+            quantity=1,
+            subscription=stripe_subscription,
+        )
+        return stripe_subscription
+
+    @override_settings(
+        RTD_ALLOW_ORGANIZATIONS=True,
+        RTD_ORG_DEFAULT_STRIPE_SUBSCRIPTION_PRICE="trialing",
+    )
+    def test_x_robots_tag_header_organization_on_trial(self):
+        stripe_subscription = self._create_stripe_subscription(
+            status=SubscriptionStatus.trialing,
+            price_id="trialing",
+        )
+        get(
+            Organization,
+            owners=[self.eric],
+            projects=[self.project],
+            stripe_subscription=stripe_subscription,
+            stripe_customer=stripe_subscription.customer,
+        )
+
+        r = self.client.get(
+            "/en/latest/", secure=True, headers={"host": "project.dev.readthedocs.io"}
+        )
+        assert r.status_code == 200
+        assert r["X-Robots-Tag"] == "noindex"
+
+    @override_settings(
+        RTD_ALLOW_ORGANIZATIONS=True,
+        RTD_ORG_DEFAULT_STRIPE_SUBSCRIPTION_PRICE="trialing",
+    )
+    def test_x_robots_tag_header_organization_with_paid_plan(self):
+        stripe_subscription = self._create_stripe_subscription(
+            status=SubscriptionStatus.active,
+            price_id="advanced",
+        )
+        get(
+            Organization,
+            owners=[self.eric],
+            projects=[self.project],
+            stripe_subscription=stripe_subscription,
+            stripe_customer=stripe_subscription.customer,
+        )
+
+        r = self.client.get(
+            "/en/latest/", secure=True, headers={"host": "project.dev.readthedocs.io"}
+        )
+        assert r.status_code == 200
+        assert "X-Robots-Tag" not in r.headers


### PR DESCRIPTION
Spammers sign up for a Business trial and get their content hosted — and then indexed by Google, which is what makes the spam valuable. This removes that incentive by serving `X-Robots-Tag: noindex` on all documentation from projects owned by organizations still on the trial plan, extending the existing middleware hook that already does this for pull request previews.

An organization counts as "on trial" when its subscription is on the default trial plan price *and* still in `trialing` status, exposed as `Organization.objects.on_trial()`. An organization trialing a paid plan (e.g. upgraded through the billing portal while inside the trial window) is deliberately treated as not-on-trial, since they've shown payment intent. Once a customer subscribes to a paid plan, the header disappears as cached responses roll over.

Things a reviewer should double-check:

- I used the `noindex` header instead of a disallow-all robots.txt (as delisted/spam projects get) because crawlers must be able to fetch a page to see `noindex` — blocking crawling can leave spam URLs indexed as bare links. Happy to add the robots.txt treatment as well if you'd rather have both.
- The check adds one `EXISTS` query per uncached response on .com (guarded by `RTD_ALLOW_ORGANIZATIONS`, so Community is unaffected). If the commercial repo has proxito query-count tests that run with organizations enabled, they'll need a +1.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeX9CebgzZy9eSesobePfm