### PR TITLE
Api: allow changing the version slug from APIv3

### DIFF
--- a/docs/user/api/v3.rst
+++ b/docs/user/api/v3.rst
@@ -653,6 +653,11 @@ Version update
     When a version is deactivated, its documentation is removed,
     and when it's activated, a new build is triggered.
 
+    Changing the ``slug`` of an active version removes the documentation
+    served under the previous slug and triggers a new build.
+    See :ref:`versions:Version URL identifier (slug)` for what to take into account
+    before renaming a version.
+
     Updates to a version also invalidates its CDN cache.
 
     **Example request**:
@@ -689,7 +694,8 @@ Version update
         {
             "active": true,
             "hidden": false,
-            "privacy_level": "public"
+            "privacy_level": "public",
+            "slug": "0.23"
         }
 
     :statuscode 204: Updated successfully
@@ -697,6 +703,11 @@ Version update
     .. note::
 
        Privacy levels are only available in :doc:`Read the Docs Business </commercial/index>`.
+
+    .. note::
+
+       You can't change the slug of versions managed by Read the Docs,
+       like ``latest`` and ``stable``.
 
 Builds
 ~~~~~~

--- a/docs/user/versions.rst
+++ b/docs/user/versions.rst
@@ -102,6 +102,7 @@ some special characters like spaces and ``/`` are replaced with a dash (``-``), 
 If the resulting slug collides with another one, a suffix is added (``_a``, ``_b``, etc.).
 
 You can change the slug of a version in :ref:`the versions tab of your project <versions:Managing your versions>`,
+or with the :ref:`API <api/v3:Version update>`,
 but you should take the following into account:
 
 - Changing the slug of an active version will result on its previous documentation being deleted, and a new build being triggered.

--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -16,6 +16,7 @@ from readthedocs.builds.constants import LATEST
 from readthedocs.builds.constants import STABLE
 from readthedocs.builds.models import Build
 from readthedocs.builds.models import Version
+from readthedocs.builds.version_slug import validate_version_slug
 from readthedocs.core.permissions import AdminPermission
 from readthedocs.core.resolver import Resolver
 from readthedocs.core.utils import slugify
@@ -398,8 +399,14 @@ class VersionUpdateSerializer(serializers.ModelSerializer):
     """
     Used when modifying (update action) a ``Version``.
 
-    It allows to change the version states and privacy level only.
+    It allows to change the version states, slug and privacy level only.
     """
+
+    # ``validate_version_slug`` is stricter than the model's ``version_slug_validator``
+    # (it normalizes the slug and compares, rather than matching a regex), and its error
+    # suggests a valid slug. We drop the model validator so it doesn't run first and
+    # mask that suggestion, which is also what the dashboard form ends up doing.
+    slug = serializers.CharField(max_length=255, validators=[])
 
     class Meta:
         model = Version
@@ -407,6 +414,7 @@ class VersionUpdateSerializer(serializers.ModelSerializer):
             "active",
             "hidden",
             "privacy_level",
+            "slug",
         ]
 
     def __init__(self, *args, **kwargs):
@@ -416,6 +424,10 @@ class VersionUpdateSerializer(serializers.ModelSerializer):
         # everything is public, we don't allow changing it.
         if not settings.ALLOW_PRIVATE_REPOS:
             self.fields.pop("privacy_level")
+
+    def validate_slug(self, slug):
+        validate_version_slug(slug, self.instance)
+        return slug
 
 
 class LanguageSerializer(serializers.Serializer):

--- a/readthedocs/api/v3/serializers.py
+++ b/readthedocs/api/v3/serializers.py
@@ -406,7 +406,7 @@ class VersionUpdateSerializer(serializers.ModelSerializer):
     # (it normalizes the slug and compares, rather than matching a regex), and its error
     # suggests a valid slug. We drop the model validator so it doesn't run first and
     # mask that suggestion, which is also what the dashboard form ends up doing.
-    slug = serializers.CharField(max_length=255, validators=[])
+    slug = serializers.CharField(max_length=255, required=False, validators=[])
 
     class Meta:
         model = Version

--- a/readthedocs/api/v3/tests/test_versions.py
+++ b/readthedocs/api/v3/tests/test_versions.py
@@ -609,6 +609,25 @@ class VersionsEndpointTests(APIEndpointMixin):
             "build_calls": 1,
         }
 
