### PR TITLE
Docs: fix typos and grammar across user docs

### DIFF
--- a/docs/user/build-customization.rst
+++ b/docs/user/build-customization.rst
@@ -376,7 +376,7 @@ Install Node.js dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 It's possible to install Node.js together with the required dependencies by using :term:`user-defined build jobs`.
-To setup it, you need to define the version of Node.js to use and install the dependencies by using ``build.jobs.post_install``:
+To set it up, you need to define the version of Node.js to use and install the dependencies by using ``build.jobs.post_install``:
 
 .. code-block:: yaml
    :caption: .readthedocs.yaml

--- a/docs/user/custom-script.rst
+++ b/docs/user/custom-script.rst
@@ -55,7 +55,7 @@ then subscribe to the event for future updates (for example, when the URL change
     }
 
     // After that, we subscribe to the Read the Docs Addons event to access data
-    // on future dispatchs (e.g. when a URL changes on a SPA)
+    // on future dispatches (e.g. when a URL changes on a SPA)
     document.addEventListener("readthedocs-addons-data-ready", function (event) {
       handleReadTheDocsData(event.detail.data());
     });

--- a/docs/user/guides/build/email-notifications.rst
+++ b/docs/user/guides/build/email-notifications.rst
@@ -2,7 +2,7 @@ How to setup email notifications
 ================================
 
 In this brief guide,
-you can learn how to setup a simple build notification via email.
+you can learn how to set up a simple build notification via email.
 
 Read the Docs allows you to configure emails that will be notified on failing builds.
 This makes sure that you are aware of failures happening in an otherwise automated process.

--- a/docs/user/guides/custom-domains.rst
+++ b/docs/user/guides/custom-domains.rst
@@ -9,12 +9,12 @@ This guide describes how to host your documentation using your own domain name, 
 Adding a custom domain
 ----------------------
 
-To setup your :doc:`custom domain </custom-domains>`, follow these steps:
+To set up your :doc:`custom domain </custom-domains>`, follow these steps:
 
-#. Go the :guilabel:`Admin` tab of your project.
+#. Go to the :guilabel:`Admin` tab of your project.
 #. Click on :guilabel:`Domains`.
 #. Enter the domain where you want to serve the documentation from (e.g. ``docs.example.com``).
-#. Mark the :guilabel:`Canonical` option if you want use this domain
+#. Mark the :guilabel:`Canonical` option if you want to use this domain
    as your :doc:`canonical domain </canonical-urls>`.
 #. Click on :guilabel:`Add`.
 #. At the top of the next page you'll find the value of the DNS record that you need to point your domain to.
@@ -59,7 +59,7 @@ Removing a custom domain
 
 To remove a custom domain:
 
-#. Go the :guilabel:`Admin` tab of your project.
+#. Go to the :guilabel:`Admin` tab of your project.
 #. Click on :guilabel:`Domains`.
 #. Click the :guilabel:`Remove` button next to the domain.
 #. Click :guilabel:`Confirm` on the confirmation page.

--- a/docs/user/guides/manage-translations-sphinx.rst
+++ b/docs/user/guides/manage-translations-sphinx.rst
@@ -2,7 +2,7 @@ How to manage translations for Sphinx projects
 ==============================================
 
 This guide walks through the process needed to manage translations of your documentation.
-Once this work is done, you can setup your project under Read the Docs to build each language of your documentation by reading :doc:`/localization`.
+Once this work is done, you can set up your project under Read the Docs to build each language of your documentation by reading :doc:`/localization`.
 
 Overview
 --------

--- a/docs/user/pull-requests.rst
+++ b/docs/user/pull-requests.rst
@@ -36,7 +36,7 @@ Build overview with changed files
 
 Pull request notifications
     A pull request notification can be shown at the top of preview pages,
-    which let readers know they aren't viewing an active version of the project.
+    which lets readers know they aren't viewing an active version of the project.
     New projects have this notification disabled by default;
     enable it from :guilabel:`Settings` → :guilabel:`Addons` → :guilabel:`Notifications`.
 
@@ -58,11 +58,11 @@ anyone who can open a pull request on your repository will be able to trigger a 
 For this reason, pull request previews are served from a different domain than your main documentation
 (``org.readthedocs.build`` and ``com.readthedocs.build``).
 
-Builds from pull requests have access to environment variables that are marked as *Public* only,
-if you have environment variables with private information, make sure they aren't marked as *Public*.
+Builds from pull requests have access to environment variables that are marked as *Public* only.
+If you have environment variables with private information, make sure they aren't marked as *Public*.
 See :ref:`environment-variables:Environment variables and build process` for more information.
 
-On |com_brand| you can set pull request previews to be private or public,
+On |com_brand| you can set pull request previews to be private or public.
 If you didn't import your project manually and your repository is public,
 the privacy level of pull request previews will be set to *Public*.
 Public pull request previews are available to anyone with the link to the preview,

