### PR TITLE
OAuth: add tests for GitHub App build status error handling

### DIFF
--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -1144,7 +1144,7 @@ class GitHubAppTests(TestCase):
         success = service.send_build_status(
             build=build, commit=commit, status=BUILD_STATUS_SUCCESS
         )
-        self.assertFalse(success)
+        assert success is False
         assert status_api_request.called
 
     @requests_mock.Mocker(kw="request")
@@ -1175,7 +1175,7 @@ class GitHubAppTests(TestCase):
         success = service.send_build_status(
             build=build, commit=commit, status=BUILD_STATUS_SUCCESS
         )
-        self.assertFalse(success)
+        assert success is False
         assert status_api_request.called
 
     @requests_mock.Mocker(kw="request")
@@ -1203,7 +1203,7 @@ class GitHubAppTests(TestCase):
         )
 
         service = self.installation.service
-        with self.assertRaises(RateLimitExceededException):
+        with pytest.raises(RateLimitExceededException):
             service.send_build_status(
                 build=build, commit=commit, status=BUILD_STATUS_SUCCESS
             )
@@ -1234,7 +1234,7 @@ class GitHubAppTests(TestCase):
         )
 
         service = self.installation.service
-        with self.assertRaises(GithubException):
+        with pytest.raises(GithubException):
             service.send_build_status(
                 build=build, commit=commit, status=BUILD_STATUS_SUCCESS
             )

--- a/readthedocs/rtd_tests/tests/test_oauth.py
+++ b/readthedocs/rtd_tests/tests/test_oauth.py
@@ -6,6 +6,7 @@ import pytest
 from allauth.socialaccount.providers.bitbucket_oauth2.provider import BitbucketOAuth2Provider
 from allauth.socialaccount.providers.gitlab.provider import GitLabProvider
 import requests_mock
+from github import GithubException
 from github import RateLimitExceededException
 from allauth.socialaccount.models import SocialAccount, SocialToken
 from allauth.socialaccount.providers.github.provider import GitHubProvider
@@ -1114,6 +1115,130 @@ class GitHubAppTests(TestCase):
             # docs, since no new documentation was produced for this commit.
             "target_url": f"https://readthedocs.org/projects/{self.project.slug}/builds/{build.pk}/",
         }
