### PR TITLE
GitHub App: don't create notification on 500 or rate limit errors when creating commit statuses

### DIFF
--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -1,5 +1,6 @@
 import json
 
+from github import GithubException
 import requests
 import structlog
 from django.conf import settings
@@ -216,7 +217,13 @@ def sync_versions_task(project_pk, tags_data, branches_data, **kwargs):
     return True
 
 
-@app.task(max_retries=3, default_retry_delay=60, queue="web")
+@app.task(
+    queue="web",
+    max_retries=3,
+    default_retry_delay=60,
+    # If GitHub is down or we hit a rate limit, we want to retry the task.
+    autoretry_for=(GithubException,),
+)
 def send_build_status(build_pk, commit, status):
     """
     Send build status to GitHub/GitLab for a given build/commit.

--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -8,7 +8,6 @@ from django.core.cache import cache
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
-from github import GithubException
 from oauthlib.oauth2.rfc6749.errors import InvalidGrantError
 from oauthlib.oauth2.rfc6749.errors import TokenExpiredError
 
@@ -217,13 +216,7 @@ def sync_versions_task(project_pk, tags_data, branches_data, **kwargs):
     return True
 
 
-@app.task(
-    queue="web",
-    max_retries=3,
-    default_retry_delay=60,
-    # If GitHub is down or we hit a rate limit, we want to retry the task.
-    autoretry_for=(GithubException,),
-)
+@app.task(max_retries=3, default_retry_delay=60, queue="web")
 def send_build_status(build_pk, commit, status):
     """
     Send build status to GitHub/GitLab for a given build/commit.

--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -1,6 +1,5 @@
 import json
 
-from github import GithubException
 import requests
 import structlog
 from django.conf import settings
@@ -9,6 +8,7 @@ from django.core.cache import cache
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
+from github import GithubException
 from oauthlib.oauth2.rfc6749.errors import InvalidGrantError
 from oauthlib.oauth2.rfc6749.errors import TokenExpiredError
 

--- a/readthedocs/oauth/services/githubapp.py
+++ b/readthedocs/oauth/services/githubapp.py
@@ -433,7 +433,18 @@ class GitHubAppService(Service):
                 context=context,
             )
             return True
-        except GithubException:
+        except RateLimitExceededException:
+            log.info(
+                "Rate limit exceeded while sending build status to GitHub",
+                project=project.slug,
+                build=build.pk,
+                commit=commit,
+                status=status,
+                exc_info=True,
+            )
+            # THis is a temporary error, we raise the exception so the caller can retry later.
+            raise
+        except GithubException as e:
             log.info(
                 "Failed to send build status to GitHub",
                 project=project.slug,
@@ -442,7 +453,12 @@ class GitHubAppService(Service):
                 status=status,
                 exc_info=True,
             )
-            return False
+            # if we lost access to the repository,
+            # return False, so the caller can handle it.
+            if e.status in [404, 403]:
+                return False
+            # Anythin else, we raise the exception, since it may be a temporary error.
+            raise
 
     def get_clone_token(self, project):
         """

--- a/readthedocs/oauth/services/githubapp.py
+++ b/readthedocs/oauth/services/githubapp.py
@@ -442,7 +442,7 @@ class GitHubAppService(Service):
                 status=status,
                 exc_info=True,
             )
-            # THis is a temporary error, we raise the exception so the caller can retry later.
+            # This is a temporary error, we raise the exception so the caller can retry later.
             raise
         except GithubException as e:
             log.info(

--- a/readthedocs/oauth/services/githubapp.py
+++ b/readthedocs/oauth/services/githubapp.py
@@ -408,6 +408,10 @@ class GitHubAppService(Service):
         """
         Create a commit status on GitHub for the given build.
 
