### PR TITLE
Builds: purge the CDN as soon as a build finishes

### DIFF
--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -786,6 +786,7 @@ def run_post_build_tasks(build_pk):
     # Avoid circular imports: readthedocs.projects.tasks imports from this module.
     from readthedocs.doc_builder.exceptions import BuildCancelled
     from readthedocs.projects.tasks.search import index_build
+    from readthedocs.projects.tasks.utils import purge_docs_cdn
     from readthedocs.projects.tasks.utils import send_external_build_status
 
     build = Build.objects.filter(pk=build_pk).select_related("project", "version").first()
@@ -804,6 +805,12 @@ def run_post_build_tasks(build_pk):
             version = build.version
             version.is_uploaded = True
             version.save(update_fields=["is_uploaded"])
+
+        # Purge the CDN now that the new files are in storage, without
+        # waiting for ``index_build``, which may lag behind on the
+        # ``reindex`` queue.
+        if build.version:
+            purge_docs_cdn.delay(version_id=build.version_id)
 
         index_build.delay(build_id=build.pk)
 

--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -806,9 +806,7 @@ def run_post_build_tasks(build_pk):
             version.is_uploaded = True
             version.save(update_fields=["is_uploaded"])
 
-        # Purge the CDN now that the new files are in storage, without
-        # waiting for ``index_build``, which may lag behind on the
-        # ``reindex`` queue.
+        # Purge the CDN now that the new files are in storage.
         if build.version:
             purge_docs_cdn.delay(version_id=build.version_id)
 

--- a/readthedocs/builds/tasks.py
+++ b/readthedocs/builds/tasks.py
@@ -806,10 +806,7 @@ def run_post_build_tasks(build_pk):
             version.is_uploaded = True
             version.save(update_fields=["is_uploaded"])
 
-        # Purge the CDN now that the new files are in storage.
-        if build.version:
-            purge_docs_cdn.delay(version_id=build.version_id)
-
+        purge_docs_cdn.delay(version_id=build.version_id)
         index_build.delay(build_id=build.pk)
 
         if "readthedocsext.spamfighting" in settings.INSTALLED_APPS:

--- a/readthedocs/builds/tests/test_tasks.py
+++ b/readthedocs/builds/tests/test_tasks.py
@@ -26,6 +26,7 @@ from readthedocs.builds.tasks import (
     delete_old_build_objects,
     post_build_overview,
     remove_orphan_build_config,
+    run_post_build_tasks,
 )
 from readthedocs.filetreediff.dataclasses import FileTreeDiff, FileTreeDiffFileStatus
 from readthedocs.notifications.models import Notification
@@ -688,3 +689,33 @@ class TestPostBuildOverview(TestCase):
         assert self.current_version.is_external
         post_build_overview(build_pk=self.current_version_build.pk)
         post_comment.assert_not_called()
+
+
+class TestRunPostBuildTasks(TestCase):
+    def setUp(self):
+        self.project = get(Project)
+        self.version = get(Version, project=self.project)
+
+    @mock.patch("readthedocs.builds.tasks.send_build_notifications")
+    @mock.patch("readthedocs.projects.tasks.utils.purge_docs_cdn")
+    @mock.patch("readthedocs.projects.tasks.search.index_build")
+    def test_successful_build_purges_cdn(self, index_build, purge_docs_cdn, send_build_notifications):
+        build = get(Build, project=self.project, version=self.version, success=True)
+
+        run_post_build_tasks(build_pk=build.pk)
+
+        # The CDN is purged as soon as the build finishes,
+        # without waiting for search indexing.
+        purge_docs_cdn.delay.assert_called_once_with(version_id=self.version.pk)
+        index_build.delay.assert_called_once_with(build_id=build.pk)
+
+    @mock.patch("readthedocs.builds.tasks.send_build_notifications")
+    @mock.patch("readthedocs.projects.tasks.utils.purge_docs_cdn")
+    @mock.patch("readthedocs.projects.tasks.search.index_build")
+    def test_failed_build_does_not_purge_cdn(self, index_build, purge_docs_cdn, send_build_notifications):
+        build = get(Build, project=self.project, version=self.version, success=False)
+
+        run_post_build_tasks(build_pk=build.pk)
+
+        purge_docs_cdn.delay.assert_not_called()
+        index_build.delay.assert_not_called()

--- a/readthedocs/builds/tests/test_tasks.py
+++ b/readthedocs/builds/tests/test_tasks.py
@@ -704,8 +704,6 @@ class TestRunPostBuildTasks(TestCase):
 
         run_post_build_tasks(build_pk=build.pk)
 