+    def test_projects_versions_update_without_slug(self):
+        """PUT without a slug keeps the current one, instead of requiring it."""
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.put(
+            reverse(
+                "projects-versions-detail",
+                kwargs={
+                    "parent_lookup_project__slug": self.project.slug,
+                    "version_slug": self.version.slug,
+                },
+            ),
+            {"active": True, "hidden": True},
+        )
+        assert response.status_code == 204
+
+        self.version.refresh_from_db()
+        assert self.version.slug == "v1.0"
+        assert self.version.hidden
+
     def test_projects_version_external(self):
         self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
         self.version.type = EXTERNAL

--- a/readthedocs/api/v3/tests/test_versions.py
+++ b/readthedocs/api/v3/tests/test_versions.py
@@ -5,7 +5,8 @@ from django.test import override_settings
 from django.urls import reverse
 from django_dynamic_fixture import get
 
-from readthedocs.builds.constants import EXTERNAL, TAG
+from readthedocs.builds.constants import EXTERNAL, LATEST, TAG
+from readthedocs.builds.forms import VersionForm
 from readthedocs.builds.models import Version
 from readthedocs.projects.constants import PRIVATE
 from readthedocs.projects.models import HTMLFile, Project
@@ -410,6 +411,203 @@ class VersionsEndpointTests(APIEndpointMixin):
         remove_build_storage_paths.delay.assert_called_once()
         remove_search_indexes.delay.assert_called_once()
         trigger_build.assert_not_called()