+        Returns True if the status was sent successfully,
+        False if the repository is no longer accessible to the installation,
+        or raises an exception if there was a temporary error.
+
         See https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status.
         """
         project = build.project
@@ -442,7 +446,7 @@ class GitHubAppService(Service):
                 status=status,
                 exc_info=True,
             )
-            # This is a temporary error, we raise the exception so the caller can retry later.
+            # This is a temporary error.
             raise
         except GithubException as e:
             log.info(

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -6,6 +6,7 @@ import pytest
 from allauth.socialaccount.providers.bitbucket_oauth2.provider import BitbucketOAuth2Provider
 from allauth.socialaccount.providers.gitlab.provider import GitLabProvider
 import requests_mock
+from github import GithubException
 from github import RateLimitExceededException
 from allauth.socialaccount.models import SocialAccount, SocialToken
 from allauth.socialaccount.providers.github.provider import GitHubProvider
@@ -1114,6 +1115,130 @@ class GitHubAppTests(TestCase):
             # docs, since no new documentation was produced for this commit.
             "target_url": f"https://readthedocs.org/projects/{self.project.slug}/builds/{build.pk}/",
         }
+
+    @requests_mock.Mocker(kw="request")
+    def test_send_build_status_repository_not_accessible(self, request):
+        """A 404 from GitHub means we lost access to the repository, so we return False."""
+        commit = "1234abc"
+        version = self.project.versions.get(slug=LATEST)
+        build = get(
+            Build,
+            project=self.project,
+            version=version,
+        )
+        request.post(
+            f"{self.api_url}/app/installations/1111/access_tokens",
+            json=self._get_access_token_json(),
+        )
+        request.get(
+            f"{self.api_url}/repositories/{self.remote_repository.remote_id}/commits/{commit}",
+            json=self._get_commit_json(commit=commit),
+        )
+        status_api_request = request.post(
+            f"{self.api_url}/repos/user/repo/statuses/{commit}",
+            status_code=404,
+            json={"message": "Not Found"},
+        )
+
+        service = self.installation.service
+        success = service.send_build_status(
+            build=build, commit=commit, status=BUILD_STATUS_SUCCESS
+        )
+        assert success is False
+        assert status_api_request.called
+
+    @requests_mock.Mocker(kw="request")
+    def test_send_build_status_forbidden(self, request):
+        """A non-rate-limit 403 also means we lost access, so we return False."""
+        commit = "1234abc"
+        version = self.project.versions.get(slug=LATEST)
+        build = get(
+            Build,
+            project=self.project,
+            version=version,
+        )
+        request.post(
+            f"{self.api_url}/app/installations/1111/access_tokens",
+            json=self._get_access_token_json(),
+        )
+        request.get(
+            f"{self.api_url}/repositories/{self.remote_repository.remote_id}/commits/{commit}",
+            json=self._get_commit_json(commit=commit),
+        )
+        status_api_request = request.post(
+            f"{self.api_url}/repos/user/repo/statuses/{commit}",
+            status_code=403,
+            json={"message": "Resource not accessible by integration"},
+        )
+
+        service = self.installation.service
+        success = service.send_build_status(
+            build=build, commit=commit, status=BUILD_STATUS_SUCCESS
+        )
+        assert success is False
+        assert status_api_request.called
+
+    @requests_mock.Mocker(kw="request")
+    def test_send_build_status_rate_limit_exceeded(self, request):
+        """Rate limit errors are temporary, so we raise instead of returning False."""
+        commit = "1234abc"
+        version = self.project.versions.get(slug=LATEST)
+        build = get(
+            Build,
+            project=self.project,
+            version=version,
+        )
+        request.post(
+            f"{self.api_url}/app/installations/1111/access_tokens",
+            json=self._get_access_token_json(),
+        )
+        request.get(
+            f"{self.api_url}/repositories/{self.remote_repository.remote_id}/commits/{commit}",
+            json=self._get_commit_json(commit=commit),
+        )
+        status_api_request = request.post(
+            f"{self.api_url}/repos/user/repo/statuses/{commit}",
+            status_code=403,
+            json={"message": "API rate limit exceeded for installation ID 1111."},
+        )
+
+        service = self.installation.service
+        with pytest.raises(RateLimitExceededException):
+            service.send_build_status(
+                build=build, commit=commit, status=BUILD_STATUS_SUCCESS
+            )
+        assert status_api_request.called
+
+    @requests_mock.Mocker(kw="request")
+    def test_send_build_status_server_error(self, request):
+        """Non rate-limit, non 404/403 errors are temporary, so we raise instead of returning False."""
+        commit = "1234abc"
+        version = self.project.versions.get(slug=LATEST)
+        build = get(
+            Build,
+            project=self.project,
+            version=version,
+        )
+        request.post(
+            f"{self.api_url}/app/installations/1111/access_tokens",
+            json=self._get_access_token_json(),
+        )
+        request.get(
+            f"{self.api_url}/repositories/{self.remote_repository.remote_id}/commits/{commit}",
+            json=self._get_commit_json(commit=commit),
+        )
+        status_api_request = request.post(
+            f"{self.api_url}/repos/user/repo/statuses/{commit}",
+            status_code=500,
+            json={"message": "Internal Server Error"},
+        )
+
+        service = self.installation.service
+        with pytest.raises(GithubException):
+            service.send_build_status(
+                build=build, commit=commit, status=BUILD_STATUS_SUCCESS
+            )
+        assert status_api_request.called
 
     @requests_mock.Mocker(kw="request")
     def test_get_clone_token(self, request):


### PR DESCRIPTION
We could also show a specific message on 500/rate limit errors; I'm not sure if that's worth it since the user can't do anything to fix that.

Closes https://github.com/readthedocs/readthedocs.org/issues/13101