### PR TITLE
Dev settings: read RTD_OPENAI_API_KEY from the environment

### DIFF
--- a/readthedocs/settings/docker_compose.py
+++ b/readthedocs/settings/docker_compose.py
@@ -61,6 +61,10 @@ class DockerBaseSettings(CommunityBaseSettings):
     ADSERVER_API_KEY = None
     ADSERVER_API_TIMEOUT = 2  # seconds - Docker for Mac is very slow
 
+    # OpenAI-backed spam rules (readthedocsext.spamfighting) read the key
+    # from settings only; docker-compose passes this variable through.
+    RTD_OPENAI_API_KEY = os.environ.get("RTD_OPENAI_API_KEY")
+
     @property
     def DOCROOT(self):
         # Add an extra directory level using the container's hostname.


### PR DESCRIPTION
Companion to readthedocs/readthedocs-ext#629, which makes the OpenAI spam rules read their key from Django settings only (dropping the old `os.environ` read inside the rule code).

Production already defines `RTD_OPENAI_API_KEY` in the ops settings. Local development did not: `common/dockerfiles/docker-compose.yml` passes the variable into the containers, but the rule code was the only thing that read it, so after #629 the OpenAI rules would silently skip in dev with a "No OpenAI API key configured" warning. This turns the variable into a setting the same way the other `RTD_*` dev knobs are handled.

Safe to merge in either order relative to #629: today's rule code checks settings before falling back to the environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
