### PR TITLE
Builds: quote the container command so docker-py can split it back

### DIFF
--- a/readthedocs/doc_builder/environments.py
+++ b/readthedocs/doc_builder/environments.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import shlex
 import subprocess
 import sys
 import uuid
@@ -403,6 +404,12 @@ class DockerBuildCommand(BuildCommand):
         escaping, such as: ``pip install requests<0.8``. When passing
         ``escape_command=True`` in the init method this escapes a good majority
         of those characters.
+
+        The string returned here is handed to ``docker-py`` as ``cmd``, and
+        ``docker-py`` runs ``shlex.split()`` over it to build the container's
+        argv. The shell script we pass to ``/bin/sh -c`` therefore has to be
+        quoted so that ``shlex.split()`` gives it back byte for byte, which is
+        what ``shlex.quote()`` guarantees.
         """
         prefix = ""
         if self.bin_path:
@@ -423,8 +430,14 @@ class DockerBuildCommand(BuildCommand):
             # variables with the `command` itself, have the same effect.
             # However, using `;` is more explicit.
             # See https://github.com/readthedocs/readthedocs.org/pull/10334
-            return f"{nice} /bin/sh -c '{prefix}; {command}'"
-        return f"{nice} /bin/sh -c '{command}'"
+            command = f"{prefix}; {command}"
+
+        # NOTE: do not hand-wrap this in `'...'`. A single quote cannot be
+        # backslash-escaped inside a single-quoted string, so any command
+        # carrying one (an image named `Gino's.png`, a `sed 's/a/b/'` in
+        # `build.jobs`) either fails `shlex.split()` with "No closing
+        # quotation" or is silently re-tokenized before the shell sees it.
+        return f"{nice} /bin/sh -c {shlex.quote(command)}"
 
     def _escape_command(self, cmd):
         r"""Escape the command by prefixing suspicious chars with `\`."""

--- a/readthedocs/doc_builder/tests/test_environments.py
+++ b/readthedocs/doc_builder/tests/test_environments.py
@@ -1,6 +1,29 @@
+import os
+import shlex
+import subprocess
+import tempfile
+
 from django.test import TestCase
 
 from readthedocs.doc_builder.environments import DockerBuildCommand
+
+
+def docker_argv(wrapped_command):
+    """
+    Build the container argv the same way ``docker-py`` does.
+
+    ``APIClient.exec_create()`` calls ``docker.utils.split_command()`` on a
+    string ``cmd``, and that function is ``shlex.split()``.
+    """
+    return shlex.split(wrapped_command)
+
+
+def shell_script(wrapped_command):
+    """Return the script ``/bin/sh -c`` receives, as the container would see it."""
+    argv = docker_argv(wrapped_command)
+    assert argv[:5] == ["nice", "-n", "10", "/bin/sh", "-c"], argv
+    assert len(argv) == 6, argv
+    return argv[5]
 
 
 class TestDockerBuildEnvironment(TestCase):
@@ -30,3 +53,95 @@ class TestDockerBuildEnvironment(TestCase):
         for command, expected in commands:
             build_command = DockerBuildCommand(command=command)
             assert build_command.get_wrapped_command() == expected, command
+
+    def test_command_with_single_quote_is_splittable(self):
+        """
+        A single quote in an argument must not break ``shlex.split()``.
+
+        ``extractbb`` is run once per image found in the LaTeX output
+        directory, so the filename is whatever the user committed.
+        """
+        commands = [
+            (["extractbb", "Gino's.png"], "extractbb Gino\\'s.png"),
+            (
+                ["extractbb", "exemple_d'une_mise_à_jour.png"],
+                "extractbb exemple_d\\'une_mise_à_jour.png",
+            ),
+            (["extractbb", "a'b'c.png"], "extractbb a\\'b\\'c.png"),
+            (["extractbb", "Gino's diagram.png"], "extractbb Gino\\'s\\ diagram.png"),
+            (["extractbb", "'"], "extractbb \\'"),
+        ]
+        for command, expected in commands:
+            build_command = DockerBuildCommand(command=command)
+            # Raises ValueError("No closing quotation") when the script is
+            # hand-wrapped in `'...'`.
+            assert shell_script(build_command.get_wrapped_command()) == expected, command
+
+    def test_unescaped_command_reaches_the_shell_unchanged(self):
+        """
+        ``escape_command=False`` commands are user shell snippets.
+
+        These come from ``build.jobs`` and ``build.commands`` in the user's
+        configuration file, and are meant to be interpreted by the shell
+        exactly as written.
+        """
+        commands = [
+            "sed -i 's/foo/bar/' docs/conf.py",
+            "echo 'two words' > docs/version.txt",
+            "python -c 'import sys; print(sys.version)'",
+            "asdf reshim python",
+            'echo "no single quotes here"',
+        ]
+        for command in commands:
+            build_command = DockerBuildCommand(
+                command=[command],
+                escape_command=False,
+            )
+            assert shell_script(build_command.get_wrapped_command()) == command, command
+
+    def test_bin_path_prefix_with_single_quote(self):
+        build_command = DockerBuildCommand(
+            command=["extractbb", "Gino's.png"],
+            bin_path="/tmp/foo",
+        )
+        assert (
+            shell_script(build_command.get_wrapped_command())
+            == "PATH=/tmp/foo:$PATH ; extractbb Gino\\'s.png"
+        )
+
+    def test_not_escaped_variables_still_expand(self):
+        build_command = DockerBuildCommand(
+            command=["mkdir", "-p", "$READTHEDOCS_OUTPUT/html", "a'b"],
+        )
+        assert (
+            shell_script(build_command.get_wrapped_command())
+            == "mkdir -p $READTHEDOCS_OUTPUT/html a\\'b"
+        )
+
+    def test_wrapped_command_runs_with_the_intended_argv(self):
+        """
+        End to end: the program inside the container gets the right argv.
+
+        ``printf '[%s]' a b`` prints ``[a][b]``, so a lost quote, a dropped
+        argument and a wrongly split one all look different in the output.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            marker = os.path.join(tmpdir, "injected")
+            cases = [
+                (["printf", "[%s]", "Gino's.png"], "[Gino's.png]"),
+                (["printf", "[%s]", "a b", "c'd"], "[a b][c'd]"),
+                (["printf", "[%s]", f"; touch {marker}"], f"[; touch {marker}]"),
+                (["printf", "[%s]", "$HOME"], "[$HOME]"),
+                (["printf", "[%s]", f"'; touch {marker}; '"], f"['; touch {marker}; ']"),
+                (["printf", "[%s]", f"$(touch {marker})"], f"[$(touch {marker})]"),
+            ]
+            for command, expected in cases:
+                script = shell_script(DockerBuildCommand(command=command).get_wrapped_command())
+                result = subprocess.run(
+                    ["/bin/sh", "-c", script],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                assert result.stdout == expected, command
+                assert not os.path.exists(marker), command


### PR DESCRIPTION
`DockerBuildCommand.get_wrapped_command()` hand-wraps the build script in `'...'`, but that string is never read by a shell first: `docker-py` runs `shlex.split()` over it to build the container's argv. A single quote cannot be backslash-escaped inside a single-quoted string, so the `\'` that `_escape_command()` produces closes the wrapper instead of escaping anything.