+
+    @requests_mock.Mocker(kw="request")
+    def test_send_build_status_repository_not_accessible(self, request):
+        """A 404 from GitHub means we lost access to the repository, so we return False."""
+        commit = "1234abc"
+        version = self.project.versions.get(slug=LATEST)
+        build = get(
+            Build,
+            project=self.project,
+            version=version,
+        )
+        request.post(
+            f"{self.api_url}/app/installations/1111/access_tokens",
+            json=self._get_access_token_json(),
+        )
+        request.get(
+            f"{self.api_url}/repositories/{self.remote_repository.remote_id}/commits/{commit}",
+            json=self._get_commit_json(commit=commit),
+        )
+        status_api_request = request.post(
+            f"{self.api_url}/repos/user/repo/statuses/{commit}",
+            status_code=404,
+            json={"message": "Not Found"},
+        )
+
+        service = self.installation.service
+        success = service.send_build_status(
+            build=build, commit=commit, status=BUILD_STATUS_SUCCESS
+        )
+        self.assertFalse(success)
+        assert status_api_request.called
+
+    @requests_mock.Mocker(kw="request")
+    def test_send_build_status_forbidden(self, request):
+        """A non-rate-limit 403 also means we lost access, so we return False."""
+        commit = "1234abc"
+        version = self.project.versions.get(slug=LATEST)
+        build = get(
+            Build,
+            project=self.project,
+            version=version,
+        )
+        request.post(
+            f"{self.api_url}/app/installations/1111/access_tokens",
+            json=self._get_access_token_json(),
+        )
+        request.get(
+            f"{self.api_url}/repositories/{self.remote_repository.remote_id}/commits/{commit}",
+            json=self._get_commit_json(commit=commit),
+        )
+        status_api_request = request.post(
+            f"{self.api_url}/repos/user/repo/statuses/{commit}",
+            status_code=403,
+            json={"message": "Resource not accessible by integration"},
+        )
+
+        service = self.installation.service
+        success = service.send_build_status(
+            build=build, commit=commit, status=BUILD_STATUS_SUCCESS
+        )
+        self.assertFalse(success)
+        assert status_api_request.called
+
+    @requests_mock.Mocker(kw="request")
+    def test_send_build_status_rate_limit_exceeded(self, request):
+        """Rate limit errors are temporary, so we raise instead of returning False."""
+        commit = "1234abc"
+        version = self.project.versions.get(slug=LATEST)
+        build = get(
+            Build,
+            project=self.project,
+            version=version,
+        )
+        request.post(
+            f"{self.api_url}/app/installations/1111/access_tokens",
+            json=self._get_access_token_json(),
+        )
+        request.get(
+            f"{self.api_url}/repositories/{self.remote_repository.remote_id}/commits/{commit}",
+            json=self._get_commit_json(commit=commit),
+        )
+        status_api_request = request.post(
+            f"{self.api_url}/repos/user/repo/statuses/{commit}",
+            status_code=403,
+            json={"message": "API rate limit exceeded for installation ID 1111."},
+        )
+
+        service = self.installation.service
+        with self.assertRaises(RateLimitExceededException):
+            service.send_build_status(
+                build=build, commit=commit, status=BUILD_STATUS_SUCCESS
+            )
+        assert status_api_request.called
+
+    @requests_mock.Mocker(kw="request")
+    def test_send_build_status_server_error(self, request):
+        """Non rate-limit, non 404/403 errors are temporary, so we raise instead of returning False."""
+        commit = "1234abc"
+        version = self.project.versions.get(slug=LATEST)
+        build = get(
+            Build,
+            project=self.project,
+            version=version,
+        )
+        request.post(
+            f"{self.api_url}/app/installations/1111/access_tokens",
+            json=self._get_access_token_json(),
+        )
+        request.get(
+            f"{self.api_url}/repositories/{self.remote_repository.remote_id}/commits/{commit}",
+            json=self._get_commit_json(commit=commit),
+        )
+        status_api_request = request.post(
+            f"{self.api_url}/repos/user/repo/statuses/{commit}",
+            status_code=500,
+            json={"message": "Internal Server Error"},
+        )
+
+        service = self.installation.service
+        with self.assertRaises(GithubException):
+            service.send_build_status(
+                build=build, commit=commit, status=BUILD_STATUS_SUCCESS
+            )
+        assert status_api_request.called
 
     @requests_mock.Mocker(kw="request")
     def test_get_clone_token(self, request):


### PR DESCRIPTION
Adds test coverage for the error-handling change in #13252 (`GitHubAppService.send_build_status`).

That PR splits GitHub errors into two buckets: a 404/403 means we lost access to the repository and should keep returning `False` so the caller can fall back or notify the user; a rate limit or any other error is temporary and should now raise instead, so we don't create a misleading "no permission" notification for something the user can't fix.

The four new tests exercise each branch by mocking the relevant HTTP status/message combinations the underlying PyGithub client uses to classify exceptions:
- 404 → returns `False`
- 403 without a rate-limit message → returns `False`
- 403 with a rate-limit message → raises `RateLimitExceededException`
- 500 → raises `GithubException`

Worth double-checking: the 403-without-rate-limit test relies on the response message *not* matching PyGithub's rate-limit detection heuristics (it checks for message prefixes like "API rate limit exceeded" or "you have exceeded a secondary rate limit"), so it's a bit coupled to PyGithub's internal classification logic rather than something under our direct control.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BK1e51NniS825yHDnGaoS2)_