### PR TITLE
Builds: don't delete uploaded versions when syncing the repository

### DIFF
--- a/readthedocs/api/v2/utils.py
+++ b/readthedocs/api/v2/utils.py
@@ -176,7 +176,12 @@ def _get_deleted_versions_qs(project, tags_data, branches_data):
 
     to_delete_qs = (
         project.versions(manager=INTERNAL)
+        # `uploaded` is the legacy flag for versions uploaded manually by the
+        # core team, `is_uploaded` marks versions created via the upload API.
+        # Neither exists in the repository, so they should never be
+        # considered deleted from it.
         .exclude(uploaded=True)
+        .exclude(is_uploaded=True)
         .exclude(slug__in=NON_REPOSITORY_VERSIONS)
     )
 

--- a/readthedocs/api/v2/utils.py
+++ b/readthedocs/api/v2/utils.py
@@ -176,12 +176,7 @@ def _get_deleted_versions_qs(project, tags_data, branches_data):
 
     to_delete_qs = (
         project.versions(manager=INTERNAL)
-        # `uploaded` is the legacy flag for versions uploaded manually by the
-        # core team, `is_uploaded` marks versions created via the upload API.
-        # Neither exists in the repository, so they should never be
-        # considered deleted from it.
         .exclude(uploaded=True)
-        .exclude(is_uploaded=True)
         .exclude(slug__in=NON_REPOSITORY_VERSIONS)
     )
 
@@ -225,11 +220,17 @@ def delete_versions_from_db(project, tags_data, branches_data):
 
 def get_deleted_active_versions(project, tags_data, branches_data):
     """Return the slug of active versions that were deleted from the repository."""
-    to_delete_qs = _get_deleted_versions_qs(
-        project=project,
-        tags_data=tags_data,
-        branches_data=branches_data,
-    ).filter(active=True)
+    to_delete_qs = (
+        _get_deleted_versions_qs(
+            project=project,
+            tags_data=tags_data,
+            branches_data=branches_data,
+        )
+        # Uploaded versions may not exist in the repository on purpose,
+        # so their absence isn't a signal for "version deleted" automation rules.
+        .exclude(is_uploaded=True)
+        .filter(active=True)
+    )
     return set(to_delete_qs.values_list("slug", flat=True))
 
 

--- a/readthedocs/rtd_tests/tests/test_sync_versions.py
+++ b/readthedocs/rtd_tests/tests/test_sync_versions.py
@@ -218,15 +218,42 @@ class TestSyncVersions(TestCase):
             Version.objects.filter(slug="external").exists(),
         )
 
-    def test_uploaded_versions_are_not_deleted(self):
+    def test_active_uploaded_versions_are_not_reported_as_deleted(self):
         Version.objects.create(
             project=self.pip,
-            identifier="upload-active",
-            verbose_name="upload-active",
+            identifier="upload-test",
+            verbose_name="upload-test",
             type=BRANCH,
             active=True,
             is_uploaded=True,
         )
+
+        branches_data = [
+            {
+                "identifier": "origin/master",
+                "verbose_name": "master",
+            },
+        ]
+
+        sync_versions_task(
+            self.pip.pk,
+            branches_data=branches_data,
+            tags_data=[],
+        )
+
+        # The version survives the sync.
+        self.assertTrue(Version.objects.filter(slug="upload-test").exists())
+
+        # Uploaded versions may not exist in the repository on purpose,
+        # so they aren't reported as deleted to "version deleted" automation rules.
+        deleted_active_versions = get_deleted_active_versions(
+            self.pip,
+            branches_data=branches_data,
+            tags_data=[],
+        )
+        assert "upload-test" not in deleted_active_versions
+
+    def test_inactive_uploaded_versions_are_deleted(self):
         Version.objects.create(
             project=self.pip,
             identifier="upload-inactive",
@@ -249,20 +276,8 @@ class TestSyncVersions(TestCase):
             tags_data=[],
         )
 
