### PR TITLE
Docs: improve Zensical intro page

### DIFF
--- a/docs/user/intro/zensical.rst
+++ b/docs/user/intro/zensical.rst
@@ -4,10 +4,12 @@ Deploying Zensical on Read the Docs
 .. meta::
    :description lang=en: Learn how to host Zensical sites on Read the Docs.
 
-Zensical_ is a modern static site generator designed to simplify building and
-maintaining project documentation. It's built by the creators of Material for MkDocs
-and shares the same core design principles and philosophy – batteries included,
-easy to use, with powerful customization options.
+Zensical_ is a static site generator for project documentation,
+built by the creators of Material for MkDocs.
+
+Read the Docs builds your Zensical site on every push,
+previews your pull requests,
+and hosts every version of your documentation.
 
 Minimal configuration is required to build an existing Zensical project on Read the Docs:
 
@@ -21,68 +23,86 @@ Minimal configuration is required to build an existing Zensical project on Read 
       tools:
         python: latest
       jobs:
-        # We recommend using a requirements file for reproducible builds.
-        # This is just a quick example to get started.
-        # https://docs.readthedocs.io/page/guides/reproducible-builds.html
+        # For reproducible builds, install with uv:
+        # https://docs.readthedocs.com/platform/stable/build-customization.html#install-dependencies-with-uv
         install:
           - pip install zensical
         build:
           html:
             - zensical build
         post_build:
+          # Copy the built site into the directory Read the Docs publishes.
           - mkdir -p $READTHEDOCS_OUTPUT/html/
           - cp --recursive site/* $READTHEDOCS_OUTPUT/html/
 
+For a complete example, see our `Zensical example repository`_.
+
 .. _Zensical: https://zensical.org/
+.. _Zensical example repository: https://github.com/readthedocs/test-builds/tree/zensical
 
-Quick start
------------
+Getting started
+---------------
 
-- If you have an existing Zensical project you want to host on Read the Docs, check out our :doc:`/intro/add-project` guide.
-- If you're new to Zensical, check out the official `Getting Started <https://zensical.org/docs/get-started/>`_ guide.
+Add your project to publish your documentation.
+If you're new to Zensical, see the official `Get started with Zensical`_ guide.
 
-Configuring Zensical and Read the Docs Addons
----------------------------------------------
+.. _Get started with Zensical: https://zensical.org/docs/get-started/
 
-There are some additional steps you can take to configure your Zensical project to work better with Read the Docs.
+.. grid:: 2
 
-.. contents::
-   :local:
-   :backlinks: none
+    .. grid-item::
+
+        .. button-link:: https://app.readthedocs.org/dashboard/import/
+            :color: primary
+            :expand:
+
+            Add a project on Community
+
+    .. grid-item::
+
+        .. button-link:: https://app.readthedocs.com/dashboard/import/
+            :color: info
+            :expand:
+
+            Add a project on Business
+
+Production examples
+-------------------
+
+Projects using Zensical on Read the Docs:
+
+DDEV
+    https://docs.ddev.com/en/stable/
+
+PDM
+    https://pdm-project.org/en/latest/
+
+cmd2
+    https://cmd2.readthedocs.io/en/stable/
 
 Set the canonical URL
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 
 A :doc:`canonical URL </canonical-urls>` allows you to specify the preferred version of a web page
 to prevent duplicated content.
 
-Set your Zensical `site URL`_ to your Read the Docs canonical URL using a
-:doc:`Read the Docs environment variable </reference/environment-variables>`:
+Set your Zensical `site URL`_ to your Read the Docs canonical URL:
 
 .. code-block:: toml
     :caption: zensical.toml
 
     [project]
-    # Note: variable interpolation is not yet supported in Zensical configuration files,
-    # so you can use the explicit value for now.
-    site_url = "https://your-project.readthedocs.io/"
+    site_url = "https://<slug>.readthedocs.io/"
+
+.. note::
+
+   Zensical doesn't support variable interpolation in its configuration file,
+   so you need to set the value explicitly
+   instead of using the :envvar:`READTHEDOCS_CANONICAL_URL` environment variable.
 
 .. _site URL: https://zensical.org/docs/setup/basics/#site_url
 
-Example repository and demo
----------------------------
+.. seealso::
 
-Example repository
-    https://github.com/readthedocs/test-builds/tree/zensical
-
-Demo
-    https://test-builds.readthedocs.io/en/zensical/
-
-Further reading
----------------
-
-* `Zensical documentation`_
-* `Markdown syntax guide`_
-
-.. _Zensical documentation: https://zensical.org/
-.. _Markdown syntax guide: https://daringfireball.net/projects/markdown/syntax
+   :doc:`/addons`
+     Configuring Addons, like the version flyout menu.


### PR DESCRIPTION
Polishes the Zensical intro page now that real projects are using it in production.

The biggest gaps were social proof and a clear next step. The page now leads with what Read the Docs adds, direct CTAs to add a project on Community or Business, and production Zensical documentation (DDEV, PDM, and cmd2) — each verified as built by Zensical and served by Read the Docs via their response headers and generator meta tags. Zensical-specific configuration (canonical URL) sits below that, based on the working test-builds example.

Things to double-check:

- The CTA button row is a new pattern for the doctool intro pages (sphinx-design buttons, which are already a dependency). If we like it, the other tool pages could adopt it in a follow-up.
- The `post_build` copy stays: `zensical build` has no output-directory flag and Zensical config can't read environment variables, so building into `site/` and copying is also what the production projects do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENQry9mujpyas4QWUAn7sv