-        # The CDN is purged as soon as the build finishes,
-        # without waiting for search indexing.
         purge_docs_cdn.delay.assert_called_once_with(version_id=self.version.pk)
         index_build.delay.assert_called_once_with(build_id=build.pk)
 

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -689,9 +689,7 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
                     'Files are synced in the storage, but "Version" object is not updated',
                 )
 
-        # Purge the CDN now that the new files are in storage, without
-        # waiting for ``index_build``, which may lag behind on the
-        # ``reindex`` queue.
+        # Purge the CDN now that the new files are in storage.
         purge_docs_cdn.delay(version_id=self.data.version.pk)
 
         # Index search data

--- a/readthedocs/projects/tasks/builds.py
+++ b/readthedocs/projects/tasks/builds.py
@@ -71,6 +71,7 @@ from .mixins import SyncRepositoryMixin
 from .search import index_build
 from .utils import BuildRequest
 from .utils import clean_build
+from .utils import purge_docs_cdn
 from .utils import send_external_build_status
 from .utils import set_builder_scale_in_protection
 from .utils import stop_consuming_tasks_and_terminate
@@ -687,6 +688,11 @@ class UpdateDocsTask(SyncRepositoryMixin, Task):
                     "Updating version db object failed. "
                     'Files are synced in the storage, but "Version" object is not updated',
                 )
+
+        # Purge the CDN now that the new files are in storage, without
+        # waiting for ``index_build``, which may lag behind on the
+        # ``reindex`` queue.
+        purge_docs_cdn.delay(version_id=self.data.version.pk)
 
         # Index search data
         index_build.delay(build_id=self.data.build_pk)

--- a/readthedocs/projects/tasks/search.py
+++ b/readthedocs/projects/tasks/search.py
@@ -17,6 +17,7 @@ from readthedocs.projects.constants import MEDIA_TYPE_HTML
 from readthedocs.projects.models import HTMLFile
 from readthedocs.projects.models import Project
 from readthedocs.search.documents import PageDocument
+from readthedocs.search.signals import search_index_updated
 from readthedocs.search.utils import index_objects
 from readthedocs.search.utils import remove_indexed_files
 from readthedocs.storage import build_media_storage
@@ -101,6 +102,16 @@ class SearchIndexer(Indexer):
             sync_id=sync_id,
             index_name=self.search_index_name,
         )
+
+        # When indexing into an index that isn't the default (e.g. while
+        # re-creating the index from scratch), live search results haven't
+        # changed, so there is nothing to purge from the CDN.
+        if not self.search_index_name:
+            search_index_updated.send(
+                sender=Project,
+                project=self.project,
+                version=self.version,
+            )
 
 
 class IndexFileIndexer(Indexer):

--- a/readthedocs/projects/tasks/search.py
+++ b/readthedocs/projects/tasks/search.py
@@ -305,6 +305,10 @@ def _process_files(*, version: Version, indexers: list[Indexer]):
             )
 
     # This signal is used for purging the CDN.
+    # The CDN is also purged as soon as a build finishes (``purge_docs_cdn``);
+    # this second purge flushes any response cached while the DB records
+    # created above were still out of date (e.g. custom 404 pages and
+    # directory index redirects).
     files_changed.send(
         sender=Project,
         project=version.project,

--- a/readthedocs/projects/tasks/search.py
+++ b/readthedocs/projects/tasks/search.py
@@ -16,7 +16,6 @@ from readthedocs.filetreediff.dataclasses import FileTreeDiffManifestFile
 from readthedocs.projects.constants import MEDIA_TYPE_HTML
 from readthedocs.projects.models import HTMLFile
 from readthedocs.projects.models import Project
-from readthedocs.projects.signals import files_changed
 from readthedocs.search.documents import PageDocument
 from readthedocs.search.utils import index_objects
 from readthedocs.search.utils import remove_indexed_files
@@ -304,16 +303,6 @@ def _process_files(*, version: Version, indexers: list[Indexer]):
                 version_slug=version.slug,
             )
 
-    # This signal is used for purging the CDN.
-    # The CDN is also purged as soon as a build finishes (``purge_docs_cdn``);
-    # this second purge flushes any response cached while the DB records
-    # created above were still out of date (e.g. custom 404 pages and
-    # directory index redirects).
-    files_changed.send(
-        sender=Project,
-        project=version.project,
-        version=version,
-    )
     return sync_id
 
 

--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -176,6 +176,9 @@ def purge_docs_cdn(version_id):
     see the new docs right away, without waiting for search indexing
     (``index_build``), which runs on the ``reindex`` queue,
     where a backlog can delay it long after the build has finished.
