### PR TITLE
Builds: run `sync_versions` in the build-isolated fleet

### DIFF
--- a/readthedocs/core/tests/test_trigger_sync_versions.py
+++ b/readthedocs/core/tests/test_trigger_sync_versions.py
@@ -1,0 +1,84 @@
+from unittest import mock
+
+import django_dynamic_fixture as fixture
+from django.core.cache import cache
+from django.test import TestCase
+from django.test import override_settings
+
+from readthedocs.builds.constants import LATEST
+from readthedocs.builds.models import Version
+from readthedocs.core.views.hooks import trigger_sync_versions
+from readthedocs.projects.models import Feature
+from readthedocs.projects.models import Project
+
+
+@mock.patch("readthedocs.core.views.hooks.app")
+@mock.patch("readthedocs.core.views.hooks.sync_repository_task")
+class TestTriggerSyncVersions(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.project = fixture.get(
+            Project,
+            slug="pip",
+            repo="https://github.com/readthedocs/pip",
+        )
+        self.version = self.project.versions.get(slug=LATEST)
+
+    def _enable_build_isolated(self, *projects):
+        # ``feature_id`` is unique, so a second project joins the same Feature.
+        feature, _ = Feature.objects.get_or_create(feature_id=Feature.USE_BUILD_ISOLATED)
+        feature.projects.add(*(projects or [self.project]))
+
+    def test_legacy_projects_use_the_celery_task(self, sync_repository_task, app):
+        assert trigger_sync_versions(self.project) == self.version.slug
+
+        sync_repository_task.apply_async.assert_called_once()
+        app.send_task.assert_not_called()
+
+    @override_settings(RTD_SYNC_REPOSITORY_ISOLATED_TASK_NAME="worker.tasks.sync_repository")
+    def test_isolated_projects_dispatch_to_the_worker(self, sync_repository_task, app):
+        self._enable_build_isolated()
+
+        assert trigger_sync_versions(self.project) == self.version.slug
+
+        sync_repository_task.apply_async.assert_not_called()
+        args, kwargs = app.send_task.call_args
+        assert args[0] == "worker.tasks.sync_repository"
+        assert kwargs["queue"] == "build:isolated"
+        assert kwargs["kwargs"]["project_pk"] == self.project.pk
+        assert kwargs["kwargs"]["build_api_key"]
+        assert kwargs["kwargs"]["environment"]["RTD_PRODUCTION_DOMAIN"]
+
+    def test_a_burst_dispatches_a_single_sync(self, sync_repository_task, app):
+        # A tag push sends one webhook per ref; they all ask for the same sync.
+        self._enable_build_isolated()
+
+        slugs = [trigger_sync_versions(self.project) for _ in range(5)]
+
+        assert slugs == [self.version.slug] * 5
+        assert app.send_task.call_count == 1
+
+    def test_the_debounce_is_per_project(self, sync_repository_task, app):
+        self._enable_build_isolated()
+        other = fixture.get(Project, slug="other", repo="https://github.com/readthedocs/other")
+        self._enable_build_isolated(other)
+
+        trigger_sync_versions(self.project)
+        trigger_sync_versions(other)
+
+        assert app.send_task.call_count == 2
+
+    def test_skip_sync_versions_is_honored(self, sync_repository_task, app):
+        self._enable_build_isolated()
+        skip, _ = Feature.objects.get_or_create(feature_id=Feature.SKIP_SYNC_VERSIONS)
+        skip.projects.add(self.project)
+
+        assert trigger_sync_versions(self.project) is None
+        app.send_task.assert_not_called()
+
+    def test_a_project_without_a_latest_version_is_skipped(self, sync_repository_task, app):
+        self._enable_build_isolated()
+        Version.objects.filter(project=self.project).delete()
+
+        assert trigger_sync_versions(self.project) is None
+        app.send_task.assert_not_called()

--- a/readthedocs/core/utils/__init__.py
+++ b/readthedocs/core/utils/__init__.py
@@ -263,6 +263,29 @@ def trigger_build(project, version=None, commit=None, from_webhook=False):
     return task, build
 
 
+def build_isolated_environment():
+    """Environment passed to every task we dispatch to the build-isolated fleet."""
+    environment = {
+        "RTD_API_URL": getattr(settings, "RTD_API_URL", settings.PUBLIC_API_URL),
+        "RTD_PRODUCTION_DOMAIN": settings.PRODUCTION_DOMAIN,
+        "RTD_HEALTHCHECK_API_HOST": settings.SLUMBER_API_HOST,
+        "RTD_ALLOW_PRIVATE_REPOS": str(settings.ALLOW_PRIVATE_REPOS),
+    }
+    if settings.RTD_DOCKER_COMPOSE:
+        # Local dev: rustfs endpoint for storage boto3 calls, and an
+        # API-via-nginx override so the build container can reach us on the
+        # compose network. The build user defaults to ``docs`` (like
+        # production) — the isolated builder has no bind-mounted docroot, so
+        # there's no host-uid mismatch to work around.
+        environment["AWS_S3_ENDPOINT_URL"] = settings.AWS_S3_ENDPOINT_URL or ""
+        # Tells the builder it's running under docker-compose
+        environment["RTD_DOCKER_COMPOSE"] = "1"
+        # TODO: update ``RTD_API_URL`` in ``docker_compose.py`` once we
+        # are fully migrated and remove this override here.
+        environment["RTD_API_URL"] = "http://nginx"
+    return environment
+
+
 def submit_to_build_isolated(*, project, build):
     """
     Dispatch a build directly to the ``build:isolated`` Celery queue.
@@ -286,24 +309,7 @@ def submit_to_build_isolated(*, project, build):
     # not the project.
     _, build_api_key = BuildAPIKey.objects.create_key(project=project)
 
-    environment = {
-        "RTD_API_URL": getattr(settings, "RTD_API_URL", settings.PUBLIC_API_URL),
-        "RTD_PRODUCTION_DOMAIN": settings.PRODUCTION_DOMAIN,
-        "RTD_HEALTHCHECK_API_HOST": settings.SLUMBER_API_HOST,
-        "RTD_ALLOW_PRIVATE_REPOS": str(settings.ALLOW_PRIVATE_REPOS),
-    }
-    if settings.RTD_DOCKER_COMPOSE:
-        # Local dev: rustfs endpoint for storage boto3 calls, and an
-        # API-via-nginx override so the build container can reach us on the
-        # compose network. The build user defaults to ``docs`` (like
-        # production) — the isolated builder has no bind-mounted docroot, so
-        # there's no host-uid mismatch to work around.
-        environment["AWS_S3_ENDPOINT_URL"] = settings.AWS_S3_ENDPOINT_URL or ""
-        # Tells the builder it's running under docker-compose
-        environment["RTD_DOCKER_COMPOSE"] = "1"
-        # TODO: update ``RTD_API_URL`` in ``docker_compose.py`` once we
-        # are fully migrated and remove this override here.
-        environment["RTD_API_URL"] = "http://nginx"
+    environment = build_isolated_environment()
 
     # Debug knob: ``KEEP_BUILD_ISOLATED_INSTANCE`` feature flag asks
     # the worker to skip its post-build self-terminate so the EC2 host

--- a/readthedocs/core/views/hooks.py
+++ b/readthedocs/core/views/hooks.py
@@ -4,15 +4,19 @@ from dataclasses import dataclass
 from typing import Literal
 
 import structlog
+from django.conf import settings
+from django.core.cache import cache
 
 from readthedocs.api.v2.models import BuildAPIKey
 from readthedocs.builds.constants import EXTERNAL
 from readthedocs.builds.constants import EXTERNAL_VERSION_STATE_CLOSED
 from readthedocs.builds.constants import EXTERNAL_VERSION_STATE_OPEN
+from readthedocs.core.utils import build_isolated_environment
 from readthedocs.core.utils import trigger_build
 from readthedocs.projects.models import Feature
 from readthedocs.projects.models import Project
 from readthedocs.projects.tasks.builds import sync_repository_task
+from readthedocs.worker import app
 
 
 @dataclass
@@ -67,6 +71,9 @@ def trigger_sync_versions(project):
     Due that `sync_repository_task` is bound to a version,
     we always pass the default version.
 
+    Projects on ``build-isolated`` are dispatched to the worker's
+    ``sync_repository`` task instead, which is bound to the project.
+
     :returns: The version slug that was used to trigger the clone.
     :rtype: str or ``None`` if failed
     """
@@ -88,13 +95,17 @@ def trigger_sync_versions(project):
             log.info("Skipping sync versions for project.", project_slug=project.slug)
             return None
 
-        _, build_api_key = BuildAPIKey.objects.create_key(project=project)
-
         log.debug(
             "Triggering sync repository.",
             project_slug=version.project.slug,
             version_slug=version.slug,
         )
+
+        if project.has_feature(Feature.USE_BUILD_ISOLATED):
+            _trigger_sync_versions_isolated(project)
+            return version.slug
+
+        _, build_api_key = BuildAPIKey.objects.create_key(project=project)
 
         options = {}
         # Use custom queue if defined, as some repositories need to
@@ -111,6 +122,27 @@ def trigger_sync_versions(project):
     except Exception:
         log.exception("Unknown sync versions exception")
     return None
+
+
+def _trigger_sync_versions_isolated(project):
+    """Dispatch the version sync to the build-isolated fleet."""
+    cache_key = f"rtd-sync-repository-isolated:{project.slug}"
+    if not cache.add(cache_key, True, 60):
+        # A sync for this project was dispatched moments ago so
+        # we skip dispatching another one.
+        log.info("Skipping sync, one was dispatched recently.")
+        return
+
+    _, build_api_key = BuildAPIKey.objects.create_key(project=project)
+    app.send_task(
+        settings.RTD_SYNC_REPOSITORY_ISOLATED_TASK_NAME,
+        kwargs={
+            "project_pk": project.pk,
+            "build_api_key": build_api_key,
+            "environment": build_isolated_environment(),
+        },
+        queue=settings.RTD_BUILD_ISOLATED_QUEUE,
+    )
 
 
 def get_or_create_external_version(project, version_data):

--- a/readthedocs/settings/base.py
+++ b/readthedocs/settings/base.py
@@ -635,6 +635,7 @@ class CommunityBaseSettings(Settings):
     # name (rather than importing the function) so this codebase doesn't
     # need the ``worker`` package installed.
     RTD_BUILD_ISOLATED_TASK_NAME = "worker.tasks.run_build"
+    RTD_SYNC_REPOSITORY_ISOLATED_TASK_NAME = "worker.tasks.sync_repository"
     RTD_BUILD_ISOLATED_QUEUE = "build:isolated"
 
     @property


### PR DESCRIPTION
We need to run `sync_versions` to sync branches/tags when a webhook is received. This task is received by build-isolated workers and don't self terminate them after running this small task.

- Context: https://readthedocs.slack.com/archives/C02DNG2HSNP/p1787830378450309
- Requires: https://github.com/readthedocs/readthedocs-builder/pull/14