### PR TITLE
Docs: drop sphinxcontrib-video

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,6 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinx.ext.intersphinx",
     "sphinxcontrib.httpdomain",
-    "sphinxcontrib.video",
     "sphinxemoji.sphinxemoji",
     "sphinxext.opengraph",
 ]

--- a/docs/user/science.rst
+++ b/docs/user/science.rst
@@ -72,8 +72,14 @@ Here's a brief overview of some :doc:`features </reference/features>` that peopl
 
     Build and publish your project for every change made through Git (GitHub, GitLab, Bitbucket etc). Preview changes via pull requests. Receive notifications when something is wrong. How does this work? Have a look at this video:
 
-    .. video:: https://anti-pattern-sphinx-video-downloader.readthedocs.io/_static/videos/enable-pull-request-builders.mp4
-       :height: 300
+    .. raw:: html
+
+        <video controls height="300" preload="auto">
+          <source
+            src="https://anti-pattern-sphinx-video-downloader.readthedocs.io/_static/videos/enable-pull-request-builders.mp4"
+            type="video/mp4"
+          >
+        </video>
 
 .. dropdown:: 💬 Collaboration and community
 

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -27,4 +27,3 @@ sphinx-copybutton
 # Markdown
 myst_parser
 
-sphinxcontrib-video

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -116,7 +116,6 @@ sphinx==8.2.3
     #   sphinx-tabs
     #   sphinxcontrib-httpdomain
     #   sphinxcontrib-jquery
-    #   sphinxcontrib-video
     #   sphinxemoji
     #   sphinxext-opengraph
 sphinx-autobuild==2025.8.25
@@ -153,8 +152,6 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sphinxcontrib-video==0.4.2
-    # via -r requirements/docs.in
 sphinxemoji==0.3.2
     # via -r requirements/docs.in
 sphinxext-opengraph==0.13.0


### PR DESCRIPTION
Our docs build is currently failing:

```
docs/user/addons.rst:101: WARNING: unknown node type: <dropdown_main: <dropdown_title...><container...>>
docs/user/addons.rst:101: WARNING: unknown node type: <dropdown_title: <inline...><inline...>>
```

The dropdown isn't the problem — the **epub** builder is (we build `epub` with `fail_on_warning: true`), and the trigger is #13225, which moved us from our fork of `sphinxcontrib-video` to upstream 0.4.2.

Sphinx transplants custom node visitors onto a translator by looking them up by builder *name* first, falling back to the builder *format* only when nothing was registered under the name ([`sphinx/registry.py`](https://github.com/sphinx-doc/sphinx/blob/v8.2.3/sphinx/registry.py#L423-L431)):

```python
handlers = self.translation_handlers.get(builder.name, None)   # 'epub'
if handlers is None:
    handlers = self.translation_handlers.get(builder.format, {})  # 'html'
```

The epub builder normally has nothing registered under `epub`, so it inherits every extension's `html` handlers. Upstream 0.4.2 added `epub=(visit_video_node_unsuported, None)` to its `add_node()` call (our fork had no epub entry). That one registration makes the name lookup succeed, so the `html` fallback never runs and the epub translator ends up knowing *only* `video_node` — sphinx-design's dropdowns become unknown nodes and the build dies.

I first wrote a `conf.py` workaround that dropped the `epub` key to restore the fallback, but the extension turned out to have exactly one call site in the entire docs tree — a single screencast on the Science page — so removing it seemed better than carrying a third-party extension plus a monkeypatch for one video. `raw:: html` is already used heavily in that same file, and the rendered `<video>` markup is equivalent to what the extension emitted.

Worth a second look:

- The mp4 stays where it was, on the `anti-pattern-sphinx-video-downloader` project. This PR doesn't change how the file is hosted.
- Losing the extension means no graceful degradation for non-HTML builders. In practice that only affected latex/man/texinfo, which we don't build, and its epub behaviour was to warn and skip — which would have failed `fail_on_warning` anyway once the dropdown crash was out of the way.
- This reopens #9489 in spirit (the fork is gone, but so is the dependency). Happy to go back to the workaround instead if we want to keep `.. video::` available for future use.

Verified by building `docs/` with the pinned requirements: the reported warnings reproduce exactly on `main`, and both `html` and `epub` build clean with `-W` after this change, with the `<video>` element present in both outputs. `requirements/docs.txt` was recompiled without `--upgrade`, so no other pins moved.

Closes the build breakage from #13225.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Kq5hTeCe1JedqHAF1UEGvt)_