+
+    Not to be confused with ``Version.purge_cdn``,
+    which signals version *metadata* changes (``version_changed``).
     """
     version = Version.objects.filter(pk=version_id).select_related("project").first()
     if not version:

--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -16,9 +16,12 @@ from readthedocs.builds.constants import BUILD_FINAL_STATES
 from readthedocs.builds.constants import BUILD_STATE_TRIGGERED
 from readthedocs.builds.constants import EXTERNAL
 from readthedocs.builds.models import Build
+from readthedocs.builds.models import Version
 from readthedocs.builds.tasks import finish_inactive_build
 from readthedocs.builds.tasks import send_build_status
 from readthedocs.core.utils.filesystem import safe_rmtree
+from readthedocs.projects.models import Project
+from readthedocs.projects.signals import files_changed
 from readthedocs.storage import build_media_storage
 from readthedocs.worker import app
 
@@ -162,6 +165,28 @@ def finish_unhealthy_builds():
             project_slugs=projects_finished,
             build_pks=builds_finished,
         )
+
+
+@app.task(queue="web")
+def purge_docs_cdn(version_id):
+    """
+    Purge the docs of the given version from the CDN.
+
+    Triggered as soon as a build finishes uploading its artifacts, so users
+    see the new docs right away. ``index_build`` purges the CDN again after
+    indexing, but it runs on the ``reindex`` queue, where a backlog can
+    delay the purge long after the build has finished.
+    """
+    version = Version.objects.filter(pk=version_id).select_related("project").first()
+    if not version:
+        log.debug("Skipping CDN purge. Version doesn't exist.", version_id=version_id)
+        return
+
+    files_changed.send(
+        sender=Project,
+        project=version.project,
+        version=version,
+    )
 
 
 def send_external_build_status(version_type, build_pk, commit, status):

--- a/readthedocs/projects/tasks/utils.py
+++ b/readthedocs/projects/tasks/utils.py
@@ -173,9 +173,9 @@ def purge_docs_cdn(version_id):
     Purge the docs of the given version from the CDN.
 
     Triggered as soon as a build finishes uploading its artifacts, so users
-    see the new docs right away. ``index_build`` purges the CDN again after
-    indexing, but it runs on the ``reindex`` queue, where a backlog can
-    delay the purge long after the build has finished.
+    see the new docs right away, without waiting for search indexing
+    (``index_build``), which runs on the ``reindex`` queue,
+    where a backlog can delay it long after the build has finished.
     """
     version = Version.objects.filter(pk=version_id).select_related("project").first()
     if not version:

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -574,8 +574,6 @@ class TestBuildTask(BuildEnvironmentBase):
 
         index_build.delay.assert_called_once_with(build_id=self.build.pk)
 
-        # The CDN is purged as soon as the build finishes,
-        # without waiting for search indexing.
         purge_docs_cdn.delay.assert_called_once_with(version_id=self.version.pk)
 
         # TODO: assert the verb and the path for each API call as well

--- a/readthedocs/projects/tests/test_build_tasks.py
+++ b/readthedocs/projects/tests/test_build_tasks.py
@@ -468,6 +468,7 @@ class TestBuildTask(BuildEnvironmentBase):
         S3_MEDIA_STORAGE_BUCKET="readthedocs-test",
     )
     @mock.patch("readthedocs.projects.tasks.builds.shutil")
+    @mock.patch("readthedocs.projects.tasks.builds.purge_docs_cdn")
     @mock.patch("readthedocs.projects.tasks.builds.index_build")
     @mock.patch("readthedocs.projects.tasks.builds.send_external_build_status")
     @mock.patch("readthedocs.projects.tasks.builds.UpdateDocsTask.send_notifications")
@@ -480,6 +481,7 @@ class TestBuildTask(BuildEnvironmentBase):
         send_notifications,
         send_external_build_status,
         index_build,
+        purge_docs_cdn,
         shutilmock,
     ):
         load_yaml_config.return_value = get_build_config(
@@ -571,6 +573,10 @@ class TestBuildTask(BuildEnvironmentBase):
         )
 
         index_build.delay.assert_called_once_with(build_id=self.build.pk)
+
+        # The CDN is purged as soon as the build finishes,
+        # without waiting for search indexing.
+        purge_docs_cdn.delay.assert_called_once_with(version_id=self.version.pk)
 
         # TODO: assert the verb and the path for each API call as well
 

--- a/readthedocs/rtd_tests/tests/test_projects_tasks.py
+++ b/readthedocs/rtd_tests/tests/test_projects_tasks.py
@@ -60,6 +60,7 @@ class SendBuildStatusTests(TestCase):
 
         send_build_status.delay.assert_not_called()
 