That has two faces, and both are reported. `extractbb` on an image named `Gino's.png` raises `ValueError: No closing quotation` before the container is ever reached — the opaque build failure in #7784 and its Sentry issue. And a command carrying an even number of quotes is silently re-tokenized, so the shell runs something the author did not write.

`shlex.quote()` is the inverse of `shlex.split()`, which is exactly the property the wrapper needs. Its output is byte-identical to today's for all five cases in the existing `test_command_escape`; the only strings that change are ones that are already broken. `$READTHEDOCS_OUTPUT` and friends still expand, since the escaping pass is untouched and only the outer quoting moves.

Worth a closer look before merging: the silent-corruption half is a real behaviour change for existing projects. Across 1,188 `.readthedocs.yaml` files pulled from GitHub (4,417 `build.jobs` / `build.commands` strings, 615 distinct), 210 do not reach the shell as written. Most are cosmetic, but `google-deepmind/mujoco`'s `sed -i 's/a\.b/c/g'` loses its backslashes and its literal dots become wildcards, PlasmaPy's `$'\n'` arrives as `$n`, and two projects' `<< 'EOF'` heredocs turn into expanding `<< EOF`. All 4,417 are delivered verbatim after the change, so those configs start behaving as written — which is the fix, but it is still a change under people's feet.

Not addressed here: an argument containing a newline is still swallowed by `\<newline>` line continuation, and an empty argument still disappears. Both are pre-existing and unchanged by this patch.

The four `GitHubAppTests::test_send_build_status_*` failures in CI are not from this branch — `main` at cf6795d24e fails the same four in build 47837, with 2276 passed against 2281 here.

---

This pull request was generated by an AI agent.