+
+    @mock.patch("readthedocs.builds.models.trigger_build")
+    @mock.patch("readthedocs.projects.tasks.utils.clean_project_resources")
+    def test_update_version_slug(self, clean_project_resources, trigger_build):
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.patch(
+            reverse(
+                "projects-versions-detail",
+                kwargs={
+                    "parent_lookup_project__slug": self.project.slug,
+                    "version_slug": self.version.slug,
+                },
+            ),
+            {"slug": "1.0"},
+        )
+        assert response.status_code == 204
+
+        self.version.refresh_from_db()
+        assert self.version.slug == "1.0"
+        # The verbose name isn't affected by a slug change.
+        assert self.version.verbose_name == "v1.0"
+
+        # Resources are cleaned up using the previous slug,
+        # and a new build is triggered to populate the new one.
+        assert clean_project_resources.call_args[1]["version_slug"] == "v1.0"
+        trigger_build.assert_called_once()
+
+    @mock.patch("readthedocs.builds.models.trigger_build")
+    @mock.patch("readthedocs.projects.tasks.utils.clean_project_resources")
+    def test_update_version_slug_of_inactive_version(self, clean_project_resources, trigger_build):
+        self.version.active = False
+        self.version.save()
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.patch(
+            reverse(
+                "projects-versions-detail",
+                kwargs={
+                    "parent_lookup_project__slug": self.project.slug,
+                    "version_slug": self.version.slug,
+                },
+            ),
+            {"slug": "1.0"},
+        )
+        assert response.status_code == 204
+
+        self.version.refresh_from_db()
+        assert self.version.slug == "1.0"
+
+        # An inactive version has no resources to clean up,
+        # and renaming it shouldn't trigger a build.
+        clean_project_resources.assert_not_called()
+        trigger_build.assert_not_called()
+
+    def test_update_version_slug_invalid(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.patch(
+            reverse(
+                "projects-versions-detail",
+                kwargs={
+                    "parent_lookup_project__slug": self.project.slug,
+                    "version_slug": self.version.slug,
+                },
+            ),
+            {"slug": "Release/1.0"},
+        )
+        assert response.status_code == 400
+        assert "release-1.0" in response.json()["slug"][0]
+
+        self.version.refresh_from_db()
+        assert self.version.slug == "v1.0"
+
+    def test_update_version_slug_already_taken(self):
+        get(Version, project=self.project, slug="1.0")
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.patch(
+            reverse(
+                "projects-versions-detail",
+                kwargs={
+                    "parent_lookup_project__slug": self.project.slug,
+                    "version_slug": self.version.slug,
+                },
+            ),
+            {"slug": "1.0"},
+        )
+        assert response.status_code == 400
+        assert response.json()["slug"] == ["A version with that slug already exists."]
+
+        self.version.refresh_from_db()
+        assert self.version.slug == "v1.0"
+
+    def test_update_version_slug_of_machine_created_version(self):
+        latest = self.project.versions.get(slug=LATEST)
+        assert latest.machine
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.patch(
+            reverse(
+                "projects-versions-detail",
+                kwargs={
+                    "parent_lookup_project__slug": self.project.slug,
+                    "version_slug": latest.slug,
+                },
+            ),
+            {"slug": "1.0"},
+        )
+        assert response.status_code == 400
+
+        latest.refresh_from_db()
+        assert latest.slug == LATEST
+
+    def test_update_version_slug_errors_match_dashboard_form(self):
+        """The API rejects slugs with the same errors as the dashboard form."""
+        get(Version, project=self.project, slug="taken")
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        for slug in ("Release/1.0", "taken"):
+            form = VersionForm(
+                {"slug": slug, "active": self.version.active},
+                instance=self.version,
+                project=self.project,
+            )
+            assert not form.is_valid(), slug
+
+            response = self.client.patch(
+                reverse(
+                    "projects-versions-detail",
+                    kwargs={
+                        "parent_lookup_project__slug": self.project.slug,
+                        "version_slug": self.version.slug,
+                    },
+                ),
+                {"slug": slug},
+            )
+            assert response.status_code == 400, slug
+            assert response.json()["slug"] == form.errors["slug"], slug
+
+    @mock.patch("readthedocs.builds.models.trigger_build")
+    @mock.patch("readthedocs.projects.tasks.utils.clean_project_resources")
+    def test_update_version_slug_side_effects_match_dashboard_form(
+        self, clean_project_resources, trigger_build
+    ):
+        """Renaming through the API cleans up and rebuilds exactly like the form does."""
+
+        def side_effects(previous_slug):
+            return {
+                "cleaned_previous_slug": (
+                    clean_project_resources.call_args[1]["version_slug"] == previous_slug
+                ),
+                "clean_calls": clean_project_resources.call_count,
+                "build_calls": trigger_build.call_count,
+            }
+
+        # Rename an active version through the dashboard form.
+        version = get(
+            Version,
+            project=self.project,
+            slug="1.0",
+            verbose_name="1.0",
+            machine=False,
+            active=True,
+            built=True,
+        )
+        form = VersionForm(
+            {"slug": "2.0", "active": True},
+            instance=version,
+            project=self.project,
+        )
+        assert form.is_valid(), form.errors
+        form.save()
+        from_form = side_effects("1.0")
+
+        clean_project_resources.reset_mock()
+        trigger_build.reset_mock()
+
+        # The same rename through the API.
+        self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")
+        response = self.client.patch(
+            reverse(
+                "projects-versions-detail",
+                kwargs={
+                    "parent_lookup_project__slug": self.project.slug,
+                    "version_slug": self.version.slug,
+                },
+            ),
+            {"slug": "3.0"},
+        )
+        assert response.status_code == 204
+        from_api = side_effects("v1.0")
+
+        assert from_api == from_form
+        assert from_form == {
+            "cleaned_previous_slug": True,
+            "clean_calls": 1,
+            "build_calls": 1,
+        }
 
     def test_projects_version_external(self):
         self.client.credentials(HTTP_AUTHORIZATION=f"Token {self.token.key}")

--- a/readthedocs/api/v3/views.py
+++ b/readthedocs/api/v3/views.py
@@ -374,12 +374,25 @@ class VersionsViewSet(
 
     def update(self, request, *args, **kwargs):
         """Overridden to call ``post_save`` method on the updated version."""
-        # Get the current value before updating.
+        # Get the current values before updating.
         version = self.get_object()
         was_active = version.active
+        previous_slug = version.slug
+
         result = super().update(request, *args, **kwargs)
+
         # Get the updated version.
-        version = self.get_object()
+        # NOTE: we can't use ``self.get_object()`` here, since versions are
+        # looked up by slug, and the slug may have just changed.
+        version.refresh_from_db()
+
+        # If the slug of an active version was changed, all its resources are
+        # still stored under the previous slug, so we clean them up and let
+        # ``post_save`` trigger a new build under the new slug.
+        if version.slug != previous_slug and was_active:
+            version.clean_resources(version_slug=previous_slug)
+            was_active = False
+
         version.post_save(was_active=was_active)
         return result
 

--- a/readthedocs/builds/forms.py
+++ b/readthedocs/builds/forms.py
@@ -10,7 +10,7 @@ from django.template.loader import render_to_string
 from django.utils.translation import gettext_lazy as _
 
 from readthedocs.builds.models import Version
-from readthedocs.builds.version_slug import generate_version_slug
+from readthedocs.builds.version_slug import validate_version_slug
 
 
 class VersionForm(forms.ModelForm):
@@ -87,19 +87,7 @@ class VersionForm(forms.ModelForm):
 
     def clean_slug(self):
         slug = self.cleaned_data["slug"]
-        validated_slug = generate_version_slug(slug)
-        if slug != validated_slug:
-            msg = _(
-                "The slug can contain lowercase letters, numbers, dots, dashes or underscores, "
-                f"and it must start with a lowercase letter or a number. Consider using '{validated_slug}'."
-            )
-            raise forms.ValidationError(msg)
-
-        # NOTE: Django already checks for unique slugs and raises a ValidationError,
-        # but that message is attached to the whole form instead of the the slug field.
-        # So we do the check here to provide a better error message.
-        if self.project.versions.filter(slug=slug).exclude(pk=self.instance.pk).exists():
-            raise forms.ValidationError(_("A version with that slug already exists."))
+        validate_version_slug(slug, self.instance)
         return slug
 
     def clean_project(self):

--- a/readthedocs/builds/version_slug.py
+++ b/readthedocs/builds/version_slug.py
@@ -22,6 +22,7 @@ import re
 import string
 from operator import truediv
 
+from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.db import models
 from django.utils.translation import gettext_lazy as _
@@ -50,6 +51,42 @@ version_slug_validator = RegexValidator(
         "Enter a valid slug consisting of lowercase letters, numbers, dots, dashes or underscores. It must start with a letter or a number."
     ),
 )
+
+
+def validate_version_slug(slug, version):
+    """
+    Validate a new slug for a given version.
+
+    These checks are shared by the dashboard form and the API,
+    so changing a slug behaves the same way everywhere.
+
+    :param slug: The new slug for the version.
+    :param version: The version the slug is being assigned to.
+    :raises django.core.exceptions.ValidationError: If the slug isn't valid.
+    """
+    # We rely on the slug to identify versions managed by Read the Docs
+    # (``latest`` and ``stable``), so it can't be changed.
+    if version.machine and slug != version.slug:
+        raise ValidationError(
+            _("The slug of versions managed by Read the Docs can't be changed."),
+        )
+
+    normalized_slug = generate_version_slug(slug)
+    if slug != normalized_slug:
+        raise ValidationError(
+            _(
+                "The slug can contain lowercase letters, numbers, dots, dashes or underscores, "
+                "and it must start with a lowercase letter or a number. "
+                "Consider using '%(slug)s'."
+            ),
+            params={"slug": normalized_slug},
+        )
+
+    # NOTE: Django already checks for unique slugs and raises a ValidationError,
+    # but that message is attached to the whole form instead of the slug field.
+    # So we do the check here to provide a better error message.
+    if version.project.versions.filter(slug=slug).exclude(pk=version.pk).exists():
+        raise ValidationError(_("A version with that slug already exists."))
 
 
 def generate_unique_version_slug(source, version):


### PR DESCRIPTION
Closes #11970.

The dashboard has allowed changing a version's slug since #11930, but the API never caught up, which blocks automating releases from CI: users can activate and deactivate versions through the API but still have to rename by hand in the dashboard. This came out of a support thread, and #12128 describes the same use case.

It's deliberately the minimal version so it can ship quickly — the form's validation moves to a shared function both writers call, and the viewset mirrors the form's cleanup on rename. The deeper version, moving validation and rename side effects onto the model, is stacked as #13283 to consider separately.

Renaming is exactly as destructive through the API as it already is through the dashboard: URLs under the old slug 404 until the user adds a redirect. #11978 tracks suggesting that redirect automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015dd6KBhKKcjy9sMgGaX4qL