+
 class PurgeDocsCDNTests(TestCase):
     def setUp(self):
         self.project = get(Project)

--- a/readthedocs/rtd_tests/tests/test_projects_tasks.py
+++ b/readthedocs/rtd_tests/tests/test_projects_tasks.py
@@ -15,7 +15,11 @@ from readthedocs.builds.constants import (
 )
 from readthedocs.builds.models import Build, Version
 from readthedocs.projects.models import Feature, Project
-from readthedocs.projects.tasks.utils import finish_unhealthy_builds, send_external_build_status
+from readthedocs.projects.tasks.utils import (
+    finish_unhealthy_builds,
+    purge_docs_cdn,
+    send_external_build_status,
+)
 
 
 class SendBuildStatusTests(TestCase):
@@ -55,6 +59,28 @@ class SendBuildStatusTests(TestCase):
         )
 
         send_build_status.delay.assert_not_called()
+
+class PurgeDocsCDNTests(TestCase):
+    def setUp(self):
+        self.project = get(Project)
+        self.version = get(Version, project=self.project)
+
+    @patch("readthedocs.projects.tasks.utils.files_changed")
+    def test_purge_docs_cdn_sends_files_changed(self, files_changed):
+        purge_docs_cdn(self.version.pk)
+
+        files_changed.send.assert_called_once_with(
+            sender=Project,
+            project=self.project,
+            version=self.version,
+        )
+
+    @patch("readthedocs.projects.tasks.utils.files_changed")
+    def test_purge_docs_cdn_version_does_not_exist(self, files_changed):
+        purge_docs_cdn(self.version.pk + 999)
+
+        files_changed.send.assert_not_called()
+
 
 class TestFinishInactiveBuildsTask(TestCase):
 

--- a/readthedocs/rtd_tests/tests/test_projects_tasks.py
+++ b/readthedocs/rtd_tests/tests/test_projects_tasks.py
@@ -15,6 +15,7 @@ from readthedocs.builds.constants import (
 )
 from readthedocs.builds.models import Build, Version
 from readthedocs.projects.models import Feature, Project
+from readthedocs.projects.tasks.search import SearchIndexer
 from readthedocs.projects.tasks.utils import (
     finish_unhealthy_builds,
     purge_docs_cdn,
@@ -81,6 +82,43 @@ class PurgeDocsCDNTests(TestCase):
         purge_docs_cdn(self.version.pk + 999)
 
         files_changed.send.assert_not_called()
+
+
+class SearchIndexUpdatedSignalTests(TestCase):
+    def setUp(self):
+        self.project = get(Project)
+        self.version = get(Version, project=self.project)
+
+    def _get_indexer(self, **kwargs):
+        return SearchIndexer(
+            project=self.project,
+            version=self.version,
+            search_ranking={},
+            search_ignore=[],
+            **kwargs,
+        )
+
+    @patch("readthedocs.projects.tasks.search.search_index_updated")
+    @patch("readthedocs.projects.tasks.search.remove_indexed_files")
+    def test_collect_sends_search_index_updated(
+        self, remove_indexed_files, search_index_updated
+    ):
+        self._get_indexer().collect(sync_id=1)
+
+        search_index_updated.send.assert_called_once_with(
+            sender=Project,
+            project=self.project,
+            version=self.version,
+        )
+
+    @patch("readthedocs.projects.tasks.search.search_index_updated")
+    @patch("readthedocs.projects.tasks.search.remove_indexed_files")
+    def test_collect_into_custom_index_does_not_send_signal(
+        self, remove_indexed_files, search_index_updated
+    ):
+        self._get_indexer(search_index_name="new-index").collect(sync_id=1)
+
+        search_index_updated.send.assert_not_called()
 
 
 class TestFinishInactiveBuildsTask(TestCase):

--- a/readthedocs/search/api/v3/tests/test_api.py
+++ b/readthedocs/search/api/v3/tests/test_api.py
@@ -210,6 +210,26 @@ class SearchAPITest(SearchTestBase):
         self.assertEqual(len(results), 2)
         self.assertEqual(resp.data["query"], "test")
 
+    def test_cache_tags(self):
+        resp = self.get(self.url, data={"q": "project:project test"})
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp["Cache-Tag"], "project,project:latest,project:rtd-search"
+        )
+
+    def test_cache_tags_multiple_projects(self):
+        resp = self.get(
+            self.url, data={"q": "project:project project:another-project test"}
+        )
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp["Cache-Tag"],
+            "project,project:latest,project:rtd-search,"
+            "another-project,another-project:latest,another-project:rtd-search",
+        )
+
     def test_search_user_me_anonymous_user(self):
         self.client.logout()
         resp = self.get(self.url, data={"q": "user:@me test"})

