### PR TITLE
OAuth: add tests for GitHub App build status error handling

### DIFF
--- a/readthedocs/oauth/services/githubapp.py
+++ b/readthedocs/oauth/services/githubapp.py
@@ -408,6 +408,10 @@ class GitHubAppService(Service):
         """
         Create a commit status on GitHub for the given build.
 
+        Returns True if the status was sent successfully,
+        False if the repository is no longer accessible to the installation,
+        or raises an exception if there was a temporary error.
+
         See https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status.
         """
         project = build.project
@@ -433,7 +437,18 @@ class GitHubAppService(Service):
                 context=context,
             )
             return True
-        except GithubException:
+        except RateLimitExceededException:
+            log.info(
+                "Rate limit exceeded while sending build status to GitHub",
+                project=project.slug,
+                build=build.pk,
+                commit=commit,
+                status=status,
+                exc_info=True,
+            )
+            # This is a temporary error.
+            raise
+        except GithubException as e:
             log.info(
                 "Failed to send build status to GitHub",
                 project=project.slug,
@@ -442,7 +457,12 @@ class GitHubAppService(Service):
                 status=status,
                 exc_info=True,
             )
-            return False
+            # if we lost access to the repository,
+            # return False, so the caller can handle it.
+            if e.status in [404, 403]:
+                return False
+            # Anythin else, we raise the exception, since it may be a temporary error.
+            raise
 
     def get_clone_token(self, project):
         """

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -6,6 +6,7 @@ import pytest
 from allauth.socialaccount.providers.bitbucket_oauth2.provider import BitbucketOAuth2Provider
 from allauth.socialaccount.providers.gitlab.provider import GitLabProvider
 import requests_mock
+from github import GithubException
 from github import RateLimitExceededException
 from allauth.socialaccount.models import SocialAccount, SocialToken
 from allauth.socialaccount.providers.github.provider import GitHubProvider
@@ -1114,6 +1115,130 @@ class GitHubAppTests(TestCase):
             # docs, since no new documentation was produced for this commit.
             "target_url": f"https://readthedocs.org/projects/{self.project.slug}/builds/{build.pk}/",
         }
+
+    @requests_mock.Mocker(kw="request")
+    def test_send_build_status_repository_not_accessible(self, request):
+        """A 404 from GitHub means we lost access to the repository, so we return False."""
+        commit = "1234abc"
+        version = self.project.versions.get(slug=LATEST)
+        build = get(
+            Build,
+            project=self.project,
+            version=version,
+        )
+        request.post(
+            f"{self.api_url}/app/installations/1111/access_tokens",
+            json=self._get_access_token_json(),
+        )
+        request.get(
+            f"{self.api_url}/repositories/{self.remote_repository.remote_id}/commits/{commit}",
+            json=self._get_commit_json(commit=commit),
+        )
+        status_api_request = request.post(
+            f"{self.api_url}/repos/user/repo/statuses/{commit}",
+            status_code=404,
+            json={"message": "Not Found"},
+        )
+
+        service = self.installation.service
+        success = service.send_build_status(
+            build=build, commit=commit, status=BUILD_STATUS_SUCCESS
+        )
+        self.assertFalse(success)
+        assert status_api_request.called
+
+    @requests_mock.Mocker(kw="request")
+    def test_send_build_status_forbidden(self, request):
+        """A non-rate-limit 403 also means we lost access, so we return False."""
+        commit = "1234abc"
+        version = self.project.versions.get(slug=LATEST)
+        build = get(
+            Build,
+            project=self.project,
+            version=version,
+        )
+        request.post(
+            f"{self.api_url}/app/installations/1111/access_tokens",
+            json=self._get_access_token_json(),
+        )
+        request.get(
+            f"{self.api_url}/repositories/{self.remote_repository.remote_id}/commits/{commit}",
+            json=self._get_commit_json(commit=commit),
+        )
+        status_api_request = request.post(
+            f"{self.api_url}/repos/user/repo/statuses/{commit}",
+            status_code=403,
+            json={"message": "Resource not accessible by integration"},
+        )
+
+        service = self.installation.service
+        success = service.send_build_status(
+            build=build, commit=commit, status=BUILD_STATUS_SUCCESS
+        )
+        self.assertFalse(success)
+        assert status_api_request.called
+
+    @requests_mock.Mocker(kw="request")
+    def test_send_build_status_rate_limit_exceeded(self, request):
+        """Rate limit errors are temporary, so we raise instead of returning False."""
+        commit = "1234abc"
+        version = self.project.versions.get(slug=LATEST)
+        build = get(
+            Build,
+            project=self.project,
+            version=version,
+        )
+        request.post(
+            f"{self.api_url}/app/installations/1111/access_tokens",
+            json=self._get_access_token_json(),
+        )
+        request.get(
+            f"{self.api_url}/repositories/{self.remote_repository.remote_id}/commits/{commit}",
+            json=self._get_commit_json(commit=commit),
+        )
+        status_api_request = request.post(
+            f"{self.api_url}/repos/user/repo/statuses/{commit}",
+            status_code=403,
+            json={"message": "API rate limit exceeded for installation ID 1111."},
+        )
+
+        service = self.installation.service
+        with self.assertRaises(RateLimitExceededException):
+            service.send_build_status(
+                build=build, commit=commit, status=BUILD_STATUS_SUCCESS
+            )
+        assert status_api_request.called
+
+    @requests_mock.Mocker(kw="request")
+    def test_send_build_status_server_error(self, request):
+        """Non rate-limit, non 404/403 errors are temporary, so we raise instead of returning False."""
+        commit = "1234abc"
+        version = self.project.versions.get(slug=LATEST)
+        build = get(
+            Build,
+            project=self.project,
+            version=version,
+        )
+        request.post(
+            f"{self.api_url}/app/installations/1111/access_tokens",
+            json=self._get_access_token_json(),
+        )
+        request.get(
+            f"{self.api_url}/repositories/{self.remote_repository.remote_id}/commits/{commit}",
+            json=self._get_commit_json(commit=commit),
+        )
+        status_api_request = request.post(
+            f"{self.api_url}/repos/user/repo/statuses/{commit}",
+            status_code=500,
+            json={"message": "Internal Server Error"},
+        )
+
+        service = self.installation.service
+        with self.assertRaises(GithubException):
+            service.send_build_status(
+                build=build, commit=commit, status=BUILD_STATUS_SUCCESS
+            )
+        assert status_api_request.called
 
     @requests_mock.Mocker(kw="request")
     def test_get_clone_token(self, request):


### PR DESCRIPTION
Cherry-picks the source change from #13252 and adds coverage for the new error paths: 404/403 (permission lost) still return False, while rate limit and other GithubException errors (e.g. 500) now raise so callers don't create a misleading "no permission" notification.


Claude-Session: https://claude.ai/code/session_01BK1e51NniS825yHDnGaoS2