--- a/docs/user/reference/git-integration.rst
+++ b/docs/user/reference/git-integration.rst
@@ -396,7 +396,7 @@ which has read access to the `contents permission <https://docs.github.com/en/re
 and it's scoped to the repository to be cloned.
 
 This token is valid for one hour and GitHub automatically grants read access to the `metadata permission <https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-metadata>`__,
-which allows to query the repository collaborators, events, and other metadata.
+which allows querying the repository collaborators, events, and other metadata.
 By default, Read the Docs doesn't show this token during the build,
 but the token is available during the whole build process.
 Make sure to not print it in your build logs,

--- a/docs/user/versioning-schemes.rst
+++ b/docs/user/versioning-schemes.rst
@@ -72,7 +72,7 @@ Changing the versioning scheme of your project will affect the URLs of your docu
 any existing links to your documentation will break.
 If you want to keep the old URLs working, you can create :doc:`redirects </user-defined-redirects>`.
 
-#. Go the :guilabel:`Admin` tab of your project.
+#. Go to the :guilabel:`Admin` tab of your project.
 #. Click on :guilabel:`Settings`.
 #. Select the new versioning scheme in the :guilabel:`URL versioning scheme` dropdown.
 #. Click on :guilabel:`Save`.

--- a/docs/user/visual-diff.rst
+++ b/docs/user/visual-diff.rst
@@ -14,7 +14,7 @@ Show diff menu in preview
 
 To enable or disable this feature for your project:
 
-#. Go the :guilabel:`Settings` tab of your project.
+#. Go to the :guilabel:`Settings` tab of your project.
 #. Click on :guilabel:`Addons`, and click on :guilabel:`Visual diff`.
 #. Check or uncheck the :guilabel:`Enable visual diff` option.
 #. Click on :guilabel:`Save`.
@@ -28,7 +28,7 @@ You can select any of those files from the dropdown to jump directly into that p
 Once there, you can toggle Visual Diff on and off by pressing the :guilabel:`Show diff` link from the UI element, or pressing the ``d`` key if you have hotkeys enabled.
 
 Visual diff shows all the sections that have changed, highlighting their differences with red/green background colors.
-You can jump between each of these chunks by clinking on the up/down arrows.
+You can jump between each of these chunks by clicking on the up/down arrows.
 
 Show build overview in pull requests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -39,7 +39,7 @@ Show build overview in pull requests
 
 To enable or disable this feature for your project:
 
-#. Go the :guilabel:`Settings` tab of your project.
+#. Go to the :guilabel:`Settings` tab of your project.
 #. Click on :guilabel:`Pull request builds`.
 #. Check or uncheck the :guilabel:`Show build overview in a comment` option.
 #. Click on :guilabel:`Update`.
@@ -58,7 +58,7 @@ You can configure a list of files or patterns to be ignored when listing the fil
 This is useful when you have files that have a date in them,
 or listing/archive files that show changes without content changes in those files.
 
-#. Go the :guilabel:`Settings` tab of your project.
+#. Go to the :guilabel:`Settings` tab of your project.
 #. Click on :guilabel:`Addons`, and click on :guilabel:`File tree diff`.
 #. In the :guilabel:`Ignored files` field, add one or more patterns to ignore, one per line.
 #. Click on :guilabel:`Save`.
@@ -76,7 +76,7 @@ Base version
 
 The base version is the version of the documentation that is used to compare against the pull request.
 By default, this is the ``latest`` version of the documentation.
-This is useful if your ``latest`` version doesn't point the default branch of your repository.
+This is useful if your ``latest`` version doesn't point to the default branch of your repository.
 
 .. note::
 
@@ -113,7 +113,7 @@ Limitations and known issues
   A snapshot of the base version's manifest is saved on the first successful build of the pull request, so the diff stays stable as the base branch moves forward.
   If the pull request is later updated against a newer base, the snapshot is not currently refreshed automatically, and the diff may show stale differences until this is addressed in a future update.
 - Invisible changes. Some sections may be highlighted as changed, even when they haven't actually visually changed.
-  This can happen when the underlying HTML changes without a corresponding visual change, for example, if a link's URL is updated
+  This can happen when the underlying HTML changes without a corresponding visual change, for example, if a link's URL is updated.
 - Tables may be shown to have changes when they have not actually changed.
   This is due to subtle variations in how HTML tables are rendered, and will be fixed in a future version.
 - The background of diff chunks may be incorrect when we are unable to detect the correct main parent element for the chunk.


### PR DESCRIPTION
Small copy fixes across the user docs, found while looking for demo material: a couple of typos ("clinking", "dispatchs"), the recurring "Go the :guilabel:..." step wording, "setup" used as a verb, a missing "to" in a few places, and some comma splices that made sentences read awkwardly.

Page titles that use "setup" were left alone on purpose, since changing a title changes its autosectionlabel target and could break existing `:ref:` links.

---
*This pull request was generated by an AI agent.*