--- a/readthedocs/search/api/v3/views.py
+++ b/readthedocs/search/api/v3/views.py
@@ -10,7 +10,9 @@ from rest_framework.throttling import AnonRateThrottle
 from rest_framework.throttling import UserRateThrottle
 
 from readthedocs.api.v3.views import APIv3Settings
+from readthedocs.core.utils import get_cache_tag
 from readthedocs.core.utils.extend import SettingsOverrideObject
+from readthedocs.proxito.cache import add_cache_tags
 from readthedocs.search import tasks
 from readthedocs.search.api.pagination import SearchPagination
 from readthedocs.search.api.v3.executor import SearchExecutor
@@ -116,7 +118,27 @@ class SearchAPI(APIv3Settings, GenericAPIView):
         self._validate_query_params()
         result = self.list()
         self._record_query(result)
+        self._add_cache_tags(result)
         return result
+
+    def _add_cache_tags(self, response):
+        """
+        Tag the response with all the projects involved in the search.
+
+        Responses are cached by the CDN when served from a public domain.
+        These tags allow purging them when the docs of any of those
+        projects change, or when their search index is updated
+        (``rtd-search`` tag, see ``search_index_updated``).
+        """
+        cache_tags = []
+        for project, version in self._get_projects_to_search():
+            cache_tags.append(project.slug)
+            cache_tags.append(get_cache_tag(project.slug, version.slug))
+            cache_tags.append(get_cache_tag(project.slug, "rtd-search"))
+        # The same project can appear more than once with different versions.
+        cache_tags = list(dict.fromkeys(cache_tags))
+        if cache_tags:
+            add_cache_tags(response, cache_tags)
 
     def _record_query(self, response):
         total_results = response.data.get("count", 0)

--- a/readthedocs/search/signals.py
+++ b/readthedocs/search/signals.py
@@ -1,5 +1,6 @@
 """We define custom Django signals to trigger before executing searches."""
 
+import django.dispatch
 import structlog
 from django.db.models.signals import post_save
 from django.db.models.signals import pre_delete
@@ -12,6 +13,10 @@ from readthedocs.search.tasks import index_objects_to_es
 
 
 log = structlog.get_logger(__name__)
+
+# Sent after the search index of a version is updated.
+# Used to purge cached search results from the CDN (``rtd-search`` cache tag).
+search_index_updated = django.dispatch.Signal()
 
 
 @receiver(post_save, sender=Project)


### PR DESCRIPTION
When the `reindex` queue backs up, the CDN purge lags far behind build completion, because it only ran at the end of `index_build`. Users see stale docs long after their build finished, and end-to-end build monitoring (`BuildLatencyMetric`) reports builds as never completing even though the `Build` rows are green.

The purge now happens in two targeted steps instead of one late whole-version purge:

1. **At build success**, a small task on the `web` queue sends `files_changed` to purge the whole version, from both build paths (legacy `on_success` and `run_post_build_tasks` — mutually exclusive per project, so one purge per build). Docs pages are served straight from storage, so they're correct as soon as this lands.
2. **After indexing**, a new `search_index_updated` signal fires from `SearchIndexer.collect()`, so the CDN receivers can purge just the `project:rtd-search` cache tag rather than the version again. This covers cached search API responses that would otherwise stay stale against the new index, and it also fires on admin/management re-indexing. Indexing into a non-default index (a full rebuild) doesn't fire it, because live results don't change until `reindex_elasticsearch --change-index` switches the alias; after a full rebuild the search cache needs a manual purge from the Cloudflare UI. A global cache tag isn't an option, since bare tags share the namespace with project slugs.

Search API v3 responses were cached without the `rtd-search` tag (only v2 had it), so the narrow purge couldn't have reached them; v3 responses are now tagged with every project involved in the search, since v3 is multi-project. The executor already caps a search at 100 projects, which keeps the `Cache-Tag` header well under Cloudflare's 16 KB limit.

Worth a careful read:

- The `search_index_updated` receiver lives in the ext repo, where the CDN purge handlers are: companion PR readthedocs/readthedocs-ext#635 (purges `{project}:rtd-search`). This PR must merge first — the ext side imports the new signal; until then, step 2 is a no-op, which is safe.
- Between the version purge and `index_build` completing, proxito responses that depend on `HTMLFile` rows (custom 404 pages, directory-index redirects) can be computed from not-yet-updated records and cached; the `rtd-search` purge doesn't cover those. Accepted as an edge case.