-        # Uploaded versions don't exist in the repository,
-        # so they must survive a versions sync.
-        self.assertTrue(Version.objects.filter(slug="upload-active").exists())
-        self.assertTrue(Version.objects.filter(slug="upload-inactive").exists())
-
-        # They aren't reported as deleted either,
-        # so "version deleted" automation rules don't delete them.
-        deleted_active_versions = get_deleted_active_versions(
-            self.pip,
-            branches_data=branches_data,
-            tags_data=[],
-        )
-        assert "upload-active" not in deleted_active_versions
-        assert "upload-inactive" not in deleted_active_versions
+        # Inactive uploaded versions are cleaned up like any other version.
+        self.assertFalse(Version.objects.filter(slug="upload-inactive").exists())
 
     def test_update_stable_version_type(self):
         self.pip.update_stable_version()

--- a/readthedocs/rtd_tests/tests/test_sync_versions.py
+++ b/readthedocs/rtd_tests/tests/test_sync_versions.py
@@ -9,6 +9,7 @@ from readthedocs.builds.constants import BRANCH, EXTERNAL, LATEST, STABLE, TAG
 from readthedocs.builds.models import (
     Version,
 )
+from readthedocs.api.v2.utils import get_deleted_active_versions
 from readthedocs.builds.tasks import sync_versions_task
 from readthedocs.organizations.models import Organization, OrganizationOwner
 from readthedocs.projects.models import Project
@@ -216,6 +217,52 @@ class TestSyncVersions(TestCase):
         self.assertTrue(
             Version.objects.filter(slug="external").exists(),
         )
+
+    def test_uploaded_versions_are_not_deleted(self):
+        Version.objects.create(
+            project=self.pip,
+            identifier="upload-active",
+            verbose_name="upload-active",
+            type=BRANCH,
+            active=True,
+            is_uploaded=True,
+        )
+        Version.objects.create(
+            project=self.pip,
+            identifier="upload-inactive",
+            verbose_name="upload-inactive",
+            type=BRANCH,
+            active=False,
+            is_uploaded=True,
+        )
+
+        branches_data = [
+            {
+                "identifier": "origin/master",
+                "verbose_name": "master",
+            },
+        ]
+
+        sync_versions_task(
+            self.pip.pk,
+            branches_data=branches_data,
+            tags_data=[],
+        )
+
+        # Uploaded versions don't exist in the repository,
+        # so they must survive a versions sync.
+        self.assertTrue(Version.objects.filter(slug="upload-active").exists())
+        self.assertTrue(Version.objects.filter(slug="upload-inactive").exists())
+
+        # They aren't reported as deleted either,
+        # so "version deleted" automation rules don't delete them.
+        deleted_active_versions = get_deleted_active_versions(
+            self.pip,
+            branches_data=branches_data,
+            tags_data=[],
+        )
+        assert "upload-active" not in deleted_active_versions
+        assert "upload-inactive" not in deleted_active_versions
 
     def test_update_stable_version_type(self):
         self.pip.update_stable_version()


### PR DESCRIPTION
Versions created with the upload API don't exist as branches or tags in the repository, so a versions sync after a regular git build reports them to "version deleted" automation rules, which could delete them. This is what deleted `upload-test` on the `test-builds` project — its "Delete version" rule matched it, orphaning the uploaded builds by setting their version to `NULL`.

Per the discussion, this is the simplest possible fix: the sync logic is untouched, and only the delete version automation action skips uploaded versions, since they may not exist in the repository on purpose. All other automation rules keep running on uploaded versions, and the sync still cleans up inactive uploaded versions like any other version. The broader questions (whether automation rules should apply to uploaded versions at all, and how uploaded versions should be deleted, given deactivate-then-sync is currently the only deletion path) are left for follow-up discussion.

One known gap to double-check: `Version.is_uploaded` is only set after the first successful upload build is processed; the upload API creates the version with it unset. Until a version's first upload completes, this fix doesn't protect it from the automation rule. Setting `is_uploaded=True` in `_get_or_create_version()` would close that window, but it interacts with the deferred hybrid-workflow questions, so it's left out here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5iydCMwrK7N8HZjgPRdXG