### PR TITLE
Builds: rename `isolated-builders` to `build-isolated`

### DIFF
--- a/readthedocs/api/v2/views/model_views.py
+++ b/readthedocs/api/v2/views/model_views.py
@@ -273,7 +273,7 @@ class BuildViewSet(DisableListEndpoint, UpdateModelMixin, UserSelectViewSet):
         if (
             not was_finished
             and build.finished
-            and build.project.has_feature(Feature.USE_ISOLATED_BUILDER)
+            and build.project.has_feature(Feature.USE_BUILD_ISOLATED)
         ):
             run_post_build_tasks.delay(build_pk=build.pk)
 

--- a/readthedocs/builds/querysets.py
+++ b/readthedocs/builds/querysets.py
@@ -227,7 +227,7 @@ class BuildQuerySet(NoReprQuerySet, models.QuerySet):
           If the project/translation belongs to an organization, we count all concurrent
           builds for all the projects from the organization.
 
-        A build counts as soon as it's been dispatched to the isolated-builders
+        A build counts as soon as it's been dispatched to the build-isolated
         fleet (``dispatched_date`` set) — it occupies a slot even while it waits
         in the broker for a builder to pick it up. A build still genuinely
         queued (``triggered`` but not yet dispatched) does not count.

--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -774,7 +774,7 @@ def remove_build_commands_storage_paths(paths):
 @app.task(queue="web")
 def run_post_build_tasks(build_pk):
     """
-    Run the post-build work for a build from the isolated-builders fleet.
+    Run the post-build work for a build from the build-isolated fleet.
 
     Triggered from ``BuildViewSet`` when a build reaches a final state —
     see ``perform_update`` there for the gating.

--- a/readthedocs/builds/tests/test_build_queryset.py
+++ b/readthedocs/builds/tests/test_build_queryset.py
@@ -44,7 +44,7 @@ class TestBuildQuerySet:
         A dispatched isolated build counts even while still ``triggered``.
 
         Once ``admit_project_builds`` dispatches a build to the
-        isolated-builders fleet (``dispatched_date`` set), it occupies a slot
+        build-isolated fleet (``dispatched_date`` set), it occupies a slot
         even while it waits in ``triggered`` for a builder to pick it up. A
         build still genuinely queued (no ``dispatched_date``) does not count.
         """

