### PR TITLE
File Tree Diff: hash the text of a page, not its HTML

### DIFF
--- a/readthedocs/filetreediff/__init__.py
+++ b/readthedocs/filetreediff/__init__.py
@@ -101,7 +101,17 @@ def get_diff(current_version: Version, base_version: Version) -> FileTreeDiff | 
     for file_path in current_version_file_paths & base_version_file_paths:
         file_a = current_version_manifest.files[file_path]
         file_b = base_version_manifest.files[file_path]
-        if file_a.main_content_hash != file_b.main_content_hash:
+        if file_a.text_hash and file_b.text_hash:
+            modified = file_a.text_hash != file_b.text_hash
+        else:
+            # One of the manifests was written before we hashed the text of
+            # the page, so ``main_content_hash`` is all both sides have. It
+            # reports pages as modified when only their attributes changed.
+            # TODO: remove this branch and ``main_content_hash`` itself once
+            # no manifest in storage is missing a text hash. ``markup_hash``
+            # replaces it, see https://github.com/readthedocs/readthedocs.org/issues/13258
+            modified = file_a.main_content_hash != file_b.main_content_hash
+        if modified:
             files.append((file_path, FileTreeDiffFileStatus.modified))
 
     return FileTreeDiff(

--- a/readthedocs/filetreediff/dataclasses.py
+++ b/readthedocs/filetreediff/dataclasses.py
@@ -20,10 +20,24 @@ class FileTreeDiffBuild:
 
 @dataclass(slots=True)
 class FileTreeDiffManifestFile:
-    """A file in a file tree manifest."""
+    """
+    A file in a file tree manifest.
+
+    ``text_hash`` is a hash of the text of the file, ``markup_hash`` a hash of
+    its HTML, both taken once the irrelevant nodes are stripped from it (see
+    ``readthedocs.search.parsers``). Comparing both tells a page whose copy
+    changed from one that only moved its markup around, which isn't used yet:
+    see https://github.com/readthedocs/readthedocs.org/issues/13258
+
+    ``main_content_hash`` is a hash of the HTML before stripping anything. It
+    is all that manifests written before the other two have, and goes away with
+    them (see the ``TODO`` in ``get_diff()``).
+    """
 
     path: str
     main_content_hash: str
+    text_hash: str | None = None
+    markup_hash: str | None = None
 
 
 @dataclass(slots=True)
@@ -47,7 +61,12 @@ class FileTreeDiffManifest:
         """
         build_id = data["build"]["id"]
         files = [
-            FileTreeDiffManifestFile(path=path, main_content_hash=file["main_content_hash"])
+            FileTreeDiffManifestFile(
+                path=path,
+                main_content_hash=file["main_content_hash"],
+                text_hash=file.get("text_hash"),
+                markup_hash=file.get("markup_hash"),
+            )
             for path, file in data["files"].items()
         ]
         return cls(build_id, files)

--- a/readthedocs/filetreediff/tests/test_filetreediff.py
+++ b/readthedocs/filetreediff/tests/test_filetreediff.py
@@ -22,18 +22,26 @@ def _mock_open(content):
     return f
 
 
-def _mock_manifest(build_id: int, files: dict[str, str]):
-    return _mock_open(
-        json.dumps(
-            {
-                "build": {"id": build_id},
-                "files": {
-                    path: {"main_content_hash": content_hash}
-                    for path, content_hash in files.items()
-                },
-            }
-        )
-    )
+def _mock_manifest(
+    build_id: int,
+    files: dict[str, str],
+    text_hashes: dict[str, str] | None = None,
+):
+    """
+    Mock the manifest file of a version.
+
+    ``files`` maps each path to the hash of its HTML, ``text_hashes`` to the
+    hash of its content, defaulting to the same hash. Manifests written before
+    the content hash was introduced don't have it, pass an empty dict for those.
+    """
+    if text_hashes is None:
+        text_hashes = files
+    manifest_files = {}
+    for path, main_content_hash in files.items():
+        manifest_files[path] = {"main_content_hash": main_content_hash}
+        if path in text_hashes:
+            manifest_files[path]["text_hash"] = text_hashes[path]
+    return _mock_open(json.dumps({"build": {"id": build_id}, "files": manifest_files}))
 
 
 # We are overriding the storage class instead of using RTD_BUILD_MEDIA_STORAGE,
@@ -121,6 +129,37 @@ class TestsFileTreeDiff(TestCase):
         assert [file.path for file in diff.deleted] == ["deleted.html"]
         assert [file.path for file in diff.modified] == ["tutorials/index.html"]
         assert not diff.outdated
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_diff_manifests_without_content_hashes(self, storage_open):
+        """Manifests written before the content hash compare by their HTML hash."""
+        storage_open.side_effect = [
+            _mock_manifest(self.build_a.id, {"index.html": "hash-changed"}, text_hashes={})(),
+            _mock_manifest(self.build_b.id, {"index.html": "hash1"}, text_hashes={})(),
+        ]
+        diff = get_diff(self.version_a, self.version_b)
+        assert [file.path for file in diff.modified] == ["index.html"]
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_diff_one_manifest_without_content_hashes(self, storage_open):
+        """When one side has no content hash, both sides compare by their HTML hash."""
+        storage_open.side_effect = [
+            _mock_manifest(self.build_a.id, {"index.html": "html1"}, {"index.html": "content1"})(),
+            _mock_manifest(self.build_b.id, {"index.html": "html1"}, text_hashes={})(),
+        ]
+        diff = get_diff(self.version_a, self.version_b)
+        assert diff.modified == []
+
+    @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
+    def test_diff_prefers_content_hashes(self, storage_open):
+        """A page whose HTML changed but whose content didn't isn't modified."""
+        text_hashes = {"index.html": "same-content"}
+        storage_open.side_effect = [
+            _mock_manifest(self.build_a.id, {"index.html": "html1"}, text_hashes)(),
+            _mock_manifest(self.build_b.id, {"index.html": "html2"}, text_hashes)(),
+        ]
+        diff = get_diff(self.version_a, self.version_b)
+        assert diff.modified == []
 
     @mock.patch.object(BuildMediaFileSystemStorageTest, "open")
     def test_missing_manifest(self, storage_open):

--- a/readthedocs/projects/tasks/search.py
+++ b/readthedocs/projects/tasks/search.py
@@ -138,14 +138,28 @@ class FileManifestIndexer(Indexer):
         self.post_build_overview = post_build_overview
 
     def process(self, html_file: HTMLFile, sync_id: int):
-        self._hashes[html_file.path] = html_file.processed_json["main_content_hash"]
+        processed_json = html_file.processed_json
+        self._hashes[html_file.path] = (
+            processed_json["main_content_hash"],
+            processed_json["text_hash"],
+            processed_json["markup_hash"],
+        )
 
     def collect(self, sync_id: int):
         manifest = FileTreeDiffManifest(
             build_id=self.build.id,
             files=[
-                FileTreeDiffManifestFile(path=path, main_content_hash=content_hash)
-                for path, content_hash in self._hashes.items()
+                FileTreeDiffManifestFile(
+                    path=path,
+                    main_content_hash=main_content_hash,
+                    text_hash=text_hash,
+                    markup_hash=markup_hash,
+                )
+                for path, (
+                    main_content_hash,
+                    text_hash,
+                    markup_hash,
+                ) in self._hashes.items()
             ],
         )
         write_manifest(self.version, manifest)

--- a/readthedocs/rtd_tests/tests/test_imported_file.py
+++ b/readthedocs/rtd_tests/tests/test_imported_file.py
@@ -364,18 +364,26 @@ class ImportedFileTests(TestCase):
                 FileTreeDiffManifestFile(
                     path="index.html",
                     main_content_hash=mock.ANY,
+                    text_hash=mock.ANY,
+                    markup_hash=mock.ANY,
                 ),
                 FileTreeDiffManifestFile(
                     path="404.html",
                     main_content_hash=mock.ANY,
+                    text_hash=mock.ANY,
+                    markup_hash=mock.ANY,
                 ),
                 FileTreeDiffManifestFile(
                     path="test.html",
                     main_content_hash=mock.ANY,
+                    text_hash=mock.ANY,
+                    markup_hash=mock.ANY,
                 ),
                 FileTreeDiffManifestFile(
                     path="api/index.html",
                     main_content_hash=mock.ANY,
+                    text_hash=mock.ANY,
+                    markup_hash=mock.ANY,
                 ),
             ],
         )

--- a/readthedocs/search/parsers.py
+++ b/readthedocs/search/parsers.py
@@ -469,6 +469,8 @@ class GenericParser:
             "title": "",
             "sections": [],
             "main_content_hash": None,
+            "text_hash": None,
+            "markup_hash": None,
         }
 
     def _process_content(self, page, content):
@@ -478,9 +480,21 @@ class GenericParser:
         title = ""
         sections = []
         main_content_hash = None
+        text_hash = None
+        markup_hash = None
         if body:
+            # The file tree diff compares these to tell if a page changed.
+            # Hashing the HTML alone reported pages as changed when only an
+            # attribute did, so the text is hashed apart from the markup.
+            # TODO: stop writing ``main_content_hash``, it's only there for
+            # manifests that predate the other two and is dropped along with
+            # the fallback in ``get_diff()``.
+            # See https://github.com/readthedocs/readthedocs.org/issues/13258
             main_content_hash = hashlib.md5(body.html.encode()).hexdigest()
             body = self._clean_body(body)
+            text = re.sub(r"\s+", " ", body.text(separator=" ")).strip()
+            text_hash = hashlib.md5(text.encode()).hexdigest()
+            markup_hash = hashlib.md5(body.html.encode()).hexdigest()
             title = self._get_page_title(body, html) or page
             sections = self._get_sections(title=title, body=body)
         else:
@@ -493,4 +507,6 @@ class GenericParser:
             "title": title,
             "sections": sections,
             "main_content_hash": main_content_hash,
+            "text_hash": text_hash,
+            "markup_hash": markup_hash,
         }

--- a/readthedocs/search/tests/data/generic/out/basic.json
+++ b/readthedocs/search/tests/data/generic/out/basic.json
@@ -3,6 +3,8 @@
     "path": "basic.html",
     "title": "Title of the page",
     "main_content_hash": "006cb661925c211be260be17d64662b5",
+    "text_hash": "ae7bd4075a928bf3d01110ef074536df",
+    "markup_hash": "006cb661925c211be260be17d64662b5",
     "sections": [
       {
         "id": "love",

--- a/readthedocs/search/tests/data/mkdocs/out/gitbook.json
+++ b/readthedocs/search/tests/data/mkdocs/out/gitbook.json
@@ -3,6 +3,8 @@
     "path": "index.html",
     "title": "Mkdocs - GitBook Theme",
     "main_content_hash": "a2050380ef001ef57754fb35b41d477d",
+    "text_hash": "6efe89c75bc85a4ecdfe34122958d13f",
+    "markup_hash": "a2050380ef001ef57754fb35b41d477d",
     "sections": [
       {
         "id": "mkdocs-gitbook-theme",

--- a/readthedocs/search/tests/data/mkdocs/out/material.json
+++ b/readthedocs/search/tests/data/mkdocs/out/material.json
@@ -3,6 +3,8 @@
     "path": "index.html",
     "title": "Overview",
     "main_content_hash": "448eb15bfef60bc49a4059a34ebeaa4b",
+    "text_hash": "9aab1816c08e70cbca67fbb3298fc03a",
+    "markup_hash": "5478d288c596a3e67ece937b9cdfcc55",
     "sections": [
       {
         "id": "",

--- a/readthedocs/search/tests/data/mkdocs/out/mkdocs-1.1.json
+++ b/readthedocs/search/tests/data/mkdocs/out/mkdocs-1.1.json
@@ -3,6 +3,8 @@
     "path": "index.html",
     "title": "MkDocs",
     "main_content_hash": "aca1f625e559fe49718abe801532b3ef",
+    "text_hash": "aa96703d7cdb4b414567b7d682a7b81d",
+    "markup_hash": "44ae8443d2d85d168bd87738c8fc32a8",
     "sections": [
       {
         "id": "mkdocs",
@@ -40,6 +42,8 @@
     "path": "404.html",
     "title": "404",
     "main_content_hash": "2f582057ff73758c152d6925eb149099",
+    "text_hash": "7f5c24be74faf261f5aa35b567b838bf",
+    "markup_hash": "2f582057ff73758c152d6925eb149099",
     "sections": [
       {
         "id": "404-page-not-found",
@@ -52,6 +56,8 @@
     "path": "configuration.html",
     "title": "Configuration",
     "main_content_hash": "6a5526f41cfef3da4c541f0465ac42e8",
+    "text_hash": "37633f38b8f817e5f818e3b209ac1ca9",
+    "markup_hash": "328e67db314934e8fb53ac4bf12fa77f",
     "sections": [
       {
         "id": "configuration",
@@ -94,6 +100,8 @@
     "path": "no-title.html",
     "title": "No title - Read the Docs MkDocs Test",
     "main_content_hash": "c02e4800b9da5e96ed35841f11072777",
+    "text_hash": "a7a8e577ce57e09847174516c22bffbf",
+    "markup_hash": "c02e4800b9da5e96ed35841f11072777",
     "sections": [
       {
         "id": "",
@@ -106,6 +114,8 @@
     "path": "no-main-header.html",
     "title": "I'm the header",
     "main_content_hash": "43010c91ae89c036b157c2a3947d63b8",
+    "text_hash": "1bda704ab824e1a72c9d5b60dfc21090",
+    "markup_hash": "43010c91ae89c036b157c2a3947d63b8",
     "sections": [
       {
         "id": "",

--- a/readthedocs/search/tests/data/mkdocs/out/readthedocs-1.1.json
+++ b/readthedocs/search/tests/data/mkdocs/out/readthedocs-1.1.json
@@ -3,6 +3,8 @@
     "path": "index.html",
     "title": "Read the Docs MkDocs Test Project",
     "main_content_hash": "25c48df9b31b31eaee235206a48239a5",
+    "text_hash": "5d91c255a344f731e6f22a02e6a02de4",
+    "markup_hash": "25c48df9b31b31eaee235206a48239a5",
     "sections": [
       {
         "id": "read-the-docs-mkdocs-test-project",
@@ -30,6 +32,8 @@
     "path": "404.html",
     "title": "404",
     "main_content_hash": "5f6d687421dad7e1409dcaa3ccd2d34d",
+    "text_hash": "7f5c24be74faf261f5aa35b567b838bf",
+    "markup_hash": "5f6d687421dad7e1409dcaa3ccd2d34d",
     "sections": [
       {
         "id": "404-page-not-found",
@@ -42,6 +46,8 @@
     "path": "versions.html",
     "title": "Versions & Themes",
     "main_content_hash": "68a6609034e0a45adb135a60b98c12b8",
+    "text_hash": "8b5245086e11b33a5a52709e4a804ff6",
+    "markup_hash": "68a6609034e0a45adb135a60b98c12b8",
     "sections": [
       {
         "id": "versions-themes",

--- a/readthedocs/search/tests/data/mkdocs/out/windmill.json
+++ b/readthedocs/search/tests/data/mkdocs/out/windmill.json
@@ -3,6 +3,8 @@
     "path": "index.html",
     "title": "Windmill theme",
     "main_content_hash": "68542e8759d648c4304f0e1ca85a0547",
+    "text_hash": "0036900dcea4d39c40e4829c069f56ed",
+    "markup_hash": "e0ce22a2d7bdb6b253dbae98e0d689ea",
     "sections": [
       {
         "id": "windmill-theme",

--- a/readthedocs/search/tests/data/pelican/out/default.json
+++ b/readthedocs/search/tests/data/pelican/out/default.json
@@ -3,6 +3,8 @@
     "path": "index.html",
     "title": "Pelican Development Blog",
     "main_content_hash": "ab49e3b7d72db4a92506ef085770e323",
+    "text_hash": "f8c7e9ef4428e08d16fde64989bc7a14",
+    "markup_hash": "77c4df927884720e3a58a5d6a71f944f",
     "sections": [
       {
         "id": "banner",

--- a/readthedocs/search/tests/data/sphinx/out/autodoc.json
+++ b/readthedocs/search/tests/data/sphinx/out/autodoc.json
@@ -2,6 +2,8 @@
   "path": "autodoc.html",
   "title": "sphinx.ext.autodoc – Include documentation from docstrings",
   "main_content_hash": "1761ca2f532958a9dda6967544cde167",
+  "text_hash": "d38b5aaf31a5f364ac32573e8b19a44f",
+  "markup_hash": "bd793d889845ec1c2c9f8fe9b1164862",
   "sections": [
     {
       "id": "directive-automodule",

--- a/readthedocs/search/tests/data/sphinx/out/httpdomain.json
+++ b/readthedocs/search/tests/data/sphinx/out/httpdomain.json
@@ -2,6 +2,8 @@
   "path": "httpdomain.html",
   "title": "Here is a nice reference",
   "main_content_hash": "b0d8f8cbfe35ca79213ac9122704706f",
+  "text_hash": "521694a2556096f0ee72a1efff07d04e",
+  "markup_hash": "67597cd5a052d5f959bc9030071eb917",
   "sections": [
     {
       "id": "get--api-v3-projects-",

--- a/readthedocs/search/tests/data/sphinx/out/local-toc.json
+++ b/readthedocs/search/tests/data/sphinx/out/local-toc.json
@@ -2,6 +2,8 @@
   "path": "local-toc.html",
   "title": "Security reports",
   "main_content_hash": "71a1ef5892c6b2181e70cc18171ae5ee",
+  "text_hash": "46841c0c2f5f7ef32aec9572914dae13",
+  "markup_hash": "ec59ed9a395d7c1cff3b116cf2c5546a",
   "sections": [
     {
       "id": "security-reports",

--- a/readthedocs/search/tests/data/sphinx/out/no-title.json
+++ b/readthedocs/search/tests/data/sphinx/out/no-title.json
@@ -2,6 +2,8 @@
   "title": "<no title>",
   "path": "no-title.html",
   "main_content_hash": "e821445de7eb6b324ef37a9780392c85",
+  "text_hash": "ec912c136d63eed995bc28fec45d36b3",
+  "markup_hash": "e821445de7eb6b324ef37a9780392c85",
   "sections": [
     {
       "id": "",

--- a/readthedocs/search/tests/data/sphinx/out/page.json
+++ b/readthedocs/search/tests/data/sphinx/out/page.json
@@ -2,6 +2,8 @@
   "path": "page.html",
   "title": "I Need Secrets (or Environment Variables) in my Build",
   "main_content_hash": "95daf5cde2bee38d4bb23edaa1d5c0f3",
+  "text_hash": "9689bf5ac3d523f2c525de38c6d05659",
+  "markup_hash": "66932ad36e8d0a3d412807b3f54ff1fb",
   "sections": [
     {
       "id": "test_py_module.test.Foo",

--- a/readthedocs/search/tests/data/sphinx/out/requests.json
+++ b/readthedocs/search/tests/data/sphinx/out/requests.json
@@ -2,6 +2,8 @@
   "path": "requests.html",
   "title": "Developer Interface",
   "main_content_hash": "fd572599b94b2319f973a73b25421d91",
+  "text_hash": "eaa231b6e1115016642de4adacc72fab",
+  "markup_hash": "25d8b707d4968d40e01a5036d9f4f549",
   "sections": [
     {
       "id": "requests.request",

--- a/readthedocs/search/tests/data/sphinx/out/toctree.json
+++ b/readthedocs/search/tests/data/sphinx/out/toctree.json
@@ -2,6 +2,8 @@
   "path": "toctree.html",
   "title": "Public API",
   "main_content_hash": "3d2e43fdc8b58752538ebd934a34b6ea",
+  "text_hash": "bcfcc5b43b25a32d19d4c6ef52bb91cd",
+  "markup_hash": "df2304666ec0d1b9b5a7da82182c20ad",
   "sections": [
     {
       "id": "public-api",

--- a/readthedocs/search/tests/test_parsers.py
+++ b/readthedocs/search/tests/test_parsers.py
@@ -382,3 +382,40 @@ class TestParsers:
         assert len(section["content"]) <= GenericParser.max_content_length
         assert section["content"].startswith("A")
         assert not section["content"].endswith("B")
+
+    def test_text_hash_ignores_markup(self):
+        """
+        A change to the markup of a page doesn't change the hash of its text.
+
+        Intersphinx renders the version of the project a reference points to
+        into its title attribute, so it changes every time that project is
+        released, even if the page linking to it wasn't touched.
+        """
+        parser = GenericParser(self.version)
+        template = """
+            <html><body><div role="main">
+                <h1>Title of the page</h1>
+                <p>See the <a href="{href}" title="(in Example v{version})">API docs</a>.</p>
+                <img src="{src}"/>
+            </div></body></html>
+        """
+        original = template.format(href="api.html", version="1.0", src="diagram.png")
+        changed = template.format(href="other.html", version="2.0", src="other.png")
+        first = parser._process_content("index.html", original)
+        second = parser._process_content("index.html", changed)
+        assert first["text_hash"] == second["text_hash"]
+        assert first["markup_hash"] != second["markup_hash"]
+
+    def test_text_hash_detects_text_changes(self):
+        """A change to the text of a page changes both hashes."""
+        parser = GenericParser(self.version)
+        template = """
+            <html><body><div role="main">
+                <h1>Title of the page</h1>
+                <p>{text}</p>
+            </div></body></html>
+        """
+        first = parser._process_content("index.html", template.format(text="Some content"))
+        second = parser._process_content("index.html", template.format(text="Other content"))
+        assert first["text_hash"] != second["text_hash"]
+        assert first["markup_hash"] != second["markup_hash"]


### PR DESCRIPTION
The "Documentation build overview" comment lists pages nobody touched, which makes the whole file list easy to dismiss. On #13248 it reported 6 modified files for a one-paragraph docs change, and 4 of them had no source change at all. The only difference inside `<main>` on those pages was an intersphinx tooltip:

```diff
- title="(in Read the Docs developer documentation v2026.08.04)"
+ title="(in Read the Docs developer documentation v2026.08.18)"
```

The dev docs were rebuilt for a release, so its `objects.inv` version bumped and every page linking into it hashed differently. We hash the serialized HTML, so any attribute carrying a version, a URL or a generated id counts as a content change.

This hashes the text instead, taken after `_clean_body()`. Not `href` and `src` values along with it: including those recreates the same failure, since renaming one page would then re-hash every page linking to it.

Manifests carry three hashes now — `text_hash`, `markup_hash` for the HTML that text came from, and the existing `main_content_hash`. The diff compares `text_hash` when both sides have one and falls back to `main_content_hash` otherwise. Without the fallback, every PR preview built before this deploys, and every one built after it against a base version that hasn't been rebuilt, would report every file as modified.

Hashing the text and the markup apart also models a distinction the diff doesn't draw yet: a page whose copy changed against one that only moved its markup around. Reporting those separately, and dropping `main_content_hash` and its fallback once no manifest needs it, is #13258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