--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -138,10 +138,10 @@ def prepare_build(
         cancel_build(running_build)
 
     # Start the build in X minutes and mark it as limited.
-    # The isolated-builders path enforces concurrency on the web side instead
+    # The build-isolated path enforces concurrency on the web side instead
     # (see :func:`admit_project_builds`), so this only applies to the legacy path.
     limit_reached, _, max_concurrent_builds = Build.objects.concurrent(project)
-    if limit_reached and not project.has_feature(Feature.USE_ISOLATED_BUILDER):
+    if limit_reached and not project.has_feature(Feature.USE_BUILD_ISOLATED):
         log.warning(
             "Delaying tasks at trigger step due to concurrency limit.",
         )
@@ -203,9 +203,9 @@ def trigger_build(project, version=None, commit=None, from_webhook=False):
     Helper that calls ``prepare_build`` and just effectively trigger the Celery
     task to be executed by a worker.
 
-    When the project has ``Feature.USE_ISOLATED_BUILDER`` enabled,
-    the build is sent directly to the ``isolated-builds`` Celery queue
-    (via :func:`submit_to_isolated_builders` below). A worker on a
+    When the project has ``Feature.USE_BUILD_ISOLATED`` enabled,
+    the build is sent directly to the ``build:isolated`` Celery queue
+    (via :func:`submit_to_build_isolated` below). A worker on a
     dedicated EC2 instance picks it up, fetches build/project data from
     the API, sparse-clones ``.readthedocs.yaml`` for ``build.os``, and
     runs the build inside a ``readthedocs/build:<os>`` container. See
@@ -243,8 +243,8 @@ def trigger_build(project, version=None, commit=None, from_webhook=False):
         # Build was skipped
         return (None, None)
 
-    # Feature-flag dispatch: isolated-builders path vs legacy Celery path.
-    if project.has_feature(Feature.USE_ISOLATED_BUILDER):
+    # Feature-flag dispatch: build-isolated path vs legacy Celery path.
+    if project.has_feature(Feature.USE_BUILD_ISOLATED):
         # Call `admit_project_builds` to dispatch immediately if there is a slot free
         admit_project_builds(project)
         return None, build
@@ -263,13 +263,13 @@ def trigger_build(project, version=None, commit=None, from_webhook=False):
     return task, build
 
 
-def submit_to_isolated_builders(*, project, build):
+def submit_to_build_isolated(*, project, build):
     """
-    Dispatch a build directly to the ``isolated-builds`` Celery queue.
+    Dispatch a build directly to the ``build:isolated`` Celery queue.
 
     Called from :func:`trigger_build` when the project has
-    ``USE_ISOLATED_BUILDER`` set. The dispatched task runs on the
-    isolated-builders EC2 fleet (worker code lives in the
+    ``USE_BUILD_ISOLATED`` set. The dispatched task runs on the
+    build-isolated EC2 fleet (worker code lives in the
     ``readthedocs-builder`` repository under ``worker/``).
 
     What this function does *not* do — deliberately — is any Git
@@ -305,21 +305,21 @@ def submit_to_isolated_builders(*, project, build):
         # are fully migrated and remove this override here.
         environment["RTD_API_URL"] = "http://nginx"
 
-    # Debug knob: ``KEEP_ISOLATED_BUILDER_INSTANCE`` feature flag asks
+    # Debug knob: ``KEEP_BUILD_ISOLATED_INSTANCE`` feature flag asks
     # the worker to skip its post-build self-terminate so the EC2 host
     # stays alive for inspection. Ignored in dev (no instance to keep).
-    no_self_terminate = project.has_feature(Feature.KEEP_ISOLATED_BUILDER_INSTANCE)
+    no_self_terminate = project.has_feature(Feature.KEEP_BUILD_ISOLATED_INSTANCE)
 
-    log.info("Dispatching build to isolated-builders queue.")
+    log.info("Dispatching build to build-isolated queue.")
     result = app.send_task(
-        settings.RTD_ISOLATED_BUILDER_TASK_NAME,
+        settings.RTD_BUILD_ISOLATED_TASK_NAME,
         kwargs={
             "build_pk": build.pk,
             "build_api_key": build_api_key,
             "environment": environment,
             "no_self_terminate": no_self_terminate,
         },
-        queue=settings.RTD_ISOLATED_BUILDER_QUEUE,
+        queue=settings.RTD_BUILD_ISOLATED_QUEUE,
     )
 
     # Save the worker task id so ``cancel_build`` can revoke it, and record the
@@ -351,7 +351,7 @@ def admit_project_builds(project):
     """
     Admit queued isolated builds for ``project`` up to the free-slot count.
 
-    Concurrency for the isolated-builders path is enforced here, on the ``web``
+    Concurrency for the build-isolated path is enforced here, on the ``web``
     side, rather than inside the build task. Builds sit in ``triggered`` until a
     slot frees; this dispatches the oldest ones to the fleet, FIFO.
 
@@ -363,7 +363,7 @@ def admit_project_builds(project):
     from readthedocs.projects.models import Feature
 
     # The legacy path enforces concurrency inside the build task itself.
-    if not project.has_feature(Feature.USE_ISOLATED_BUILDER):
+    if not project.has_feature(Feature.USE_BUILD_ISOLATED):
         return
 
     # Serialize admission across the whole concurrency scope so two passes can't
@@ -398,7 +398,7 @@ def admit_project_builds(project):
                         attached_to=build,
                     )
                     log.info("Admitting queued build.")
-                    submit_to_isolated_builders(project=project, build=build)
+                    submit_to_build_isolated(project=project, build=build)
                 else:
                     # Blocked by the concurrency limit: surface the wait in the UI.
                     # A later finish hook or the beat sweep will admit it.

--- a/readthedocs/projects/models.py
+++ b/readthedocs/projects/models.py
@@ -2108,8 +2108,8 @@ class Feature(models.Model):
     BUILD_IN_PARALLEL = "build_in_parallel"
     USE_GVISOR_RUNTIME = "use_gvisor_runtime"
     TERMINATE_INSTANCE_ON_BUILD_FINISH = "terminate_instance_on_build_finish"
-    USE_ISOLATED_BUILDER = "use_isolated_builder"
-    KEEP_ISOLATED_BUILDER_INSTANCE = "keep_isolated_builder_instance"
+    USE_BUILD_ISOLATED = "use_build_isolated"
+    KEEP_BUILD_ISOLATED_INSTANCE = "keep_build_isolated_instance"
     ALLOW_DIRECT_ARTIFACTS_UPLOAD = "allow_direct_artifacts_upload"
 
     FEATURES = (
@@ -2185,16 +2185,16 @@ class Feature(models.Model):
             _("Build: Terminate instance on build finish."),
         ),
         (
-            USE_ISOLATED_BUILDER,
+            USE_BUILD_ISOLATED,
             _(
-                "Build: Dispatch this project's builds to the `isolated-builders` ASG "
+                "Build: Dispatch this project's builds to the `build-isolated` ASG "
                 "instead of the `build-default` ASG."
             ),
         ),
         (
-            KEEP_ISOLATED_BUILDER_INSTANCE,
+            KEEP_BUILD_ISOLATED_INSTANCE,
             _(
-                "Build: Debug mode for `isolated-builders` — keep the EC2 instance "
+                "Build: Debug mode for `build-isolated` — keep the EC2 instance "
                 "running after the build completes (instead of having the worker "
                 "self-terminate it via the AWS API)."
             ),

--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -128,7 +128,7 @@ def finish_unhealthy_builds():
     - **Inactive:** a running build whose last healthcheck was more than
       ``RTD_BUILD_HEALTHCHECK_TIMEOUT`` seconds ago (its builder went silent).
 
-    - **Lost:** an isolated-builders build that was dispatched to the fleet more
+    - **Lost:** an build-isolated build that was dispatched to the fleet more
       than ``RTD_BUILD_DISPATCH_TIMEOUT`` seconds ago but no builder ever picked
       it up (still ``triggered``). ``dispatched_date`` is only set on the
       isolated path, so this never touches legacy builds.

--- a/readthedocs/rtd_tests/tests/test_core_utils.py
+++ b/readthedocs/rtd_tests/tests/test_core_utils.py
@@ -265,8 +265,8 @@ class CoreUtilTests(TestCase):
         [RTDProductFeature(TYPE_CONCURRENT_BUILDS, value=4).to_item()]
     ),
 )
-class IsolatedBuilderConcurrencyTests(TestCase):
-    """Concurrency admission for the isolated-builders path."""
+class BuildIsolatedConcurrencyTests(TestCase):
+    """Concurrency admission for the build-isolated path."""
 
     def setUp(self):
         self.project = get(
@@ -275,7 +275,7 @@ class IsolatedBuilderConcurrencyTests(TestCase):
             main_language_project=None,
             max_concurrent_builds=3,
         )
-        feature = get(Feature, feature_id=Feature.USE_ISOLATED_BUILDER)
+        feature = get(Feature, feature_id=Feature.USE_BUILD_ISOLATED)
         feature.projects.add(self.project)
         self.version = get(Version, project=self.project)
 

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -174,7 +174,7 @@ class CommunityBaseSettings(Settings):
     RTD_CLEAN_AFTER_BUILD = False
     RTD_BUILD_HEALTHCHECK_TIMEOUT = 60 # seconds
     RTD_BUILD_HEALTHCHECK_DELAY = 15 # seconds
-    # How long a build may sit dispatched to the isolated-builders fleet before
+    # How long a build may sit dispatched to the build-isolated fleet before
     # we consider it "lost" (no builder ever picked it up) and cancel it.
     RTD_BUILD_DISPATCH_TIMEOUT = 5 * 60  # seconds
     RTD_MAX_CONCURRENT_BUILDS = 4
@@ -628,14 +628,14 @@ class CommunityBaseSettings(Settings):
 
     BUILD_TIME_LIMIT = 900  # seconds
 
-    # Celery task name + queue for the isolated-builders worker.
+    # Celery task name + queue for the build-isolated worker.
     # Must match what the worker registers in
     # ``readthedocs-builder/worker/tasks.py`` (``@app.task(name=...)``)
     # and ``worker/celery.py`` (``task_default_queue``). We dispatch by
     # name (rather than importing the function) so this codebase doesn't
     # need the ``worker`` package installed.
-    RTD_ISOLATED_BUILDER_TASK_NAME = "worker.tasks.run_build"
-    RTD_ISOLATED_BUILDER_QUEUE = "isolated-builds"
+    RTD_BUILD_ISOLATED_TASK_NAME = "worker.tasks.run_build"
+    RTD_BUILD_ISOLATED_QUEUE = "build:isolated"
 
     @property
     def BUILD_MEMORY_LIMIT(self):

--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -17,7 +17,7 @@ class DockerBaseSettings(CommunityBaseSettings):
     RTD_DOCKER_USER = f"{os.geteuid()}:{os.getegid()}"
     BUILD_MEMORY_LIMIT = "2g"
 
-    # Personal access token used by the isolated-builder dev container's
+    # Personal access token used by the build-isolated dev container's
     # entrypoint to clone the readthedocs-builder repo when it's
     # private. Not strictly needed when the host's checkout is
     # bind-mounted into the dev container (the entrypoint skips the

--- a/readthedocs/upload/api/views.py
+++ b/readthedocs/upload/api/views.py
@@ -17,7 +17,7 @@ from readthedocs.builds.models import Build
 from readthedocs.builds.models import Version
 from readthedocs.core.permissions import AdminPermission
 from readthedocs.core.utils import prepare_build
-from readthedocs.core.utils import submit_to_isolated_builders
+from readthedocs.core.utils import submit_to_build_isolated
 from readthedocs.doc_builder.exceptions import BuildUserError
 from readthedocs.notifications.models import Notification
 from readthedocs.projects.models import Feature
@@ -223,7 +223,7 @@ class UploadCompleteView(APIv3Settings, APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        submit_to_isolated_builders(project=project, build=build)
+        submit_to_build_isolated(project=project, build=build)
 
         return Response(
             {"build": BuildSerializer(build).data},


### PR DESCRIPTION
This matches the convention we use for the other fleets and queues.